### PR TITLE
Wang et al (2015) allyl additions to double bonds

### DIFF
--- a/input/kinetics/families/R_Addition_MultipleBond/rules.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/rules.py
@@ -40874,3 +40874,103 @@ entry(
     AGV BMK/cbsb7 with 1dHR
     """
 )
+
+entry(
+    index = 3133,
+    label = "Cds-HH_Cds-HH;CsJ-CdHH",
+    kinetics = Arrhenius(
+        A = (6.75E+02, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.700,
+        Ea = (11.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Wang CBS-QB3""",
+    longDesc = 
+    """
+    Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+    
+    Table 4
+    allyl + ethene <=> pent-1-en-5-yl
+
+    CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions
+    around single bonds, tunneling with Eckart potentials.
+    """
+)
+
+entry(
+    index = 3134,
+    label = "Cds-HH_Cds-CsH;CsJ-CdHH",
+    kinetics = Arrhenius(
+        A = (7.80E+02, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.530,
+        Ea = (11.0, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Wang CBS-QB3""",
+    longDesc = 
+    """
+    Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+    
+    Table 4
+    allyl + propene = hex-1-en-5-yl
+
+    CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions
+    around single bonds, tunneling with Eckart potentials.
+    """
+)
+
+entry(
+    index = 3135,
+    label = "Cds-CsH_Cds-HH;CsJ-CdHH",
+    kinetics = Arrhenius(
+        A = (3.43E+01, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.840,
+        Ea = (12.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Wang CBS-QB3""",
+    longDesc = 
+    """
+    Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+    
+    Table 4
+    allyl + propene = 4-methylpent-1-en-5-yl
+
+    CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions
+    around single bonds, tunneling with Eckart potentials.
+    """
+)
+
+entry(
+    index = 3136,
+    label = "Cds-CsH_Cds-CsH;CsJ-CdHH",
+    kinetics = Arrhenius(
+        A = (1.19E+02, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.700,
+        Ea = (11.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Wang CBS-QB3""",
+    longDesc = 
+    """
+    Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+    
+    Table 4
+    allyl + 2-butene = 4-methylhex-1-en-5-yl
+
+    CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions
+    around single bonds, tunneling with Eckart potentials.
+    """
+)

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -98,3 +98,213 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {5,S}
 
+ethene
+1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+
+propene_1
+1 *2 C u0 p0 c0 {2,D} {3,S} {9,S}
+2 *1 C u0 p0 c0 {1,D} {4,S} {5,S}
+3 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+9 H u0 p0 c0 {1,S}
+
+propene_2
+1 *1 C u0 p0 c0 {2,D} {3,S} {9,S}
+2 *2 C u0 p0 c0 {1,D} {4,S} {5,S}
+3 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+9 H u0 p0 c0 {1,S}
+
+
+butene1_1
+1 *1 C u0 p0 c0 {2,D} {5,S} {6,S}
+2 *2 C u0 p0 c0 {1,D} {4,S} {7,S}
+3  C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4  C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+
+butene1_2
+1 *2 C u0 p0 c0 {2,D} {5,S} {6,S}
+2 *1 C u0 p0 c0 {1,D} {4,S} {7,S}
+3  C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4  C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+
+butene2
+1 *1 C u0 p0 c0 {2,D} {3,S} {11,S}
+2 *2 C u0 p0 c0 {1,D} {4,S} {12,S}
+3  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4  C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {2,S}
+
+allyl
+multiplicity 2
+1 *3 C u1 p0 c0 {2,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {3,D} {8,S}
+3 C u0 p0 c0 {2,D} {6,S} {7,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {2,S}
+
+pent1en5yl
+multiplicity 2
+1  C u0 p0 c0 {3,D} {6,S} {7,S}
+2 *2 C u1 p0 c0 {4,S} {8,S} {9,S}
+3  C u0 p0 c0 {1,D} {5,S} {10,S}
+4 *1 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5 *3 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+
+hex1en5yl
+multiplicity 2
+1  C u0 p0 c0 {2,D} {7,S} {8,S}
+2  C u0 p0 c0 {1,D} {5,S} {12,S}
+3  C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+4 *2 C u1 p0 c0 {3,S} {6,S} {13,S}
+5 *3 C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
+6 *1 C u0 p0 c0 {4,S} {5,S} {14,S} {15,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {6,S}
+15 H u0 p0 c0 {6,S}
+16 H u0 p0 c0 {5,S}
+17 H u0 p0 c0 {5,S}
+
+methylpentenyl
+multiplicity 2
+1  C u0 p0 c0 {4,D} {7,S} {8,S}
+2 *2 C u1 p0 c0 {6,S} {10,S} {11,S}
+3  C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+4  C u0 p0 c0 {1,D} {5,S} {9,S}
+5 *3 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6 *1 C u0 p0 c0 {2,S} {3,S} {5,S} {15,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {6,S}
+16 H u0 p0 c0 {5,S}
+17 H u0 p0 c0 {5,S}
+
+hept1en5yl
+multiplicity 2
+1  C u0 p0 c0 {2,D} {8,S} {9,S}
+2  C u0 p0 c0 {1,D} {6,S} {10,S}
+3  C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
+4 *2 C u1 p0 c0 {5,S} {7,S} {14,S}
+5  C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
+6 *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
+7 *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {4,S}
+15 H u0 p0 c0 {5,S}
+16 H u0 p0 c0 {5,S}
+17 H u0 p0 c0 {6,S}
+18 H u0 p0 c0 {6,S}
+19 H u0 p0 c0 {7,S}
+20 H u0 p0 c0 {7,S}
+
+C7H13
+multiplicity 2
+1  C u0 p0 c0 {2,D} {8,S} {9,S}
+2  C u0 p0 c0 {1,D} {6,S} {15,S}
+3 *2 C u1 p0 c0 {7,S} {10,S} {11,S}
+4  C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+5  C u0 p0 c0 {4,S} {7,S} {18,S} {19,S}
+6 *3 C u0 p0 c0 {2,S} {7,S} {16,S} {17,S}
+7 *1 C u0 p0 c0 {3,S} {5,S} {6,S} {20,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
+15 H u0 p0 c0 {2,S}
+16 H u0 p0 c0 {6,S}
+17 H u0 p0 c0 {6,S}
+18 H u0 p0 c0 {5,S}
+19 H u0 p0 c0 {5,S}
+20 H u0 p0 c0 {7,S}
+
+C7H13_2
+multiplicity 2
+1  C u0 p0 c0 {2,D} {8,S} {9,S}
+2  C u0 p0 c0 {1,D} {6,S} {13,S}
+3  C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+4 *2 C u1 p0 c0 {3,S} {7,S} {17,S}
+5  C u0 p0 c0 {7,S} {14,S} {15,S} {16,S}
+6 *3 C u0 p0 c0 {2,S} {7,S} {18,S} {19,S}
+7 *1 C u0 p0 c0 {4,S} {5,S} {6,S} {20,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {2,S}
+14 H u0 p0 c0 {5,S}
+15 H u0 p0 c0 {5,S}
+16 H u0 p0 c0 {5,S}
+17 H u0 p0 c0 {4,S}
+18 H u0 p0 c0 {6,S}
+19 H u0 p0 c0 {6,S}
+20 H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -87,3 +87,172 @@ using Cantherm. One of the rotors had coupling and did not converge back to the
 same initial geometry. It was forced to go back by editing the scan log.
 """,
 )
+
+
+entry(
+    index = 4,
+    label = "allyl + ethene <=> pent1en5yl",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (2.70E+03, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.700,
+        Ea = (11.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ["Wang, K.", "Villano, S.M.", "Dean, A.M."],
+        title = u'Reactions of allylic radicals that impact molecular weight growth kinetics',
+        journal = "PCCP",
+        pages = """6255-6273""",
+        year = "2015",
+        url = "http://pubs.rsc.org/en/content/articlepdf/2015/CP/C4CP05308G",
+    ),
+    longDesc = 
+u"""
+Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+Table 4
+CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
+""",
+)
+
+entry(
+    index = 5,
+    label = "allyl + propene_1 <=> hex1en5yl",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.56E+03, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.530,
+        Ea = (11.0, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ["Wang, K.", "Villano, S.M.", "Dean, A.M."],
+        title = u'Reactions of allylic radicals that impact molecular weight growth kinetics',
+        journal = "PCCP",
+        pages = """6255-6273""",
+        year = "2015",
+        url = "http://pubs.rsc.org/en/content/articlepdf/2015/CP/C4CP05308G",
+    ),
+    longDesc = 
+u"""
+Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+Table 4
+CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
+""",
+)
+
+entry(
+    index = 6,
+    label = "allyl + propene_2 <=> methylpentenyl",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (1.37E+02, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.840,
+        Ea = (12.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ["Wang, K.", "Villano, S.M.", "Dean, A.M."],
+        title = u'Reactions of allylic radicals that impact molecular weight growth kinetics',
+        journal = "PCCP",
+        pages = """6255-6273""",
+        year = "2015",
+        url = "http://pubs.rsc.org/en/content/articlepdf/2015/CP/C4CP05308G",
+    ),
+    longDesc = 
+u"""
+Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+Table 4
+CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
+""",
+)
+
+entry(
+    index = 7,
+    label = "allyl + butene1_1 <=> hept1en5yl",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.31E+03, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.620,
+        Ea = (10.9, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ["Wang, K.", "Villano, S.M.", "Dean, A.M."],
+        title = u'Reactions of allylic radicals that impact molecular weight growth kinetics',
+        journal = "PCCP",
+        pages = """6255-6273""",
+        year = "2015",
+        url = "http://pubs.rsc.org/en/content/articlepdf/2015/CP/C4CP05308G",
+    ),
+    longDesc = 
+u"""
+Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+Table 4
+CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
+""",
+)
+
+entry(
+    index = 8,
+    label = "allyl + butene1_2 <=> C7H13",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (1.22E+01, 'cm^3/(mol*s)', '*|/', 2),
+        n = 3.060,
+        Ea = (11.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ["Wang, K.", "Villano, S.M.", "Dean, A.M."],
+        title = u'Reactions of allylic radicals that impact molecular weight growth kinetics',
+        journal = "PCCP",
+        pages = """6255-6273""",
+        year = "2015",
+        url = "http://pubs.rsc.org/en/content/articlepdf/2015/CP/C4CP05308G",
+    ),
+    longDesc = 
+u"""
+Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+Table 4
+CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
+""",
+)
+
+entry(
+    index = 9,
+    label = "allyl + butene2 <=> C7H13_2",
+    degeneracy = 8,
+    kinetics = Arrhenius(
+        A = (9.53E+02, 'cm^3/(mol*s)', '*|/', 2),
+        n = 2.700,
+        Ea = (11.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ["Wang, K.", "Villano, S.M.", "Dean, A.M."],
+        title = u'Reactions of allylic radicals that impact molecular weight growth kinetics',
+        journal = "PCCP",
+        pages = """6255-6273""",
+        year = "2015",
+        url = "http://pubs.rsc.org/en/content/articlepdf/2015/CP/C4CP05308G",
+    ),
+    longDesc = 
+u"""
+Wang et al. Phys. Chem. Chem. Phys., 2015, 17, 6255--6273
+Table 4
+CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
+""",
+)


### PR DESCRIPTION
This PR adds some of the content of Table 4 of Wang et al (2015) in the form of
* 6 training reactions
* 4 rate rules

The rates pertain to the addition of allyl radical to double bonds in ethene, propene, and butene-like compounds, and are based on CBS-QB3 estimates.

Although, the newly added tree nodes already existed, they were now given a higher rank the already existing rate rules, as I believe they are more accurate.
