### PR TITLE
Cyclic database improvements

### DIFF
--- a/input/kinetics/families/Diels_alder_addition/groups.py
+++ b/input/kinetics/families/Diels_alder_addition/groups.py
@@ -1706,3 +1706,31 @@ u"""
 
 """,
 )
+
+forbidden(
+    label= 'benzyl_isomer1',
+    group=
+"""
+1 C 0 {2,D}
+2 C 0 {1,D} {3,S} {7,S}
+3 C 0 {2,S} {4,D}
+4 C 0 {3,D} {5,S}
+5 C 1 {4,S} {6,S}
+6 C 0 {5,S} {7,D}
+7 C 0 {2,S} {6,D}
+"""
+    )
+
+forbidden(
+    label= 'benzyl_isomer2',
+    group=
+"""
+1 C 0 {2,D}
+2 C 0 {1,D} {3,S} {7,S}
+3 C 1 {2,S} {4,S}
+4 C 0 {3,S} {5,D}
+5 C 0 {4,D} {6,S}
+6 C 0 {5,S} {7,D}
+7 C 0 {2,S} {6,D}
+"""
+    )

--- a/input/kinetics/families/H_shift_cyclopentadiene/training/dictionary.txt
+++ b/input/kinetics/families/H_shift_cyclopentadiene/training/dictionary.txt
@@ -1,21 +1,21 @@
-C7H9-4
-multiplicity 2
-1     C u0 p0 c0 {3,S} {7,S} {9,S} {10,S}
-2  *2 C u0 p0 c0 {4,S} {5,S} {8,S} {11,S}
-3  *5 C u0 p0 c0 {1,S} {4,D} {6,S}
-4  *1 C u0 p0 c0 {2,S} {3,D} {12,S}
-5  *3 C u0 p0 c0 {2,S} {6,D} {13,S}
-6  *4 C u0 p0 c0 {3,S} {5,D} {14,S}
-7     C u1 p0 c0 {1,S} {15,S} {16,S}
-8  *6 H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {1,S}
-11    H u0 p0 c0 {2,S}
+C9H8-2
+1  *2 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+2  *1 C u0 p0 c0 {1,S} {3,D} {5,S}
+3  *5 C u0 p0 c0 {2,D} {6,S} {7,S}
+4  *3 C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {2,S} {8,D} {13,S}
+6  *4 C u0 p0 c0 {3,S} {4,D} {14,S}
+7     C u0 p0 c0 {3,S} {9,D} {15,S}
+8     C u0 p0 c0 {5,D} {9,S} {17,S}
+9     C u0 p0 c0 {7,D} {8,S} {16,S}
+10 *6 H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
 12    H u0 p0 c0 {4,S}
 13    H u0 p0 c0 {5,S}
 14    H u0 p0 c0 {6,S}
 15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {9,S}
+17    H u0 p0 c0 {8,S}
 
 C7H9
 multiplicity 2
@@ -36,24 +36,43 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
-C7H9-2
+C7H9-4
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {4,S} {8,S} {11,S}
-2     C u0 p0 c0 {3,S} {7,S} {9,S} {10,S}
-3  *1 C u0 p0 c0 {1,S} {2,S} {5,D}
-4  *3 C u0 p0 c0 {1,S} {6,D} {12,S}
-5  *5 C u0 p0 c0 {3,D} {6,S} {13,S}
-6  *4 C u0 p0 c0 {4,D} {5,S} {14,S}
-7     C u1 p0 c0 {2,S} {15,S} {16,S}
-8  *6 H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {1,S}
+1     C u0 p0 c0 {3,S} {7,S} {9,S} {10,S}
+2  *2 C u0 p0 c0 {4,S} {5,S} {8,S} {11,S}
+3  *5 C u0 p0 c0 {1,S} {4,D} {6,S}
+4  *1 C u0 p0 c0 {2,S} {3,D} {12,S}
+5  *3 C u0 p0 c0 {2,S} {6,D} {13,S}
+6  *4 C u0 p0 c0 {3,S} {5,D} {14,S}
+7     C u1 p0 c0 {1,S} {15,S} {16,S}
+8  *6 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {4,S}
 13    H u0 p0 c0 {5,S}
 14    H u0 p0 c0 {6,S}
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
+
+C9H8
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
+2  *5 C u0 p0 c0 {1,S} {5,D} {6,S}
+3  *2 C u0 p0 c0 {1,S} {7,D} {11,S}
+4     C u0 p0 c0 {1,S} {8,D} {12,S}
+5  *4 C u0 p0 c0 {2,D} {7,S} {13,S}
+6     C u0 p0 c0 {2,S} {9,D} {15,S}
+7  *3 C u0 p0 c0 {3,D} {5,S} {14,S}
+8     C u0 p0 c0 {4,D} {9,S} {17,S}
+9     C u0 p0 c0 {6,D} {8,S} {16,S}
+10 *6 H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {9,S}
+17    H u0 p0 c0 {8,S}
 
 C7H9-3
 multiplicity 2
@@ -68,6 +87,25 @@ multiplicity 2
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-2
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {8,S} {11,S}
+2     C u0 p0 c0 {3,S} {7,S} {9,S} {10,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *3 C u0 p0 c0 {1,S} {6,D} {12,S}
+5  *5 C u0 p0 c0 {3,D} {6,S} {13,S}
+6  *4 C u0 p0 c0 {4,D} {5,S} {14,S}
+7     C u1 p0 c0 {2,S} {15,S} {16,S}
+8  *6 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {1,S}
 12    H u0 p0 c0 {4,S}
 13    H u0 p0 c0 {5,S}
 14    H u0 p0 c0 {6,S}

--- a/input/kinetics/families/H_shift_cyclopentadiene/training/dictionary.txt
+++ b/input/kinetics/families/H_shift_cyclopentadiene/training/dictionary.txt
@@ -1,0 +1,76 @@
+C7H9-4
+multiplicity 2
+1     C u0 p0 c0 {3,S} {7,S} {9,S} {10,S}
+2  *2 C u0 p0 c0 {4,S} {5,S} {8,S} {11,S}
+3  *5 C u0 p0 c0 {1,S} {4,D} {6,S}
+4  *1 C u0 p0 c0 {2,S} {3,D} {12,S}
+5  *3 C u0 p0 c0 {2,S} {6,D} {13,S}
+6  *4 C u0 p0 c0 {3,S} {5,D} {14,S}
+7     C u1 p0 c0 {1,S} {15,S} {16,S}
+8  *6 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
+3  *2 C u0 p0 c0 {1,S} {5,D} {11,S}
+4  *5 C u0 p0 c0 {1,S} {6,D} {12,S}
+5  *3 C u0 p0 c0 {3,D} {6,S} {13,S}
+6  *4 C u0 p0 c0 {4,D} {5,S} {14,S}
+7     C u1 p0 c0 {2,S} {15,S} {16,S}
+8  *6 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-2
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {8,S} {11,S}
+2     C u0 p0 c0 {3,S} {7,S} {9,S} {10,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *3 C u0 p0 c0 {1,S} {6,D} {12,S}
+5  *5 C u0 p0 c0 {3,D} {6,S} {13,S}
+6  *4 C u0 p0 c0 {4,D} {5,S} {14,S}
+7     C u1 p0 c0 {2,S} {15,S} {16,S}
+8  *6 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-3
+multiplicity 2
+1  *1 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {3,S} {7,S} {10,S} {11,S}
+3  *5 C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *2 C u0 p0 c0 {1,S} {6,D} {12,S}
+5  *4 C u0 p0 c0 {3,D} {6,S} {13,S}
+6  *3 C u0 p0 c0 {4,D} {5,S} {14,S}
+7     C u1 p0 c0 {2,S} {15,S} {16,S}
+8  *6 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/H_shift_cyclopentadiene/training/reactions.py
+++ b/input/kinetics/families/H_shift_cyclopentadiene/training/reactions.py
@@ -35,3 +35,18 @@ Taken from entry: product21 <=> product22
 """,
 )
 
+
+
+entry(
+    index = 3,
+    label = "C9H8 <=> C9H8-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.2e+09, 's^-1'), n=0.96, Ea=(6.8, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt22 <=> INDENE
+""",
+)
+

--- a/input/kinetics/families/H_shift_cyclopentadiene/training/reactions.py
+++ b/input/kinetics/families/H_shift_cyclopentadiene/training/reactions.py
@@ -7,3 +7,31 @@ longDesc = u"""
 Put kinetic parameters for reactions to use as a training set for fitting
 group additivity values in this file.
 """
+
+
+entry(
+    index = 1,
+    label = "C7H9 <=> C7H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.39e+07, 's^-1'), n=1.58, Ea=(21.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addB <=> product21
+""",
+)
+
+entry(
+    index = 2,
+    label = "C7H9-3 <=> C7H9-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.06e+07, 's^-1'), n=1.74, Ea=(24.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product21 <=> product22
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
@@ -1,59 +1,297 @@
-C7H9
+C6H9-3
 multiplicity 2
-1  *4 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {12,S}
-5     C u0 p0 c0 {2,S} {4,D} {13,S}
-6  *2 C u0 p0 c0 {1,S} {7,D} {14,S}
-7  *3 C u0 p0 c0 {6,D} {15,S} {16,S}
+1  *5 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {6,S} {9,S} {10,S} {11,S}
+3  *2 C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *4 C u0 p0 c0 {1,S} {6,D} {13,S}
+5  *3 C u0 p0 c0 {3,D} {14,S} {15,S}
+6  *1 C u1 p0 c0 {2,S} {4,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+
+C6H9-2
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+3  *5 C u0 p0 c0 {4,S} {5,S} {11,S} {12,S}
+4  *4 C u0 p0 c0 {1,S} {3,S} {6,D}
+5  *2 C u1 p0 c0 {2,S} {3,S} {13,S}
+6     C u0 p0 c0 {4,D} {14,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+
+C6H9-6
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+3  *3 C u0 p0 c0 {4,S} {5,S} {11,S} {12,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {6,D}
+5  *2 C u1 p0 c0 {2,S} {3,S} {13,S}
+6     C u0 p0 c0 {4,D} {14,S} {15,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+
+C6H9-5
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
+3  *2 C u0 p0 c0 {1,S} {4,D} {11,S}
+4  *3 C u0 p0 c0 {3,D} {12,S} {13,S}
+5     C u0 p0 c0 {6,D} {14,S} {15,S}
+6  *1 C u1 p0 c0 {2,S} {5,D}
+7     H u0 p0 c0 {1,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {3,S}
 12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
 
-C7H9-6
+C6H9-4
 multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
-2  *1 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3  *4 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
-4     C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
-5  *2 C u1 p0 c0 {1,S} {3,S} {7,S}
-6     C u0 p0 c0 {4,S} {7,D} {15,S}
-7     C u0 p0 c0 {5,S} {6,D} {16,S}
+1  *3 C u0 p0 c0 {4,S} {5,S} {9,S} {10,S}
+2  *5 C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {6,D}
+5  *2 C u1 p0 c0 {1,S} {2,S} {14,S}
+6  *4 C u0 p0 c0 {2,S} {4,D} {15,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+
+C5H5-2
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2  *4 C u0 p0 c0 {1,S} {3,D} {8,S}
+3  *1 C u0 p0 c0 {2,D} {4,S} {9,S}
+4  *3 C u0 p0 c0 {3,S} {5,D} {10,S}
+5  *2 C u1 p0 c0 {1,S} {4,D}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+
+C7H11
+multiplicity 2
+1  *5 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+3  *2 C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *4 C u0 p0 c0 {1,S} {6,D} {7,S}
+5  *3 C u0 p0 c0 {3,D} {13,S} {14,S}
+6     C u0 p0 c0 {4,D} {15,S} {16,S}
+7  *1 C u1 p0 c0 {4,S} {17,S} {18,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {7,S}
+
+C5H5
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *4 C u0 p0 c0 {1,S} {4,D} {8,S}
+3  *2 C u0 p0 c0 {1,S} {5,T}
+4  *1 C u1 p0 c0 {2,D} {9,S}
+5  *3 C u0 p0 c0 {3,T} {10,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+
+C5H7
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,S} {4,D} {8,S}
+3  *4 C u0 p0 c0 {1,S} {5,D} {9,S}
+4  *3 C u0 p0 c0 {2,D} {10,S} {11,S}
+5  *1 C u1 p0 c0 {3,D} {12,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+
+C6H7-3
+multiplicity 2
+1  *5 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *4 C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *2 C u0 p0 c0 {1,S} {6,T}
+5  *1 C u1 p0 c0 {3,D} {12,S}
+6  *3 C u0 p0 c0 {4,T} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+
+C6H7-2
+multiplicity 2
+1  *5 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u0 p0 c0 {2,S} {4,D} {5,S}
+4  *4 C u0 p0 c0 {1,S} {3,D} {12,S}
+5  *3 C u0 p0 c0 {3,S} {6,D} {13,S}
+6  *2 C u1 p0 c0 {1,S} {5,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+
+C6H7-5
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+3     C u0 p0 c0 {4,D} {11,S} {12,S}
+4  *1 C u1 p0 c0 {1,S} {3,D}
+5  *2 C u0 p0 c0 {2,S} {6,T}
+6  *3 C u0 p0 c0 {5,T} {13,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+
+C6H7-4
+multiplicity 2
+1  *5 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *4 C u0 p0 c0 {1,S} {2,S} {4,D}
+4  *1 C u0 p0 c0 {3,D} {5,S} {12,S}
+5  *3 C u0 p0 c0 {4,S} {6,D} {13,S}
+6  *2 C u1 p0 c0 {1,S} {5,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+
+C6H7-6
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *5 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
+3  *1 C u0 p0 c0 {1,S} {4,S} {5,D}
+4  *3 C u0 p0 c0 {3,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {12,S} {13,S}
+6  *2 C u1 p0 c0 {2,S} {4,D}
+7     H u0 p0 c0 {1,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+C7H11-4
+multiplicity 2
+1  *3 C u0 p0 c0 {5,S} {6,S} {10,S} {11,S}
+2  *5 C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
+5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
+6  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+7  *4 C u0 p0 c0 {2,S} {6,D} {18,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {3,S}
 14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
 
-C7H9-4
+C7H11-5
 multiplicity 2
-1  *6 C u0 p0 c0 {3,S} {5,D} {10,S}
-2  *5 C u0 p0 c0 {3,D} {4,S} {11,S}
-3  *7 C u0 p0 c0 {1,S} {2,D} {12,S}
-4  *2 C u0 p0 c0 {2,S} {6,D} {8,S}
-5  *4 C u0 p0 c0 {1,D} {7,S} {9,S}
-6  *3 C u0 p0 c0 {4,D} {13,S} {14,S}
-7  *1 C u1 p0 c0 {5,S} {15,S} {16,S}
-8     H u0 p0 c0 {4,S}
-9     H u0 p0 c0 {5,S}
-10    H u0 p0 c0 {1,S}
+1  *5 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+2  *4 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+4  *2 C u0 p0 c0 {1,S} {3,S} {5,D}
+5  *3 C u0 p0 c0 {4,D} {15,S} {16,S}
+6     C u0 p0 c0 {7,D} {17,S} {18,S}
+7  *1 C u1 p0 c0 {2,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+
+C7H11-6
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+2  *4 C u0 p0 c0 {1,S} {6,S} {10,S} {11,S}
+3  *3 C u0 p0 c0 {5,S} {6,S} {12,S} {13,S}
+4     C u0 p0 c0 {5,S} {14,S} {15,S} {16,S}
+5  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+6  *1 C u0 p0 c0 {2,S} {3,S} {7,D}
+7     C u0 p0 c0 {6,D} {17,S} {18,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {7,S}
 
 C7H9-5
 multiplicity 2
@@ -110,5 +348,153 @@ multiplicity 2
 13    H u0 p0 c0 {4,S}
 14    H u0 p0 c0 {5,S}
 15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H11-2
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {6,S} {10,S} {11,S}
+3  *5 C u0 p0 c0 {5,S} {6,S} {12,S} {13,S}
+4     C u0 p0 c0 {5,S} {14,S} {15,S} {16,S}
+5  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+6  *4 C u0 p0 c0 {2,S} {3,S} {7,D}
+7     C u0 p0 c0 {6,D} {17,S} {18,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {7,S}
+
+C7H11-3
+multiplicity 2
+1  *5 C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+2     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+3     C u0 p0 c0 {7,S} {13,S} {14,S} {15,S}
+4  *2 C u0 p0 c0 {1,S} {2,S} {6,D}
+5  *4 C u0 p0 c0 {1,S} {7,D} {16,S}
+6  *3 C u0 p0 c0 {4,D} {17,S} {18,S}
+7  *1 C u1 p0 c0 {3,S} {5,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+
+C5H7-2
+multiplicity 2
+1  *5 C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+2  *3 C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {10,S}
+4  *4 C u0 p0 c0 {1,S} {5,D} {11,S}
+5  *1 C u0 p0 c0 {2,S} {4,D} {12,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+
+C7H9-6
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *4 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
+5  *2 C u1 p0 c0 {1,S} {3,S} {7,S}
+6     C u0 p0 c0 {4,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C6H9
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {4,D} {5,S}
+3  *2 C u0 p0 c0 {1,S} {6,D} {9,S}
+4     C u0 p0 c0 {2,D} {10,S} {11,S}
+5  *1 C u1 p0 c0 {2,S} {12,S} {13,S}
+6  *3 C u0 p0 c0 {3,D} {14,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+
+C7H9
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {13,S}
+6  *2 C u0 p0 c0 {1,S} {7,D} {14,S}
+7  *3 C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C6H7
+multiplicity 2
+1  *5 C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+2     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+3  *4 C u0 p0 c0 {1,S} {4,D} {12,S}
+4  *1 C u1 p0 c0 {2,S} {3,D}
+5  *2 C u0 p0 c0 {1,S} {6,T}
+6  *3 C u0 p0 c0 {5,T} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+
+C7H9-4
+multiplicity 2
+1  *6 C u0 p0 c0 {3,S} {5,D} {10,S}
+2  *5 C u0 p0 c0 {3,D} {4,S} {11,S}
+3  *7 C u0 p0 c0 {1,S} {2,D} {12,S}
+4  *2 C u0 p0 c0 {2,S} {6,D} {8,S}
+5  *4 C u0 p0 c0 {1,D} {7,S} {9,S}
+6  *3 C u0 p0 c0 {4,D} {13,S} {14,S}
+7  *1 C u1 p0 c0 {5,S} {15,S} {16,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
@@ -1,0 +1,114 @@
+C7H9
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {13,S}
+6  *2 C u0 p0 c0 {1,S} {7,D} {14,S}
+7  *3 C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-6
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *4 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
+5  *2 C u1 p0 c0 {1,S} {3,S} {7,S}
+6     C u0 p0 c0 {4,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-4
+multiplicity 2
+1  *6 C u0 p0 c0 {3,S} {5,D} {10,S}
+2  *5 C u0 p0 c0 {3,D} {4,S} {11,S}
+3  *7 C u0 p0 c0 {1,S} {2,D} {12,S}
+4  *2 C u0 p0 c0 {2,S} {6,D} {8,S}
+5  *4 C u0 p0 c0 {1,D} {7,S} {9,S}
+6  *3 C u0 p0 c0 {4,D} {13,S} {14,S}
+7  *1 C u1 p0 c0 {5,S} {15,S} {16,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-5
+multiplicity 2
+1     C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+2  *4 C u0 p0 c0 {3,S} {7,S} {10,S} {11,S}
+3  *2 C u0 p0 c0 {2,S} {4,D} {6,S}
+4  *3 C u0 p0 c0 {1,S} {3,D} {12,S}
+5     C u0 p0 c0 {1,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7  *1 C u1 p0 c0 {2,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-2
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {5,S} {6,S} {9,S}
+3  *3 C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+4     C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+5  *2 C u1 p0 c0 {2,S} {3,S} {14,S}
+6     C u0 p0 c0 {2,S} {7,D} {15,S}
+7     C u0 p0 c0 {4,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-3
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3  *2 C u1 p0 c0 {1,S} {6,S} {12,S}
+4  *4 C u0 p0 c0 {2,S} {5,D} {13,S}
+5  *6 C u0 p0 c0 {4,D} {7,S} {14,S}
+6  *5 C u0 p0 c0 {3,S} {7,D} {15,S}
+7  *7 C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -7,3 +7,44 @@ longDesc = u"""
 Put kinetic parameters for reactions to use as a training set for fitting
 group additivity values in this file.
 """
+
+
+entry(
+    index = 1,
+    label = "C7H9 <=> C7H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.8e+10, 's^-1'), n=0.51, Ea=(30.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addD <=> product8
+""",
+)
+
+entry(
+    index = 2,
+    label = "C7H9-3 <=> C7H9-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.03e+10, 's^-1'), n=1.1, Ea=(37, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product4 <=> product16
+""",
+)
+
+entry(
+    index = 3,
+    label = "C7H9-5 <=> C7H9-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.39e+11, 's^-1'), n=0.26, Ea=(26.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product22 <=> product25
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -48,3 +48,148 @@ Taken from entry: product22 <=> product25
 """,
 )
 
+
+
+entry(
+    index = 4,
+    label = "C6H9 <=> C6H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.12e+09, 's^-1'), n=0.63, Ea=(27.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_1 <=> prod_2
+""",
+)
+
+entry(
+    index = 5,
+    label = "C7H11 <=> C7H11-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.71e+11, 's^-1'), n=0.2, Ea=(27.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_6 <=> prod_4
+""",
+)
+
+entry(
+    index = 6,
+    label = "C6H9-3 <=> C6H9-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.53e+07, 's^-1'), n=1.05, Ea=(9.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_7 <=> prod_8
+""",
+)
+
+entry(
+    index = 7,
+    label = "C7H11-3 <=> C7H11-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.6e+10, 's^-1'), n=0.2, Ea=(9.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_10 <=> prod_11
+""",
+)
+
+entry(
+    index = 8,
+    label = "C6H9-5 <=> C6H9-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.47e+07, 's^-1'), n=0.85, Ea=(10.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_19 <=> prod_2
+""",
+)
+
+entry(
+    index = 9,
+    label = "C7H11-5 <=> C7H11-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.6e+11, 's^-1'), n=0.27, Ea=(10.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_20 <=> prod_4
+""",
+)
+
+entry(
+    index = 10,
+    label = "C5H7 <=> C5H7-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.29e+09, 's^-1'), n=0.62, Ea=(9.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_21 <=> prod_22
+""",
+)
+
+entry(
+    index = 11,
+    label = "C5H5 <=> C5H5-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.88e+10, 's^-1'), n=0.31, Ea=(12.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_23 <=> prod_24
+""",
+)
+
+entry(
+    index = 12,
+    label = "C6H7 <=> C6H7-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.05e+11, 's^-1'), n=0.12, Ea=(12.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_25 <=> prod_26
+""",
+)
+
+entry(
+    index = 13,
+    label = "C6H7-3 <=> C6H7-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.8e+11, 's^-1'), n=0.1, Ea=(11.8, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_27 <=> prod_28
+""",
+)
+
+entry(
+    index = 14,
+    label = "C6H7-5 <=> C6H7-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.47e+11, 's^-1'), n=0.15, Ea=(14, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_29 <=> prod_30
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
@@ -22,6 +22,50 @@ multiplicity 2
 20    H u0 p0 c0 {10,S}
 21    H u0 p0 c0 {10,S}
 
+C10H9-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,D} {4,S}
+2  *5 C u0 p0 c0 {1,S} {8,D} {11,S}
+3  *3 C u0 p0 c0 {1,D} {5,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {15,S}
+6     C u0 p0 c0 {4,D} {7,S} {16,S}
+7     C u0 p0 c0 {5,D} {6,S} {17,S}
+8  *6 C u0 p0 c0 {2,D} {9,S} {14,S}
+9  *4 C u0 p0 c0 {8,S} {10,D} {18,S}
+10 *1 C u1 p0 c0 {9,D} {19,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {8,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {10,S}
+
+C10H9
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  *5 C u0 p0 c0 {1,S} {8,D} {11,S}
+3  *3 C u1 p0 c0 {1,S} {6,S} {12,S}
+4     C u0 p0 c0 {1,S} {7,D} {13,S}
+5  *1 C u0 p0 c0 {1,S} {9,D} {14,S}
+6     C u0 p0 c0 {3,S} {10,D} {16,S}
+7     C u0 p0 c0 {4,D} {10,S} {17,S}
+8  *6 C u0 p0 c0 {2,D} {9,S} {15,S}
+9  *4 C u0 p0 c0 {5,D} {8,S} {19,S}
+10    C u0 p0 c0 {6,D} {7,S} {18,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {8,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {10,S}
+19    H u0 p0 c0 {9,S}
+
 C7H9
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
@@ -1,21 +1,26 @@
-C7H9-4
+C10H11
 multiplicity 2
-1  *4 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
-2     C u0 p0 c0 {4,S} {5,S} {10,S} {11,S}
-3  *2 C u0 p0 c0 {1,S} {6,S} {7,D}
-4  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
-5     C u0 p0 c0 {2,S} {6,D} {13,S}
-6     C u0 p0 c0 {3,S} {5,D} {14,S}
-7  *3 C u0 p0 c0 {3,D} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {6,S}
+1     C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {5,D}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4  *2 C u0 p0 c0 {2,S} {7,D} {14,S}
+5  *7 C u0 p0 c0 {2,D} {8,S} {16,S}
+6     C u0 p0 c0 {3,D} {7,S} {17,S}
+7  *3 C u0 p0 c0 {4,D} {6,S} {15,S}
+8  *6 C u0 p0 c0 {5,S} {9,D} {18,S}
+9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
 15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
 
 C7H9
 multiplicity 2
@@ -32,6 +37,25 @@ multiplicity 2
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-4
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {4,S} {5,S} {10,S} {11,S}
+3  *2 C u0 p0 c0 {1,S} {6,S} {7,D}
+4  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+5     C u0 p0 c0 {2,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7  *3 C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
 14    H u0 p0 c0 {6,S}
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
@@ -73,4 +97,124 @@ multiplicity 2
 14    H u0 p0 c0 {5,S}
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
+
+C10H11-3
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u0 p0 c0 {1,S} {5,D} {12,S}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4  *8 C u0 p0 c0 {1,S} {7,D} {14,S}
+5  *3 C u0 p0 c0 {2,D} {6,S} {15,S}
+6     C u0 p0 c0 {3,D} {5,S} {16,S}
+7  *7 C u0 p0 c0 {4,D} {8,S} {17,S}
+8  *6 C u0 p0 c0 {7,S} {9,D} {18,S}
+9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2  *1 C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4  *5 C u0 p0 c0 {1,S} {3,S} {8,D}
+5  *3 C u1 p0 c0 {1,S} {9,S} {17,S}
+6  *4 C u0 p0 c0 {2,S} {10,D} {18,S}
+7     C u0 p0 c0 {3,S} {9,D} {16,S}
+8  *7 C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {5,S} {7,D} {20,S}
+10 *6 C u0 p0 c0 {6,D} {8,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-5
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4  *3 C u1 p0 c0 {1,S} {7,S} {8,S}
+5  *6 C u0 p0 c0 {2,S} {6,D} {16,S}
+6  *4 C u0 p0 c0 {3,S} {5,D} {17,S}
+7     C u0 p0 c0 {4,S} {10,D} {18,S}
+8     C u0 p0 c0 {4,S} {9,D} {19,S}
+9     C u0 p0 c0 {8,D} {10,S} {20,S}
+10    C u0 p0 c0 {7,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-4
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3  *1 C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4  *3 C u1 p0 c0 {1,S} {8,S} {17,S}
+5     C u0 p0 c0 {2,S} {8,D} {15,S}
+6  *8 C u0 p0 c0 {2,S} {9,D} {16,S}
+7  *4 C u0 p0 c0 {3,S} {10,D} {18,S}
+8     C u0 p0 c0 {4,S} {5,D} {19,S}
+9  *7 C u0 p0 c0 {6,D} {10,S} {20,S}
+10 *6 C u0 p0 c0 {7,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-6
+multiplicity 2
+1  *5 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
+2  *3 C u0 p0 c0 {3,D} {5,S} {6,S}
+3  *2 C u0 p0 c0 {1,S} {2,D} {13,S}
+4  *6 C u0 p0 c0 {1,S} {9,D} {14,S}
+5     C u0 p0 c0 {2,S} {8,D} {16,S}
+6     C u0 p0 c0 {2,S} {7,D} {17,S}
+7     C u0 p0 c0 {6,D} {8,S} {18,S}
+8     C u0 p0 c0 {5,D} {7,S} {19,S}
+9  *4 C u0 p0 c0 {4,D} {10,S} {15,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {9,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
 

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
@@ -1,0 +1,76 @@
+C7H9-4
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {4,S} {5,S} {10,S} {11,S}
+3  *2 C u0 p0 c0 {1,S} {6,S} {7,D}
+4  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+5     C u0 p0 c0 {2,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7  *3 C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3  *2 C u0 p0 c0 {1,S} {5,S} {7,D}
+4     C u0 p0 c0 {2,S} {5,D} {11,S}
+5     C u0 p0 c0 {3,S} {4,D} {12,S}
+6  *1 C u1 p0 c0 {1,S} {13,S} {14,S}
+7  *3 C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {5,S} {7,S}
+2  *4 C u0 p0 c0 {1,S} {3,S} {4,S} {8,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {9,S} {10,S}
+4     C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {6,D} {14,S}
+6     C u0 p0 c0 {4,S} {5,D} {13,S}
+7  *3 C u1 p0 c0 {1,S} {15,S} {16,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-3
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {5,S} {7,S}
+2  *1 C u0 p0 c0 {1,S} {3,S} {4,S} {8,S}
+3  *4 C u0 p0 c0 {1,S} {2,S} {9,S} {10,S}
+4     C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {6,D} {14,S}
+6     C u0 p0 c0 {4,S} {5,D} {13,S}
+7  *3 C u1 p0 c0 {1,S} {15,S} {16,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
@@ -76,3 +76,18 @@ Taken from entry: pdt55 <=> pdt58
 """,
 )
 
+
+
+entry(
+    index = 6,
+    label = "C10H9 <=> C10H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.3e+12, 's^-1'), n=0.45, Ea=(25.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
+    longDesc = 
+u"""
+Taken from entry: prod2 <=> prod5
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
@@ -35,3 +35,44 @@ Taken from entry: product39 <=> product37
 """,
 )
 
+
+
+entry(
+    index = 3,
+    label = "C10H11 <=> C10H11-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.69e+11, 's^-1'), n=0.22, Ea=(40, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt18 <=> pdt19
+""",
+)
+
+entry(
+    index = 4,
+    label = "C10H11-3 <=> C10H11-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.19e+11, 's^-1'), n=0.08, Ea=(16.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt14 <=> pdt23
+""",
+)
+
+entry(
+    index = 5,
+    label = "C10H11-5 <=> C10H11-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.02e+11, 's^-1'), n=0.79, Ea=(35.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt55 <=> pdt58
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
@@ -7,3 +7,31 @@ longDesc = u"""
 Put kinetic parameters for reactions to use as a training set for fitting
 group additivity values in this file.
 """
+
+
+entry(
+    index = 1,
+    label = "C7H9 <=> C7H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.32e+10, 's^-1'), n=0.35, Ea=(10.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product38 <=> product39
+""",
+)
+
+entry(
+    index = 2,
+    label = "C7H9-3 <=> C7H9-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.95e+12, 's^-1'), n=0.12, Ea=(3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product39 <=> product37
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -1,3 +1,983 @@
+C2H3O3
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+2 *2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 *3 O u0 p2 c0 {1,S} {4,S}
+4    O u0 p2 c0 {3,S} {8,S}
+5    O u0 p2 c0 {1,D}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {4,S}
+
+C6H9-3
+multiplicity 2
+1  *3 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {6,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *1 C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,D} {14,S} {15,S}
+6  *2 C u1 p0 c0 {2,S} {4,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+
+C6H9-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+3  *1 C u0 p0 c0 {4,S} {5,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {3,S} {6,D}
+5  *2 C u1 p0 c0 {2,S} {3,S} {13,S}
+6     C u0 p0 c0 {4,D} {14,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+
+methylpentenyl
+multiplicity 2
+1     C u0 p0 c0 {4,D} {7,S} {8,S}
+2  *2 C u1 p0 c0 {6,S} {10,S} {11,S}
+3     C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,D} {5,S} {9,S}
+5  *3 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u0 p0 c0 {2,S} {3,S} {5,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C6H9-5
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {4,D} {11,S}
+4     C u0 p0 c0 {3,D} {12,S} {13,S}
+5     C u0 p0 c0 {6,D} {14,S} {15,S}
+6  *2 C u1 p0 c0 {2,S} {5,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+
+C6H9-4
+multiplicity 2
+1     C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+2  *1 C u0 p0 c0 {5,S} {6,S} {9,S} {10,S}
+3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+4     C u0 p0 c0 {1,S} {3,S} {6,D}
+5  *2 C u1 p0 c0 {1,S} {2,S} {14,S}
+6     C u0 p0 c0 {2,S} {4,D} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+
+C6H6-4
+1     C u0 p0 c0 {2,S} {3,S} {6,D}
+2  *1 C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4  *2 C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+C6H6-5
+1     C u0 p0 c0 {2,S} {3,S} {6,D}
+2  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4  *1 C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+CH3
+multiplicity 2
+1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+C6H6-2
+1  *1 C u0 p0 c0 {2,S} {3,D} {7,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3  *2 C u0 p0 c0 {1,D} {5,S} {9,S}
+4     C u0 p0 c0 {2,D} {6,S} {10,S}
+5     C u0 p0 c0 {3,S} {6,D} {11,S}
+6     C u0 p0 c0 {4,S} {5,D} {12,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+
+C6H6-3
+1  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+2     C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *2 C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+C7H10
+1     C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+4  *2 C u0 p0 c0 {1,S} {3,S} {6,D}
+5     C u0 p0 c0 {2,S} {6,S} {7,D}
+6  *1 C u0 p0 c0 {4,D} {5,S} {15,S}
+7     C u0 p0 c0 {5,D} {16,S} {17,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {7,S}
+
+C7H11
+multiplicity 2
+1  *3 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+3     C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *1 C u0 p0 c0 {1,S} {6,S} {7,D}
+5     C u0 p0 c0 {3,D} {17,S} {18,S}
+6  *2 C u1 p0 c0 {4,S} {13,S} {14,S}
+7     C u0 p0 c0 {4,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+
+C7H13
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {15,S}
+3  *2 C u1 p0 c0 {7,S} {10,S} {11,S}
+4     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+5     C u0 p0 c0 {4,S} {7,S} {18,S} {19,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {16,S} {17,S}
+7  *1 C u0 p0 c0 {3,S} {5,S} {6,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {2,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {7,S}
+
+C7H9-21
+multiplicity 2
+1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
+2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
+3     C u0 p0 c0 {2,S} {6,D} {11,S}
+4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
+5     C u0 p0 c0 {2,D} {15,S} {16,S}
+6     C u0 p0 c0 {3,D} {13,S} {14,S}
+7  *2 C u1 p0 c0 {1,S} {4,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+
+H
+multiplicity 2
+1 *3 H u1 p0 c0
+
+pent1en5yl
+multiplicity 2
+1     C u0 p0 c0 {3,D} {6,S} {7,S}
+2  *2 C u1 p0 c0 {4,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,D} {5,S} {10,S}
+4  *1 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5  *3 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+
+ethene
+1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+
+hex1en5yl
+multiplicity 2
+1     C u0 p0 c0 {2,D} {7,S} {8,S}
+2     C u0 p0 c0 {1,D} {5,S} {12,S}
+3     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+4  *2 C u1 p0 c0 {3,S} {6,S} {13,S}
+5  *3 C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
+6  *1 C u0 p0 c0 {4,S} {5,S} {14,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C6H11
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2     C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5  *1 C u0 p0 c0 {1,S} {6,D} {16,S}
+6  *2 C u1 p0 c0 {5,D} {17,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+
+C2H2O
+1 *2 C u0 p0 c0 {2,D} {4,S} {5,S}
+2 *1 C u0 p0 c0 {1,D} {3,D}
+3    O u0 p2 c0 {2,D}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+
+C3H4
+1 *2 C u0 p0 c0 {3,D} {4,S} {5,S}
+2    C u0 p0 c0 {3,D} {6,S} {7,S}
+3 *1 C u0 p0 c0 {1,D} {2,D}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+
+C3H3
+multiplicity 2
+1 *3 C u1 p0 c0 {2,S} {4,S} {5,S}
+2    C u0 p0 c0 {1,S} {3,T}
+3    C u0 p0 c0 {2,T} {6,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {3,S}
+
+CH2O
+1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *2 O u0 p2 c0 {1,D}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+propene_2
+1 *1 C u0 p0 c0 {2,D} {3,S} {9,S}
+2 *2 C u0 p0 c0 {1,D} {4,S} {5,S}
+3    C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {1,S}
+
+propene_1
+1 *2 C u0 p0 c0 {2,D} {3,S} {9,S}
+2 *1 C u0 p0 c0 {1,D} {4,S} {5,S}
+3    C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {1,S}
+
+C7H8-4
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4     C u0 p0 c0 {1,S} {7,D} {11,S}
+5  *1 C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7     C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C5H6-2
+1     C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *1 C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4  *2 C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C6H7-3
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+3     C u0 p0 c0 {4,D} {11,S} {12,S}
+4  *2 C u1 p0 c0 {1,S} {3,D}
+5     C u0 p0 c0 {2,S} {6,T}
+6     C u0 p0 c0 {5,T} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+
+C5H5-2
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *1 C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,T}
+4  *2 C u1 p0 c0 {2,D} {9,S}
+5     C u0 p0 c0 {3,T} {10,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+
+C7H8-3
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4     C u0 p0 c0 {1,S} {7,D} {11,S}
+5  *2 C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7     C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
+5     C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7  *2 C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C6H7-2
+multiplicity 2
+1  *3 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {5,D}
+4     C u0 p0 c0 {1,S} {6,T}
+5  *2 C u1 p0 c0 {3,D} {12,S}
+6     C u0 p0 c0 {4,T} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+
+C7H8-7
+1     C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {5,S} {6,S} {7,D}
+3  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5  *2 C u0 p0 c0 {2,S} {3,D} {12,S}
+6     C u0 p0 c0 {2,S} {4,D} {13,S}
+7     C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-6
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {12,S}
+7  *2 C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-5
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *1 C u0 p0 c0 {1,S} {3,D} {4,S}
+3  *2 C u0 p0 c0 {2,D} {6,S} {14,S}
+4     C u0 p0 c0 {2,S} {7,D} {15,S}
+5     C u0 p0 c0 {6,D} {7,S} {11,S}
+6     C u0 p0 c0 {3,S} {5,D} {12,S}
+7     C u0 p0 c0 {4,D} {5,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+
+C4H7O2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,D} {4,S}
+3     O u0 p2 c0 {2,D}
+4  *3 C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
+5  *1 C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
+6  *2 O u1 p2 c0 {5,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+C7H8-9
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {4,S} {7,D}
+3  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5  *2 C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {12,S}
+7     C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-8
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,D} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4  *2 C u0 p0 c0 {2,D} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {15,S}
+6     C u0 p0 c0 {4,S} {7,D} {12,S}
+7     C u0 p0 c0 {5,S} {6,D} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+
+C7H10-2
+1     C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+2     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+3     C u0 p0 c0 {5,S} {13,S} {14,S} {15,S}
+4  *2 C u0 p0 c0 {1,S} {2,S} {6,D}
+5     C u0 p0 c0 {1,S} {3,S} {7,D}
+6  *1 C u0 p0 c0 {4,D} {7,S} {16,S}
+7     C u0 p0 c0 {5,D} {6,S} {17,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+
+C2H3
+multiplicity 2
+1    C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *3 C u1 p0 c0 {1,D} {5,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {2,S}
+
+C2H2
+1 *1 C u0 p0 c0 {2,T} {3,S}
+2 *2 C u0 p0 c0 {1,T} {4,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {2,S}
+
+C7H9-6
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {14,S}
+5     C u0 p0 c0 {3,S} {7,D} {16,S}
+6     C u0 p0 c0 {4,D} {7,S} {13,S}
+7     C u0 p0 c0 {5,D} {6,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+
+C6H9
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {5,D}
+3     C u0 p0 c0 {1,S} {6,D} {9,S}
+4  *2 C u1 p0 c0 {2,S} {10,S} {11,S}
+5     C u0 p0 c0 {2,D} {12,S} {13,S}
+6     C u0 p0 c0 {3,D} {14,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+
+C6H8
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,S} {6,D}
+4  *2 C u0 p0 c0 {2,S} {5,D} {11,S}
+5  *1 C u0 p0 c0 {3,S} {4,D} {12,S}
+6     C u0 p0 c0 {3,D} {13,S} {14,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+
+C7H6
+1  *2 C u0 p0 c0 {2,S} {3,S} {7,D}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     C u0 p0 c0 {7,D} {12,S} {13,S}
+7  *1 C u0 p0 c0 {1,D} {6,D}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
+C7H7
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {12,S}
+5     C u0 p0 c0 {3,D} {4,S} {13,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
+7  *2 C u1 p0 c0 {6,D} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+
+C7H11-5
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {3,S} {5,D}
+5     C u0 p0 c0 {4,D} {15,S} {16,S}
+6     C u0 p0 c0 {7,D} {17,S} {18,S}
+7  *2 C u1 p0 c0 {2,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+
+C7H8
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4  *2 C u0 p0 c0 {1,S} {7,D} {11,S}
+5     C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7  *1 C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H9
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+2  *1 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {1,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C6H7
+multiplicity 2
+1  *3 C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+2     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+3  *1 C u0 p0 c0 {1,S} {4,D} {12,S}
+4  *2 C u1 p0 c0 {2,S} {3,D}
+5     C u0 p0 c0 {1,S} {6,T}
+6     C u0 p0 c0 {5,T} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+
+C6H6
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,D}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {7,S}
+5     C u0 p0 c0 {3,D} {4,S} {9,S}
+6  *1 C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+C3H5O
+multiplicity 2
+1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2    C u0 p0 c0 {1,S} {3,S} {7,D}
+3 *3 C u1 p0 c0 {2,S} {8,S} {9,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    O u0 p2 c0 {2,D}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C7H7-2
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C6H8-2
+1     C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *2 C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6  *1 C u0 p0 c0 {4,D} {5,S} {14,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+
+allyl
+multiplicity 2
+1    C u0 p0 c0 {2,S} {3,D} {4,S}
+2 *3 C u1 p0 c0 {1,S} {5,S} {6,S}
+3    C u0 p0 c0 {1,D} {7,S} {8,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+
+C3H4-3
+1 *1 C u0 p0 c0 {3,D} {4,S} {5,S}
+2    C u0 p0 c0 {3,D} {6,S} {7,S}
+3 *2 C u0 p0 c0 {1,D} {2,D}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+
+C3H4-2
+1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 *2 C u0 p0 c0 {1,S} {3,T}
+3 *1 C u0 p0 c0 {2,T} {7,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {3,S}
+
+C3H4-4
+1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 *1 C u0 p0 c0 {1,S} {3,T}
+3 *2 C u0 p0 c0 {2,T} {7,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {3,S}
+
+C7H13_2
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {13,S}
+3     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+4  *2 C u1 p0 c0 {3,S} {7,S} {17,S}
+5     C u0 p0 c0 {7,S} {14,S} {15,S} {16,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {18,S} {19,S}
+7  *1 C u0 p0 c0 {4,S} {5,S} {6,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+
+C5H7-2
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+2  *1 C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {10,S}
+4     C u0 p0 c0 {1,S} {5,D} {11,S}
+5     C u0 p0 c0 {2,S} {4,D} {12,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+
+C7H8-12
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,S} {4,D} {5,S}
+3     C u0 p0 c0 {4,S} {6,S} {7,D}
+4  *1 C u0 p0 c0 {2,D} {3,S} {12,S}
+5     C u0 p0 c0 {2,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {11,S}
+7     C u0 p0 c0 {3,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-11
+1     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,S} {6,D}
+3     C u0 p0 c0 {2,S} {5,S} {7,D}
+4  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
+5  *2 C u0 p0 c0 {3,S} {4,D} {11,S}
+6     C u0 p0 c0 {2,D} {14,S} {15,S}
+7     C u0 p0 c0 {3,D} {12,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+
+C7H8-10
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {4,S} {7,D}
+3  *2 C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5  *1 C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {12,S}
+7     C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+hept1en5yl
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {10,S}
+3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
+4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
+5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
 C7H9-14
 multiplicity 2
 1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {7,S}
@@ -17,12 +997,24 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
-C2H2O
-1 *2 C u0 p0 c0 {2,D} {4,S} {5,S}
-2 *1 C u0 p0 c0 {1,D} {3,D}
-3    O u0 p2 c0 {2,D}
-4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {1,S}
+C7H9-15
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,S} {7,D}
+4  *2 C u1 p0 c0 {2,S} {6,S} {12,S}
+5     C u0 p0 c0 {3,S} {6,D} {13,S}
+6     C u0 p0 c0 {4,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 C7H9-16
 multiplicity 2
@@ -157,87 +1149,24 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
-C6H6
-1  *2 C u0 p0 c0 {2,S} {3,S} {6,D}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,D} {5,S} {7,S}
-5     C u0 p0 c0 {3,D} {4,S} {9,S}
-6  *1 C u0 p0 c0 {1,D} {11,S} {12,S}
-7     H u0 p0 c0 {4,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {5,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {6,S}
-12    H u0 p0 c0 {6,S}
-
-CH2O
-1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 *2 O u0 p2 c0 {1,D}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-
-propene_2
-1 *1 C u0 p0 c0 {2,D} {3,S} {9,S}
-2 *2 C u0 p0 c0 {1,D} {4,S} {5,S}
-3    C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
-4    H u0 p0 c0 {2,S}
-5    H u0 p0 c0 {2,S}
-6    H u0 p0 c0 {3,S}
-7    H u0 p0 c0 {3,S}
-8    H u0 p0 c0 {3,S}
-9    H u0 p0 c0 {1,S}
-
-propene_1
-1 *2 C u0 p0 c0 {2,D} {3,S} {9,S}
-2 *1 C u0 p0 c0 {1,D} {4,S} {5,S}
-3    C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
-4    H u0 p0 c0 {2,S}
-5    H u0 p0 c0 {2,S}
-6    H u0 p0 c0 {3,S}
-7    H u0 p0 c0 {3,S}
-8    H u0 p0 c0 {3,S}
-9    H u0 p0 c0 {1,S}
-
-C7H8-4
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *2 C u0 p0 c0 {1,S} {5,D} {9,S}
-3     C u0 p0 c0 {1,S} {6,D} {10,S}
-4     C u0 p0 c0 {1,S} {7,D} {11,S}
-5  *1 C u0 p0 c0 {2,D} {6,S} {12,S}
-6     C u0 p0 c0 {3,D} {5,S} {13,S}
-7     C u0 p0 c0 {4,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
+C7H9-19
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {6,D}
+2  *1 C u0 p0 c0 {1,S} {4,S} {5,D}
+3     C u0 p0 c0 {1,S} {7,D} {8,S}
+4  *2 C u1 p0 c0 {2,S} {9,S} {10,S}
+5     C u0 p0 c0 {2,D} {11,S} {12,S}
+6     C u0 p0 c0 {1,D} {15,S} {16,S}
+7     C u0 p0 c0 {3,D} {13,S} {14,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
 12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
 14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
-
-C3H5O
-multiplicity 2
-1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
-2    C u0 p0 c0 {1,S} {3,S} {7,D}
-3 *3 C u1 p0 c0 {2,S} {8,S} {9,S}
-4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {1,S}
-6    H u0 p0 c0 {1,S}
-7    O u0 p2 c0 {2,D}
-8    H u0 p0 c0 {3,S}
-9    H u0 p0 c0 {3,S}
-
-C2H3O3
-multiplicity 2
-1 *1 C u0 p0 c0 {2,S} {3,S} {5,D}
-2 *2 C u1 p0 c0 {1,S} {6,S} {7,S}
-3 *3 O u0 p2 c0 {1,S} {4,S}
-4    O u0 p2 c0 {3,S} {8,S}
-5    O u0 p2 c0 {1,D}
-6    H u0 p0 c0 {2,S}
-7    H u0 p0 c0 {2,S}
-8    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
 
 butene2
 1  *1 C u0 p0 c0 {2,D} {3,S} {11,S}
@@ -253,159 +1182,11 @@ butene2
 11    H u0 p0 c0 {1,S}
 12    H u0 p0 c0 {2,S}
 
-C7H8-5
-1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
-2  *1 C u0 p0 c0 {1,S} {3,D} {4,S}
-3  *2 C u0 p0 c0 {2,D} {6,S} {14,S}
-4     C u0 p0 c0 {2,S} {7,D} {15,S}
-5     C u0 p0 c0 {6,D} {7,S} {11,S}
-6     C u0 p0 c0 {3,S} {5,D} {12,S}
-7     C u0 p0 c0 {4,D} {5,S} {13,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {1,S}
-11    H u0 p0 c0 {5,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-
-methylpentenyl
-multiplicity 2
-1     C u0 p0 c0 {4,D} {7,S} {8,S}
-2  *2 C u1 p0 c0 {6,S} {10,S} {11,S}
-3     C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {1,D} {5,S} {9,S}
-5  *3 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
-6  *1 C u0 p0 c0 {2,S} {3,S} {5,S} {15,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {5,S}
-
-C4H7O2
-multiplicity 2
-1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {3,D} {4,S}
-3     O u0 p2 c0 {2,D}
-4  *3 C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
-5  *1 C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
-6  *2 O u1 p2 c0 {5,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {5,S}
-
-C6H6-4
-1     C u0 p0 c0 {2,S} {3,S} {6,D}
-2  *1 C u0 p0 c0 {1,S} {4,D} {7,S}
-3     C u0 p0 c0 {1,S} {5,D} {8,S}
-4  *2 C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6     C u0 p0 c0 {1,D} {11,S} {12,S}
-7     H u0 p0 c0 {2,S}
-8     H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {6,S}
-12    H u0 p0 c0 {6,S}
-
-C6H6-5
-1     C u0 p0 c0 {2,S} {3,S} {6,D}
-2  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
-3     C u0 p0 c0 {1,S} {5,D} {8,S}
-4  *1 C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6     C u0 p0 c0 {1,D} {11,S} {12,S}
-7     H u0 p0 c0 {2,S}
-8     H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {6,S}
-12    H u0 p0 c0 {6,S}
-
-CH3
-multiplicity 2
-1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
-2    H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-
 HO2
 multiplicity 2
 1    O u0 p2 c0 {2,S} {3,S}
 2 *3 O u1 p2 c0 {1,S}
 3    H u0 p0 c0 {1,S}
-
-C5H6-2
-1     C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
-2  *1 C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {9,S}
-4  *2 C u0 p0 c0 {2,D} {5,S} {10,S}
-5     C u0 p0 c0 {3,D} {4,S} {11,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {5,S}
-
-C6H6-2
-1  *1 C u0 p0 c0 {2,S} {3,D} {7,S}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3  *2 C u0 p0 c0 {1,D} {5,S} {9,S}
-4     C u0 p0 c0 {2,D} {6,S} {10,S}
-5     C u0 p0 c0 {3,S} {6,D} {11,S}
-6     C u0 p0 c0 {4,S} {5,D} {12,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {5,S}
-12    H u0 p0 c0 {6,S}
-
-C6H6-3
-1  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
-2     C u0 p0 c0 {1,S} {4,D} {7,S}
-3     C u0 p0 c0 {1,S} {5,D} {8,S}
-4     C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6  *2 C u0 p0 c0 {1,D} {11,S} {12,S}
-7     H u0 p0 c0 {2,S}
-8     H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {6,S}
-12    H u0 p0 c0 {6,S}
-
-C7H9-15
-multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
-3     C u0 p0 c0 {1,S} {5,S} {7,D}
-4  *2 C u1 p0 c0 {2,S} {6,S} {12,S}
-5     C u0 p0 c0 {3,S} {6,D} {13,S}
-6     C u0 p0 c0 {4,S} {5,D} {14,S}
-7     C u0 p0 c0 {3,D} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11 *3 H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
 
 C4H9
 multiplicity 2
@@ -423,62 +1204,43 @@ multiplicity 2
 12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {3,S}
 
-C7H8-2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2     C u0 p0 c0 {1,S} {5,D} {9,S}
-3     C u0 p0 c0 {1,S} {6,D} {10,S}
-4  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
-5     C u0 p0 c0 {2,D} {6,S} {12,S}
-6     C u0 p0 c0 {3,D} {5,S} {13,S}
-7  *2 C u0 p0 c0 {4,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
-
-C7H13
+C7H9-20
 multiplicity 2
-1     C u0 p0 c0 {2,D} {8,S} {9,S}
-2     C u0 p0 c0 {1,D} {6,S} {15,S}
-3  *2 C u1 p0 c0 {7,S} {10,S} {11,S}
-4     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
-5     C u0 p0 c0 {4,S} {7,S} {18,S} {19,S}
-6  *3 C u0 p0 c0 {2,S} {7,S} {16,S} {17,S}
-7  *1 C u0 p0 c0 {3,S} {5,S} {6,S} {20,S}
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {4,S} {6,D}
+4     C u0 p0 c0 {3,S} {5,S} {7,D}
+5  *2 C u1 p0 c0 {2,S} {4,S} {12,S}
+6     C u0 p0 c0 {3,D} {15,S} {16,S}
+7     C u0 p0 c0 {4,D} {13,S} {14,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {2,S}
-16    H u0 p0 c0 {6,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {5,S}
-19    H u0 p0 c0 {5,S}
-20    H u0 p0 c0 {7,S}
-
-C7H8-7
-1     C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
-2     C u0 p0 c0 {5,S} {6,S} {7,D}
-3  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {1,S} {6,D} {11,S}
-5  *2 C u0 p0 c0 {2,S} {3,D} {12,S}
-6     C u0 p0 c0 {2,S} {4,D} {13,S}
-7     C u0 p0 c0 {2,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
 14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+
+C7H9-22
+multiplicity 2
+1  *1 C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {5,S}
+4     C u0 p0 c0 {1,S} {6,S} {7,D}
+5     C u0 p0 c0 {3,S} {6,D} {14,S}
+6     C u0 p0 c0 {4,S} {5,D} {13,S}
+7     C u0 p0 c0 {4,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
 15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 C5H5
 multiplicity 2
@@ -506,107 +1268,67 @@ C5H6
 10    H u0 p0 c0 {4,S}
 11    H u0 p0 c0 {5,S}
 
-allyl
+C5H7
 multiplicity 2
-1    C u0 p0 c0 {2,S} {3,D} {4,S}
-2 *3 C u1 p0 c0 {1,S} {5,S} {6,S}
-3    C u0 p0 c0 {1,D} {7,S} {8,S}
-4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {2,S}
-6    H u0 p0 c0 {2,S}
-7    H u0 p0 c0 {3,S}
-8    H u0 p0 c0 {3,S}
-
-C7H7-2
-multiplicity 2
-1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
+1  *3 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
 2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4     C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
-7     C u0 p0 c0 {6,D} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {5,D} {9,S}
+4     C u0 p0 c0 {2,D} {10,S} {11,S}
+5  *2 C u1 p0 c0 {3,D} {12,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
 8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {3,S}
-12 *3 H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {7,S}
-
-H
-multiplicity 2
-1 *3 H u1 p0 c0
-
-C7H8-9
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {4,S} {7,D}
-3  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,S} {6,D} {11,S}
-5  *2 C u0 p0 c0 {3,D} {6,S} {13,S}
-6     C u0 p0 c0 {4,D} {5,S} {12,S}
-7     C u0 p0 c0 {2,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
-
-C7H8-8
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {1,S} {4,D} {10,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4  *2 C u0 p0 c0 {2,D} {6,S} {13,S}
-5     C u0 p0 c0 {3,D} {7,S} {15,S}
-6     C u0 p0 c0 {4,S} {7,D} {12,S}
-7     C u0 p0 c0 {5,S} {6,D} {14,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {5,S}
-
-C7H8-3
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *1 C u0 p0 c0 {1,S} {5,D} {9,S}
-3     C u0 p0 c0 {1,S} {6,D} {10,S}
-4     C u0 p0 c0 {1,S} {7,D} {11,S}
-5  *2 C u0 p0 c0 {2,D} {6,S} {12,S}
-6     C u0 p0 c0 {3,D} {5,S} {13,S}
-7     C u0 p0 c0 {4,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
 
-C7H9-6
+C4H5
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {14,S}
-5     C u0 p0 c0 {3,S} {7,D} {16,S}
-6     C u0 p0 c0 {4,D} {7,S} {13,S}
-7     C u0 p0 c0 {5,D} {6,S} {15,S}
+1    C u0 p0 c0 {2,D} {4,S} {5,S}
+2    C u0 p0 c0 {1,D} {6,S} {7,S}
+3    C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *3 C u1 p0 c0 {1,S} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C4H7
+multiplicity 2
+1     C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2     C u0 p0 c0 {1,S} {3,D} {4,S}
+3     C u0 p0 c0 {2,D} {8,S} {9,S}
+4  *3 C u1 p0 c0 {2,S} {10,S} {11,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+
+C7H11-4
+multiplicity 2
+1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
+5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
+6     C u0 p0 c0 {1,S} {4,S} {7,D}
+7     C u0 p0 c0 {2,S} {6,D} {18,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {5,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
 
 C7H9-7
 multiplicity 2
@@ -627,45 +1349,43 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
-C7H13_2
+C7H9-4
 multiplicity 2
-1     C u0 p0 c0 {2,D} {8,S} {9,S}
-2     C u0 p0 c0 {1,D} {6,S} {13,S}
-3     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
-4  *2 C u1 p0 c0 {3,S} {7,S} {17,S}
-5     C u0 p0 c0 {7,S} {14,S} {15,S} {16,S}
-6  *3 C u0 p0 c0 {2,S} {7,S} {18,S} {19,S}
-7  *1 C u0 p0 c0 {4,S} {5,S} {6,S} {20,S}
+1     C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2  *1 C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {14,S}
+6     C u0 p0 c0 {1,S} {7,D} {13,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
 8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {2,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {4,S}
-18    H u0 p0 c0 {6,S}
-19    H u0 p0 c0 {6,S}
-20    H u0 p0 c0 {7,S}
-
-pent1en5yl
-multiplicity 2
-1     C u0 p0 c0 {3,D} {6,S} {7,S}
-2  *2 C u1 p0 c0 {4,S} {8,S} {9,S}
-3     C u0 p0 c0 {1,D} {5,S} {10,S}
-4  *1 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
-5  *3 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {5,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {4,S}
+10 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-5
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *2 C u1 p0 c0 {2,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 C7H9-2
 multiplicity 2
@@ -705,19 +1425,47 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
-C2H3
+C7H11-2
 multiplicity 2
-1    C u0 p0 c0 {2,D} {3,S} {4,S}
-2 *3 C u1 p0 c0 {1,D} {5,S}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {2,S}
+1     C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
+3  *1 C u0 p0 c0 {5,S} {6,S} {12,S} {13,S}
+4     C u0 p0 c0 {5,S} {14,S} {15,S} {16,S}
+5  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+6     C u0 p0 c0 {2,S} {3,S} {7,D}
+7     C u0 p0 c0 {6,D} {17,S} {18,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {3,S}
+13 *3 H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {7,S}
 
-C2H2
-1 *1 C u0 p0 c0 {2,T} {3,S}
-2 *2 C u0 p0 c0 {1,T} {4,S}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {2,S}
+C7H11-3
+multiplicity 2
+1  *3 C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+2     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+3     C u0 p0 c0 {7,S} {13,S} {14,S} {15,S}
+4     C u0 p0 c0 {1,S} {2,S} {6,D}
+5  *1 C u0 p0 c0 {1,S} {7,D} {16,S}
+6     C u0 p0 c0 {4,D} {17,S} {18,S}
+7  *2 C u1 p0 c0 {3,S} {5,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
 
 C7H9-8
 multiplicity 2
@@ -757,174 +1505,6 @@ multiplicity 2
 15    H u0 p0 c0 {5,S}
 16    H u0 p0 c0 {6,S}
 
-C7H8-6
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,S} {6,D} {11,S}
-5     C u0 p0 c0 {3,D} {6,S} {13,S}
-6     C u0 p0 c0 {4,D} {5,S} {12,S}
-7  *2 C u0 p0 c0 {2,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
-
-C7H6
-1  *2 C u0 p0 c0 {2,S} {3,S} {7,D}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4     C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6     C u0 p0 c0 {7,D} {12,S} {13,S}
-7  *1 C u0 p0 c0 {1,D} {6,D}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {6,S}
-
-C7H7
-multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,D} {9,S}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,D} {5,S} {12,S}
-5     C u0 p0 c0 {3,D} {4,S} {13,S}
-6  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
-7  *2 C u1 p0 c0 {6,D} {14,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {6,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {7,S}
-
-C7H8
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2     C u0 p0 c0 {1,S} {5,D} {9,S}
-3     C u0 p0 c0 {1,S} {6,D} {10,S}
-4  *2 C u0 p0 c0 {1,S} {7,D} {11,S}
-5     C u0 p0 c0 {2,D} {6,S} {12,S}
-6     C u0 p0 c0 {3,D} {5,S} {13,S}
-7  *1 C u0 p0 c0 {4,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
-
-C7H9
-multiplicity 2
-1     C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
-2  *1 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
-3  *2 C u1 p0 c0 {1,S} {2,S} {12,S}
-4     C u0 p0 c0 {1,S} {6,D} {13,S}
-5     C u0 p0 c0 {1,S} {7,D} {14,S}
-6     C u0 p0 c0 {4,D} {7,S} {15,S}
-7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11 *3 H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
-
-C7H9-4
-multiplicity 2
-1     C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2  *1 C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {12,S}
-5     C u0 p0 c0 {2,S} {4,D} {14,S}
-6     C u0 p0 c0 {1,S} {7,D} {13,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10 *3 H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
-
-ethene
-1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 *2 C u0 p0 c0 {1,D} {5,S} {6,S}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {2,S}
-6    H u0 p0 c0 {2,S}
-
-C7H9-5
-multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *1 C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4     C u0 p0 c0 {1,S} {6,D} {12,S}
-5     C u0 p0 c0 {3,D} {6,S} {13,S}
-6     C u0 p0 c0 {4,D} {5,S} {14,S}
-7  *2 C u1 p0 c0 {2,S} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
-
-hex1en5yl
-multiplicity 2
-1     C u0 p0 c0 {2,D} {7,S} {8,S}
-2     C u0 p0 c0 {1,D} {5,S} {12,S}
-3     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
-4  *2 C u1 p0 c0 {3,S} {6,S} {13,S}
-5  *3 C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
-6  *1 C u0 p0 c0 {4,S} {5,S} {14,S} {15,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {5,S}
-
-C7H8-10
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {4,S} {7,D}
-3  *2 C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,S} {6,D} {11,S}
-5  *1 C u0 p0 c0 {3,D} {6,S} {13,S}
-6     C u0 p0 c0 {4,D} {5,S} {12,S}
-7     C u0 p0 c0 {2,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
-
 butene1_2
 1  *2 C u0 p0 c0 {2,D} {5,S} {6,S}
 2  *1 C u0 p0 c0 {1,D} {4,S} {7,S}
@@ -938,49 +1518,6 @@ butene1_2
 10    H u0 p0 c0 {3,S}
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {4,S}
-
-hept1en5yl
-multiplicity 2
-1     C u0 p0 c0 {2,D} {8,S} {9,S}
-2     C u0 p0 c0 {1,D} {6,S} {10,S}
-3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
-4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
-5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
-6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
-7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {6,S}
-19    H u0 p0 c0 {7,S}
-20    H u0 p0 c0 {7,S}
-
-C6H11
-multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
-2     C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
-3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
-5  *1 C u0 p0 c0 {1,S} {6,D} {16,S}
-6  *2 C u1 p0 c0 {5,D} {17,S}
-7     H u0 p0 c0 {2,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
 
 butene1_1
 1  *1 C u0 p0 c0 {2,D} {5,S} {6,S}

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -1,3 +1,412 @@
+C7H9-14
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {7,S}
+2  *3 C u0 p0 c0 {1,S} {8,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *2 C u1 p0 c0 {1,S} {15,S} {16,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C2H2O
+1 *2 C u0 p0 c0 {2,D} {4,S} {5,S}
+2 *1 C u0 p0 c0 {1,D} {3,D}
+3    O u0 p2 c0 {2,D}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+
+C7H9-16
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,S} {7,D}
+4  *2 C u1 p0 c0 {1,S} {6,S} {12,S}
+5     C u0 p0 c0 {3,S} {6,D} {13,S}
+6     C u0 p0 c0 {4,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-17
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {6,S} {7,D}
+4  *2 C u1 p0 c0 {1,S} {3,S} {12,S}
+5     C u0 p0 c0 {1,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-10
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {6,D} {12,S}
+4     C u0 p0 c0 {2,S} {5,D} {11,S}
+5     C u0 p0 c0 {4,D} {6,S} {14,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7  *2 C u1 p0 c0 {1,S} {15,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-11
+multiplicity 2
+1     C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {6,S} {7,D}
+4  *2 C u1 p0 c0 {2,S} {3,S} {13,S}
+5     C u0 p0 c0 {1,S} {6,D} {12,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-12
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *2 C u1 p0 c0 {2,S} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {16,S}
+6     C u0 p0 c0 {4,S} {7,D} {14,S}
+7     C u0 p0 c0 {5,S} {6,D} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+
+C7H9-13
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {5,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {6,S} {12,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5  *3 C u0 p0 c0 {1,S} {7,D} {13,S}
+6     C u0 p0 c0 {3,S} {4,D} {14,S}
+7     C u0 p0 c0 {5,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-18
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {4,S} {5,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {6,S} {7,D}
+4  *2 C u1 p0 c0 {1,S} {2,S} {12,S}
+5     C u0 p0 c0 {2,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C6H6
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,D}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {7,S}
+5     C u0 p0 c0 {3,D} {4,S} {9,S}
+6  *1 C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+CH2O
+1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *2 O u0 p2 c0 {1,D}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+propene_2
+1 *1 C u0 p0 c0 {2,D} {3,S} {9,S}
+2 *2 C u0 p0 c0 {1,D} {4,S} {5,S}
+3    C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {1,S}
+
+propene_1
+1 *2 C u0 p0 c0 {2,D} {3,S} {9,S}
+2 *1 C u0 p0 c0 {1,D} {4,S} {5,S}
+3    C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {1,S}
+
+C7H8-4
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4     C u0 p0 c0 {1,S} {7,D} {11,S}
+5  *1 C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7     C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C3H5O
+multiplicity 2
+1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2    C u0 p0 c0 {1,S} {3,S} {7,D}
+3 *3 C u1 p0 c0 {2,S} {8,S} {9,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    O u0 p2 c0 {2,D}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C2H3O3
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+2 *2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 *3 O u0 p2 c0 {1,S} {4,S}
+4    O u0 p2 c0 {3,S} {8,S}
+5    O u0 p2 c0 {1,D}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {4,S}
+
+butene2
+1  *1 C u0 p0 c0 {2,D} {3,S} {11,S}
+2  *2 C u0 p0 c0 {1,D} {4,S} {12,S}
+3     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+5     H u0 p0 c0 {3,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+
+C7H8-5
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *1 C u0 p0 c0 {1,S} {3,D} {4,S}
+3  *2 C u0 p0 c0 {2,D} {6,S} {14,S}
+4     C u0 p0 c0 {2,S} {7,D} {15,S}
+5     C u0 p0 c0 {6,D} {7,S} {11,S}
+6     C u0 p0 c0 {3,S} {5,D} {12,S}
+7     C u0 p0 c0 {4,D} {5,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+
+methylpentenyl
+multiplicity 2
+1     C u0 p0 c0 {4,D} {7,S} {8,S}
+2  *2 C u1 p0 c0 {6,S} {10,S} {11,S}
+3     C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,D} {5,S} {9,S}
+5  *3 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u0 p0 c0 {2,S} {3,S} {5,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C4H7O2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,D} {4,S}
+3     O u0 p2 c0 {2,D}
+4  *3 C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
+5  *1 C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
+6  *2 O u1 p2 c0 {5,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+C6H6-4
+1     C u0 p0 c0 {2,S} {3,S} {6,D}
+2  *1 C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4  *2 C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+C6H6-5
+1     C u0 p0 c0 {2,S} {3,S} {6,D}
+2  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4  *1 C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+CH3
+multiplicity 2
+1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+HO2
+multiplicity 2
+1    O u0 p2 c0 {2,S} {3,S}
+2 *3 O u1 p2 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+C5H6-2
+1     C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *1 C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4  *2 C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C6H6-2
+1  *1 C u0 p0 c0 {2,S} {3,D} {7,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3  *2 C u0 p0 c0 {1,D} {5,S} {9,S}
+4     C u0 p0 c0 {2,D} {6,S} {10,S}
+5     C u0 p0 c0 {3,S} {6,D} {11,S}
+6     C u0 p0 c0 {4,S} {5,D} {12,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+
+C6H6-3
+1  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+2     C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *2 C u0 p0 c0 {1,D} {11,S} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+C7H9-15
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,S} {7,D}
+4  *2 C u1 p0 c0 {2,S} {6,S} {12,S}
+5     C u0 p0 c0 {3,S} {6,D} {13,S}
+6     C u0 p0 c0 {4,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
 C4H9
 multiplicity 2
 1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
@@ -14,35 +423,544 @@ multiplicity 2
 12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {3,S}
 
-C2H3O3
-multiplicity 2
-1 *1 C u0 p0 c0 {2,S} {3,S} {5,D}
-2 *2 C u1 p0 c0 {1,S} {6,S} {7,S}
-3 *3 O u0 p2 c0 {1,S} {4,S}
-4    O u0 p2 c0 {3,S} {8,S}
-5    O u0 p2 c0 {1,D}
-6    H u0 p0 c0 {2,S}
-7    H u0 p0 c0 {2,S}
-8    H u0 p0 c0 {4,S}
+C7H8-2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
+5     C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7  *2 C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
 
-C2H2O
-1 *2 C u0 p0 c0 {2,D} {4,S} {5,S}
-2 *1 C u0 p0 c0 {1,D} {3,D}
-3    O u0 p2 c0 {2,D}
+C7H13
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {15,S}
+3  *2 C u1 p0 c0 {7,S} {10,S} {11,S}
+4     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+5     C u0 p0 c0 {4,S} {7,S} {18,S} {19,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {16,S} {17,S}
+7  *1 C u0 p0 c0 {3,S} {5,S} {6,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {2,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {7,S}
+
+C7H8-7
+1     C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
+2     C u0 p0 c0 {5,S} {6,S} {7,D}
+3  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5  *2 C u0 p0 c0 {2,S} {3,D} {12,S}
+6     C u0 p0 c0 {2,S} {4,D} {13,S}
+7     C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C5H5
+multiplicity 2
+1  *3 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {7,S}
+3     C u0 p0 c0 {1,S} {5,D} {8,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+
+C5H6
+1     C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4  *1 C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+allyl
+multiplicity 2
+1    C u0 p0 c0 {2,S} {3,D} {4,S}
+2 *3 C u1 p0 c0 {1,S} {5,S} {6,S}
+3    C u0 p0 c0 {1,D} {7,S} {8,S}
 4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
 
-HO2
+C7H7-2
 multiplicity 2
-1    O u0 p2 c0 {2,S} {3,S}
-2 *3 O u1 p2 c0 {1,S}
+1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+H
+multiplicity 2
+1 *3 H u1 p0 c0
+
+C7H8-9
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {4,S} {7,D}
+3  *1 C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5  *2 C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {12,S}
+7     C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-8
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,D} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4  *2 C u0 p0 c0 {2,D} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {15,S}
+6     C u0 p0 c0 {4,S} {7,D} {12,S}
+7     C u0 p0 c0 {5,S} {6,D} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+
+C7H8-3
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4     C u0 p0 c0 {1,S} {7,D} {11,S}
+5  *2 C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7     C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H9-6
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {14,S}
+5     C u0 p0 c0 {3,S} {7,D} {16,S}
+6     C u0 p0 c0 {4,D} {7,S} {13,S}
+7     C u0 p0 c0 {5,D} {6,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+
+C7H9-7
+multiplicity 2
+1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {13,S}
+5     C u0 p0 c0 {2,S} {4,D} {12,S}
+6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H13_2
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {13,S}
+3     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+4  *2 C u1 p0 c0 {3,S} {7,S} {17,S}
+5     C u0 p0 c0 {7,S} {14,S} {15,S} {16,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {18,S} {19,S}
+7  *1 C u0 p0 c0 {4,S} {5,S} {6,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+
+pent1en5yl
+multiplicity 2
+1     C u0 p0 c0 {3,D} {6,S} {7,S}
+2  *2 C u1 p0 c0 {4,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,D} {5,S} {10,S}
+4  *1 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5  *3 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+
+C7H9-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *2 C u1 p0 c0 {2,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-3
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {6,D} {11,S}
+4     C u0 p0 c0 {1,S} {7,D} {12,S}
+5  *2 C u1 p0 c0 {2,S} {6,S} {13,S}
+6     C u0 p0 c0 {3,D} {5,S} {14,S}
+7     C u0 p0 c0 {4,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C2H3
+multiplicity 2
+1    C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *3 C u1 p0 c0 {1,D} {5,S}
 3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {2,S}
 
 C2H2
 1 *1 C u0 p0 c0 {2,T} {3,S}
 2 *2 C u0 p0 c0 {1,T} {4,S}
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {2,S}
+
+C7H9-8
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {14,S}
+6     C u0 p0 c0 {4,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-9
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3  *2 C u1 p0 c0 {1,S} {5,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {15,S}
+6     C u0 p0 c0 {4,D} {7,S} {16,S}
+7     C u0 p0 c0 {5,D} {6,S} {14,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+
+C7H8-6
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {12,S}
+7  *2 C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H6
+1  *2 C u0 p0 c0 {2,S} {3,S} {7,D}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6     C u0 p0 c0 {7,D} {12,S} {13,S}
+7  *1 C u0 p0 c0 {1,D} {6,D}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
+C7H7
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {12,S}
+5     C u0 p0 c0 {3,D} {4,S} {13,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
+7  *2 C u1 p0 c0 {6,D} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+
+C7H8
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4  *2 C u0 p0 c0 {1,S} {7,D} {11,S}
+5     C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7  *1 C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H9
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+2  *1 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {1,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-4
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2  *1 C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {14,S}
+6     C u0 p0 c0 {1,S} {7,D} {13,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+ethene
+1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+
+C7H9-5
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *2 C u1 p0 c0 {2,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+hex1en5yl
+multiplicity 2
+1     C u0 p0 c0 {2,D} {7,S} {8,S}
+2     C u0 p0 c0 {1,D} {5,S} {12,S}
+3     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+4  *2 C u1 p0 c0 {3,S} {6,S} {13,S}
+5  *3 C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
+6  *1 C u0 p0 c0 {4,S} {5,S} {14,S} {15,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C7H8-10
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {4,S} {7,D}
+3  *2 C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5  *1 C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {12,S}
+7     C u0 p0 c0 {2,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+butene1_2
+1  *2 C u0 p0 c0 {2,D} {5,S} {6,S}
+2  *1 C u0 p0 c0 {1,D} {4,S} {7,S}
+3     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4     C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+
+hept1en5yl
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {10,S}
+3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
+4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
+5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
 
 C6H11
 multiplicity 2
@@ -64,247 +982,17 @@ multiplicity 2
 16    H u0 p0 c0 {5,S}
 17    H u0 p0 c0 {6,S}
 
-CH2O
-1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 *2 O u0 p2 c0 {1,D}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-
-C3H5O
-multiplicity 2
-1    C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
-2    C u0 p0 c0 {1,S} {3,D} {4,S}
-3    O u0 p2 c0 {2,D}
-4 *3 C u1 p0 c0 {2,S} {8,S} {9,S}
-5    H u0 p0 c0 {1,S}
-6    H u0 p0 c0 {1,S}
-7    H u0 p0 c0 {1,S}
-8    H u0 p0 c0 {4,S}
-9    H u0 p0 c0 {4,S}
-
-C4H7O2
-multiplicity 2
-1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {3,D} {4,S}
-3     O u0 p2 c0 {2,D}
-4  *3 C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
-5  *1 C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
-6  *2 O u1 p2 c0 {5,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {5,S}
-
-ethene
-1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 *2 C u0 p0 c0 {1,D} {5,S} {6,S}
-3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {2,S}
-
-propene_1
-1 *2 C u0 p0 c0 {2,D} {3,S} {9,S}
-2 *1 C u0 p0 c0 {1,D} {4,S} {5,S}
-3 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
-4 H u0 p0 c0 {2,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {3,S}
-9 H u0 p0 c0 {1,S}
-
-propene_2
-1 *1 C u0 p0 c0 {2,D} {3,S} {9,S}
-2 *2 C u0 p0 c0 {1,D} {4,S} {5,S}
-3 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
-4 H u0 p0 c0 {2,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {3,S}
-9 H u0 p0 c0 {1,S}
-
-
 butene1_1
-1 *1 C u0 p0 c0 {2,D} {5,S} {6,S}
-2 *2 C u0 p0 c0 {1,D} {4,S} {7,S}
-3  C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
-4  C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
-5  H u0 p0 c0 {1,S}
-6  H u0 p0 c0 {1,S}
-7  H u0 p0 c0 {2,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {3,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {4,S}
-12 H u0 p0 c0 {4,S}
-
-butene1_2
-1 *2 C u0 p0 c0 {2,D} {5,S} {6,S}
-2 *1 C u0 p0 c0 {1,D} {4,S} {7,S}
-3  C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
-4  C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
-5  H u0 p0 c0 {1,S}
-6  H u0 p0 c0 {1,S}
-7  H u0 p0 c0 {2,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {3,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {4,S}
-12 H u0 p0 c0 {4,S}
-
-butene2
-1 *1 C u0 p0 c0 {2,D} {3,S} {11,S}
-2 *2 C u0 p0 c0 {1,D} {4,S} {12,S}
-3  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
-4  C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
-5  H u0 p0 c0 {3,S}
-6  H u0 p0 c0 {3,S}
-7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {4,S}
-9  H u0 p0 c0 {4,S}
-10 H u0 p0 c0 {4,S}
-11 H u0 p0 c0 {1,S}
-12 H u0 p0 c0 {2,S}
-
-allyl
-multiplicity 2
-1 *3 C u1 p0 c0 {2,S} {4,S} {5,S}
-2 C u0 p0 c0 {1,S} {3,D} {8,S}
-3 C u0 p0 c0 {2,D} {6,S} {7,S}
-4 H u0 p0 c0 {1,S}
-5 H u0 p0 c0 {1,S}
-6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {2,S}
-
-pent1en5yl
-multiplicity 2
-1  C u0 p0 c0 {3,D} {6,S} {7,S}
-2 *2 C u1 p0 c0 {4,S} {8,S} {9,S}
-3  C u0 p0 c0 {1,D} {5,S} {10,S}
-4 *1 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
-5 *3 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
-6  H u0 p0 c0 {1,S}
-7  H u0 p0 c0 {1,S}
-8  H u0 p0 c0 {2,S}
-9  H u0 p0 c0 {2,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {5,S}
-12 H u0 p0 c0 {5,S}
-13 H u0 p0 c0 {4,S}
-14 H u0 p0 c0 {4,S}
-
-hex1en5yl
-multiplicity 2
-1  C u0 p0 c0 {2,D} {7,S} {8,S}
-2  C u0 p0 c0 {1,D} {5,S} {12,S}
-3  C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
-4 *2 C u1 p0 c0 {3,S} {6,S} {13,S}
-5 *3 C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
-6 *1 C u0 p0 c0 {4,S} {5,S} {14,S} {15,S}
-7  H u0 p0 c0 {1,S}
-8  H u0 p0 c0 {1,S}
-9  H u0 p0 c0 {3,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {3,S}
-12 H u0 p0 c0 {2,S}
-13 H u0 p0 c0 {4,S}
-14 H u0 p0 c0 {6,S}
-15 H u0 p0 c0 {6,S}
-16 H u0 p0 c0 {5,S}
-17 H u0 p0 c0 {5,S}
-
-methylpentenyl
-multiplicity 2
-1  C u0 p0 c0 {4,D} {7,S} {8,S}
-2 *2 C u1 p0 c0 {6,S} {10,S} {11,S}
-3  C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
-4  C u0 p0 c0 {1,D} {5,S} {9,S}
-5 *3 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
-6 *1 C u0 p0 c0 {2,S} {3,S} {5,S} {15,S}
-7  H u0 p0 c0 {1,S}
-8  H u0 p0 c0 {1,S}
-9  H u0 p0 c0 {4,S}
-10 H u0 p0 c0 {2,S}
-11 H u0 p0 c0 {2,S}
-12 H u0 p0 c0 {3,S}
-13 H u0 p0 c0 {3,S}
-14 H u0 p0 c0 {3,S}
-15 H u0 p0 c0 {6,S}
-16 H u0 p0 c0 {5,S}
-17 H u0 p0 c0 {5,S}
-
-hept1en5yl
-multiplicity 2
-1  C u0 p0 c0 {2,D} {8,S} {9,S}
-2  C u0 p0 c0 {1,D} {6,S} {10,S}
-3  C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
-4 *2 C u1 p0 c0 {5,S} {7,S} {14,S}
-5  C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
-6 *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
-7 *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
-8  H u0 p0 c0 {1,S}
-9  H u0 p0 c0 {1,S}
-10 H u0 p0 c0 {2,S}
-11 H u0 p0 c0 {3,S}
-12 H u0 p0 c0 {3,S}
-13 H u0 p0 c0 {3,S}
-14 H u0 p0 c0 {4,S}
-15 H u0 p0 c0 {5,S}
-16 H u0 p0 c0 {5,S}
-17 H u0 p0 c0 {6,S}
-18 H u0 p0 c0 {6,S}
-19 H u0 p0 c0 {7,S}
-20 H u0 p0 c0 {7,S}
-
-C7H13
-multiplicity 2
-1  C u0 p0 c0 {2,D} {8,S} {9,S}
-2  C u0 p0 c0 {1,D} {6,S} {15,S}
-3 *2 C u1 p0 c0 {7,S} {10,S} {11,S}
-4  C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
-5  C u0 p0 c0 {4,S} {7,S} {18,S} {19,S}
-6 *3 C u0 p0 c0 {2,S} {7,S} {16,S} {17,S}
-7 *1 C u0 p0 c0 {3,S} {5,S} {6,S} {20,S}
-8  H u0 p0 c0 {1,S}
-9  H u0 p0 c0 {1,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {3,S}
-12 H u0 p0 c0 {4,S}
-13 H u0 p0 c0 {4,S}
-14 H u0 p0 c0 {4,S}
-15 H u0 p0 c0 {2,S}
-16 H u0 p0 c0 {6,S}
-17 H u0 p0 c0 {6,S}
-18 H u0 p0 c0 {5,S}
-19 H u0 p0 c0 {5,S}
-20 H u0 p0 c0 {7,S}
-
-C7H13_2
-multiplicity 2
-1  C u0 p0 c0 {2,D} {8,S} {9,S}
-2  C u0 p0 c0 {1,D} {6,S} {13,S}
-3  C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
-4 *2 C u1 p0 c0 {3,S} {7,S} {17,S}
-5  C u0 p0 c0 {7,S} {14,S} {15,S} {16,S}
-6 *3 C u0 p0 c0 {2,S} {7,S} {18,S} {19,S}
-7 *1 C u0 p0 c0 {4,S} {5,S} {6,S} {20,S}
-8  H u0 p0 c0 {1,S}
-9  H u0 p0 c0 {1,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {3,S}
-12 H u0 p0 c0 {3,S}
-13 H u0 p0 c0 {2,S}
-14 H u0 p0 c0 {5,S}
-15 H u0 p0 c0 {5,S}
-16 H u0 p0 c0 {5,S}
-17 H u0 p0 c0 {4,S}
-18 H u0 p0 c0 {6,S}
-19 H u0 p0 c0 {6,S}
-20 H u0 p0 c0 {7,S}
+1  *1 C u0 p0 c0 {2,D} {5,S} {6,S}
+2  *2 C u0 p0 c0 {1,D} {4,S} {7,S}
+3     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4     C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
 

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -164,11 +164,24 @@ C6H6-3
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
-HO2
-multiplicity 2
-1    O u0 p2 c0 {2,S} {3,S}
-2 *3 O u1 p2 c0 {1,S}
-3    H u0 p0 c0 {1,S}
+C9H8
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
+2     C u0 p0 c0 {1,S} {5,D} {6,S}
+3     C u0 p0 c0 {1,S} {7,D} {11,S}
+4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,D} {7,S} {13,S}
+6     C u0 p0 c0 {2,S} {9,D} {15,S}
+7     C u0 p0 c0 {3,D} {5,S} {14,S}
+8  *2 C u0 p0 c0 {4,D} {9,S} {17,S}
+9     C u0 p0 c0 {6,D} {8,S} {16,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {9,S}
+17    H u0 p0 c0 {8,S}
 
 C7H10
 1     C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
@@ -233,24 +246,21 @@ multiplicity 2
 19    H u0 p0 c0 {5,S}
 20    H u0 p0 c0 {7,S}
 
-C7H9-21
+C4H9
 multiplicity 2
-1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
-2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
-3     C u0 p0 c0 {2,S} {6,D} {11,S}
-4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
-5     C u0 p0 c0 {2,D} {15,S} {16,S}
-6     C u0 p0 c0 {3,D} {13,S} {14,S}
-7  *2 C u1 p0 c0 {1,S} {4,D}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {1,S}
+1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+2     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+4  *3 C u1 p0 c0 {1,S} {2,S} {3,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
 
 H
 multiplicity 2
@@ -465,6 +475,28 @@ multiplicity 2
 20    H u0 p0 c0 {8,S}
 21    H u0 p0 c0 {10,S}
 
+C10H9-3
+multiplicity 2
+1  *1 C u0 p0 c0 {4,S} {5,S} {11,S} {12,S}
+2     C u0 p0 c0 {3,D} {4,S} {6,S}
+3     C u0 p0 c0 {2,D} {7,S} {8,S}
+4  *2 C u1 p0 c0 {1,S} {2,S} {13,S}
+5     C u0 p0 c0 {1,S} {6,D} {14,S}
+6     C u0 p0 c0 {2,S} {5,D} {15,S}
+7     C u0 p0 c0 {3,S} {9,D} {16,S}
+8     C u0 p0 c0 {3,S} {10,D} {17,S}
+9     C u0 p0 c0 {7,D} {10,S} {18,S}
+10    C u0 p0 c0 {8,D} {9,S} {19,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {10,S}
+
 ethene
 1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
 2 *2 C u0 p0 c0 {1,D} {5,S} {6,S}
@@ -492,6 +524,66 @@ multiplicity 2
 15    H u0 p0 c0 {6,S}
 16    H u0 p0 c0 {5,S}
 17    H u0 p0 c0 {5,S}
+
+C10H8-2
+1     C u0 p0 c0 {2,D} {3,S} {4,S}
+2     C u0 p0 c0 {1,D} {5,S} {6,S}
+3  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
+4     C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,S} {9,D} {13,S}
+6     C u0 p0 c0 {2,S} {10,D} {14,S}
+7  *2 C u0 p0 c0 {3,D} {8,S} {15,S}
+8     C u0 p0 c0 {4,D} {7,S} {16,S}
+9     C u0 p0 c0 {5,D} {10,S} {17,S}
+10    C u0 p0 c0 {6,D} {9,S} {18,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {9,S}
+18    H u0 p0 c0 {10,S}
+
+C10H8-3
+1     C u0 p0 c0 {2,D} {3,S} {4,S}
+2     C u0 p0 c0 {1,D} {5,S} {6,S}
+3  *2 C u0 p0 c0 {1,S} {7,D} {11,S}
+4     C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,S} {9,D} {13,S}
+6     C u0 p0 c0 {2,S} {10,D} {14,S}
+7  *1 C u0 p0 c0 {3,D} {8,S} {15,S}
+8     C u0 p0 c0 {4,D} {7,S} {16,S}
+9     C u0 p0 c0 {5,D} {10,S} {17,S}
+10    C u0 p0 c0 {6,D} {9,S} {18,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {9,S}
+18    H u0 p0 c0 {10,S}
+
+C10H8-4
+1  *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+2     C u0 p0 c0 {1,S} {4,S} {6,D}
+3     C u0 p0 c0 {1,S} {7,D} {13,S}
+4     C u0 p0 c0 {2,S} {8,D} {14,S}
+5  *2 C u0 p0 c0 {1,D} {9,S} {15,S}
+6     C u0 p0 c0 {2,D} {10,S} {16,S}
+7     C u0 p0 c0 {3,D} {8,S} {11,S}
+8     C u0 p0 c0 {4,D} {7,S} {12,S}
+9     C u0 p0 c0 {5,S} {10,D} {17,S}
+10    C u0 p0 c0 {6,S} {9,D} {18,S}
+11    H u0 p0 c0 {7,S}
+12    H u0 p0 c0 {8,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {9,S}
+18    H u0 p0 c0 {10,S}
 
 C6H11
 multiplicity 2
@@ -538,21 +630,22 @@ multiplicity 2
 5    H u0 p0 c0 {1,S}
 6    H u0 p0 c0 {3,S}
 
-C6H7-8
-multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,D} {9,S}
-3  *2 C u1 p0 c0 {1,S} {5,S} {10,S}
-4     C u0 p0 c0 {2,D} {6,S} {11,S}
-5     C u0 p0 c0 {3,S} {6,D} {12,S}
-6     C u0 p0 c0 {4,S} {5,D} {13,S}
-7     H u0 p0 c0 {1,S}
-8  *3 H u0 p0 c0 {1,S}
+C7H8-2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {5,D} {9,S}
+3     C u0 p0 c0 {1,S} {6,D} {10,S}
+4  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
+5     C u0 p0 c0 {2,D} {6,S} {12,S}
+6     C u0 p0 c0 {3,D} {5,S} {13,S}
+7  *2 C u0 p0 c0 {4,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {3,S}
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
 
 CH2O
 1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
@@ -658,22 +751,21 @@ C7H8-3
 14    H u0 p0 c0 {7,S}
 15    H u0 p0 c0 {7,S}
 
-C7H8-2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2     C u0 p0 c0 {1,S} {5,D} {9,S}
-3     C u0 p0 c0 {1,S} {6,D} {10,S}
-4  *1 C u0 p0 c0 {1,S} {7,D} {11,S}
-5     C u0 p0 c0 {2,D} {6,S} {12,S}
-6     C u0 p0 c0 {3,D} {5,S} {13,S}
-7  *2 C u0 p0 c0 {4,D} {14,S} {15,S}
-8     H u0 p0 c0 {1,S}
+C6H7-8
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3  *2 C u1 p0 c0 {1,S} {5,S} {10,S}
+4     C u0 p0 c0 {2,D} {6,S} {11,S}
+5     C u0 p0 c0 {3,S} {6,D} {12,S}
+6     C u0 p0 c0 {4,S} {5,D} {13,S}
+7     H u0 p0 c0 {1,S}
+8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {3,S}
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {7,S}
 
 C9H8-2
 1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
@@ -899,20 +991,20 @@ multiplicity 2
 12    H u0 p0 c0 {6,S}
 13    H u0 p0 c0 {6,S}
 
-C6H7-4
+C6H7-6
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
-3     C u0 p0 c0 {2,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,S} {6,D} {11,S}
-5     C u0 p0 c0 {3,D} {6,S} {12,S}
-6     C u0 p0 c0 {4,D} {5,S} {13,S}
+1  *1 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {6,D}
+3  *2 C u1 p0 c0 {1,S} {2,S} {9,S}
+4     C u0 p0 c0 {1,S} {5,D} {10,S}
+5     C u0 p0 c0 {2,S} {4,D} {11,S}
+6     C u0 p0 c0 {2,D} {12,S} {13,S}
 7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
 13    H u0 p0 c0 {6,S}
 
 C7H10-2
@@ -934,22 +1026,6 @@ C7H10-2
 16    H u0 p0 c0 {6,S}
 17    H u0 p0 c0 {7,S}
 
-C6H7-6
-multiplicity 2
-1  *1 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {6,D}
-3  *2 C u1 p0 c0 {1,S} {2,S} {9,S}
-4     C u0 p0 c0 {1,S} {5,D} {10,S}
-5     C u0 p0 c0 {2,S} {4,D} {11,S}
-6     C u0 p0 c0 {2,D} {12,S} {13,S}
-7     H u0 p0 c0 {1,S}
-8  *3 H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {5,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {6,S}
-
 C2H3
 multiplicity 2
 1    C u0 p0 c0 {2,D} {3,S} {4,S}
@@ -964,24 +1040,26 @@ C2H2
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {2,S}
 
-C7H9-6
+C7H11-4
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {14,S}
-5     C u0 p0 c0 {3,S} {7,D} {16,S}
-6     C u0 p0 c0 {4,D} {7,S} {13,S}
-7     C u0 p0 c0 {5,D} {6,S} {15,S}
+1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
+5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
+6     C u0 p0 c0 {1,S} {4,S} {7,D}
+7     C u0 p0 c0 {2,S} {6,D} {18,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {5,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
 
 C6H9
 multiplicity 2
@@ -1073,26 +1151,24 @@ multiplicity 2
 20    H u0 p0 c0 {9,S}
 21    H u0 p0 c0 {10,S}
 
-C7H11-5
+C7H9-7
 multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
-3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {1,S} {3,S} {5,D}
-5     C u0 p0 c0 {4,D} {15,S} {16,S}
-6     C u0 p0 c0 {7,D} {17,S} {18,S}
-7  *2 C u1 p0 c0 {2,S} {6,D}
+1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {13,S}
+5     C u0 p0 c0 {2,S} {4,D} {12,S}
+6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
 8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 C7H8
 1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
@@ -1160,28 +1236,27 @@ C6H6
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
-hept1en5yl
-multiplicity 2
-1     C u0 p0 c0 {2,D} {8,S} {9,S}
-2     C u0 p0 c0 {1,D} {6,S} {10,S}
-3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
-4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
-5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
-6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
-7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {4,S}
+C10H10-9
+1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+2     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+4     C u0 p0 c0 {2,S} {3,S} {8,D}
+5     C u0 p0 c0 {1,S} {6,D} {15,S}
+6     C u0 p0 c0 {2,S} {5,D} {16,S}
+7  *2 C u0 p0 c0 {3,D} {10,S} {17,S}
+8     C u0 p0 c0 {4,D} {9,S} {18,S}
+9     C u0 p0 c0 {8,S} {10,D} {19,S}
+10    C u0 p0 c0 {7,S} {9,D} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
 15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {6,S}
-19    H u0 p0 c0 {7,S}
-20    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
 
 C3H5O
 multiplicity 2
@@ -1195,22 +1270,24 @@ multiplicity 2
 8    H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
-C7H7-2
+C7H9-8
 multiplicity 2
-1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4     C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
-7     C u0 p0 c0 {6,D} {13,S} {14,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {3,S}
-12 *3 H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {7,S}
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {14,S}
+6     C u0 p0 c0 {4,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 
 C6H8-2
 1     C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
@@ -1304,6 +1381,28 @@ multiplicity 2
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
 
+C10H9-4
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {6,D}
+3     C u0 p0 c0 {1,S} {7,D} {12,S}
+4  *2 C u1 p0 c0 {1,S} {8,S} {13,S}
+5     C u0 p0 c0 {2,S} {9,D} {16,S}
+6     C u0 p0 c0 {2,D} {10,S} {17,S}
+7     C u0 p0 c0 {3,D} {9,S} {14,S}
+8     C u0 p0 c0 {4,S} {10,D} {18,S}
+9     C u0 p0 c0 {5,D} {7,S} {15,S}
+10    C u0 p0 c0 {6,S} {8,D} {19,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {9,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {10,S}
+
 C10H11
 multiplicity 2
 1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
@@ -1365,6 +1464,28 @@ multiplicity 2
 11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {6,S}
+
+C10H9-2
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+2     C u0 p0 c0 {1,S} {3,D} {5,S}
+3     C u0 p0 c0 {2,D} {6,S} {7,S}
+4  *2 C u1 p0 c0 {1,S} {8,S} {13,S}
+5     C u0 p0 c0 {2,S} {8,D} {14,S}
+6     C u0 p0 c0 {3,S} {9,D} {15,S}
+7     C u0 p0 c0 {3,S} {10,D} {16,S}
+8     C u0 p0 c0 {4,S} {5,D} {17,S}
+9     C u0 p0 c0 {6,D} {10,S} {18,S}
+10    C u0 p0 c0 {7,D} {9,S} {19,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {10,S}
 
 C10H10-4
 1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
@@ -1571,27 +1692,28 @@ C10H10-8
 19    H u0 p0 c0 {9,S}
 20    H u0 p0 c0 {10,S}
 
-C10H10-9
-1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
-2     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
-3  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
-4     C u0 p0 c0 {2,S} {3,S} {8,D}
-5     C u0 p0 c0 {1,S} {6,D} {15,S}
-6     C u0 p0 c0 {2,S} {5,D} {16,S}
-7  *2 C u0 p0 c0 {3,D} {10,S} {17,S}
-8     C u0 p0 c0 {4,D} {9,S} {18,S}
-9     C u0 p0 c0 {8,S} {10,D} {19,S}
-10    C u0 p0 c0 {7,S} {9,D} {20,S}
-11    H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {1,S}
-13    H u0 p0 c0 {2,S}
-14    H u0 p0 c0 {2,S}
+hept1en5yl
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {10,S}
+3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
+4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
+5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
 15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {6,S}
-17    H u0 p0 c0 {7,S}
-18    H u0 p0 c0 {8,S}
-19    H u0 p0 c0 {9,S}
-20    H u0 p0 c0 {10,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
 
 C7H9-14
 multiplicity 2
@@ -1783,19 +1905,21 @@ multiplicity 2
 15    H u0 p0 c0 {6,S}
 16    H u0 p0 c0 {6,S}
 
-butene2
-1  *1 C u0 p0 c0 {2,D} {3,S} {11,S}
-2  *2 C u0 p0 c0 {1,D} {4,S} {12,S}
-3     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
-4     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
-5     H u0 p0 c0 {3,S}
-6     H u0 p0 c0 {3,S}
-7     H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {4,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {2,S}
+C6H7-4
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {6,S} {12,S}
+6     C u0 p0 c0 {4,D} {5,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
 
 C4H5-2
 multiplicity 2
@@ -1833,40 +1957,72 @@ multiplicity 2
 20    H u0 p0 c0 {9,S}
 21    H u0 p0 c0 {10,S}
 
-C9H8
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
-2     C u0 p0 c0 {1,S} {5,D} {6,S}
+HO2
+multiplicity 2
+1    O u0 p2 c0 {2,S} {3,S}
+2 *3 O u1 p2 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+C10H9
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u1 p0 c0 {1,S} {5,S} {6,S}
+3     C u0 p0 c0 {1,S} {7,D} {12,S}
+4     C u0 p0 c0 {1,S} {8,D} {13,S}
+5     C u0 p0 c0 {2,S} {9,D} {14,S}
+6     C u0 p0 c0 {2,S} {10,D} {15,S}
+7     C u0 p0 c0 {3,D} {8,S} {16,S}
+8     C u0 p0 c0 {4,D} {7,S} {17,S}
+9     C u0 p0 c0 {5,D} {10,S} {18,S}
+10    C u0 p0 c0 {6,D} {9,S} {19,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {10,S}
+
+C10H8
+1  *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2  *2 C u0 p0 c0 {1,D} {5,S} {6,S}
 3     C u0 p0 c0 {1,S} {7,D} {11,S}
-4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
-5     C u0 p0 c0 {2,D} {7,S} {13,S}
-6     C u0 p0 c0 {2,S} {9,D} {15,S}
-7     C u0 p0 c0 {3,D} {5,S} {14,S}
-8  *2 C u0 p0 c0 {4,D} {9,S} {17,S}
-9     C u0 p0 c0 {6,D} {8,S} {16,S}
-10    H u0 p0 c0 {1,S}
+4     C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,S} {9,D} {13,S}
+6     C u0 p0 c0 {2,S} {10,D} {14,S}
+7     C u0 p0 c0 {3,D} {8,S} {15,S}
+8     C u0 p0 c0 {4,D} {7,S} {16,S}
+9     C u0 p0 c0 {5,D} {10,S} {17,S}
+10    C u0 p0 c0 {6,D} {9,S} {18,S}
 11    H u0 p0 c0 {3,S}
 12    H u0 p0 c0 {4,S}
 13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {9,S}
-17    H u0 p0 c0 {8,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {9,S}
+18    H u0 p0 c0 {10,S}
 
-C4H9
+C7H9-21
 multiplicity 2
-1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
-2     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
-3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
-4  *3 C u1 p0 c0 {1,S} {2,S} {3,S}
-5     H u0 p0 c0 {1,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
+1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
+2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
+3     C u0 p0 c0 {2,S} {6,D} {11,S}
+4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
+5     C u0 p0 c0 {2,D} {15,S} {16,S}
+6     C u0 p0 c0 {3,D} {13,S} {14,S}
+7  *2 C u1 p0 c0 {1,S} {4,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
 11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
 
 C7H9-20
 multiplicity 2
@@ -1959,6 +2115,20 @@ multiplicity 2
 8    H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
+butene2
+1  *1 C u0 p0 c0 {2,D} {3,S} {11,S}
+2  *2 C u0 p0 c0 {1,D} {4,S} {12,S}
+3     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+5     H u0 p0 c0 {3,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+
 C4H7
 multiplicity 2
 1     C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
@@ -1973,45 +2143,45 @@ multiplicity 2
 10    H u0 p0 c0 {4,S}
 11    H u0 p0 c0 {4,S}
 
-C7H11-4
+C7H9-6
 multiplicity 2
-1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
-3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
-5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
-6     C u0 p0 c0 {1,S} {4,S} {7,D}
-7     C u0 p0 c0 {2,S} {6,D} {18,S}
+1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {14,S}
+5     C u0 p0 c0 {3,S} {7,D} {16,S}
+6     C u0 p0 c0 {4,D} {7,S} {13,S}
+7     C u0 p0 c0 {5,D} {6,S} {15,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+
+C7H11-5
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {3,S} {5,D}
+5     C u0 p0 c0 {4,D} {15,S} {16,S}
+6     C u0 p0 c0 {7,D} {17,S} {18,S}
+7  *2 C u1 p0 c0 {2,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {3,S}
 14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {4,S}
-17    H u0 p0 c0 {4,S}
-18    H u0 p0 c0 {7,S}
-
-C7H9-7
-multiplicity 2
-1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {13,S}
-5     C u0 p0 c0 {2,S} {4,D} {12,S}
-6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
 
 C7H9-4
 multiplicity 2
@@ -2131,24 +2301,22 @@ multiplicity 2
 17    H u0 p0 c0 {6,S}
 18    H u0 p0 c0 {6,S}
 
-C7H9-8
+C7H7-2
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
-3     C u0 p0 c0 {1,S} {5,D} {12,S}
-4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
-5     C u0 p0 c0 {3,D} {7,S} {14,S}
-6     C u0 p0 c0 {4,S} {7,D} {15,S}
-7     C u0 p0 c0 {5,S} {6,D} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
 
 C7H9-9
 multiplicity 2

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -164,6 +164,25 @@ C6H6-3
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
+C9H8
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
+2     C u0 p0 c0 {1,S} {5,D} {6,S}
+3     C u0 p0 c0 {1,S} {7,D} {11,S}
+4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,D} {7,S} {13,S}
+6     C u0 p0 c0 {2,S} {9,D} {15,S}
+7     C u0 p0 c0 {3,D} {5,S} {14,S}
+8  *2 C u0 p0 c0 {4,D} {9,S} {17,S}
+9     C u0 p0 c0 {6,D} {8,S} {16,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {9,S}
+17    H u0 p0 c0 {8,S}
+
 C7H10
 1     C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
 2     C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
@@ -227,28 +246,73 @@ multiplicity 2
 19    H u0 p0 c0 {5,S}
 20    H u0 p0 c0 {7,S}
 
-C7H9-21
+C4H9
 multiplicity 2
-1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
-2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
-3     C u0 p0 c0 {2,S} {6,D} {11,S}
-4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
-5     C u0 p0 c0 {2,D} {15,S} {16,S}
-6     C u0 p0 c0 {3,D} {13,S} {14,S}
-7  *2 C u1 p0 c0 {1,S} {4,D}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {1,S}
+1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+2     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+4  *3 C u1 p0 c0 {1,S} {2,S} {3,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
 
 H
 multiplicity 2
 1 *3 H u1 p0 c0
+
+C10H11-9
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *1 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {8,D} {15,S}
+5     C u0 p0 c0 {2,S} {7,D} {17,S}
+6  *2 C u1 p0 c0 {2,S} {9,S} {18,S}
+7     C u0 p0 c0 {3,S} {5,D} {16,S}
+8     C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {6,S} {10,D} {20,S}
+10    C u0 p0 c0 {8,S} {9,D} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-8
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4     C u0 p0 c0 {1,S} {3,S} {8,D}
+5  *2 C u1 p0 c0 {1,S} {9,S} {18,S}
+6     C u0 p0 c0 {2,S} {10,D} {16,S}
+7     C u0 p0 c0 {3,S} {9,D} {17,S}
+8     C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {5,S} {7,D} {21,S}
+10    C u0 p0 c0 {6,D} {8,S} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {9,S}
 
 pent1en5yl
 multiplicity 2
@@ -266,6 +330,150 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {4,S}
 14    H u0 p0 c0 {4,S}
+
+C10H11-3
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *1 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {9,D} {15,S}
+5  *2 C u1 p0 c0 {2,S} {8,S} {17,S}
+6     C u0 p0 c0 {2,S} {10,D} {18,S}
+7     C u0 p0 c0 {3,S} {8,D} {16,S}
+8     C u0 p0 c0 {5,S} {7,D} {19,S}
+9     C u0 p0 c0 {4,D} {10,S} {20,S}
+10    C u0 p0 c0 {6,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-2
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *3 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4  *2 C u1 p0 c0 {1,S} {8,S} {16,S}
+5     C u0 p0 c0 {2,S} {9,D} {17,S}
+6     C u0 p0 c0 {2,S} {10,D} {18,S}
+7     C u0 p0 c0 {3,S} {8,D} {15,S}
+8     C u0 p0 c0 {4,S} {7,D} {19,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {6,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-5
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u1 p0 c0 {1,S} {5,S} {12,S}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4     C u0 p0 c0 {1,S} {7,D} {14,S}
+5     C u0 p0 c0 {2,S} {8,D} {15,S}
+6     C u0 p0 c0 {3,D} {8,S} {16,S}
+7     C u0 p0 c0 {4,D} {9,S} {18,S}
+8     C u0 p0 c0 {5,D} {6,S} {17,S}
+9     C u0 p0 c0 {7,S} {10,D} {19,S}
+10    C u0 p0 c0 {9,D} {20,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-4
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u1 p0 c0 {1,S} {5,S} {12,S}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
+5     C u0 p0 c0 {2,S} {8,D} {15,S}
+6     C u0 p0 c0 {3,D} {8,S} {16,S}
+7     C u0 p0 c0 {4,D} {9,S} {19,S}
+8     C u0 p0 c0 {5,D} {6,S} {17,S}
+9     C u0 p0 c0 {7,S} {10,D} {18,S}
+10    C u0 p0 c0 {9,D} {20,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-7
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *1 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {8,D} {16,S}
+5     C u0 p0 c0 {2,S} {10,D} {17,S}
+6  *2 C u1 p0 c0 {2,S} {8,S} {18,S}
+7     C u0 p0 c0 {3,S} {9,D} {15,S}
+8     C u0 p0 c0 {4,D} {6,S} {21,S}
+9     C u0 p0 c0 {7,D} {10,S} {19,S}
+10    C u0 p0 c0 {5,D} {9,S} {20,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {8,S}
+
+C10H11-6
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {4,S} {6,S} {12,S}
+3  *3 C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+4     C u0 p0 c0 {2,S} {7,D} {8,S}
+5  *2 C u1 p0 c0 {1,S} {10,S} {17,S}
+6     C u0 p0 c0 {2,S} {9,D} {16,S}
+7     C u0 p0 c0 {4,D} {9,S} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {20,S}
+9     C u0 p0 c0 {6,D} {7,S} {19,S}
+10    C u0 p0 c0 {5,S} {8,D} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {8,S}
+21    H u0 p0 c0 {10,S}
 
 ethene
 1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
@@ -339,6 +547,25 @@ multiplicity 2
 4    H u0 p0 c0 {1,S}
 5    H u0 p0 c0 {1,S}
 6    H u0 p0 c0 {3,S}
+
+C9H8-2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
+2     C u0 p0 c0 {1,S} {5,S} {6,D}
+3     C u0 p0 c0 {1,S} {7,D} {11,S}
+4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,S} {9,D} {15,S}
+6     C u0 p0 c0 {2,D} {8,S} {16,S}
+7     C u0 p0 c0 {3,D} {9,S} {14,S}
+8  *2 C u0 p0 c0 {4,D} {6,S} {17,S}
+9     C u0 p0 c0 {5,D} {7,S} {13,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {9,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {8,S}
 
 CH2O
 1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
@@ -544,6 +771,54 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {5,S}
 
+C10H11-11
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4     C u0 p0 c0 {1,S} {7,S} {8,D}
+5     C u0 p0 c0 {2,S} {7,D} {16,S}
+6  *2 C u1 p0 c0 {3,S} {9,S} {17,S}
+7     C u0 p0 c0 {4,S} {5,D} {18,S}
+8     C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {6,S} {10,D} {21,S}
+10    C u0 p0 c0 {8,S} {9,D} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15 *3 H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {9,S}
+
+C10H11-10
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {4,S} {6,S} {12,S}
+3  *3 C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+4     C u0 p0 c0 {2,S} {7,D} {8,S}
+5  *2 C u1 p0 c0 {1,S} {7,S} {17,S}
+6     C u0 p0 c0 {2,S} {9,D} {16,S}
+7     C u0 p0 c0 {4,D} {5,S} {21,S}
+8     C u0 p0 c0 {4,S} {10,D} {20,S}
+9     C u0 p0 c0 {6,D} {10,S} {19,S}
+10    C u0 p0 c0 {8,D} {9,S} {18,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {10,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {8,S}
+21    H u0 p0 c0 {7,S}
+
 C7H8-9
 1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
 2     C u0 p0 c0 {1,S} {4,S} {7,D}
@@ -578,6 +853,30 @@ C7H8-8
 14    H u0 p0 c0 {7,S}
 15    H u0 p0 c0 {5,S}
 
+C10H11-14
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4     C u0 p0 c0 {1,S} {3,S} {8,D}
+5  *2 C u1 p0 c0 {1,S} {9,S} {18,S}
+6     C u0 p0 c0 {2,S} {7,D} {16,S}
+7     C u0 p0 c0 {3,S} {6,D} {17,S}
+8     C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {5,S} {10,D} {21,S}
+10    C u0 p0 c0 {8,S} {9,D} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {9,S}
+
 C7H10-2
 1     C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
 2     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
@@ -611,24 +910,26 @@ C2H2
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {2,S}
 
-C7H9-6
+C7H11-4
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {14,S}
-5     C u0 p0 c0 {3,S} {7,D} {16,S}
-6     C u0 p0 c0 {4,D} {7,S} {13,S}
-7     C u0 p0 c0 {5,D} {6,S} {15,S}
+1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
+5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
+6     C u0 p0 c0 {1,S} {4,S} {7,D}
+7     C u0 p0 c0 {2,S} {6,D} {18,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {5,S}
+11 *3 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
 
 C6H9
 multiplicity 2
@@ -696,26 +997,48 @@ multiplicity 2
 13    H u0 p0 c0 {5,S}
 14    H u0 p0 c0 {7,S}
 
-C7H11-5
+C10H11-12
 multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
-3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {1,S} {3,S} {5,D}
-5     C u0 p0 c0 {4,D} {15,S} {16,S}
-6     C u0 p0 c0 {7,D} {17,S} {18,S}
-7  *2 C u1 p0 c0 {2,S} {6,D}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4     C u0 p0 c0 {1,S} {7,D} {8,S}
+5     C u0 p0 c0 {2,S} {9,D} {16,S}
+6  *2 C u1 p0 c0 {3,S} {7,S} {17,S}
+7     C u0 p0 c0 {4,D} {6,S} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
 14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {5,S}
+15 *3 H u0 p0 c0 {3,S}
 16    H u0 p0 c0 {5,S}
 17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C7H9-7
+multiplicity 2
+1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {13,S}
+5     C u0 p0 c0 {2,S} {4,D} {12,S}
+6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 C7H8
 1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
@@ -783,6 +1106,28 @@ C6H6
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
+C10H10-9
+1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+2     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+4     C u0 p0 c0 {2,S} {3,S} {8,D}
+5     C u0 p0 c0 {1,S} {6,D} {15,S}
+6     C u0 p0 c0 {2,S} {5,D} {16,S}
+7  *2 C u0 p0 c0 {3,D} {10,S} {17,S}
+8     C u0 p0 c0 {4,D} {9,S} {18,S}
+9     C u0 p0 c0 {8,S} {10,D} {19,S}
+10    C u0 p0 c0 {7,S} {9,D} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+
 C3H5O
 multiplicity 2
 1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
@@ -795,22 +1140,24 @@ multiplicity 2
 8    H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
-C7H7-2
+C7H9-8
 multiplicity 2
-1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4     C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
-7     C u0 p0 c0 {6,D} {13,S} {14,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {3,S}
-12 *3 H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {7,S}
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {14,S}
+6     C u0 p0 c0 {4,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 
 C6H8-2
 1     C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
@@ -904,6 +1251,184 @@ multiplicity 2
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
 
+C10H11
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2  *3 C u0 p0 c0 {1,S} {6,S} {7,S} {12,S}
+3     C u0 p0 c0 {4,S} {8,S} {13,S} {14,S}
+4  *2 C u1 p0 c0 {1,S} {3,S} {15,S}
+5     C u0 p0 c0 {1,S} {8,D} {17,S}
+6     C u0 p0 c0 {2,S} {9,D} {18,S}
+7     C u0 p0 c0 {2,S} {10,D} {19,S}
+8     C u0 p0 c0 {3,S} {5,D} {16,S}
+9     C u0 p0 c0 {6,D} {10,S} {20,S}
+10    C u0 p0 c0 {7,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H10
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {6,D} {7,S}
+4     C u0 p0 c0 {1,S} {9,D} {14,S}
+5     C u0 p0 c0 {2,S} {8,D} {15,S}
+6  *2 C u0 p0 c0 {3,D} {8,S} {16,S}
+7     C u0 p0 c0 {3,S} {10,D} {17,S}
+8     C u0 p0 c0 {5,D} {6,S} {18,S}
+9     C u0 p0 c0 {4,D} {10,S} {19,S}
+10    C u0 p0 c0 {7,D} {9,S} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+
+C10H10-4
+1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+2     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+4     C u0 p0 c0 {2,S} {3,S} {8,D}
+5     C u0 p0 c0 {1,S} {9,D} {15,S}
+6     C u0 p0 c0 {2,S} {10,D} {16,S}
+7  *2 C u0 p0 c0 {3,D} {10,S} {17,S}
+8     C u0 p0 c0 {4,D} {9,S} {18,S}
+9     C u0 p0 c0 {5,D} {8,S} {19,S}
+10    C u0 p0 c0 {6,D} {7,S} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+
+C10H10-5
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {6,S} {7,D}
+4     C u0 p0 c0 {1,S} {8,D} {14,S}
+5     C u0 p0 c0 {2,S} {6,D} {15,S}
+6     C u0 p0 c0 {3,S} {5,D} {16,S}
+7  *2 C u0 p0 c0 {3,D} {9,S} {17,S}
+8     C u0 p0 c0 {4,D} {10,S} {18,S}
+9     C u0 p0 c0 {7,S} {10,D} {19,S}
+10    C u0 p0 c0 {8,S} {9,D} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+
+C10H10-6
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3     C u0 p0 c0 {1,S} {6,S} {7,D}
+4  *1 C u0 p0 c0 {1,S} {8,D} {14,S}
+5     C u0 p0 c0 {2,S} {6,D} {15,S}
+6     C u0 p0 c0 {3,S} {5,D} {16,S}
+7     C u0 p0 c0 {3,D} {9,S} {17,S}
+8  *2 C u0 p0 c0 {4,D} {10,S} {18,S}
+9     C u0 p0 c0 {7,S} {10,D} {19,S}
+10    C u0 p0 c0 {8,S} {9,D} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+
+C10H10-7
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3     C u0 p0 c0 {1,S} {6,D} {7,S}
+4  *1 C u0 p0 c0 {1,S} {8,D} {14,S}
+5     C u0 p0 c0 {2,S} {9,D} {15,S}
+6     C u0 p0 c0 {3,D} {8,S} {16,S}
+7     C u0 p0 c0 {3,S} {10,D} {17,S}
+8  *2 C u0 p0 c0 {4,D} {6,S} {18,S}
+9     C u0 p0 c0 {5,D} {10,S} {19,S}
+10    C u0 p0 c0 {7,D} {9,S} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+
+C10H10-2
+1  *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2  *2 C u0 p0 c0 {1,D} {5,S} {11,S}
+3     C u0 p0 c0 {1,S} {7,D} {12,S}
+4     C u0 p0 c0 {1,S} {8,D} {13,S}
+5     C u0 p0 c0 {2,S} {6,D} {14,S}
+6     C u0 p0 c0 {5,D} {7,S} {16,S}
+7     C u0 p0 c0 {3,D} {6,S} {15,S}
+8     C u0 p0 c0 {4,D} {9,S} {17,S}
+9     C u0 p0 c0 {8,S} {10,D} {18,S}
+10    C u0 p0 c0 {9,D} {19,S} {20,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {10,S}
+20    H u0 p0 c0 {10,S}
+
+C10H10-3
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {6,S} {7,D}
+4     C u0 p0 c0 {1,S} {9,D} {15,S}
+5     C u0 p0 c0 {2,S} {8,D} {14,S}
+6     C u0 p0 c0 {3,S} {10,D} {18,S}
+7  *2 C u0 p0 c0 {3,D} {9,S} {19,S}
+8     C u0 p0 c0 {5,D} {10,S} {16,S}
+9     C u0 p0 c0 {4,D} {7,S} {20,S}
+10    C u0 p0 c0 {6,D} {8,S} {17,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {10,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {9,S}
+
 C7H8-12
 1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
 2  *2 C u0 p0 c0 {1,S} {4,D} {5,S}
@@ -954,6 +1479,28 @@ C7H8-10
 13    H u0 p0 c0 {5,S}
 14    H u0 p0 c0 {7,S}
 15    H u0 p0 c0 {7,S}
+
+C10H10-8
+1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+2     C u0 p0 c0 {3,S} {6,S} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {4,D}
+4  *2 C u0 p0 c0 {3,D} {7,S} {8,S}
+5     C u0 p0 c0 {1,S} {7,D} {15,S}
+6     C u0 p0 c0 {2,S} {9,D} {16,S}
+7     C u0 p0 c0 {4,S} {5,D} {17,S}
+8     C u0 p0 c0 {4,S} {10,D} {18,S}
+9     C u0 p0 c0 {6,D} {10,S} {19,S}
+10    C u0 p0 c0 {8,D} {9,S} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
 
 hept1en5yl
 multiplicity 2
@@ -1182,27 +1729,66 @@ butene2
 11    H u0 p0 c0 {1,S}
 12    H u0 p0 c0 {2,S}
 
+C4H5-2
+multiplicity 2
+1    C u0 p0 c0 {2,S} {3,D} {5,S}
+2    C u0 p0 c0 {1,S} {4,D} {6,S}
+3    C u0 p0 c0 {1,D} {7,S} {8,S}
+4 *3 C u1 p0 c0 {2,D} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+
+C10H11-13
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3     C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4  *2 C u1 p0 c0 {1,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {7,D} {16,S}
+6     C u0 p0 c0 {3,S} {9,D} {17,S}
+7     C u0 p0 c0 {4,S} {5,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
 HO2
 multiplicity 2
 1    O u0 p2 c0 {2,S} {3,S}
 2 *3 O u1 p2 c0 {1,S}
 3    H u0 p0 c0 {1,S}
 
-C4H9
+C7H9-21
 multiplicity 2
-1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
-2     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
-3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
-4  *3 C u1 p0 c0 {1,S} {2,S} {3,S}
-5     H u0 p0 c0 {1,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
+1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
+2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
+3     C u0 p0 c0 {2,S} {6,D} {11,S}
+4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
+5     C u0 p0 c0 {2,D} {15,S} {16,S}
+6     C u0 p0 c0 {3,D} {13,S} {14,S}
+7  *2 C u1 p0 c0 {1,S} {4,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
 11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
 
 C7H9-20
 multiplicity 2
@@ -1309,45 +1895,45 @@ multiplicity 2
 10    H u0 p0 c0 {4,S}
 11    H u0 p0 c0 {4,S}
 
-C7H11-4
+C7H9-6
 multiplicity 2
-1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
-3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
-5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
-6     C u0 p0 c0 {1,S} {4,S} {7,D}
-7     C u0 p0 c0 {2,S} {6,D} {18,S}
+1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {14,S}
+5     C u0 p0 c0 {3,S} {7,D} {16,S}
+6     C u0 p0 c0 {4,D} {7,S} {13,S}
+7     C u0 p0 c0 {5,D} {6,S} {15,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+
+C7H11-5
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {3,S} {5,D}
+5     C u0 p0 c0 {4,D} {15,S} {16,S}
+6     C u0 p0 c0 {7,D} {17,S} {18,S}
+7  *2 C u1 p0 c0 {2,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {3,S}
 14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {4,S}
-17    H u0 p0 c0 {4,S}
-18    H u0 p0 c0 {7,S}
-
-C7H9-7
-multiplicity 2
-1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {13,S}
-5     C u0 p0 c0 {2,S} {4,D} {12,S}
-6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
 
 C7H9-4
 multiplicity 2
@@ -1467,24 +2053,22 @@ multiplicity 2
 17    H u0 p0 c0 {6,S}
 18    H u0 p0 c0 {6,S}
 
-C7H9-8
+C7H7-2
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
-3     C u0 p0 c0 {1,S} {5,D} {12,S}
-4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
-5     C u0 p0 c0 {3,D} {7,S} {14,S}
-6     C u0 p0 c0 {4,S} {7,D} {15,S}
-7     C u0 p0 c0 {5,S} {6,D} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
 
 C7H9-9
 multiplicity 2

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -164,24 +164,11 @@ C6H6-3
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
-C9H8
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
-2     C u0 p0 c0 {1,S} {5,D} {6,S}
-3     C u0 p0 c0 {1,S} {7,D} {11,S}
-4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
-5     C u0 p0 c0 {2,D} {7,S} {13,S}
-6     C u0 p0 c0 {2,S} {9,D} {15,S}
-7     C u0 p0 c0 {3,D} {5,S} {14,S}
-8  *2 C u0 p0 c0 {4,D} {9,S} {17,S}
-9     C u0 p0 c0 {6,D} {8,S} {16,S}
-10    H u0 p0 c0 {1,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {9,S}
-17    H u0 p0 c0 {8,S}
+HO2
+multiplicity 2
+1    O u0 p2 c0 {2,S} {3,S}
+2 *3 O u1 p2 c0 {1,S}
+3    H u0 p0 c0 {1,S}
 
 C7H10
 1     C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
@@ -246,21 +233,24 @@ multiplicity 2
 19    H u0 p0 c0 {5,S}
 20    H u0 p0 c0 {7,S}
 
-C4H9
+C7H9-21
 multiplicity 2
-1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
-2     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
-3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
-4  *3 C u1 p0 c0 {1,S} {2,S} {3,S}
-5     H u0 p0 c0 {1,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
+1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
+2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
+3     C u0 p0 c0 {2,S} {6,D} {11,S}
+4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
+5     C u0 p0 c0 {2,D} {15,S} {16,S}
+6     C u0 p0 c0 {3,D} {13,S} {14,S}
+7  *2 C u1 p0 c0 {1,S} {4,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
 11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
 
 H
 multiplicity 2
@@ -548,24 +538,21 @@ multiplicity 2
 5    H u0 p0 c0 {1,S}
 6    H u0 p0 c0 {3,S}
 
-C9H8-2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
-2     C u0 p0 c0 {1,S} {5,S} {6,D}
-3     C u0 p0 c0 {1,S} {7,D} {11,S}
-4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
-5     C u0 p0 c0 {2,S} {9,D} {15,S}
-6     C u0 p0 c0 {2,D} {8,S} {16,S}
-7     C u0 p0 c0 {3,D} {9,S} {14,S}
-8  *2 C u0 p0 c0 {4,D} {6,S} {17,S}
-9     C u0 p0 c0 {5,D} {7,S} {13,S}
-10    H u0 p0 c0 {1,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {9,S}
-14    H u0 p0 c0 {7,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {6,S}
-17    H u0 p0 c0 {8,S}
+C6H7-8
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3  *2 C u1 p0 c0 {1,S} {5,S} {10,S}
+4     C u0 p0 c0 {2,D} {6,S} {11,S}
+5     C u0 p0 c0 {3,S} {6,D} {12,S}
+6     C u0 p0 c0 {4,S} {5,D} {13,S}
+7     H u0 p0 c0 {1,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
 
 CH2O
 1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
@@ -688,21 +675,24 @@ C7H8-2
 14    H u0 p0 c0 {7,S}
 15    H u0 p0 c0 {7,S}
 
-C6H7-2
-multiplicity 2
-1  *3 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
-2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
-3  *1 C u0 p0 c0 {1,S} {2,S} {5,D}
-4     C u0 p0 c0 {1,S} {6,T}
-5  *2 C u1 p0 c0 {3,D} {12,S}
-6     C u0 p0 c0 {4,T} {13,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
+C9H8-2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
+2     C u0 p0 c0 {1,S} {5,S} {6,D}
+3     C u0 p0 c0 {1,S} {7,D} {11,S}
+4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,S} {9,D} {15,S}
+6     C u0 p0 c0 {2,D} {8,S} {16,S}
+7     C u0 p0 c0 {3,D} {9,S} {14,S}
+8  *2 C u0 p0 c0 {4,D} {6,S} {17,S}
+9     C u0 p0 c0 {5,D} {7,S} {13,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {9,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {8,S}
 
 C7H8-7
 1     C u0 p0 c0 {3,S} {4,S} {8,S} {9,S}
@@ -853,6 +843,22 @@ C7H8-8
 14    H u0 p0 c0 {7,S}
 15    H u0 p0 c0 {5,S}
 
+C6H7-5
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4     C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6  *2 C u1 p0 c0 {1,S} {12,S} {13,S}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
 C10H11-14
 multiplicity 2
 1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
@@ -877,6 +883,38 @@ multiplicity 2
 20    H u0 p0 c0 {10,S}
 21    H u0 p0 c0 {9,S}
 
+C6H7-7
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {6,D}
+3  *2 C u1 p0 c0 {1,S} {5,S} {9,S}
+4     C u0 p0 c0 {2,S} {5,D} {10,S}
+5     C u0 p0 c0 {3,S} {4,D} {11,S}
+6     C u0 p0 c0 {2,D} {12,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
+C6H7-4
+multiplicity 2
+1  *1 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {6,S} {12,S}
+6     C u0 p0 c0 {4,D} {5,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+
 C7H10-2
 1     C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
 2     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
@@ -896,6 +934,22 @@ C7H10-2
 16    H u0 p0 c0 {6,S}
 17    H u0 p0 c0 {7,S}
 
+C6H7-6
+multiplicity 2
+1  *1 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {6,D}
+3  *2 C u1 p0 c0 {1,S} {2,S} {9,S}
+4     C u0 p0 c0 {1,S} {5,D} {10,S}
+5     C u0 p0 c0 {2,S} {4,D} {11,S}
+6     C u0 p0 c0 {2,D} {12,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
 C2H3
 multiplicity 2
 1    C u0 p0 c0 {2,D} {3,S} {4,S}
@@ -910,26 +964,24 @@ C2H2
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {2,S}
 
-C7H11-4
+C7H9-6
 multiplicity 2
-1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
-3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
-5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
-6     C u0 p0 c0 {1,S} {4,S} {7,D}
-7     C u0 p0 c0 {2,S} {6,D} {18,S}
+1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {14,S}
+5     C u0 p0 c0 {3,S} {7,D} {16,S}
+6     C u0 p0 c0 {4,D} {7,S} {13,S}
+7     C u0 p0 c0 {5,D} {6,S} {15,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11 *3 H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {4,S}
-17    H u0 p0 c0 {4,S}
-18    H u0 p0 c0 {7,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
 
 C6H9
 multiplicity 2
@@ -1021,24 +1073,26 @@ multiplicity 2
 20    H u0 p0 c0 {9,S}
 21    H u0 p0 c0 {10,S}
 
-C7H9-7
+C7H11-5
 multiplicity 2
-1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {13,S}
-5     C u0 p0 c0 {2,S} {4,D} {12,S}
-6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
+1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {3,S} {5,D}
+5     C u0 p0 c0 {4,D} {15,S} {16,S}
+6     C u0 p0 c0 {7,D} {17,S} {18,S}
+7  *2 C u1 p0 c0 {2,S} {6,D}
 8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
 
 C7H8
 1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
@@ -1106,27 +1160,28 @@ C6H6
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
-C10H10-9
-1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
-2     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
-3  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
-4     C u0 p0 c0 {2,S} {3,S} {8,D}
-5     C u0 p0 c0 {1,S} {6,D} {15,S}
-6     C u0 p0 c0 {2,S} {5,D} {16,S}
-7  *2 C u0 p0 c0 {3,D} {10,S} {17,S}
-8     C u0 p0 c0 {4,D} {9,S} {18,S}
-9     C u0 p0 c0 {8,S} {10,D} {19,S}
-10    C u0 p0 c0 {7,S} {9,D} {20,S}
-11    H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {1,S}
-13    H u0 p0 c0 {2,S}
-14    H u0 p0 c0 {2,S}
+hept1en5yl
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {6,S} {10,S}
+3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
+4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
+5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
+6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
 15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {6,S}
-17    H u0 p0 c0 {7,S}
-18    H u0 p0 c0 {8,S}
-19    H u0 p0 c0 {9,S}
-20    H u0 p0 c0 {10,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
 
 C3H5O
 multiplicity 2
@@ -1140,24 +1195,22 @@ multiplicity 2
 8    H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
-C7H9-8
+C7H7-2
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
-3     C u0 p0 c0 {1,S} {5,D} {12,S}
-4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
-5     C u0 p0 c0 {3,D} {7,S} {14,S}
-6     C u0 p0 c0 {4,S} {7,D} {15,S}
-7     C u0 p0 c0 {5,S} {6,D} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {9,S}
+5     C u0 p0 c0 {3,D} {4,S} {10,S}
+6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {3,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
 
 C6H8-2
 1     C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
@@ -1296,6 +1349,22 @@ C10H10
 18    H u0 p0 c0 {8,S}
 19    H u0 p0 c0 {9,S}
 20    H u0 p0 c0 {10,S}
+
+C6H7-2
+multiplicity 2
+1  *3 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {5,D}
+4     C u0 p0 c0 {1,S} {6,T}
+5  *2 C u1 p0 c0 {3,D} {12,S}
+6     C u0 p0 c0 {4,T} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
 
 C10H10-4
 1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
@@ -1502,28 +1571,27 @@ C10H10-8
 19    H u0 p0 c0 {9,S}
 20    H u0 p0 c0 {10,S}
 
-hept1en5yl
-multiplicity 2
-1     C u0 p0 c0 {2,D} {8,S} {9,S}
-2     C u0 p0 c0 {1,D} {6,S} {10,S}
-3     C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
-4  *2 C u1 p0 c0 {5,S} {7,S} {14,S}
-5     C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
-6  *3 C u0 p0 c0 {2,S} {7,S} {17,S} {18,S}
-7  *1 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {4,S}
+C10H10-9
+1     C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+2     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {4,S} {7,D}
+4     C u0 p0 c0 {2,S} {3,S} {8,D}
+5     C u0 p0 c0 {1,S} {6,D} {15,S}
+6     C u0 p0 c0 {2,S} {5,D} {16,S}
+7  *2 C u0 p0 c0 {3,D} {10,S} {17,S}
+8     C u0 p0 c0 {4,D} {9,S} {18,S}
+9     C u0 p0 c0 {8,S} {10,D} {19,S}
+10    C u0 p0 c0 {7,S} {9,D} {20,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
 15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {6,S}
-19    H u0 p0 c0 {7,S}
-20    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
 
 C7H9-14
 multiplicity 2
@@ -1765,30 +1833,40 @@ multiplicity 2
 20    H u0 p0 c0 {9,S}
 21    H u0 p0 c0 {10,S}
 
-HO2
-multiplicity 2
-1    O u0 p2 c0 {2,S} {3,S}
-2 *3 O u1 p2 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-
-C7H9-21
-multiplicity 2
-1     C u0 p0 c0 {7,S} {8,S} {9,S} {10,S}
-2  *3 C u0 p0 c0 {3,S} {4,S} {5,D}
-3     C u0 p0 c0 {2,S} {6,D} {11,S}
-4  *1 C u0 p0 c0 {2,S} {7,D} {12,S}
-5     C u0 p0 c0 {2,D} {15,S} {16,S}
-6     C u0 p0 c0 {3,D} {13,S} {14,S}
-7  *2 C u1 p0 c0 {1,S} {4,D}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
+C9H8
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {10,S}
+2     C u0 p0 c0 {1,S} {5,D} {6,S}
+3     C u0 p0 c0 {1,S} {7,D} {11,S}
+4  *1 C u0 p0 c0 {1,S} {8,D} {12,S}
+5     C u0 p0 c0 {2,D} {7,S} {13,S}
+6     C u0 p0 c0 {2,S} {9,D} {15,S}
+7     C u0 p0 c0 {3,D} {5,S} {14,S}
+8  *2 C u0 p0 c0 {4,D} {9,S} {17,S}
+9     C u0 p0 c0 {6,D} {8,S} {16,S}
 10    H u0 p0 c0 {1,S}
 11    H u0 p0 c0 {3,S}
 12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {9,S}
+17    H u0 p0 c0 {8,S}
+
+C4H9
+multiplicity 2
+1     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+2     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+4  *3 C u1 p0 c0 {1,S} {2,S} {3,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
 
 C7H9-20
 multiplicity 2
@@ -1895,45 +1973,45 @@ multiplicity 2
 10    H u0 p0 c0 {4,S}
 11    H u0 p0 c0 {4,S}
 
-C7H9-6
+C7H11-4
 multiplicity 2
-1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *3 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *2 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {14,S}
-5     C u0 p0 c0 {3,S} {7,D} {16,S}
-6     C u0 p0 c0 {4,D} {7,S} {13,S}
-7     C u0 p0 c0 {5,D} {6,S} {15,S}
+1     C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
+3     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
+5  *2 C u1 p0 c0 {1,S} {2,S} {3,S}
+6     C u0 p0 c0 {1,S} {4,S} {7,D}
+7     C u0 p0 c0 {2,S} {6,D} {18,S}
 8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {5,S}
-
-C7H11-5
-multiplicity 2
-1  *3 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
-2  *1 C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
-3     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
-4     C u0 p0 c0 {1,S} {3,S} {5,D}
-5     C u0 p0 c0 {4,D} {15,S} {16,S}
-6     C u0 p0 c0 {7,D} {17,S} {18,S}
-7  *2 C u1 p0 c0 {2,S} {6,D}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {3,S}
 14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {5,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
+
+C7H9-7
+multiplicity 2
+1  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {13,S}
+5     C u0 p0 c0 {2,S} {4,D} {12,S}
+6  *3 C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 C7H9-4
 multiplicity 2
@@ -2053,22 +2131,24 @@ multiplicity 2
 17    H u0 p0 c0 {6,S}
 18    H u0 p0 c0 {6,S}
 
-C7H7-2
+C7H9-8
 multiplicity 2
-1  *2 C u1 p0 c0 {2,S} {3,S} {6,S}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {11,S}
-4     C u0 p0 c0 {2,D} {5,S} {9,S}
-5     C u0 p0 c0 {3,D} {4,S} {10,S}
-6  *1 C u0 p0 c0 {1,S} {7,D} {12,S}
-7     C u0 p0 c0 {6,D} {13,S} {14,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {3,S}
-12 *3 H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {7,S}
+1  *1 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,D} {12,S}
+4  *2 C u1 p0 c0 {1,S} {6,S} {13,S}
+5     C u0 p0 c0 {3,D} {7,S} {14,S}
+6     C u0 p0 c0 {4,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 
 C7H9-9
 multiplicity 2

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -819,3 +819,227 @@ Taken from entry: C3H3 + C3H4a <=> prod_29
 """,
 )
 
+
+
+entry(
+    index = 50,
+    label = "C5H6 + C5H5 <=> C10H11",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(288, 'cm^3/(mol*s)'), n=2.8, Ea=(8.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: CPD + CPDyl <=> adducte
+""",
+)
+
+entry(
+    index = 51,
+    label = "C5H6-2 + C5H5 <=> C10H11-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(288, 'cm^3/(mol*s)'), n=2.74, Ea=(3.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: CPD + CPDyl <=> adductd
+""",
+)
+
+entry(
+    index = 52,
+    label = "C10H10 + H <=> C10H11-3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (9.09e+07, 'cm^3/(mol*s)'),
+        n = 1.71,
+        Ea = (2.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt11 + H <=> pdt10bis
+""",
+)
+
+entry(
+    index = 53,
+    label = "C10H11-4 <=> C6H6-2 + C4H5-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(7.14e+12, 's^-1'), n=0.52, Ea=(22.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt12 <=> benzene + butadieneyl
+""",
+)
+
+entry(
+    index = 54,
+    label = "C10H10-2 + H <=> C10H11-5",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.81e+06, 'cm^3/(mol*s)'),
+        n = 1.95,
+        Ea = (5.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt13 + H <=> pdt12
+""",
+)
+
+entry(
+    index = 55,
+    label = "C9H8 + CH3 <=> C10H11-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2480, 'cm^3/(mol*s)'), n=2.89, Ea=(-0.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt22 + CH3 <=> pdt21
+""",
+)
+
+entry(
+    index = 56,
+    label = "C10H11-7 <=> C10H10-3 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.49e+09, 's^-1'), n=1.41, Ea=(38.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt23 <=> pdt30 + H
+""",
+)
+
+entry(
+    index = 57,
+    label = "C10H10-4 + H <=> C10H11-8",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (9.09e+07, 'cm^3/(mol*s)'),
+        n = 1.71,
+        Ea = (2.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt26 + H <=> pdt19
+""",
+)
+
+entry(
+    index = 58,
+    label = "C10H10-5 + H <=> C10H11-9",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.26e+08, 'cm^3/(mol*s)'),
+        n = 1.63,
+        Ea = (1.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt31 + H <=> pdt8
+""",
+)
+
+entry(
+    index = 59,
+    label = "C10H11-10 <=> C9H8-2 + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.72e+10, 's^-1'), n=1.33, Ea=(51.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt32 <=> pdt22 + CH3
+""",
+)
+
+entry(
+    index = 60,
+    label = "C10H10-6 + H <=> C10H11-11",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.93e+08, 'cm^3/(mol*s)'),
+        n = 1.6,
+        Ea = (1.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt31 + H <=> pdt29
+""",
+)
+
+entry(
+    index = 61,
+    label = "C10H10-7 + H <=> C10H11-12",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.93e+08, 'cm^3/(mol*s)'),
+        n = 1.6,
+        Ea = (1.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt30 + H <=> pdt29
+""",
+)
+
+entry(
+    index = 62,
+    label = "C10H10-8 + H <=> C10H11-13",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.93e+08, 'cm^3/(mol*s)'),
+        n = 1.6,
+        Ea = (1.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt35 + H <=> pdt29
+""",
+)
+
+entry(
+    index = 63,
+    label = "C10H10-9 + H <=> C10H11-14",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.61e+07, 'cm^3/(mol*s)'),
+        n = 1.71,
+        Ea = (4.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt38 + H <=> pdt37
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -1125,3 +1125,72 @@ Taken from entry: cyC6H7 <=> benzene + H
 """,
 )
 
+
+
+entry(
+    index = 69,
+    label = "C10H8 + H <=> C10H9",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.63e+09, 'cm^3/(mol*s)'),
+        n = 1.61,
+        Ea = (0.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
+    longDesc = 
+u"""
+Taken from entry: biCPD3ene + H <=> adducta
+""",
+)
+
+entry(
+    index = 70,
+    label = "C10H8-2 + H <=> C10H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.61e+10, 'cm^3/(mol*s)'),
+        n = 1.52,
+        Ea = (0.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
+    longDesc = 
+u"""
+Taken from entry: biCPD3ene + H <=> adductb
+""",
+)
+
+entry(
+    index = 71,
+    label = "C10H8-3 + H <=> C10H9-3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.61e+10, 'cm^3/(mol*s)'),
+        n = 1.52,
+        Ea = (0.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
+    longDesc = 
+u"""
+Taken from entry: biCPD3ene + H <=> adductc
+""",
+)
+
+entry(
+    index = 72,
+    label = "C10H9-4 <=> C10H8-4 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.34e+08, 's^-1'), n=1.55, Ea=(15.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
+    longDesc = 
+u"""
+Taken from entry: prod4 <=> naphthalene + H
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -256,3 +256,289 @@ Table 4
 CBS-QB3, high-P limit, atomization method for energies, hindered rotors for torsions around single bonds, tunneling with Eckart potentials.
 """,
 )
+
+entry(
+    index = 10,
+    label = "C7H8 + H <=> C7H9",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.36e+08, 'cm^3/(mol*s)'),
+        n = 1.56,
+        Ea = (0.6, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: vinylCPD + H <=> addA
+""",
+)
+
+entry(
+    index = 11,
+    label = "C7H8-2 + H <=> C7H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.01e+08, 'cm^3/(mol*s)'),
+        n = 1.6,
+        Ea = (2.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: vinylCPD + H <=> addB
+""",
+)
+
+entry(
+    index = 12,
+    label = "C7H8-3 + H <=> C7H9-3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.3e+09, 'cm^3/(mol*s)'),
+        n = 1.48,
+        Ea = (0.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: vinylCPD + H <=> addC
+""",
+)
+
+entry(
+    index = 13,
+    label = "C7H8-4 + H <=> C7H9-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (9.41e+08, 'cm^3/(mol*s)'),
+        n = 1.57,
+        Ea = (1.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: vinylCPD + H <=> addD
+""",
+)
+
+entry(
+    index = 14,
+    label = "C7H9-5 <=> ethene + C5H5",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.87e+11, 's^-1'), n=0.68, Ea=(13.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addB <=> CPDyl + C2H4
+""",
+)
+
+entry(
+    index = 15,
+    label = "C7H9-6 <=> C6H6 + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.06e+11, 's^-1'), n=1.15, Ea=(39.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product7 <=> FULVENE + CH3
+""",
+)
+
+entry(
+    index = 16,
+    label = "C7H9-7 <=> C5H6 + C2H3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.5e+12, 's^-1'), n=0.81, Ea=(33.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addD <=> CPD + C2H3
+""",
+)
+
+entry(
+    index = 17,
+    label = "C7H9-8 <=> C6H6-2 + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.07e+11, 's^-1'), n=0.83, Ea=(22.8, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product2 <=> BENZENE + CH3
+""",
+)
+
+entry(
+    index = 18,
+    label = "C7H9-9 <=> C7H8-5 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.03e+09, 's^-1'), n=1.36, Ea=(26.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product2 <=> TOLUENE + H
+""",
+)
+
+entry(
+    index = 19,
+    label = "C7H9-10 <=> C7H8-6 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.01e+09, 's^-1'), n=1.23, Ea=(28.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product5 <=> product13 + H
+""",
+)
+
+entry(
+    index = 20,
+    label = "C7H9-11 <=> C7H8-7 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.47e+10, 's^-1'), n=1.17, Ea=(41.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product12 <=> product14 + H
+""",
+)
+
+entry(
+    index = 21,
+    label = "C7H9-12 <=> C7H8-8 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.58e+10, 's^-1'), n=1.38, Ea=(48.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product4 <=> product15 + H
+""",
+)
+
+entry(
+    index = 22,
+    label = "C7H9-13 <=> C5H6-2 + C2H3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.89e+12, 's^-1'), n=0.87, Ea=(45, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addC <=> CPD + C2H3
+""",
+)
+
+entry(
+    index = 23,
+    label = "C6H6-3 + CH3 <=> C7H9-14",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(263, 'cm^3/(mol*s)'), n=2.89, Ea=(6.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + CH3 <=> product18
+""",
+)
+
+entry(
+    index = 24,
+    label = "C7H9-15 <=> C7H8-9 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.47e+10, 's^-1'), n=1.17, Ea=(41.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product24 <=> product13 + H
+""",
+)
+
+entry(
+    index = 25,
+    label = "C6H6-4 + CH3 <=> C7H9-16",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2790, 'cm^3/(mol*s)'), n=2.91, Ea=(1.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + CH3 <=> product32
+""",
+)
+
+entry(
+    index = 26,
+    label = "C6H6-5 + CH3 <=> C7H9-17",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2470, 'cm^3/(mol*s)'), n=2.88, Ea=(2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + CH3 <=> product31
+""",
+)
+
+entry(
+    index = 27,
+    label = "C7H9-18 <=> C7H8-10 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.03e+10, 's^-1'), n=1.22, Ea=(40.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product37 <=> product13 + H
+""",
+)
+
+entry(
+    index = 28,
+    label = "C2H2 + C5H5 <=> C7H7",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(25500, 'cm^3/(mol*s)'), n=2.27, Ea=(10.2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: CPDyl + ethyne <=> product44
+""",
+)
+
+entry(
+    index = 29,
+    label = "C7H6 + H <=> C7H7-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.1e+09, 'cm^3/(mol*s)'),
+        n = 1.43,
+        Ea = (4.13, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: FA + H <=> vinylCPDyl
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -542,3 +542,280 @@ Taken from entry: FA + H <=> vinylCPDyl
 """,
 )
 
+
+
+entry(
+    index = 30,
+    label = "C3H4 + allyl <=> C6H9",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(42, 'cm^3/(mol*s)'), n=3.27, Ea=(11, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: aC3H5 + C3H4a <=> prod_1
+""",
+)
+
+entry(
+    index = 31,
+    label = "C6H9-2 <=> C6H8 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(7.93e+09, 's^-1'), n=1.27, Ea=(31, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_2 <=> prod_3 + H
+""",
+)
+
+entry(
+    index = 32,
+    label = "C3H4 + C4H7 <=> C7H11",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(18.6, 'cm^3/(mol*s)'), n=3, Ea=(9.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H4a + iC4H7 <=> prod_6
+""",
+)
+
+entry(
+    index = 33,
+    label = "C7H11-2 <=> C7H10 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.37e+08, 's^-1'), n=1.3, Ea=(29.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_4 <=> prod_5 + H
+""",
+)
+
+entry(
+    index = 34,
+    label = "C3H4-2 + allyl <=> C6H9-3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (267000, 'cm^3/(mol*s)'),
+        n = 2.15,
+        Ea = (12.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H4p + aC3H5 <=> prod_7
+""",
+)
+
+entry(
+    index = 35,
+    label = "C6H9-4 <=> C6H8-2 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(7.99e+10, 's^-1'), n=1, Ea=(32.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_8 <=> prod_9 + H
+""",
+)
+
+entry(
+    index = 36,
+    label = "C3H4-2 + C4H7 <=> C7H11-3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(121, 'cm^3/(mol*s)'), n=2.9, Ea=(10.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H4p + iC4H7 <=> prod_10
+""",
+)
+
+entry(
+    index = 37,
+    label = "C7H11-4 <=> C7H10-2 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.77e+09, 's^-1'), n=1.4, Ea=(32, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_11 <=> prod_12 + H
+""",
+)
+
+entry(
+    index = 38,
+    label = "C3H4 + C4H5 <=> C7H9-19",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(128, 'cm^3/(mol*s)'), n=3.05, Ea=(7.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H4a + BD2YL <=> prod_13
+""",
+)
+
+entry(
+    index = 39,
+    label = "C7H9-20 <=> C7H8-11 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4e+10, 's^-1'), n=1.27, Ea=(44.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_14 <=> prod_15 + H
+""",
+)
+
+entry(
+    index = 40,
+    label = "C3H4-2 + C4H5 <=> C7H9-21",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1900, 'cm^3/(mol*s)'), n=2.92, Ea=(8.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H4p + BD2YL <=> prod_16
+""",
+)
+
+entry(
+    index = 41,
+    label = "C7H9-22 <=> C7H8-12 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.47e+10, 's^-1'), n=1.22, Ea=(45.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_17 <=> prod_18 + H
+""",
+)
+
+entry(
+    index = 42,
+    label = "C3H4-3 + allyl <=> C6H9-5",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3960, 'cm^3/(mol*s)'), n=2.65, Ea=(11.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: aC3H5 + C3H4a <=> prod_19
+""",
+)
+
+entry(
+    index = 43,
+    label = "C3H4-3 + C4H7 <=> C7H11-5",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(37, 'cm^3/(mol*s)'), n=2.89, Ea=(9.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H4a + iC4H7 <=> prod_20
+""",
+)
+
+entry(
+    index = 44,
+    label = "C2H2 + allyl <=> C5H7",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (238000, 'cm^3/(mol*s)'),
+        n = 2.26,
+        Ea = (12.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: aC3H5 + C2H2 <=> prod_21
+""",
+)
+
+entry(
+    index = 45,
+    label = "C5H7-2 <=> C5H6 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.19e+09, 's^-1'), n=1.37, Ea=(31.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_22 <=> CPD + H
+""",
+)
+
+entry(
+    index = 46,
+    label = "C2H2 + C3H3 <=> C5H5-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.27e+06, 'cm^3/(mol*s)'),
+        n = 2.15,
+        Ea = (10.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H3 + C2H2 <=> prod_23
+""",
+)
+
+entry(
+    index = 47,
+    label = "C3H4-2 + C3H3 <=> C6H7",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(7040, 'cm^3/(mol*s)'), n=2.87, Ea=(9.8, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H3 + C3H4p <=> prod_25
+""",
+)
+
+entry(
+    index = 48,
+    label = "C3H4-4 + C3H3 <=> C6H7-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(285, 'cm^3/(mol*s)'), n=2.93, Ea=(11.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H3 + C3H4p <=> prod_27
+""",
+)
+
+entry(
+    index = 49,
+    label = "C3H4-3 + C3H3 <=> C6H7-3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(850, 'cm^3/(mol*s)'), n=2.81, Ea=(8.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: C3H3 + C3H4a <=> prod_29
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -1043,3 +1043,85 @@ Taken from entry: pdt38 + H <=> pdt37
 """,
 )
 
+
+
+entry(
+    index = 64,
+    label = "C6H6 + H <=> C6H7-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.69e+09, 'cm^3/(mol*s)'),
+        n = 1.46,
+        Ea = (-0.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + H <=> C5H4CH3
+""",
+)
+
+entry(
+    index = 65,
+    label = "C6H6-3 + H <=> C6H7-5",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.31e+08, 'cm^3/(mol*s)'), n=1.76, Ea=(2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + H <=> C5H5CH2-1
+""",
+)
+
+entry(
+    index = 66,
+    label = "C6H6-5 + H <=> C6H7-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.26e+09, 'cm^3/(mol*s)'),
+        n = 1.48,
+        Ea = (0.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + H <=> C5H5CH2-3
+""",
+)
+
+entry(
+    index = 67,
+    label = "C6H6-4 + H <=> C6H7-7",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.52e+09, 'cm^3/(mol*s)'),
+        n = 1.52,
+        Ea = (0.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    longDesc = 
+u"""
+Taken from entry: FULVENE + H <=> C5H5CH2-2
+""",
+)
+
+entry(
+    index = 68,
+    label = "C6H7-8 <=> C6H6-2 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.84e+09, 's^-1'), n=1.3, Ea=(27.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    longDesc = 
+u"""
+Taken from entry: cyC6H7 <=> benzene + H
+""",
+)
+

--- a/input/kinetics/families/R_Recombination/training/dictionary.txt
+++ b/input/kinetics/families/R_Recombination/training/dictionary.txt
@@ -1,3 +1,22 @@
+C7H10
+1  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+4     C u0 p0 c0 {1,S} {6,D} {14,S}
+5     C u0 p0 c0 {1,S} {7,D} {15,S}
+6     C u0 p0 c0 {4,D} {7,S} {16,S}
+7     C u0 p0 c0 {5,D} {6,S} {17,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+
 C3H7
 multiplicity 2
 1    C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
@@ -73,11 +92,6 @@ multiplicity 2
 8 H u0 p0 c0 {2,S}
 9 H u0 p0 c0 {2,S}
 
-OH
-multiplicity 2
-1 * O u1 p2 c0 {2,S}
-2   H u0 p0 c0 {1,S}
-
 1-hydroxybutyl
 multiplicity 2
 1    C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
@@ -102,6 +116,11 @@ HNO3
 4 O u0 p3 c-1 {1,S}
 5 H u0 p0 c0 {2,S}
 
+O2
+multiplicity 3
+1 * O u1 p2 c0 {2,S}
+2   O u1 p2 c0 {1,S}
+
 CH3
 multiplicity 2
 1 * C u1 p0 c0 {2,S} {3,S} {4,S}
@@ -123,6 +142,19 @@ multiplicity 2
 10 H u0 p0 c0 {2,S}
 11 H u0 p0 c0 {4,S}
 12 H u0 p0 c0 {4,S}
+
+C5H5
+multiplicity 2
+1    C u0 p0 c0 {2,D} {5,S} {6,S}
+2    C u0 p0 c0 {1,D} {3,S} {7,S}
+3    C u0 p0 c0 {2,S} {4,D} {8,S}
+4    C u0 p0 c0 {3,D} {5,S} {9,S}
+5  * C u1 p0 c0 {1,S} {4,S} {10,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+10   H u0 p0 c0 {5,S}
 
 NO2-2
 multiplicity 2
@@ -147,10 +179,10 @@ multiplicity 2
 3 * O u1 p2 c0 {1,S}
 4   O u0 p3 c-1 {1,S}
 
-O2
-multiplicity 3
+OH
+multiplicity 2
 1 * O u1 p2 c0 {2,S}
-2   O u1 p2 c0 {1,S}
+2   H u0 p0 c0 {1,S}
 
 NO2
 multiplicity 2

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -242,3 +242,23 @@ Quantum dynamics calculations. Reaction potential energy suraface was studied us
 """,
 )
 
+
+
+entry(
+    index = 10,
+    label = "C5H5 + C2H5 <=> C7H10",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.34e+15, 'cm^3/(mol*s)'),
+        n = -0.7,
+        Ea = (-0.5, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: ethyl + CPDyl <=> ethylCPD
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -1,3 +1,225 @@
+C7H9-14
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {2,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *1 C u1 p0 c0 {1,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-15
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+2     C u0 p0 c0 {4,S} {5,S} {6,S} {9,S}
+3  *2 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+4     C u0 p0 c0 {2,S} {3,S} {12,S} {13,S}
+5  *1 C u1 p0 c0 {1,S} {2,S} {14,S}
+6     C u0 p0 c0 {2,S} {7,D} {15,S}
+7     C u0 p0 c0 {1,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-16
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2  *4 C u0 p0 c0 {3,S} {5,S} {7,S} {9,S}
+3  *2 C u0 p0 c0 {1,S} {2,S} {10,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+5  *1 C u1 p0 c0 {2,S} {4,S} {14,S}
+6     C u0 p0 c0 {1,S} {7,D} {15,S}
+7     C u0 p0 c0 {2,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-17
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3     C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+4  *2 C u0 p0 c0 {1,S} {7,S} {11,S} {12,S}
+5     C u0 p0 c0 {3,S} {6,S} {7,D}
+6  *1 C u1 p0 c0 {1,S} {5,S} {15,S}
+7     C u0 p0 c0 {4,S} {5,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-10
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {11,S}
+2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {5,S} {6,S}
+4     C u0 p0 c0 {2,S} {5,D} {12,S}
+5     C u0 p0 c0 {3,S} {4,D} {13,S}
+6     C u0 p0 c0 {3,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-11
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {6,S} {12,S}
+4     C u0 p0 c0 {2,S} {5,D} {13,S}
+5     C u0 p0 c0 {4,D} {7,S} {14,S}
+6     C u0 p0 c0 {3,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-12
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {9,S} {10,S}
+2  *2 C u0 p0 c0 {3,S} {5,S} {8,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {2,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-13
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {6,S} {12,S}
+4     C u0 p0 c0 {1,S} {5,D} {13,S}
+5     C u0 p0 c0 {4,D} {7,S} {14,S}
+6     C u0 p0 c0 {3,S} {7,D} {15,S}
+7     C u0 p0 c0 {5,S} {6,D} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+S1C4b
+multiplicity 2
+1  *1 C u1 p0 c0 {2,S} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *6 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *5 C u0 p0 c0 {3,S} {5,D} {6,S}
+5     O u0 p2 c0 {4,D}
+6  *2 O u0 p2 c0 {4,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13 *3 H u0 p0 c0 {6,S}
+
+C7H9-18
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3  *2 C u0 p0 c0 {1,S} {5,S} {11,S} {14,S}
+4     C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
+5     C u0 p0 c0 {3,S} {4,S} {7,D}
+6  *1 C u1 p0 c0 {1,S} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-19
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {6,S} {7,D}
+4  *1 C u1 p0 c0 {1,S} {3,S} {12,S}
+5     C u0 p0 c0 {1,S} {6,D} {13,S}
+6     C u0 p0 c0 {3,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+S2C4b
+multiplicity 2
+1  *1 C u1 p0 c0 {2,S} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *6 C u0 p0 c0 {2,S} {4,D} {5,S}
+4     O u0 p2 c0 {3,D}
+5  *5 C u0 p0 c0 {3,S} {6,S} {11,S} {12,S}
+6  *2 O u0 p2 c0 {5,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13 *3 H u0 p0 c0 {6,S}
+
 C2H3O3
 multiplicity 2
 1 *2 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
@@ -8,6 +230,398 @@ multiplicity 2
 6    H u0 p0 c0 {1,S}
 7    O u0 p2 c0 {2,D}
 8 *1 O u1 p2 c0 {3,S}
+
+C7H7-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,S} {7,D} {12,S}
+6     C u0 p0 c0 {4,D} {7,S} {14,S}
+7     C u0 p0 c0 {5,D} {6,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {6,S}
+
+C7H7-3
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
+7  *1 C u1 p0 c0 {6,D} {14,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H9-21
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {5,S} {7,D}
+4  *1 C u1 p0 c0 {1,S} {6,S} {12,S}
+5     C u0 p0 c0 {3,S} {6,D} {13,S}
+6     C u0 p0 c0 {4,S} {5,D} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-20
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3     C u0 p0 c0 {2,S} {5,S} {7,D}
+4     C u0 p0 c0 {1,S} {5,D} {11,S}
+5     C u0 p0 c0 {3,S} {4,D} {12,S}
+6  *1 C u1 p0 c0 {1,S} {13,S} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-22
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,S} {7,D}
+4     C u0 p0 c0 {2,S} {5,D} {11,S}
+5     C u0 p0 c0 {3,S} {4,D} {12,S}
+6  *1 C u1 p0 c0 {1,S} {13,S} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C4H7O2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,S} {3,D} {4,S}
+3     O u0 p2 c0 {2,D}
+4  *6 C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
+6  *1 O u1 p2 c0 {5,S}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+C7H9-6
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-7
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {1,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-4
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {14,S}
+6     C u0 p0 c0 {1,S} {7,D} {13,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-5
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *1 C u1 p0 c0 {2,S} {15,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {7,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {5,D} {11,S}
+4     C u0 p0 c0 {1,S} {6,D} {12,S}
+5     C u0 p0 c0 {3,D} {6,S} {13,S}
+6     C u0 p0 c0 {4,D} {5,S} {14,S}
+7  *1 C u1 p0 c0 {2,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-3
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {5,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {6,D} {11,S}
+4  *1 C u1 p0 c0 {2,S} {6,S} {12,S}
+5     C u0 p0 c0 {1,S} {7,D} {13,S}
+6     C u0 p0 c0 {3,D} {4,S} {14,S}
+7     C u0 p0 c0 {5,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+S2C4
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+3  *6 C u0 p0 c0 {2,S} {4,D} {5,S}
+4     O u0 p2 c0 {3,D}
+5  *4 C u0 p0 c0 {3,S} {6,S} {12,S} {13,S}
+6  *1 O u1 p2 c0 {5,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+C7H7-4
+multiplicity 2
+1  *1 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4     C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6  *4 C u0 p0 c0 {1,S} {7,D} {12,S}
+7  *2 C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13 *3 H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-5
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *2 C u0 p0 c0 {1,S} {7,D} {13,S}
+7  *1 C u1 p0 c0 {6,D} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13 *3 H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-6
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *2 C u0 p0 c0 {7,D} {13,S} {14,S}
+7  *1 C u1 p0 c0 {1,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13 *3 H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+
+C7H7-7
+multiplicity 2
+1  *1 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4     C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H9-8
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-9
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {13,S}
+6     C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+S1C4
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {2,S} {12,D} {13,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9  *3 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    O u0 p2 c0 {4,D}
+13 *1 O u1 p2 c0 {4,S}
+
+C7H7
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2     C u0 p0 c0 {1,S} {3,S} {5,S} {9,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {10,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5     C u0 p0 c0 {2,S} {7,D} {12,S}
+6     C u0 p0 c0 {4,D} {7,S} {13,S}
+7     C u0 p0 c0 {5,D} {6,S} {14,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C4H7O2b
+multiplicity 2
+1  *6 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *4 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+3  *5 C u0 p0 c0 {1,S} {4,S} {10,D}
+4  *2 C u1 p0 c0 {3,S} {11,S} {12,S}
+5  *1 O u0 p2 c0 {2,S} {13,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    O u0 p2 c0 {3,D}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13 *3 H u0 p0 c0 {5,S}
 
 C2H3O3-2
 multiplicity 2
@@ -20,100 +634,39 @@ multiplicity 2
 7    H u0 p0 c0 {2,S}
 8 *3 H u0 p0 c0 {4,S}
 
-
-S1C4
+C7H9
 multiplicity 2
-1 *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2 *5 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
-3 *6 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
-4 *4 C u0 p0 c0 {3,S} {5,D} {6,S}
-5    O u0 p2 c0 {4,D}
-6 *1 O u1 p2 c0 {4,S}
-7 *3 H u0 p0 c0 {1,S}
-8    H u0 p0 c0 {1,S}
-9    H u0 p0 c0 {1,S}
-10   H u0 p0 c0 {2,S}
-11   H u0 p0 c0 {2,S}
-12   H u0 p0 c0 {3,S}
-13   H u0 p0 c0 {3,S}
-
-S1C4b
-multiplicity 2
-1 *1  C u1 p0 c0 {2,S} {7,S} {8,S}
-2 *4  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3 *6  C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
-4 *5  C u0 p0 c0 {3,S} {5,D} {6,S}
-5     O u0 p2 c0 {4,D}
-6 *2  O u0 p2 c0 {4,S} {13,S}
-7     H u0 p0 c0 {1,S}
+1     C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+2  *2 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {1,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
 8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
+9  *3 H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {3,S}
-13 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 
-S2C4
+C7H7-8
 multiplicity 2
-1 *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2 *5 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
-3 *6 C u0 p0 c0 {2,S} {4,D} {5,S}
-4    O u0 p2 c0 {3,D}
-5 *4 C u0 p0 c0 {3,S} {6,S} {12,S} {13,S}
-6 *1 O u1 p2 c0 {5,S}
-7    H u0 p0 c0 {1,S}
-8    H u0 p0 c0 {1,S}
-9 *3 H u0 p0 c0 {1,S}
-10   H u0 p0 c0 {2,S}
-11   H u0 p0 c0 {2,S}
-12   H u0 p0 c0 {5,S}
-13   H u0 p0 c0 {5,S}
-
-S2C4b
-multiplicity 2
-1 *1  C u1 p0 c0 {2,S} {7,S} {8,S}
-2 *4  C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3 *6  C u0 p0 c0 {2,S} {4,D} {5,S}
-4     O u0 p2 c0 {3,D}
-5 *5  C u0 p0 c0 {3,S} {6,S} {11,S} {12,S}
-6 *2  O u0 p2 c0 {5,S} {13,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6     C u0 p0 c0 {7,D} {13,S} {14,S}
+7  *1 C u1 p0 c0 {1,S} {6,D}
+8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {5,S}
-12    H u0 p0 c0 {5,S}
-13 *3 H u0 p0 c0 {6,S}
-
-C4H7O2
-multiplicity 2
-1 *2  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2 *5  C u0 p0 c0 {1,S} {3,D} {4,S}
-3     O u0 p2 c0 {2,D}
-4 *6  C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
-5 *4  C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
-6 *1  O u1 p2 c0 {5,S}
-7 *3  H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {3,S}
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {5,S}
-
-C4H7O2b
-multiplicity 2
-1 *2  C u1 p0 c0 {2,S} {8,S} {9,S}
-2 *5  C u0 p0 c0 {1,S} {3,D} {4,S}
-3     O u0 p2 c0 {2,D}
-4 *6  C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
-5 *4  C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
-6 *1  O u0 p2 c0 {5,S} {7,S}
-7 *3  H u0 p0 c0 {6,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
 

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -231,39 +231,56 @@ multiplicity 2
 7    O u0 p2 c0 {2,D}
 8 *1 O u1 p2 c0 {3,S}
 
-C7H7-2
+C7H9-8
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
-4     C u0 p0 c0 {1,S} {6,D} {11,S}
-5     C u0 p0 c0 {3,S} {7,D} {12,S}
-6     C u0 p0 c0 {4,D} {7,S} {14,S}
-7     C u0 p0 c0 {5,D} {6,S} {13,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {2,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 
-C7H7-3
+C7H9-9
 multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,D} {9,S}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,D} {5,S} {11,S}
-5     C u0 p0 c0 {3,D} {4,S} {12,S}
-6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
-7  *1 C u1 p0 c0 {6,D} {14,S}
+1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {13,S}
+6     C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
 8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+C5H5-2
+multiplicity 2
+1  *1 C u1 p0 c0 {2,S} {5,S} {7,S}
+2     C u0 p0 c0 {1,S} {3,D} {8,S}
+3     C u0 p0 c0 {2,D} {4,S} {9,S}
+4     C u0 p0 c0 {3,S} {5,D} {10,S}
+5  *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+6  *3 H u0 p0 c0 {5,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
 
 C7H9-21
 multiplicity 2
@@ -322,6 +339,19 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
+C5H5
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2     C u0 p0 c0 {1,S} {3,D} {8,S}
+3     C u0 p0 c0 {2,D} {4,S} {9,S}
+4     C u0 p0 c0 {3,S} {5,D} {10,S}
+5  *1 C u1 p0 c0 {1,S} {4,D}
+6  *3 H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+
 C4H7O2
 multiplicity 2
 1  *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
@@ -337,6 +367,86 @@ multiplicity 2
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {5,S}
+
+C6H7-3
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {2,S} {4,D}
+4     C u0 p0 c0 {3,D} {5,S} {12,S}
+5     C u0 p0 c0 {4,S} {6,D} {13,S}
+6  *1 C u1 p0 c0 {1,S} {5,D}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+
+C6H7-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,D} {4,S}
+3     C u0 p0 c0 {2,D} {5,S} {12,S}
+4     C u0 p0 c0 {2,S} {6,D} {13,S}
+5  *1 C u1 p0 c0 {3,S} {6,S} {11,S}
+6  *2 C u0 p0 c0 {4,D} {5,S} {10,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+
+C6H7-5
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {4,S} {5,D}
+4     C u0 p0 c0 {3,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {12,S} {13,S}
+6  *1 C u1 p0 c0 {2,S} {4,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+C6H7-4
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,S} {4,D}
+3  *1 C u1 p0 c0 {2,S} {6,S} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {12,S}
+5     C u0 p0 c0 {4,S} {6,D} {13,S}
+6  *2 C u0 p0 c0 {3,S} {5,D} {10,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+
+C6H7-6
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {6,D}
+3  *1 C u1 p0 c0 {1,S} {5,S} {9,S}
+4     C u0 p0 c0 {2,S} {5,D} {11,S}
+5  *2 C u0 p0 c0 {3,S} {4,D} {10,S}
+6     C u0 p0 c0 {2,D} {12,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10 *3 H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
 
 C7H9-6
 multiplicity 2
@@ -536,43 +646,39 @@ multiplicity 2
 13    H u0 p0 c0 {7,S}
 14    H u0 p0 c0 {7,S}
 
-C7H9-8
+C7H7-2
 multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {13,S}
-5     C u0 p0 c0 {3,S} {7,D} {14,S}
-6     C u0 p0 c0 {4,D} {7,S} {15,S}
-7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8  *3 H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,S} {7,D} {12,S}
+6     C u0 p0 c0 {4,D} {7,S} {14,S}
+7     C u0 p0 c0 {5,D} {6,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {6,S}
 
-C7H9-9
+C7H7-3
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {12,S}
-5     C u0 p0 c0 {2,S} {4,D} {13,S}
-6     C u0 p0 c0 {1,S} {7,D} {14,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
+7  *1 C u1 p0 c0 {6,D} {14,S}
 8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
 
 S1C4
 multiplicity 2
@@ -652,6 +758,22 @@ multiplicity 2
 14    H u0 p0 c0 {5,S}
 15    H u0 p0 c0 {6,S}
 16    H u0 p0 c0 {7,S}
+
+C6H7
+multiplicity 2
+1  *2 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {2,S} {4,D} {5,S}
+4     C u0 p0 c0 {1,S} {3,D} {12,S}
+5     C u0 p0 c0 {3,S} {6,D} {13,S}
+6  *1 C u1 p0 c0 {1,S} {5,D}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
 
 C7H7-8
 multiplicity 2

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -166,6 +166,30 @@ multiplicity 2
 12    H u0 p0 c0 {3,S}
 13 *3 H u0 p0 c0 {6,S}
 
+C10H11-15
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3  *2 C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4  *5 C u0 p0 c0 {1,S} {3,S} {8,D}
+5  *1 C u1 p0 c0 {1,S} {9,S} {16,S}
+6     C u0 p0 c0 {2,S} {9,D} {17,S}
+7     C u0 p0 c0 {3,S} {10,D} {18,S}
+8     C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {5,S} {6,D} {20,S}
+10    C u0 p0 c0 {7,D} {8,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
 C7H9-18
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
@@ -220,6 +244,78 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13 *3 H u0 p0 c0 {6,S}
 
+C10H11-7
+multiplicity 2
+1  *2 C u0 p0 c0 {4,S} {5,S} {6,S} {11,S}
+2     C u0 p0 c0 {4,S} {7,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {8,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {2,S} {3,S}
+5     C u0 p0 c0 {1,S} {7,D} {16,S}
+6     C u0 p0 c0 {1,S} {9,D} {18,S}
+7     C u0 p0 c0 {2,S} {5,D} {17,S}
+8     C u0 p0 c0 {3,S} {10,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-3
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {5,D}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4     C u0 p0 c0 {2,S} {7,D} {14,S}
+5  *7 C u0 p0 c0 {2,D} {8,S} {16,S}
+6     C u0 p0 c0 {3,D} {7,S} {17,S}
+7     C u0 p0 c0 {4,D} {6,S} {15,S}
+8  *6 C u0 p0 c0 {5,S} {9,D} {18,S}
+9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-16
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *2 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4  *4 C u0 p0 c0 {1,S} {7,S} {8,D}
+5     C u0 p0 c0 {2,S} {6,D} {16,S}
+6     C u0 p0 c0 {3,S} {5,D} {17,S}
+7  *1 C u1 p0 c0 {4,S} {9,S} {18,S}
+8     C u0 p0 c0 {4,D} {10,S} {20,S}
+9     C u0 p0 c0 {7,S} {10,D} {19,S}
+10    C u0 p0 c0 {8,S} {9,D} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {8,S}
+21    H u0 p0 c0 {10,S}
+
 C2H3O3
 multiplicity 2
 1 *2 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
@@ -231,43 +327,207 @@ multiplicity 2
 7    O u0 p2 c0 {2,D}
 8 *1 O u1 p2 c0 {3,S}
 
-C7H9-8
+C10H11-14
 multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {13,S}
-5     C u0 p0 c0 {3,S} {7,D} {14,S}
-6     C u0 p0 c0 {4,D} {7,S} {15,S}
-7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8  *3 H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {13,S} {14,S}
+3  *2 C u0 p0 c0 {1,S} {6,S} {12,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {6,D} {16,S}
+6     C u0 p0 c0 {3,S} {5,D} {17,S}
+7     C u0 p0 c0 {4,S} {9,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {7,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
-C7H9-9
+C10H11-2
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {12,S}
-5     C u0 p0 c0 {2,S} {4,D} {13,S}
-6     C u0 p0 c0 {1,S} {7,D} {14,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2  *1 C u1 p0 c0 {4,S} {5,S} {6,S}
+3  *7 C u0 p0 c0 {1,S} {7,D} {14,S}
+4     C u0 p0 c0 {2,S} {8,D} {15,S}
+5     C u0 p0 c0 {2,S} {9,D} {16,S}
+6  *6 C u0 p0 c0 {2,S} {10,D} {17,S}
+7  *5 C u0 p0 c0 {3,D} {10,S} {21,S}
+8     C u0 p0 c0 {4,D} {9,S} {18,S}
+9     C u0 p0 c0 {5,D} {8,S} {19,S}
+10 *4 C u0 p0 c0 {6,D} {7,S} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {7,S}
+
+C10H11-8
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3     C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {7,D} {16,S}
+6     C u0 p0 c0 {3,S} {9,D} {17,S}
+7     C u0 p0 c0 {4,S} {5,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {21,S}
+10    C u0 p0 c0 {8,D} {9,S} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {9,S}
+
+C10H11-12
+multiplicity 2
+1     C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3  *2 C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {3,S} {8,S}
+5     C u0 p0 c0 {1,S} {9,D} {16,S}
+6     C u0 p0 c0 {2,S} {7,D} {17,S}
+7     C u0 p0 c0 {3,S} {6,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C7H7-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,S} {7,D} {12,S}
+6     C u0 p0 c0 {4,D} {7,S} {14,S}
+7     C u0 p0 c0 {5,D} {6,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {6,S}
+
+C10H11-9
+multiplicity 2
+1     C u0 p0 c0 {4,S} {5,S} {6,S} {11,S}
+2  *2 C u0 p0 c0 {4,S} {7,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {8,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {2,S} {3,S}
+5     C u0 p0 c0 {1,S} {7,D} {16,S}
+6     C u0 p0 c0 {1,S} {9,D} {18,S}
+7     C u0 p0 c0 {2,S} {5,D} {17,S}
+8     C u0 p0 c0 {3,S} {10,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-18
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2     C u0 p0 c0 {4,D} {5,S} {6,S}
+3  *5 C u0 p0 c0 {1,S} {7,D} {14,S}
+4     C u0 p0 c0 {2,D} {8,S} {16,S}
+5     C u0 p0 c0 {2,S} {9,D} {18,S}
+6     C u0 p0 c0 {2,S} {10,D} {19,S}
+7  *4 C u0 p0 c0 {3,D} {8,S} {17,S}
+8  *1 C u1 p0 c0 {4,S} {7,S} {15,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {6,D} {9,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {8,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C7H7-3
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
+7  *1 C u1 p0 c0 {6,D} {14,S}
 8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C10H11-13
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4  *1 C u1 p0 c0 {1,S} {8,S} {15,S}
+5     C u0 p0 c0 {2,S} {9,D} {16,S}
+6     C u0 p0 c0 {2,S} {10,D} {17,S}
+7     C u0 p0 c0 {3,S} {8,D} {18,S}
+8     C u0 p0 c0 {4,S} {7,D} {19,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {6,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
 C5H5-2
 multiplicity 2
@@ -368,6 +628,54 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {5,S}
 
+C10H11-11
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {10,D} {17,S}
+5  *1 C u1 p0 c0 {2,S} {8,S} {15,S}
+6     C u0 p0 c0 {2,S} {9,D} {16,S}
+7     C u0 p0 c0 {3,S} {8,D} {18,S}
+8     C u0 p0 c0 {5,S} {7,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {21,S}
+10    C u0 p0 c0 {4,D} {9,S} {20,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {9,S}
+
+C10H11-10
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4  *1 C u1 p0 c0 {1,S} {8,S} {15,S}
+5     C u0 p0 c0 {2,S} {8,D} {16,S}
+6     C u0 p0 c0 {2,S} {9,D} {17,S}
+7     C u0 p0 c0 {3,S} {10,D} {18,S}
+8     C u0 p0 c0 {4,S} {5,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {20,S}
+10    C u0 p0 c0 {7,D} {9,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
 C6H7-3
 multiplicity 2
 1  *2 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
@@ -431,6 +739,30 @@ multiplicity 2
 11    H u0 p0 c0 {3,S}
 12    H u0 p0 c0 {4,S}
 13    H u0 p0 c0 {5,S}
+
+C10H11-17
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {11,S} {12,S}
+2     C u0 p0 c0 {3,D} {5,S} {6,S}
+3     C u0 p0 c0 {1,S} {2,D} {13,S}
+4  *5 C u0 p0 c0 {1,S} {9,D} {14,S}
+5     C u0 p0 c0 {2,S} {7,D} {15,S}
+6     C u0 p0 c0 {2,S} {8,D} {16,S}
+7     C u0 p0 c0 {5,D} {8,S} {17,S}
+8     C u0 p0 c0 {6,D} {7,S} {18,S}
+9  *4 C u0 p0 c0 {4,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
 
 C6H7-6
 multiplicity 2
@@ -646,39 +978,91 @@ multiplicity 2
 13    H u0 p0 c0 {7,S}
 14    H u0 p0 c0 {7,S}
 
-C7H7-2
+C10H11-5
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
-4     C u0 p0 c0 {1,S} {6,D} {11,S}
-5     C u0 p0 c0 {3,S} {7,D} {12,S}
-6     C u0 p0 c0 {4,D} {7,S} {14,S}
-7     C u0 p0 c0 {5,D} {6,S} {13,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {6,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+2  *5 C u0 p0 c0 {1,S} {4,D} {5,S}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4     C u0 p0 c0 {2,D} {6,S} {14,S}
+5  *8 C u0 p0 c0 {2,S} {7,D} {15,S}
+6     C u0 p0 c0 {3,D} {4,S} {16,S}
+7  *7 C u0 p0 c0 {5,D} {8,S} {17,S}
+8  *6 C u0 p0 c0 {7,S} {9,D} {18,S}
+9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
 
-C7H7-3
+C10H11-4
 multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,D} {9,S}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,D} {5,S} {11,S}
-5     C u0 p0 c0 {3,D} {4,S} {12,S}
-6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
-7  *1 C u1 p0 c0 {6,D} {14,S}
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2  *6 C u0 p0 c0 {4,S} {5,S} {6,D}
+3  *7 C u0 p0 c0 {1,S} {7,D} {14,S}
+4  *1 C u1 p0 c0 {2,S} {8,S} {15,S}
+5     C u0 p0 c0 {2,S} {10,D} {17,S}
+6  *4 C u0 p0 c0 {2,D} {7,S} {19,S}
+7  *5 C u0 p0 c0 {3,D} {6,S} {21,S}
+8     C u0 p0 c0 {4,S} {9,D} {16,S}
+9     C u0 p0 c0 {8,D} {10,S} {20,S}
+10    C u0 p0 c0 {5,D} {9,S} {18,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {10,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {7,S}
+
+C7H9-8
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+C7H9-9
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {13,S}
+6     C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
 8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
 S1C4
 multiplicity 2
@@ -695,6 +1079,30 @@ multiplicity 2
 11    H u0 p0 c0 {3,S}
 12    O u0 p2 c0 {4,D}
 13 *1 O u1 p2 c0 {4,S}
+
+C10H11
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,D} {12,S}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4  *5 C u0 p0 c0 {1,S} {7,D} {14,S}
+5     C u0 p0 c0 {2,D} {6,S} {15,S}
+6     C u0 p0 c0 {3,D} {5,S} {16,S}
+7  *7 C u0 p0 c0 {4,D} {8,S} {17,S}
+8  *6 C u0 p0 c0 {7,S} {9,D} {18,S}
+9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
 
 C7H7
 multiplicity 2
@@ -791,4 +1199,28 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13    H u0 p0 c0 {6,S}
 14    H u0 p0 c0 {6,S}
+
+C10H11-6
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2  *7 C u0 p0 c0 {4,S} {5,D} {6,S}
+3  *8 C u0 p0 c0 {1,S} {7,D} {14,S}
+4  *1 C u1 p0 c0 {2,S} {8,S} {15,S}
+5     C u0 p0 c0 {2,D} {9,S} {17,S}
+6  *4 C u0 p0 c0 {2,S} {10,D} {18,S}
+7  *6 C u0 p0 c0 {3,D} {10,S} {21,S}
+8     C u0 p0 c0 {4,S} {9,D} {16,S}
+9     C u0 p0 c0 {5,S} {8,D} {19,S}
+10 *5 C u0 p0 c0 {6,D} {7,S} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {7,S}
 

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -166,30 +166,6 @@ multiplicity 2
 12    H u0 p0 c0 {3,S}
 13 *3 H u0 p0 c0 {6,S}
 
-C10H11-15
-multiplicity 2
-1  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
-2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
-3  *2 C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
-4  *5 C u0 p0 c0 {1,S} {3,S} {8,D}
-5  *1 C u1 p0 c0 {1,S} {9,S} {16,S}
-6     C u0 p0 c0 {2,S} {9,D} {17,S}
-7     C u0 p0 c0 {3,S} {10,D} {18,S}
-8     C u0 p0 c0 {4,D} {10,S} {19,S}
-9     C u0 p0 c0 {5,S} {6,D} {20,S}
-10    C u0 p0 c0 {7,D} {8,S} {21,S}
-11    H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {2,S}
-14 *3 H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {3,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {7,S}
-19    H u0 p0 c0 {8,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {10,S}
-
 C7H9-18
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
@@ -244,6 +220,158 @@ multiplicity 2
 12    H u0 p0 c0 {5,S}
 13 *3 H u0 p0 c0 {6,S}
 
+C7H9-8
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
+4     C u0 p0 c0 {3,S} {6,D} {13,S}
+5     C u0 p0 c0 {3,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+
+S1C4
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {2,S} {12,D} {13,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9  *3 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    O u0 p2 c0 {4,D}
+13 *1 O u1 p2 c0 {4,S}
+
+C7H7-6
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *2 C u0 p0 c0 {7,D} {13,S} {14,S}
+7  *1 C u1 p0 c0 {1,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13 *3 H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+
+C2H3O3
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 *5 C u0 p0 c0 {1,S} {3,S} {7,D}
+3 *4 O u0 p2 c0 {2,S} {8,S}
+4 *3 H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    O u0 p2 c0 {2,D}
+8 *1 O u1 p2 c0 {3,S}
+
+C6H7-4
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,S} {4,D}
+3  *1 C u1 p0 c0 {2,S} {6,S} {11,S}
+4     C u0 p0 c0 {2,D} {5,S} {12,S}
+5     C u0 p0 c0 {4,S} {6,D} {13,S}
+6  *2 C u0 p0 c0 {3,S} {5,D} {10,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+
+C7H7-7
+multiplicity 2
+1  *1 C u1 p0 c0 {2,S} {3,S} {6,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4     C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {7,D} {12,S}
+7     C u0 p0 c0 {6,D} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C6H7-6
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,S} {6,D}
+3  *1 C u1 p0 c0 {1,S} {5,S} {9,S}
+4     C u0 p0 c0 {2,S} {5,D} {11,S}
+5  *2 C u0 p0 c0 {3,S} {4,D} {10,S}
+6     C u0 p0 c0 {2,D} {12,S} {13,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10 *3 H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
+C6H7-7
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *1 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {6,S} {12,S}
+6     C u0 p0 c0 {4,D} {5,S} {13,S}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+
+C10H11-4
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2  *6 C u0 p0 c0 {4,S} {5,S} {6,D}
+3  *7 C u0 p0 c0 {1,S} {7,D} {14,S}
+4  *1 C u1 p0 c0 {2,S} {8,S} {15,S}
+5     C u0 p0 c0 {2,S} {10,D} {17,S}
+6  *4 C u0 p0 c0 {2,D} {7,S} {19,S}
+7  *5 C u0 p0 c0 {3,D} {6,S} {21,S}
+8     C u0 p0 c0 {4,S} {9,D} {16,S}
+9     C u0 p0 c0 {8,D} {10,S} {20,S}
+10    C u0 p0 c0 {5,D} {9,S} {18,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {10,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {7,S}
+
 C10H11-7
 multiplicity 2
 1  *2 C u0 p0 c0 {4,S} {5,S} {6,S} {11,S}
@@ -268,266 +396,56 @@ multiplicity 2
 20    H u0 p0 c0 {9,S}
 21    H u0 p0 c0 {10,S}
 
-C10H11-3
+C6H7-8
 multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
-2  *5 C u0 p0 c0 {1,S} {4,S} {5,D}
-3     C u0 p0 c0 {1,S} {6,D} {13,S}
-4     C u0 p0 c0 {2,S} {7,D} {14,S}
-5  *7 C u0 p0 c0 {2,D} {8,S} {16,S}
-6     C u0 p0 c0 {3,D} {7,S} {17,S}
-7     C u0 p0 c0 {4,D} {6,S} {15,S}
-8  *6 C u0 p0 c0 {5,S} {9,D} {18,S}
-9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
-10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
-11 *3 H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {1,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {4,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {8,S}
-19    H u0 p0 c0 {9,S}
-20    H u0 p0 c0 {10,S}
-21    H u0 p0 c0 {10,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {9,S}
+4     C u0 p0 c0 {2,D} {5,S} {10,S}
+5     C u0 p0 c0 {3,D} {4,S} {11,S}
+6  *1 C u1 p0 c0 {1,S} {12,S} {13,S}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
 
-C10H11-16
+C7H9-9
 multiplicity 2
-1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
-2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
-3  *2 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
-4  *4 C u0 p0 c0 {1,S} {7,S} {8,D}
-5     C u0 p0 c0 {2,S} {6,D} {16,S}
-6     C u0 p0 c0 {3,S} {5,D} {17,S}
-7  *1 C u1 p0 c0 {4,S} {9,S} {18,S}
-8     C u0 p0 c0 {4,D} {10,S} {20,S}
-9     C u0 p0 c0 {7,S} {10,D} {19,S}
-10    C u0 p0 c0 {8,S} {9,D} {21,S}
-11    H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {2,S}
-14 *3 H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {3,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {7,S}
-19    H u0 p0 c0 {9,S}
-20    H u0 p0 c0 {8,S}
-21    H u0 p0 c0 {10,S}
-
-C2H3O3
-multiplicity 2
-1 *2 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
-2 *5 C u0 p0 c0 {1,S} {3,S} {7,D}
-3 *4 O u0 p2 c0 {2,S} {8,S}
-4 *3 H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {1,S}
-6    H u0 p0 c0 {1,S}
-7    O u0 p2 c0 {2,D}
-8 *1 O u1 p2 c0 {3,S}
-
-C10H11-14
-multiplicity 2
-1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
-2     C u0 p0 c0 {1,S} {5,S} {13,S} {14,S}
-3  *2 C u0 p0 c0 {1,S} {6,S} {12,S} {15,S}
-4  *1 C u1 p0 c0 {1,S} {7,S} {8,S}
-5     C u0 p0 c0 {2,S} {6,D} {16,S}
-6     C u0 p0 c0 {3,S} {5,D} {17,S}
-7     C u0 p0 c0 {4,S} {9,D} {18,S}
-8     C u0 p0 c0 {4,S} {10,D} {19,S}
-9     C u0 p0 c0 {7,D} {10,S} {20,S}
-10    C u0 p0 c0 {8,D} {9,S} {21,S}
-11    H u0 p0 c0 {1,S}
-12 *3 H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {2,S}
-14    H u0 p0 c0 {2,S}
-15    H u0 p0 c0 {3,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {7,S}
-19    H u0 p0 c0 {8,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {10,S}
-
-C10H11-2
-multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
-2  *1 C u1 p0 c0 {4,S} {5,S} {6,S}
-3  *7 C u0 p0 c0 {1,S} {7,D} {14,S}
-4     C u0 p0 c0 {2,S} {8,D} {15,S}
-5     C u0 p0 c0 {2,S} {9,D} {16,S}
-6  *6 C u0 p0 c0 {2,S} {10,D} {17,S}
-7  *5 C u0 p0 c0 {3,D} {10,S} {21,S}
-8     C u0 p0 c0 {4,D} {9,S} {18,S}
-9     C u0 p0 c0 {5,D} {8,S} {19,S}
-10 *4 C u0 p0 c0 {6,D} {7,S} {20,S}
-11 *3 H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {1,S}
-13    H u0 p0 c0 {1,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {8,S}
-19    H u0 p0 c0 {9,S}
-20    H u0 p0 c0 {10,S}
-21    H u0 p0 c0 {7,S}
-
-C10H11-8
-multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
-2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
-3     C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
-4  *1 C u1 p0 c0 {1,S} {7,S} {8,S}
-5     C u0 p0 c0 {2,S} {7,D} {16,S}
-6     C u0 p0 c0 {3,S} {9,D} {17,S}
-7     C u0 p0 c0 {4,S} {5,D} {18,S}
-8     C u0 p0 c0 {4,S} {10,D} {19,S}
-9     C u0 p0 c0 {6,D} {10,S} {21,S}
-10    C u0 p0 c0 {8,D} {9,S} {20,S}
-11 *3 H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {2,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {3,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {7,S}
-19    H u0 p0 c0 {8,S}
-20    H u0 p0 c0 {10,S}
-21    H u0 p0 c0 {9,S}
-
-C10H11-12
-multiplicity 2
-1     C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
-2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
-3  *2 C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
-4  *1 C u1 p0 c0 {1,S} {3,S} {8,S}
-5     C u0 p0 c0 {1,S} {9,D} {16,S}
-6     C u0 p0 c0 {2,S} {7,D} {17,S}
-7     C u0 p0 c0 {3,S} {6,D} {18,S}
-8     C u0 p0 c0 {4,S} {10,D} {19,S}
-9     C u0 p0 c0 {5,D} {10,S} {20,S}
-10    C u0 p0 c0 {8,D} {9,S} {21,S}
-11    H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {2,S}
-14 *3 H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {3,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {7,S}
-19    H u0 p0 c0 {8,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {10,S}
-
-C7H7-2
-multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
-2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
-4     C u0 p0 c0 {1,S} {6,D} {11,S}
-5     C u0 p0 c0 {3,S} {7,D} {12,S}
-6     C u0 p0 c0 {4,D} {7,S} {14,S}
-7     C u0 p0 c0 {5,D} {6,S} {13,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {6,S}
-
-C10H11-9
-multiplicity 2
-1     C u0 p0 c0 {4,S} {5,S} {6,S} {11,S}
-2  *2 C u0 p0 c0 {4,S} {7,S} {12,S} {13,S}
-3     C u0 p0 c0 {4,S} {8,S} {14,S} {15,S}
-4  *1 C u1 p0 c0 {1,S} {2,S} {3,S}
-5     C u0 p0 c0 {1,S} {7,D} {16,S}
-6     C u0 p0 c0 {1,S} {9,D} {18,S}
-7     C u0 p0 c0 {2,S} {5,D} {17,S}
-8     C u0 p0 c0 {3,S} {10,D} {19,S}
-9     C u0 p0 c0 {6,D} {10,S} {20,S}
-10    C u0 p0 c0 {8,D} {9,S} {21,S}
-11    H u0 p0 c0 {1,S}
-12 *3 H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {2,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {3,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {7,S}
-18    H u0 p0 c0 {6,S}
-19    H u0 p0 c0 {8,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {10,S}
-
-C10H11-18
-multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
-2     C u0 p0 c0 {4,D} {5,S} {6,S}
-3  *5 C u0 p0 c0 {1,S} {7,D} {14,S}
-4     C u0 p0 c0 {2,D} {8,S} {16,S}
-5     C u0 p0 c0 {2,S} {9,D} {18,S}
-6     C u0 p0 c0 {2,S} {10,D} {19,S}
-7  *4 C u0 p0 c0 {3,D} {8,S} {17,S}
-8  *1 C u1 p0 c0 {4,S} {7,S} {15,S}
-9     C u0 p0 c0 {5,D} {10,S} {20,S}
-10    C u0 p0 c0 {6,D} {9,S} {21,S}
-11 *3 H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {1,S}
-13    H u0 p0 c0 {1,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {8,S}
-16    H u0 p0 c0 {4,S}
-17    H u0 p0 c0 {7,S}
-18    H u0 p0 c0 {5,S}
-19    H u0 p0 c0 {6,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {10,S}
-
-C7H7-3
-multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,D} {9,S}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,D} {5,S} {11,S}
-5     C u0 p0 c0 {3,D} {4,S} {12,S}
-6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
-7  *1 C u1 p0 c0 {6,D} {14,S}
+1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,D} {12,S}
+5     C u0 p0 c0 {2,S} {4,D} {13,S}
+6     C u0 p0 c0 {1,S} {7,D} {14,S}
+7     C u0 p0 c0 {6,D} {15,S} {16,S}
 8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
 
-C10H11-13
+C6H7-3
 multiplicity 2
-1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
-2  *2 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
-3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
-4  *1 C u1 p0 c0 {1,S} {8,S} {15,S}
-5     C u0 p0 c0 {2,S} {9,D} {16,S}
-6     C u0 p0 c0 {2,S} {10,D} {17,S}
-7     C u0 p0 c0 {3,S} {8,D} {18,S}
-8     C u0 p0 c0 {4,S} {7,D} {19,S}
-9     C u0 p0 c0 {5,D} {10,S} {20,S}
-10    C u0 p0 c0 {6,D} {9,S} {21,S}
-11    H u0 p0 c0 {1,S}
-12 *3 H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {3,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {5,S}
-17    H u0 p0 c0 {6,S}
-18    H u0 p0 c0 {7,S}
-19    H u0 p0 c0 {8,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {10,S}
+1  *2 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {2,S} {4,D}
+4     C u0 p0 c0 {3,D} {5,S} {12,S}
+5     C u0 p0 c0 {4,S} {6,D} {13,S}
+6  *1 C u1 p0 c0 {1,S} {5,D}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
 
 C5H5-2
 multiplicity 2
@@ -561,24 +479,29 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
-C7H9-20
+C10H11-18
 multiplicity 2
-1  *4 C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
-2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
-3     C u0 p0 c0 {2,S} {5,S} {7,D}
-4     C u0 p0 c0 {1,S} {5,D} {11,S}
-5     C u0 p0 c0 {3,S} {4,D} {12,S}
-6  *1 C u1 p0 c0 {1,S} {13,S} {14,S}
-7     C u0 p0 c0 {3,D} {15,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {6,S}
-15    H u0 p0 c0 {7,S}
-16    H u0 p0 c0 {7,S}
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2     C u0 p0 c0 {4,D} {5,S} {6,S}
+3  *5 C u0 p0 c0 {1,S} {7,D} {14,S}
+4     C u0 p0 c0 {2,D} {8,S} {16,S}
+5     C u0 p0 c0 {2,S} {9,D} {18,S}
+6     C u0 p0 c0 {2,S} {10,D} {19,S}
+7  *4 C u0 p0 c0 {3,D} {8,S} {17,S}
+8  *1 C u1 p0 c0 {4,S} {7,S} {15,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {6,D} {9,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {8,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
 C7H9-22
 multiplicity 2
@@ -676,69 +599,101 @@ multiplicity 2
 20    H u0 p0 c0 {9,S}
 21    H u0 p0 c0 {10,S}
 
-C6H7-3
+C10H11-13
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
-2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
-3     C u0 p0 c0 {1,S} {2,S} {4,D}
-4     C u0 p0 c0 {3,D} {5,S} {12,S}
-5     C u0 p0 c0 {4,S} {6,D} {13,S}
-6  *1 C u1 p0 c0 {1,S} {5,D}
-7  *3 H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2  *2 C u0 p0 c0 {1,S} {5,S} {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {7,S} {13,S} {14,S}
+4  *1 C u1 p0 c0 {1,S} {8,S} {15,S}
+5     C u0 p0 c0 {2,S} {9,D} {16,S}
+6     C u0 p0 c0 {2,S} {10,D} {17,S}
+7     C u0 p0 c0 {3,S} {8,D} {18,S}
+8     C u0 p0 c0 {4,S} {7,D} {19,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {6,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
-C6H7-2
+C10H11-12
 multiplicity 2
-1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {3,D} {4,S}
-3     C u0 p0 c0 {2,D} {5,S} {12,S}
-4     C u0 p0 c0 {2,S} {6,D} {13,S}
-5  *1 C u1 p0 c0 {3,S} {6,S} {11,S}
-6  *2 C u0 p0 c0 {4,D} {5,S} {10,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10 *3 H u0 p0 c0 {6,S}
-11    H u0 p0 c0 {5,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
+1     C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3  *2 C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {3,S} {8,S}
+5     C u0 p0 c0 {1,S} {9,D} {16,S}
+6     C u0 p0 c0 {2,S} {7,D} {17,S}
+7     C u0 p0 c0 {3,S} {6,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {5,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
-C6H7-5
+C10H11-15
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2  *2 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
-3     C u0 p0 c0 {1,S} {4,S} {5,D}
-4     C u0 p0 c0 {3,S} {6,D} {11,S}
-5     C u0 p0 c0 {3,D} {12,S} {13,S}
-6  *1 C u1 p0 c0 {2,S} {4,D}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13    H u0 p0 c0 {5,S}
+1  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+2     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+3  *2 C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+4  *5 C u0 p0 c0 {1,S} {3,S} {8,D}
+5  *1 C u1 p0 c0 {1,S} {9,S} {16,S}
+6     C u0 p0 c0 {2,S} {9,D} {17,S}
+7     C u0 p0 c0 {3,S} {10,D} {18,S}
+8     C u0 p0 c0 {4,D} {10,S} {19,S}
+9     C u0 p0 c0 {5,S} {6,D} {20,S}
+10    C u0 p0 c0 {7,D} {8,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
-C6H7-4
+C10H11-14
 multiplicity 2
-1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {3,S} {4,D}
-3  *1 C u1 p0 c0 {2,S} {6,S} {11,S}
-4     C u0 p0 c0 {2,D} {5,S} {12,S}
-5     C u0 p0 c0 {4,S} {6,D} {13,S}
-6  *2 C u0 p0 c0 {3,S} {5,D} {10,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10 *3 H u0 p0 c0 {6,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {13,S} {14,S}
+3  *2 C u0 p0 c0 {1,S} {6,S} {12,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {6,D} {16,S}
+6     C u0 p0 c0 {3,S} {5,D} {17,S}
+7     C u0 p0 c0 {4,S} {9,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {7,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
 
 C10H11-17
 multiplicity 2
@@ -764,59 +719,77 @@ multiplicity 2
 20    H u0 p0 c0 {10,S}
 21    H u0 p0 c0 {10,S}
 
-C6H7-6
+C10H11-16
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,S} {6,D}
-3  *1 C u1 p0 c0 {1,S} {5,S} {9,S}
-4     C u0 p0 c0 {2,S} {5,D} {11,S}
-5  *2 C u0 p0 c0 {3,S} {4,D} {10,S}
-6     C u0 p0 c0 {2,D} {12,S} {13,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {3,S}
-10 *3 H u0 p0 c0 {5,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {6,S}
-
-C7H9-6
-multiplicity 2
-1  *4 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2  *2 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
-3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
-4     C u0 p0 c0 {3,S} {6,D} {13,S}
-5     C u0 p0 c0 {3,S} {7,D} {14,S}
-6     C u0 p0 c0 {4,D} {7,S} {15,S}
-7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10 *3 H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
+1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3  *2 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4  *4 C u0 p0 c0 {1,S} {7,S} {8,D}
+5     C u0 p0 c0 {2,S} {6,D} {16,S}
+6     C u0 p0 c0 {3,S} {5,D} {17,S}
+7  *1 C u1 p0 c0 {4,S} {9,S} {18,S}
+8     C u0 p0 c0 {4,D} {10,S} {20,S}
+9     C u0 p0 c0 {7,S} {10,D} {19,S}
+10    C u0 p0 c0 {8,S} {9,D} {21,S}
+11    H u0 p0 c0 {1,S}
 12    H u0 p0 c0 {2,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {8,S}
+21    H u0 p0 c0 {10,S}
 
-C7H9-7
+C10H11-9
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
-2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
-4     C u0 p0 c0 {1,S} {6,D} {13,S}
-5     C u0 p0 c0 {1,S} {7,D} {14,S}
-6     C u0 p0 c0 {4,D} {7,S} {15,S}
-7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8  *3 H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
+1     C u0 p0 c0 {4,S} {5,S} {6,S} {11,S}
+2  *2 C u0 p0 c0 {4,S} {7,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {8,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {2,S} {3,S}
+5     C u0 p0 c0 {1,S} {7,D} {16,S}
+6     C u0 p0 c0 {1,S} {9,D} {18,S}
+7     C u0 p0 c0 {2,S} {5,D} {17,S}
+8     C u0 p0 c0 {3,S} {10,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {20,S}
+10    C u0 p0 c0 {8,D} {9,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {10,S}
+
+C10H11-8
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {11,S}
+2     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+3     C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
+4  *1 C u1 p0 c0 {1,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {7,D} {16,S}
+6     C u0 p0 c0 {3,S} {9,D} {17,S}
+7     C u0 p0 c0 {4,S} {5,D} {18,S}
+8     C u0 p0 c0 {4,S} {10,D} {19,S}
+9     C u0 p0 c0 {6,D} {10,S} {21,S}
+10    C u0 p0 c0 {8,D} {9,S} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {9,S}
 
 C7H9-4
 multiplicity 2
@@ -944,39 +917,53 @@ multiplicity 2
 13 *3 H u0 p0 c0 {6,S}
 14    H u0 p0 c0 {7,S}
 
-C7H7-6
+C10H11-3
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,D} {9,S}
-3     C u0 p0 c0 {1,S} {5,D} {10,S}
-4     C u0 p0 c0 {2,D} {5,S} {11,S}
-5     C u0 p0 c0 {3,D} {4,S} {12,S}
-6  *2 C u0 p0 c0 {7,D} {13,S} {14,S}
-7  *1 C u1 p0 c0 {1,S} {6,D}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {5,S}
-13 *3 H u0 p0 c0 {6,S}
-14    H u0 p0 c0 {6,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {5,D}
+3     C u0 p0 c0 {1,S} {6,D} {13,S}
+4     C u0 p0 c0 {2,S} {7,D} {14,S}
+5  *7 C u0 p0 c0 {2,D} {8,S} {16,S}
+6     C u0 p0 c0 {3,D} {7,S} {17,S}
+7     C u0 p0 c0 {4,D} {6,S} {15,S}
+8  *6 C u0 p0 c0 {5,S} {9,D} {18,S}
+9  *4 C u0 p0 c0 {8,D} {10,S} {19,S}
+10 *1 C u1 p0 c0 {9,S} {20,S} {21,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
 
-C7H7-7
+C10H11-2
 multiplicity 2
-1  *1 C u1 p0 c0 {2,S} {3,S} {6,S}
-2     C u0 p0 c0 {1,S} {4,D} {8,S}
-3     C u0 p0 c0 {1,S} {5,D} {9,S}
-4     C u0 p0 c0 {2,D} {5,S} {10,S}
-5     C u0 p0 c0 {3,D} {4,S} {11,S}
-6  *2 C u0 p0 c0 {1,S} {7,D} {12,S}
-7     C u0 p0 c0 {6,D} {13,S} {14,S}
-8     H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {4,S}
-11    H u0 p0 c0 {5,S}
-12 *3 H u0 p0 c0 {6,S}
-13    H u0 p0 c0 {7,S}
-14    H u0 p0 c0 {7,S}
+1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+2  *1 C u1 p0 c0 {4,S} {5,S} {6,S}
+3  *7 C u0 p0 c0 {1,S} {7,D} {14,S}
+4     C u0 p0 c0 {2,S} {8,D} {15,S}
+5     C u0 p0 c0 {2,S} {9,D} {16,S}
+6  *6 C u0 p0 c0 {2,S} {10,D} {17,S}
+7  *5 C u0 p0 c0 {3,D} {10,S} {21,S}
+8     C u0 p0 c0 {4,D} {9,S} {18,S}
+9     C u0 p0 c0 {5,D} {8,S} {19,S}
+10 *4 C u0 p0 c0 {6,D} {7,S} {20,S}
+11 *3 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {7,S}
 
 C10H11-5
 multiplicity 2
@@ -1002,42 +989,68 @@ multiplicity 2
 20    H u0 p0 c0 {10,S}
 21    H u0 p0 c0 {10,S}
 
-C10H11-4
+C6H7-5
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
-2  *6 C u0 p0 c0 {4,S} {5,S} {6,D}
-3  *7 C u0 p0 c0 {1,S} {7,D} {14,S}
-4  *1 C u1 p0 c0 {2,S} {8,S} {15,S}
-5     C u0 p0 c0 {2,S} {10,D} {17,S}
-6  *4 C u0 p0 c0 {2,D} {7,S} {19,S}
-7  *5 C u0 p0 c0 {3,D} {6,S} {21,S}
-8     C u0 p0 c0 {4,S} {9,D} {16,S}
-9     C u0 p0 c0 {8,D} {10,S} {20,S}
-10    C u0 p0 c0 {5,D} {9,S} {18,S}
-11 *3 H u0 p0 c0 {1,S}
-12    H u0 p0 c0 {1,S}
-13    H u0 p0 c0 {1,S}
-14    H u0 p0 c0 {3,S}
-15    H u0 p0 c0 {4,S}
-16    H u0 p0 c0 {8,S}
-17    H u0 p0 c0 {5,S}
-18    H u0 p0 c0 {10,S}
-19    H u0 p0 c0 {6,S}
-20    H u0 p0 c0 {9,S}
-21    H u0 p0 c0 {7,S}
+1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {4,S} {5,D}
+4     C u0 p0 c0 {3,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,D} {12,S} {13,S}
+6  *1 C u1 p0 c0 {2,S} {4,D}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
 
-C7H9-8
+C7H7-2
 multiplicity 2
-1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+1     C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {5,S}
+4     C u0 p0 c0 {1,S} {6,D} {11,S}
+5     C u0 p0 c0 {3,S} {7,D} {12,S}
+6     C u0 p0 c0 {4,D} {7,S} {14,S}
+7     C u0 p0 c0 {5,D} {6,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {6,S}
+
+C7H7-3
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2     C u0 p0 c0 {1,S} {4,D} {9,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4     C u0 p0 c0 {2,D} {5,S} {11,S}
+5     C u0 p0 c0 {3,D} {4,S} {12,S}
+6  *4 C u0 p0 c0 {1,S} {7,D} {13,S}
+7  *1 C u1 p0 c0 {6,D} {14,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H9-6
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
 3  *1 C u1 p0 c0 {1,S} {4,S} {5,S}
 4     C u0 p0 c0 {3,S} {6,D} {13,S}
 5     C u0 p0 c0 {3,S} {7,D} {14,S}
 6     C u0 p0 c0 {4,D} {7,S} {15,S}
 7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {2,S}
+10 *3 H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {2,S}
 13    H u0 p0 c0 {4,S}
@@ -1045,40 +1058,24 @@ multiplicity 2
 15    H u0 p0 c0 {6,S}
 16    H u0 p0 c0 {7,S}
 
-C7H9-9
+C7H9-20
 multiplicity 2
-1  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
-2     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {11,S}
-4     C u0 p0 c0 {1,S} {5,D} {12,S}
-5     C u0 p0 c0 {2,S} {4,D} {13,S}
-6     C u0 p0 c0 {1,S} {7,D} {14,S}
-7     C u0 p0 c0 {6,D} {15,S} {16,S}
-8  *3 H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {2,S}
+1  *4 C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3     C u0 p0 c0 {2,S} {5,S} {7,D}
+4     C u0 p0 c0 {1,S} {5,D} {11,S}
+5     C u0 p0 c0 {3,S} {4,D} {12,S}
+6  *1 C u1 p0 c0 {1,S} {13,S} {14,S}
+7     C u0 p0 c0 {3,D} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
 10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {3,S}
-12    H u0 p0 c0 {4,S}
-13    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
 14    H u0 p0 c0 {6,S}
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
-
-S1C4
-multiplicity 2
-1  *5 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
-2  *6 C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
-3  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
-4  *4 C u0 p0 c0 {2,S} {12,D} {13,S}
-5     H u0 p0 c0 {1,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {2,S}
-8     H u0 p0 c0 {2,S}
-9  *3 H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {3,S}
-12    O u0 p2 c0 {4,D}
-13 *1 O u1 p2 c0 {4,S}
 
 C10H11
 multiplicity 2
@@ -1121,21 +1118,40 @@ multiplicity 2
 13    H u0 p0 c0 {6,S}
 14    H u0 p0 c0 {7,S}
 
-C4H7O2b
+C6H7-2
 multiplicity 2
-1  *6 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
-2  *4 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
-3  *5 C u0 p0 c0 {1,S} {4,S} {10,D}
-4  *2 C u1 p0 c0 {3,S} {11,S} {12,S}
-5  *1 O u0 p2 c0 {2,S} {13,S}
-6     H u0 p0 c0 {1,S}
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,D} {4,S}
+3     C u0 p0 c0 {2,D} {5,S} {12,S}
+4     C u0 p0 c0 {2,S} {6,D} {13,S}
+5  *1 C u1 p0 c0 {3,S} {6,S} {11,S}
+6  *2 C u0 p0 c0 {4,D} {5,S} {10,S}
 7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+
+C7H9-7
+multiplicity 2
+1  *2 C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+2     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {1,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8  *3 H u0 p0 c0 {1,S}
 9     H u0 p0 c0 {2,S}
-10    O u0 p2 c0 {3,D}
-11    H u0 p0 c0 {4,S}
-12    H u0 p0 c0 {4,S}
-13 *3 H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 
 C2H3O3-2
 multiplicity 2
@@ -1147,25 +1163,6 @@ multiplicity 2
 6    H u0 p0 c0 {2,S}
 7    H u0 p0 c0 {2,S}
 8 *3 H u0 p0 c0 {4,S}
-
-C7H9
-multiplicity 2
-1     C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
-2  *2 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
-3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
-4     C u0 p0 c0 {1,S} {6,D} {13,S}
-5     C u0 p0 c0 {1,S} {7,D} {14,S}
-6     C u0 p0 c0 {4,D} {7,S} {15,S}
-7     C u0 p0 c0 {5,D} {6,S} {16,S}
-8     H u0 p0 c0 {1,S}
-9  *3 H u0 p0 c0 {2,S}
-10    H u0 p0 c0 {2,S}
-11    H u0 p0 c0 {2,S}
-12    H u0 p0 c0 {3,S}
-13    H u0 p0 c0 {4,S}
-14    H u0 p0 c0 {5,S}
-15    H u0 p0 c0 {6,S}
-16    H u0 p0 c0 {7,S}
 
 C6H7
 multiplicity 2
@@ -1182,6 +1179,22 @@ multiplicity 2
 11    H u0 p0 c0 {2,S}
 12    H u0 p0 c0 {4,S}
 13    H u0 p0 c0 {5,S}
+
+C4H7O2b
+multiplicity 2
+1  *6 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *4 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+3  *5 C u0 p0 c0 {1,S} {4,S} {10,D}
+4  *2 C u1 p0 c0 {3,S} {11,S} {12,S}
+5  *1 O u0 p2 c0 {2,S} {13,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    O u0 p2 c0 {3,D}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13 *3 H u0 p0 c0 {5,S}
 
 C7H7-8
 multiplicity 2
@@ -1223,4 +1236,23 @@ multiplicity 2
 19    H u0 p0 c0 {9,S}
 20    H u0 p0 c0 {10,S}
 21    H u0 p0 c0 {7,S}
+
+C7H9
+multiplicity 2
+1     C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+2  *2 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+3  *1 C u1 p0 c0 {1,S} {2,S} {12,S}
+4     C u0 p0 c0 {1,S} {6,D} {13,S}
+5     C u0 p0 c0 {1,S} {7,D} {14,S}
+6     C u0 p0 c0 {4,D} {7,S} {15,S}
+7     C u0 p0 c0 {5,D} {6,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
 

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -478,3 +478,18 @@ Taken from entry: pdt58 <=> pdt20
 """,
 )
 
+
+
+entry(
+    index = 33,
+    label = "C6H7-7 <=> C6H7-8",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(0.00218, 's^-1'), n=4.91, Ea=(40.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    longDesc = 
+u"""
+Taken from entry: C5H4CH3 <=> C5H5CH2-1
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -305,3 +305,57 @@ Taken from entry: vinylCPDyl <=> product41
 """,
 )
 
+
+
+entry(
+    index = 20,
+    label = "C5H5 <=> C5H5-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.15e+10, 's^-1'), n=0.98, Ea=(26.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_24 <=> CPDyl
+""",
+)
+
+entry(
+    index = 21,
+    label = "C6H7 <=> C6H7-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.71e+10, 's^-1'), n=1.01, Ea=(27.8, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_26 <=> meCPDyl
+""",
+)
+
+entry(
+    index = 22,
+    label = "C6H7-3 <=> C6H7-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.8e+10, 's^-1'), n=1.01, Ea=(28.2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_28 <=> meCPDyl
+""",
+)
+
+entry(
+    index = 23,
+    label = "C6H7-5 <=> C6H7-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.24e+09, 's^-1'), n=1.12, Ea=(39.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C3""",
+    longDesc = 
+u"""
+Taken from entry: prod_30 <=> prod_33
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -359,3 +359,122 @@ Taken from entry: prod_30 <=> prod_33
 """,
 )
 
+
+
+entry(
+    index = 24,
+    label = "C10H11 <=> C10H11-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(0.107, 's^-1'), n=3.67, Ea=(29.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt14 <=> pdt20
+""",
+)
+
+entry(
+    index = 25,
+    label = "C10H11-3 <=> C10H11-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(250000, 's^-1'), n=1.95, Ea=(24, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt18 <=> pdt25
+""",
+)
+
+entry(
+    index = 26,
+    label = "C10H11-5 <=> C10H11-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.59e+08, 's^-1'), n=1.01, Ea=(26.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt16 <=> pdt20
+""",
+)
+
+entry(
+    index = 27,
+    label = "C10H11-7 <=> C10H11-8",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.67e+09, 's^-1'), n=1.14, Ea=(22.4, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt28 <=> pdt29
+""",
+)
+
+entry(
+    index = 28,
+    label = "C10H11-9 <=> C10H11-10",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.46e+07, 's^-1'), n=1.66, Ea=(31.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt28 <=> pdt23
+""",
+)
+
+entry(
+    index = 29,
+    label = "C10H11-11 <=> C10H11-12",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.83e+08, 's^-1'), n=1.45, Ea=(31.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt10bis <=> pdt37
+""",
+)
+
+entry(
+    index = 30,
+    label = "C10H11-13 <=> C10H11-14",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.36e+06, 's^-1'), n=1.7, Ea=(31.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: adductd <=> pdt55
+""",
+)
+
+entry(
+    index = 31,
+    label = "C10H11-15 <=> C10H11-16",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.78e+06, 's^-1'), n=1.75, Ea=(25.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt15 <=> pdt55
+""",
+)
+
+entry(
+    index = 32,
+    label = "C10H11-17 <=> C10H11-18",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.04e+07, 's^-1'), n=1.61, Ea=(27.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: C10H11""",
+    longDesc = 
+u"""
+Taken from entry: pdt58 <=> pdt20
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -109,3 +109,199 @@ u"""
 Quantum chemistry calculations at the M08SO/MG3S* level using Qchem. High-pressure-limit rate coefficient computed using Cantherm with 1D hindered rotor treatment for all relevant rotors. (*A computational grid with 75 radial points and 434 angular points per radial point was used in the calculations for all species)
 """,
 )
+
+entry(
+    index = 5,
+    label = "C7H9 <=> C7H9-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.97e+06, 's^-1'), n=1.8, Ea=(37.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addA <=> addB
+""",
+)
+
+entry(
+    index = 6,
+    label = "C7H9-3 <=> C7H9-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.81e+07, 's^-1'), n=1.72, Ea=(44.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addC <=> addD
+""",
+)
+
+entry(
+    index = 7,
+    label = "C7H9-5 <=> C7H9-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.37e+06, 's^-1'), n=1.6, Ea=(25.1, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addB <=> product7
+""",
+)
+
+entry(
+    index = 8,
+    label = "C7H9-7 <=> C7H9-8",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.88e+09, 's^-1'), n=1, Ea=(21.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addA <=> product7
+""",
+)
+
+entry(
+    index = 9,
+    label = "C7H9-9 <=> C7H9-10",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.36e+08, 's^-1'), n=1.39, Ea=(24.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: addD <=> product10
+""",
+)
+
+entry(
+    index = 10,
+    label = "C7H9-11 <=> C7H9-12",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.11e+09, 's^-1'), n=1.34, Ea=(47.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product4 <=> product9
+""",
+)
+
+entry(
+    index = 11,
+    label = "C7H9-13 <=> C7H9-14",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.03e+06, 's^-1'), n=1.96, Ea=(50.8, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product2 <=> product5
+""",
+)
+
+entry(
+    index = 12,
+    label = "C7H9-15 <=> C7H9-16",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(367000, 's^-1'), n=2.24, Ea=(34.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product17 <=> product6
+""",
+)
+
+entry(
+    index = 13,
+    label = "C7H9-17 <=> C7H9-18",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.9e+10, 's^-1'), n=0.87, Ea=(34.5, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product29 <=> product23
+""",
+)
+
+entry(
+    index = 14,
+    label = "C7H9-19 <=> C7H9-20",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(285000, 's^-1'), n=2.15, Ea=(43.9, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product31 <=> product35
+""",
+)
+
+entry(
+    index = 15,
+    label = "C7H9-21 <=> C7H9-22",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(671000, 's^-1'), n=2.07, Ea=(48.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product32 <=> product38
+""",
+)
+
+entry(
+    index = 16,
+    label = "C7H7 <=> C7H7-2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.41e+08, 's^-1'), n=1.52, Ea=(38.6, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product34 <=> product46
+""",
+)
+
+entry(
+    index = 17,
+    label = "C7H7-3 <=> C7H7-4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.08e+06, 's^-1'), n=1.99, Ea=(25.2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product44 <=> vinylCPDyl
+""",
+)
+
+entry(
+    index = 18,
+    label = "C7H7-5 <=> C7H7-6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.08e+06, 's^-1'), n=1.99, Ea=(25.2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: product44 <=> product41
+""",
+)
+
+entry(
+    index = 19,
+    label = "C7H7-7 <=> C7H7-8",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.08e+06, 's^-1'), n=1.99, Ea=(25.2, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    longDesc = 
+u"""
+Taken from entry: vinylCPDyl <=> product41
+""",
+)
+

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -195,14 +195,16 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-8.29,-7.302,-6.501,-5.499,-4.58,-3.778,-2.608],'cal/(mol*K)'),
-        H298 = (17.8,'kcal/mol'),
-        S298 = (53.75,'cal/(mol*K)'),
+        Cpdata = ([-6.51,-5.19333,-4.47333,-3.76,-3.44333,-2.94667,-2.47],'cal/(mol*K)','+|-',[2.72057,3.42407,4.84068,5.11681,5.13207,5.8757,8.29108]),
+        H298 = (33.1097,'kcal/mol','+|-',24.8344),
+        S298 = (53.2167,'cal/(mol*K)','+|-',9.77287),
     ),
-    shortDesc = u"""""",
+    shortDesc = u"""Fitted from thermo library values""",
     longDesc = 
 u"""
-
+Fitted from species product6 from vinylCPD_H library.
+Fitted from species product17 from vinylCPD_H library.
+Fitted from species product23 from vinylCPD_H library.
 """,
 )
 
@@ -252,14 +254,14 @@ entry(
     label = "bicyclo[3.2.1]octane",
     group = 
 """
-1 * Cs u0 {2,S} {6,S} {8,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {4,S} {6,S} {7,S}
-6   Cs u0 {1,S} {5,S}
-7   Cs u0 {5,S} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {3,S} {5,S} {6,S}
+2   Cs u0 {3,S} {4,S} {7,S}
+3   Cs u0 {1,S} {2,S}
+4   Cs u0 {2,S} {5,S}
+5   Cs u0 {1,S} {4,S}
+6   Cs u0 {1,S} {8,S}
+7   Cs u0 {2,S} {8,S}
+8   Cs u0 {6,S} {7,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -308,14 +310,14 @@ entry(
     label = "bicyclo[3.2.1]octene",
     group = 
 """
-1 * Cs u0 {2,S} {6,S} {8,S}
-2   C  u0 {1,S} {3,D}
-3   C  u0 {2,D} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {4,S} {6,S} {7,S}
-6   Cs u0 {1,S} {5,S}
-7   Cs u0 {5,S} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {3,S} {5,S} {6,S}
+2   Cs u0 {3,S} {4,S} {7,S}
+3   Cs u0 {1,S} {2,S}
+4   Cs u0 {2,S} {5,S}
+5   Cs u0 {1,S} {4,S}
+6   C  u0 {1,S} {8,D}
+7   Cs u0 {2,S} {8,S}
+8   C  u0 {6,D} {7,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -347,15 +349,15 @@ entry(
     label = "indane",
     group = 
 """
-1 * Cs u0 {2,S} {3,S}
-2   Cs u0 {1,S} {4,S}
-3   Cs u0 {1,S} {5,S}
-4   C  u0 {2,S} {5,B} {6,B}
-5   C  u0 {3,S} {4,B} {7,B}
-6   C  u0 {4,B} {8,B}
-7   C  u0 {5,B} {9,B}
-8   C  u0 {6,B} {9,B}
-9   C  u0 {7,B} {8,B}
+1   C  u0 {2,B} {3,S} {5,B}
+2   C  u0 {1,B} {4,S} {6,B}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   C  u0 {1,B} {8,B}
+6   C  u0 {2,B} {9,B}
+7 * Cs u0 {3,S} {4,S}
+8   C  u0 {5,B} {9,B}
+9   C  u0 {6,B} {8,B}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -375,26 +377,26 @@ entry(
     label = "indene",
     group = 
 """
-1 * Cs u0 {2,S} {4,S}
-2   C  u0 {1,S} {3,B} {5,B}
-3   C  u0 {2,B} {6,S} {7,B}
-4   C  u0 {1,S} {6,D}
-5   C  u0 {2,B} {8,B}
-6   C  u0 {3,S} {4,D}
-7   C  u0 {3,B} {9,B}
-8   C  u0 {5,B} {9,B}
-9   C  u0 {7,B} {8,B}
+1   C  u0 {2,B} {3,S} {4,B}
+2   C  u0 {1,B} {5,S} {6,B}
+3 * Cs u0 {1,S} {7,S}
+4   C  u0 {1,B} {8,B}
+5   C  u0 {2,S} {7,D}
+6   C  u0 {2,B} {9,B}
+7   C  u0 {3,S} {5,D}
+8   C  u0 {4,B} {9,B}
+9   C  u0 {6,B} {8,B}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-3.88,-4.29,-3.89,-2.96,-1.83,-2.2,-1.31],'cal/(mol*K)'),
-        H298 = (2.1,'kcal/mol'),
-        S298 = (33.08,'cal/(mol*K)'),
+        Cpdata = ([-3.07,-2.67,-2.42,-2.22,-2.2,-2.23,-2.04],'cal/(mol*K)'),
+        H298 = (5.01,'kcal/mol'),
+        S298 = (32.84,'cal/(mol*K)'),
     ),
-    shortDesc = u"""""",
+    shortDesc = u"""Fitted from thermo library values""",
     longDesc = 
 u"""
-
+Fitted from species INDENE from C10H11 library.
 """,
 )
 
@@ -405,13 +407,13 @@ entry(
 """
 1 * Cs u0 {2,S} {3,S} {4,S}
 2   Cs u0 {1,S} {5,S} {6,S}
-3   Cs u0 {1,S} {9,S}
-4   Cs u0 {1,S} {7,S}
-5   Cs u0 {2,S} {8,S}
-6   Cs u0 {2,S} {9,S}
-7   Cs u0 {4,S} {8,S}
-8   Cs u0 {5,S} {7,S}
-9   Cs u0 {3,S} {6,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {1,S} {8,S}
+5   Cs u0 {2,S} {9,S}
+6   Cs u0 {2,S} {7,S}
+7   Cs u0 {3,S} {6,S}
+8   Cs u0 {4,S} {9,S}
+9   Cs u0 {5,S} {8,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -501,15 +503,15 @@ entry(
     label = "2.3.3a.4.5.6-hexahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {9,S}
-2   Cd u0 {1,S} {3,D} {7,S}
-3   Cd u0 {2,D} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cs u0 {2,S} {6,S} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1   Cd u0 {2,S} {3,S} {4,D}
+2   Cs u0 {1,S} {5,S} {6,S}
+3 * Cs u0 {1,S} {7,S}
+4   Cd u0 {1,D} {8,S}
+5   Cs u0 {2,S} {9,S}
+6   Cs u0 {2,S} {7,S}
+7   Cs u0 {3,S} {6,S}
+8   Cs u0 {4,S} {9,S}
+9   Cs u0 {5,S} {8,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -529,15 +531,15 @@ entry(
     label = "2.4.5.6.7.7a-hexahydro-1H-indene",
     group = 
 """
-1 * Cd u0 {2,D} {5,S} {9,S}
-2   Cd u0 {1,D} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1 * Cd u0 {2,S} {3,D} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cd u0 {1,D} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cs u0 {1,S} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cs u0 {5,S} {9,S}
+9   Cs u0 {6,S} {8,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -557,15 +559,15 @@ entry(
     label = "2.3.3a.4.5.7a-hexahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {9,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S} {6,S}
-6   Cd u0 {5,S} {7,D}
-7   Cd u0 {6,D} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1 * Cs u0 {2,S} {3,S} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cd u0 {2,S} {8,D}
+6   Cs u0 {1,S} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,D} {9,S}
+9   Cs u0 {6,S} {8,S}
 """,
     thermo = u'2.4.5.6.7.7a-hexahydro-1H-indene',
     shortDesc = u"""""",
@@ -580,15 +582,15 @@ entry(
     label = "2.3.3a.4.7.7a-hexahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {9,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cd u0 {6,S} {8,D}
-8   Cd u0 {7,D} {9,S}
-9   Cs u0 {1,S} {8,S}
+1 * Cs u0 {2,S} {3,S} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cs u0 {1,S} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,S} {9,D}
+9   Cd u0 {6,S} {8,D}
 """,
     thermo = u'2.4.5.6.7.7a-hexahydro-1H-indene',
     shortDesc = u"""""",
@@ -603,15 +605,15 @@ entry(
     label = "2.3.4.5.6.7-hexahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {9,S}
-2   Cd u0 {1,S} {3,S} {7,D}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cd u0 {2,D} {6,S} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1   Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D} {5,S} {6,S}
+3 * Cs u0 {1,S} {7,S}
+4   Cs u0 {1,S} {8,S}
+5   Cs u0 {2,S} {9,S}
+6   Cs u0 {2,S} {7,S}
+7   Cs u0 {3,S} {6,S}
+8   Cs u0 {4,S} {9,S}
+9   Cs u0 {5,S} {8,S}
 """,
     thermo = u'2.4.5.6.7.7a-hexahydro-1H-indene',
     shortDesc = u"""""",
@@ -626,15 +628,15 @@ entry(
     label = "3a.4.5.6.7.7a-hexahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {9,S}
-2   Cs u0 {1,S} {3,S} {7,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cs u0 {2,S} {6,S} {8,S}
-8   Cd u0 {7,S} {9,D}
-9   Cd u0 {1,S} {8,D}
+1   Cs u0 {2,S} {3,S} {4,S}
+2   Cs u0 {1,S} {5,S} {6,S}
+3 * Cs u0 {1,S} {7,S}
+4   Cs u0 {1,S} {8,S}
+5   Cs u0 {2,S} {9,S}
+6   Cd u0 {2,S} {7,D}
+7   Cd u0 {3,S} {6,D}
+8   Cs u0 {4,S} {9,S}
+9   Cs u0 {5,S} {8,S}
 """,
     thermo = u'2.4.5.6.7.7a-hexahydro-1H-indene',
     shortDesc = u"""""",
@@ -661,15 +663,15 @@ entry(
     label = "2.3.3a.7a-tetrahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {9,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S} {6,S}
-6   Cd u0 {5,S} {7,D}
-7   Cd u0 {6,D} {8,S}
-8   Cd u0 {7,S} {9,D}
-9   Cd u0 {1,S} {8,D}
+1 * Cs u0 {2,S} {3,S} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cd u0 {2,S} {8,D}
+6   Cd u0 {1,S} {9,D}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,D} {9,S}
+9   Cd u0 {6,D} {8,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -689,15 +691,15 @@ entry(
     label = "C12CCCC1=CCC=C2",
     group = 
 """
-1 * Cs u0 {2,S} {9,S}
-2   Cd u0 {1,S} {3,D} {7,S}
-3   Cd u0 {2,D} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cd u0 {4,S} {6,D}
-6   Cd u0 {5,D} {7,S}
-7   Cs u0 {2,S} {6,S} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1   Cd u0 {2,S} {3,S} {4,D}
+2   Cs u0 {1,S} {5,S} {6,S}
+3 * Cs u0 {1,S} {7,S}
+4   Cd u0 {1,D} {8,S}
+5   Cd u0 {2,S} {9,D}
+6   Cs u0 {2,S} {7,S}
+7   Cs u0 {3,S} {6,S}
+8   Cs u0 {4,S} {9,S}
+9   Cd u0 {5,D} {8,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -717,15 +719,15 @@ entry(
     label = "2.3.4.5-tetrahydro-1H-indene",
     group = 
 """
-1 * Cd u0 {2,S} {5,D} {9,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cd u0 {1,D} {4,S} {6,S}
-6   Cd u0 {5,S} {7,D}
-7   Cd u0 {6,D} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1 * Cd u0 {2,D} {3,S} {6,S}
+2   Cd u0 {1,D} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cd u0 {2,S} {8,D}
+6   Cs u0 {1,S} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,D} {9,S}
+9   Cs u0 {6,S} {8,S}
 """,
     thermo = u'2.3.3a.7a-tetrahydro-1H-indene',
     shortDesc = u"""""",
@@ -740,15 +742,15 @@ entry(
     label = "2.3.4.7-tetrahydro-1H-indene",
     group = 
 """
-1 * Cd u0 {2,S} {5,D} {9,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cd u0 {1,D} {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cd u0 {6,S} {8,D}
-8   Cd u0 {7,D} {9,S}
-9   Cs u0 {1,S} {8,S}
+1 * Cd u0 {2,D} {3,S} {6,S}
+2   Cd u0 {1,D} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cs u0 {1,S} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,S} {9,D}
+9   Cd u0 {6,S} {8,D}
 """,
     thermo = u'2.3.3a.7a-tetrahydro-1H-indene',
     shortDesc = u"""""",
@@ -763,15 +765,15 @@ entry(
     label = "2.3.3a.4-tetrahydro-1H-indene",
     group = 
 """
-1 * Cd u0 {2,S} {5,S} {9,D}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cd u0 {6,S} {8,D}
-8   Cd u0 {7,D} {9,S}
-9   Cd u0 {1,D} {8,S}
+1 * Cd u0 {2,S} {3,S} {6,D}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cd u0 {1,D} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,S} {9,D}
+9   Cd u0 {6,S} {8,D}
 """,
     thermo = u'2.3.3a.7a-tetrahydro-1H-indene',
     shortDesc = u"""""",
@@ -786,15 +788,15 @@ entry(
     label = "2.3.5.6-tetrahydro-1H-indene",
     group = 
 """
-1 * Cd u0 {2,S} {5,S} {9,D}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cd u0 {1,S} {4,S} {6,D}
-6   Cd u0 {5,D} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cd u0 {1,D} {8,S}
+1 * Cd u0 {2,S} {3,S} {6,D}
+2   Cd u0 {1,S} {4,S} {5,D}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cd u0 {2,D} {8,S}
+6   Cd u0 {1,D} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cs u0 {5,S} {9,S}
+9   Cs u0 {6,S} {8,S}
 """,
     thermo = u'2.3.3a.7a-tetrahydro-1H-indene',
     shortDesc = u"""""",
@@ -809,15 +811,15 @@ entry(
     label = "2.6.7.7a-tetrahydro-1H-indene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {9,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cd u0 {3,S} {5,D}
-5   Cd u0 {1,S} {4,D} {6,S}
-6   Cd u0 {5,S} {7,D}
-7   Cd u0 {6,D} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {1,S} {8,S}
+1 * Cs u0 {2,S} {3,S} {6,S}
+2   Cd u0 {1,S} {4,D} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cd u0 {2,D} {7,S}
+5   Cd u0 {2,S} {8,D}
+6   Cs u0 {1,S} {9,S}
+7   Cs u0 {3,S} {4,S}
+8   Cd u0 {5,D} {9,S}
+9   Cs u0 {6,S} {8,S}
 """,
     thermo = u'2.3.3a.7a-tetrahydro-1H-indene',
     shortDesc = u"""""",
@@ -844,14 +846,14 @@ entry(
     label = "octahydropentalene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {8,S}
-2   Cs u0 {1,S} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S} {6,S}
-6   Cs u0 {5,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {2,S} {3,S} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cs u0 {1,S} {8,S}
+7   Cs u0 {3,S} {4,S}
+8   Cs u0 {5,S} {6,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -999,14 +1001,14 @@ entry(
     label = "1.2.3.3a.4.6a-hexahydropentalene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {8,S}
-2   Cs u0 {1,S} {3,S} {6,S}
-3   Cs u0 {2,S} {4,S}
-4   Cd u0 {3,S} {5,D}
-5   Cd u0 {1,S} {4,D}
-6   Cs u0 {2,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {2,S} {4,S} {6,S}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cs u0 {2,S} {7,S}
+4   Cd u0 {1,S} {7,D}
+5   Cs u0 {2,S} {8,S}
+6   Cs u0 {1,S} {8,S}
+7   Cd u0 {3,S} {4,D}
+8   Cs u0 {5,S} {6,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1026,14 +1028,14 @@ entry(
     label = "1.2.3.3a.4.5-hexahydropentalene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {8,S}
-2   Cd u0 {1,S} {3,D} {6,S}
-3   Cd u0 {2,D} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S}
-6   Cs u0 {2,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {2,S} {4,S} {6,S}
+2   Cd u0 {1,S} {3,D} {5,S}
+3   Cd u0 {2,D} {7,S}
+4   Cs u0 {1,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cs u0 {1,S} {8,S}
+7   Cs u0 {3,S} {4,S}
+8   Cs u0 {5,S} {6,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1065,14 +1067,14 @@ entry(
     label = "1.3a.4.6a-tetrahydropentalene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {8,S}
-2   Cs u0 {1,S} {3,S} {6,S}
-3   Cd u0 {2,S} {4,D}
-4   Cd u0 {3,D} {5,S}
-5   Cs u0 {1,S} {4,S}
-6   Cs u0 {2,S} {7,S}
-7   Cd u0 {6,S} {8,D}
-8   Cd u0 {1,S} {7,D}
+1 * Cs u0 {2,S} {4,S} {6,S}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cd u0 {2,S} {7,D}
+4   Cs u0 {1,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cd u0 {1,S} {8,D}
+7   Cd u0 {3,D} {4,S}
+8   Cd u0 {5,S} {6,D}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1092,14 +1094,14 @@ entry(
     label = "1.3a.6.6a-tetrahydropentalene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {8,S}
-2   Cs u0 {1,S} {3,S} {6,S}
-3   Cd u0 {2,S} {4,D}
-4   Cd u0 {3,D} {5,S}
-5   Cs u0 {1,S} {4,S}
-6   Cd u0 {2,S} {7,D}
-7   Cd u0 {6,D} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {2,S} {4,S} {6,S}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cd u0 {2,S} {7,D}
+4   Cs u0 {1,S} {7,S}
+5   Cd u0 {2,S} {8,D}
+6   Cs u0 {1,S} {8,S}
+7   Cd u0 {3,D} {4,S}
+8   Cd u0 {5,D} {6,S}
 """,
     thermo = u'C12CCC=C1CC=C2',
     shortDesc = u"""""",
@@ -1114,14 +1116,14 @@ entry(
     label = "1.2.6.6a-tetrahydropentalene",
     group = 
 """
-1 * Cs u0 {2,S} {5,S} {8,S}
-2   Cd u0 {1,S} {3,S} {6,D}
-3   Cd u0 {2,S} {4,D}
-4   Cd u0 {3,D} {5,S}
-5   Cs u0 {1,S} {4,S}
-6   Cd u0 {2,D} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {1,S} {7,S}
+1 * Cs u0 {2,S} {4,S} {6,S}
+2   Cd u0 {1,S} {3,S} {5,D}
+3   Cd u0 {2,S} {7,D}
+4   Cs u0 {1,S} {7,S}
+5   Cd u0 {2,D} {8,S}
+6   Cs u0 {1,S} {8,S}
+7   Cd u0 {3,D} {4,S}
+8   Cs u0 {5,S} {6,S}
 """,
     thermo = u'C12CCC=C1CC=C2',
     shortDesc = u"""""",
@@ -1136,14 +1138,14 @@ entry(
     label = "C12CCC=C1CC=C2",
     group = 
 """
-1 * Cd u0 {2,S} {5,S} {8,D}
-2   Cs u0 {1,S} {3,S} {6,S}
-3   Cd u0 {2,S} {4,D}
-4   Cd u0 {3,D} {5,S}
-5   Cs u0 {1,S} {4,S}
-6   Cs u0 {2,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cd u0 {1,D} {7,S}
+1 * Cd u0 {2,S} {4,S} {6,D}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cd u0 {2,S} {7,D}
+4   Cs u0 {1,S} {7,S}
+5   Cs u0 {2,S} {8,S}
+6   Cd u0 {1,D} {8,S}
+7   Cd u0 {3,D} {4,S}
+8   Cs u0 {5,S} {6,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1343,10 +1345,10 @@ entry(
 2   Cs u0 {1,S} {3,S} {4,S}
 3   Cs u0 {1,S} {2,S}
 4   Cs u0 {2,S} {6,S}
-5   Cs u0 {1,S} {8,S}
-6   Cs u0 {4,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {5,S} {7,S}
+5   Cs u0 {1,S} {7,S}
+6   Cs u0 {4,S} {8,S}
+7   Cs u0 {5,S} {8,S}
+8   Cs u0 {6,S} {7,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1370,11 +1372,11 @@ entry(
 2   Cs u0 {1,S} {3,S} {4,S}
 3   Cs u0 {1,S} {2,S}
 4   Cs u0 {2,S} {6,S}
-5   Cs u0 {1,S} {9,S}
-6   Cs u0 {4,S} {7,S}
-7   Cs u0 {6,S} {8,S}
-8   Cs u0 {7,S} {9,S}
-9   Cs u0 {5,S} {8,S}
+5   Cs u0 {1,S} {7,S}
+6   Cs u0 {4,S} {8,S}
+7   Cs u0 {5,S} {9,S}
+8   Cs u0 {6,S} {9,S}
+9   Cs u0 {7,S} {8,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1630,14 +1632,14 @@ entry(
     label = "methylidenebicyclo[2.2.1]heptane",
     group = 
 """
-1 * Cs u0 {3,S} {4,S} {7,S}
-2   Cs u0 {3,S} {5,S} {6,S}
-3   Cs u0 {1,S} {2,S}
-4   Cs u0 {1,S} {5,S}
-5   Cs u0 {2,S} {4,S}
-6   Cs u0 {2,S} {7,S}
-7   Cd u0 {1,S} {6,S} {8,D}
-8   Cd u0 {7,D}
+1 * Cs u0 {3,S} {4,S} {6,S}
+2   Cs u0 {4,S} {5,S} {7,S}
+3   Cd u0 {1,S} {5,S} {8,D}
+4   Cs u0 {1,S} {2,S}
+5   Cs u0 {2,S} {3,S}
+6   Cs u0 {1,S} {7,S}
+7   Cs u0 {2,S} {6,S}
+8   Cd u0 {3,D}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1682,12 +1684,12 @@ entry(
     label = "bicyclo[2.2.0]hex-1(4)-ene",
     group = 
 """
-1 * Cs u0 {2,S} {6,S}
-2   Cs u0 {1,S} {5,S}
-3   Cs u0 {4,S} {6,S}
-4   Cs u0 {3,S} {5,S}
-5   C  u0 {2,S} {4,S} {6,D}
-6   C  u0 {1,S} {3,S} {5,D}
+1   C  u0 {2,D} {4,S} {6,S}
+2   C  u0 {1,D} {3,S} {5,S}
+3 * Cs u0 {2,S} {4,S}
+4   Cs u0 {1,S} {3,S}
+5   Cs u0 {2,S} {6,S}
+6   Cs u0 {1,S} {5,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1707,11 +1709,11 @@ entry(
     label = "bicyclo[2.1.0]pent-1(4)-ene",
     group = 
 """
-1 * C u0 {2,S} {5,S}
-2   C u0 {1,S} {4,S}
-3   C u0 {4,S} {5,S}
-4   C u0 {2,S} {3,S} {5,D}
-5   C u0 {1,S} {3,S} {4,D}
+1   C u0 {2,D} {3,S} {5,S}
+2   C u0 {1,D} {3,S} {4,S}
+3   C u0 {1,S} {2,S}
+4 * C u0 {2,S} {5,S}
+5   C u0 {1,S} {4,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1755,16 +1757,16 @@ entry(
     label = "tricyclo[4.4.0.0(3.9)]decane",
     group = 
 """
-1  * Cs u0 {2,S} {6,S} {10,S}
-2    Cs u0 {1,S} {3,S}
-3    Cs u0 {2,S} {4,S} {9,S}
-4    Cs u0 {3,S} {5,S}
-5    Cs u0 {4,S} {6,S}
-6    Cs u0 {1,S} {5,S} {7,S}
-7    Cs u0 {6,S} {8,S}
-8    Cs u0 {7,S} {9,S}
-9    Cs u0 {3,S} {8,S} {10,S}
-10   Cs u0 {1,S} {9,S}
+1  * Cs u0 {4,S} {5,S} {6,S}
+2    Cs u0 {3,S} {5,S} {7,S}
+3    Cs u0 {2,S} {6,S} {10,S}
+4    Cs u0 {1,S} {8,S} {9,S}
+5    Cs u0 {1,S} {2,S}
+6    Cs u0 {1,S} {3,S}
+7    Cs u0 {2,S} {8,S}
+8    Cs u0 {4,S} {7,S}
+9    Cs u0 {4,S} {10,S}
+10   Cs u0 {3,S} {9,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -1776,6 +1778,1433 @@ entry(
     longDesc = 
 u"""
 
+""",
+)
+
+entry(
+    index = 74,
+    label = "product1",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {5,S}
+2   Cs u0 {1,S} {3,S} {4,S}
+3   Cs u0 {1,S} {2,S}
+4   Cd u0 {2,S} {6,D}
+5   Cs u0 {1,S} {6,S}
+6 * Cd u0 {4,D} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-5.53,-5.88833,-6.0675,-5.87167,-5.755,-5.22583,-3.91833],'cal/(mol*K)','+|-',[13.695,15.6123,16.4506,15.9745,14.9052,13.0715,9.23303]),
+        H298 = (33.7772,'kcal/mol','+|-',4.36481),
+        S298 = (75.9204,'cal/(mol*K)','+|-',29.7929),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product1 from vinylCPD_H library.
+Fitted from species product19 from vinylCPD_H library.
+Fitted from species product19 from vinylCPD_H library.
+Fitted from species product36 from vinylCPD_H library.
+Fitted from species product39 from vinylCPD_H library.
+Fitted from species pdt24 from C10H11 library.
+Fitted from species pdt24 from C10H11 library.
+Fitted from species pdt57 from C10H11 library.
+Fitted from species biring1 from Fulvene_H library.
+Fitted from species prod1 from naphthalene_H library.
+Fitted from species prod3 from naphthalene_H library.
+Fitted from species prod3 from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 75,
+    label = "product3",
+    group = 
+"""
+1   Cs u0 {2,S} {4,S} {5,S}
+2   Cs u0 {1,S} {3,S} {6,S}
+3 * Cs u0 {2,S} {4,S}
+4   Cs u0 {1,S} {3,S}
+5   Cs u0 {1,S} {7,S}
+6   Cd u0 {2,S} {7,D}
+7   Cd u0 {5,S} {6,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.49,-5.912,-5.48,-4.912,-4.61,-4.122,-3.47],'cal/(mol*K)','+|-',[11.276,13.3805,14.1663,13.3764,12.968,11.469,9.42729]),
+        H298 = (37.631,'kcal/mol','+|-',6.50583),
+        S298 = (71.26,'cal/(mol*K)','+|-',32.7404),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product3 from vinylCPD_H library.
+Fitted from species product8 from vinylCPD_H library.
+Fitted from species product25 from vinylCPD_H library.
+Fitted from species pdt7 from C10H11 library.
+Fitted from species pdt7 from C10H11 library.
+""",
+)
+
+entry(
+    index = 76,
+    label = "product23",
+    group = 
+"""
+1 * Cd u0 {3,S} {4,S} {6,D}
+2   Cs u0 {3,S} {5,S} {7,S}
+3   Cs u0 {1,S} {2,S}
+4   Cs u0 {1,S} {5,S}
+5   Cs u0 {2,S} {4,S}
+6   Cd u0 {1,D} {7,S}
+7   Cs u0 {2,S} {6,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.785,-6.005,-5.34,-4.815,-4.35,-3.915,-3.05],'cal/(mol*K)','+|-',[8.69809,7.63302,6.62712,5.8579,4.61531,3.60941,2.13015]),
+        H298 = (71.868,'kcal/mol','+|-',63.5123),
+        S298 = (58.32,'cal/(mol*K)','+|-',1.69706),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product23 from vinylCPD_H library.
+Fitted from species product29 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 77,
+    label = "product25",
+    group = 
+"""
+1 * Cd u0 {2,S} {4,S} {6,D}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cs u0 {2,S} {4,S}
+4   Cs u0 {1,S} {3,S}
+5   Cs u0 {2,S} {7,S}
+6   Cd u0 {1,D} {7,S}
+7   Cs u0 {5,S} {6,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.32,-5.85,-5.4,-4.81,-4.34,-3.92,-3.03],'cal/(mol*K)'),
+        H298 = (45.173,'kcal/mol'),
+        S298 = (60.95,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product25 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 78,
+    label = "product29",
+    group = 
+"""
+1 * Cd u0 {3,D} {5,S} {7,S}
+2   Cs u0 {3,S} {4,S} {6,S}
+3   Cd u0 {1,D} {2,S}
+4   Cs u0 {2,S} {7,S}
+5   Cs u0 {1,S} {6,S}
+6   Cs u0 {2,S} {5,S}
+7   Cs u0 {1,S} {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.05,-5.36,-4.88,-4.32,-3.96,-3.61,-2.87],'cal/(mol*K)'),
+        H298 = (94.073,'kcal/mol'),
+        S298 = (58.92,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product29 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 79,
+    label = "product34",
+    group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cs u0 {1,S} {2,S}
+4   Cd u0 {1,S} {6,D}
+5   Cd u0 {2,S} {7,D}
+6   Cd u0 {4,D} {7,S}
+7   Cd u0 {5,D} {6,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.38,-4.49,-4.61,-4.23,-4.095,-3.75,-3.51],'cal/(mol*K)','+|-',[1.89346,4.02361,4.97034,5.32536,5.73956,5.79873,8.8756]),
+        H298 = (41.913,'kcal/mol','+|-',20.8172),
+        S298 = (62.305,'cal/(mol*K)','+|-',13.2229),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product34 from vinylCPD_H library.
+Fitted from species product46 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 80,
+    label = "product36",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {5,S}
+2   Cs u0 {1,S} {3,S} {4,S}
+3   Cs u0 {1,S} {2,S}
+4 * Cs u0 {2,S} {6,S}
+5   Cs u0 {1,S} {6,S}
+6   Cd u0 {4,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.97,-4.68,-4.47,-4.27,-4.21,-3.94,-3.36],'cal/(mol*K)'),
+        H298 = (32.543,'kcal/mol'),
+        S298 = (65.1674,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product36 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 81,
+    label = "product42",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {4,S}
+2   Cs u0 {1,S} {3,S} {5,S}
+3 * Cd u0 {1,S} {2,S}
+4   Cs u0 {1,S} {6,S}
+5   Cd u0 {2,S} {6,D}
+6   Cd u0 {4,S} {5,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.48,-3.9,-3.81,-3.6,-3.7,-3.68,-3.44],'cal/(mol*K)'),
+        H298 = (47.323,'kcal/mol'),
+        S298 = (66.8874,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product42 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 82,
+    label = "product45",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3 * Cd u0 {1,S} {4,D}
+4   Cd u0 {2,S} {3,D}
+5   Cd u0 {2,S} {7,D}
+6   Cs u0 {1,S} {7,S}
+7   Cd u0 {5,D} {6,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-5.23,-4.36,-3.97,-3.6,-3.53,-3.44,-3.16],'cal/(mol*K)'),
+        H298 = (39.483,'kcal/mol'),
+        S298 = (62.16,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product45 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 83,
+    label = "product46",
+    group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Cs u0 {1,S} {3,S} {5,S}
+3   Cs u0 {1,S} {2,S}
+4   Cd u0 {1,D} {6,S}
+5   Cs u0 {2,S} {7,S}
+6   Cd u0 {4,S} {7,D}
+7   Cd u0 {5,S} {6,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-5.31,-5.83,-5.92,-5.53,-5.17,-4.71,-3.89],'cal/(mol*K)'),
+        H298 = (48.433,'kcal/mol'),
+        S298 = (65.9,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product46 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 84,
+    label = "product46-1",
+    group = 
+"""
+1 * Cd u0 {2,S} {3,S} {5,D}
+2   Cs u0 {1,S} {3,S} {4,S}
+3   Cs u0 {1,S} {2,S}
+4   Cd u0 {2,S} {7,D}
+5   Cd u0 {1,D} {6,S}
+6   Cs u0 {5,S} {7,S}
+7   Cd u0 {4,D} {6,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.82,-4.74,-4.65,-4.52,-4.39,-4.28,-4.42],'cal/(mol*K)'),
+        H298 = (53.563,'kcal/mol'),
+        S298 = (63.9,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species product46 from vinylCPD_H library.
+""",
+)
+
+entry(
+    index = 85,
+    label = "pdt8",
+    group = 
+"""
+1  * Cs u0 {2,S} {3,S} {4,S}
+2    Cs u0 {1,S} {5,S} {6,S}
+3    Cd u0 {1,S} {7,D}
+4    Cs u0 {1,S} {9,S}
+5    Cs u0 {2,S} {7,S}
+6    Cd u0 {2,S} {8,D}
+7    Cd u0 {3,D} {5,S}
+8    Cd u0 {6,D} {10,S}
+9    Cd u0 {4,S} {10,D}
+10   Cd u0 {8,S} {9,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.535,-6.635,-6.36,-5.495,-4.605,-3.68,-2.31],'cal/(mol*K)','+|-',[3.13605,3.13605,2.84019,2.426,1.71595,1.18341,0.473366]),
+        H298 = (13.728,'kcal/mol','+|-',10.9884),
+        S298 = (54.235,'cal/(mol*K)','+|-',0.296985),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt8 from C10H11 library.
+Fitted from species pdt23 from C10H11 library.
+""",
+)
+
+entry(
+    index = 86,
+    label = "pdt8-1",
+    group = 
+"""
+1    Cs u0 {2,S} {4,S} {6,S}
+2    Cs u0 {1,S} {3,S} {5,S}
+3  * Cs u0 {2,S} {7,S}
+4    Cd u0 {1,S} {7,D}
+5    Cd u0 {2,S} {8,D}
+6    Cd u0 {1,S} {9,D}
+7    Cd u0 {3,S} {4,D}
+8    Cd u0 {5,D} {10,S}
+9    Cd u0 {6,D} {10,S}
+10   Cs u0 {8,S} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.31,-5.81,-5.33,-4.69,-3.97,-3.35,-2.88],'cal/(mol*K)'),
+        H298 = (14.973,'kcal/mol'),
+        S298 = (52.13,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt8 from C10H11 library.
+""",
+)
+
+entry(
+    index = 87,
+    label = "pdt8-2",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {6,S}
+2  * Cs u0 {1,S} {4,S} {5,S}
+3    Cd u0 {1,S} {7,D}
+4    Cs u0 {2,S} {9,S}
+5    Cs u0 {2,S} {7,S}
+6    Cd u0 {1,S} {8,D}
+7    Cd u0 {3,D} {5,S}
+8    Cd u0 {6,D} {10,S}
+9    Cd u0 {4,S} {10,D}
+10   Cd u0 {8,S} {9,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.3425,-7.0575,-5.85,-4.7975,-3.47,-2.58,-1.35],'cal/(mol*K)','+|-',[4.00405,3.66182,6.7465,8.34184,9.49513,9.23012,7.85553]),
+        H298 = (6.758,'kcal/mol','+|-',29.8859),
+        S298 = (51.8325,'cal/(mol*K)','+|-',9.6992),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt8 from C10H11 library.
+Fitted from species pdt23 from C10H11 library.
+Fitted from species pdt28 from C10H11 library.
+Fitted from species pdt29 from C10H11 library.
+""",
+)
+
+entry(
+    index = 88,
+    label = "pdt10bis",
+    group = 
+"""
+1  * Cs u0 {2,S} {4,S} {6,S}
+2    Cs u0 {1,S} {3,S} {5,S}
+3    Cs u0 {2,S} {7,S}
+4    Cs u0 {1,S} {8,S}
+5    Cd u0 {2,S} {10,D}
+6    Cd u0 {1,S} {9,D}
+7    Cd u0 {3,S} {8,D}
+8    Cd u0 {4,S} {7,D}
+9    Cd u0 {6,D} {10,S}
+10   Cd u0 {5,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.455,-6.46,-6.15,-5.28,-4.38,-3.47,-2.41],'cal/(mol*K)','+|-',[0.532536,0.946731,1.53844,1.65678,1.53844,1.30176,2.24849]),
+        H298 = (3.073,'kcal/mol','+|-',13.7744),
+        S298 = (52.44,'cal/(mol*K)','+|-',1.21622),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt10bis from C10H11 library.
+Fitted from species pdt37 from C10H11 library.
+""",
+)
+
+entry(
+    index = 89,
+    label = "pdt10bis-1",
+    group = 
+"""
+1  * Cs u0 {2,S} {3,S} {4,S}
+2    Cs u0 {1,S} {5,S} {6,S}
+3    Cs u0 {1,S} {9,S}
+4    Cd u0 {1,S} {10,D}
+5    Cd u0 {2,S} {8,D}
+6    Cd u0 {2,S} {7,D}
+7    Cd u0 {6,D} {9,S}
+8    Cd u0 {5,D} {10,S}
+9    Cs u0 {3,S} {7,S}
+10   Cd u0 {4,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.91,-7.26,-6.54,-5.57,-4.35,-3.43,-2.07],'cal/(mol*K)'),
+        H298 = (7.733,'kcal/mol'),
+        S298 = (54.59,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt10bis from C10H11 library.
+""",
+)
+
+entry(
+    index = 90,
+    label = "pdt11",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {6,S}
+2    Cd u0 {1,S} {4,D} {5,S}
+3    Cd u0 {1,S} {8,D}
+4    Cd u0 {2,D} {7,S}
+5    Cd u0 {2,S} {10,D}
+6    Cs u0 {1,S} {9,S}
+7    Cd u0 {4,S} {9,D}
+8    Cd u0 {3,D} {10,S}
+9  * Cd u0 {6,S} {7,D}
+10   Cd u0 {5,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-10.475,-10.72,-10,-8.715,-6.555,-5.06,-3.055],'cal/(mol*K)','+|-',[6.21292,6.62712,5.79873,4.4378,1.71595,0.355024,3.13605]),
+        H298 = (1.5665,'kcal/mol','+|-',21.2797),
+        S298 = (58.74,'cal/(mol*K)','+|-',4.18607),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt11 from C10H11 library.
+Fitted from species prod4 from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 91,
+    label = "pdt17",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {4,S} {5,S}
+2  * Cs u0 {1,S} {8,S}
+3    Cs u0 {1,S} {9,S}
+4    Cs u0 {1,S} {7,S}
+5    Cd u0 {1,S} {6,D}
+6    Cd u0 {5,D} {10,S}
+7    Cd u0 {4,S} {8,D}
+8    Cd u0 {2,S} {7,D}
+9    Cd u0 {3,S} {10,D}
+10   Cd u0 {6,S} {9,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.34,-6.73,-6.55,-6.13,-5.34,-4.43,-2.23],'cal/(mol*K)'),
+        H298 = (14.573,'kcal/mol'),
+        S298 = (57.37,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt17 from C10H11 library.
+""",
+)
+
+entry(
+    index = 92,
+    label = "pdt17-1",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {4,S} {5,S}
+2    Cs u0 {1,S} {8,S}
+3    Cd u0 {1,S} {7,D}
+4    Cd u0 {1,S} {6,D}
+5    Cs u0 {1,S} {9,S}
+6  * Cd u0 {4,D} {9,S}
+7    Cd u0 {3,D} {10,S}
+8    Cd u0 {2,S} {10,D}
+9    Cs u0 {5,S} {6,S}
+10   Cd u0 {7,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.72,-6.82,-6.48,-5.99,-5.19,-4.29,-2.12],'cal/(mol*K)'),
+        H298 = (14.743,'kcal/mol'),
+        S298 = (57.75,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt17 from C10H11 library.
+""",
+)
+
+entry(
+    index = 93,
+    label = "pdt19",
+    group = 
+"""
+1    Cs u0 {2,S} {4,S} {6,S}
+2    Cd u0 {1,S} {3,D} {5,S}
+3  * Cd u0 {2,D} {7,S}
+4    Cs u0 {1,S} {9,S}
+5    Cs u0 {2,S} {8,S}
+6    Cs u0 {1,S} {10,S}
+7    Cd u0 {3,S} {9,D}
+8    Cd u0 {5,S} {10,D}
+9    Cd u0 {4,S} {7,D}
+10   Cd u0 {6,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.98,-7.21,-6.77,-5.84,-4.695,-3.755,-2.135],'cal/(mol*K)','+|-',[2.95853,2.36683,1.77512,1.4201,0.88756,0.650878,0.295853]),
+        H298 = (2.333,'kcal/mol','+|-',14.9058),
+        S298 = (51.955,'cal/(mol*K)','+|-',2.95571),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt19 from C10H11 library.
+Fitted from species pdt37 from C10H11 library.
+""",
+)
+
+entry(
+    index = 94,
+    label = "pdt19-1",
+    group = 
+"""
+1    Cs u0 {2,S} {4,S} {6,S}
+2    Cd u0 {1,S} {3,S} {5,D}
+3    Cs u0 {2,S} {10,S}
+4    Cd u0 {1,S} {7,D}
+5    Cd u0 {2,D} {8,S}
+6    Cs u0 {1,S} {9,S}
+7  * Cd u0 {4,D} {10,S}
+8    Cd u0 {5,S} {9,D}
+9    Cd u0 {6,S} {8,D}
+10   Cs u0 {3,S} {7,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.27,-7.7,-6.87,-5.9,-4.53,-3.57,-2.03],'cal/(mol*K)'),
+        H298 = (7.693,'kcal/mol'),
+        S298 = (54.74,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt19 from C10H11 library.
+""",
+)
+
+entry(
+    index = 95,
+    label = "pdt21",
+    group = 
+"""
+1   Cs u0 {2,S} {4,S} {5,S}
+2   Cd u0 {1,S} {3,D} {6,S}
+3   Cd u0 {2,D} {8,S}
+4   Cs u0 {1,S} {9,S}
+5   Cs u0 {1,S} {7,S}
+6   Cd u0 {2,S} {7,D}
+7 * Cd u0 {5,S} {6,D}
+8   Cd u0 {3,S} {9,D}
+9   Cd u0 {4,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.07,-7.77333,-7.70333,-6.73333,-5.47333,-4.32333,-2.97333],'cal/(mol*K)','+|-',[3.26137,4.03866,3.95722,3.57416,2.7068,2.08753,1.35534]),
+        H298 = (2.643,'kcal/mol','+|-',4.3516),
+        S298 = (60.4632,'cal/(mol*K)','+|-',1.24756),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt21 from C10H11 library.
+Fitted from species pdt27 from C10H11 library.
+Fitted from species pdt32 from C10H11 library.
+""",
+)
+
+entry(
+    index = 96,
+    label = "pdt21-1",
+    group = 
+"""
+1   Cd u0 {2,S} {3,S} {6,D}
+2   Cs u0 {1,S} {4,S} {5,S}
+3 * Cs u0 {1,S} {7,S}
+4   Cs u0 {2,S} {8,S}
+5   Cd u0 {2,S} {7,D}
+6   Cd u0 {1,D} {9,S}
+7   Cd u0 {3,S} {5,D}
+8   Cd u0 {4,S} {9,D}
+9   Cd u0 {6,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.68,-6.81,-6.56,-5.84,-4.8,-3.99,-3.4],'cal/(mol*K)'),
+        H298 = (6.863,'kcal/mol'),
+        S298 = (57.6932,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt21 from C10H11 library.
+""",
+)
+
+entry(
+    index = 97,
+    label = "pdt21-2",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {4,S}
+2   Cd u0 {1,S} {5,D} {6,S}
+3   Cs u0 {1,S} {9,S}
+4   Cd u0 {1,S} {7,D}
+5   Cd u0 {2,D} {7,S}
+6   Cs u0 {2,S} {8,S}
+7 * Cd u0 {4,D} {5,S}
+8   Cd u0 {6,S} {9,D}
+9   Cd u0 {3,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.68,-6.81,-6.56,-5.84,-4.8,-3.99,-3.4],'cal/(mol*K)'),
+        H298 = (6.863,'kcal/mol'),
+        S298 = (57.6932,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt21 from C10H11 library.
+""",
+)
+
+entry(
+    index = 98,
+    label = "pdt21-3",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {5,S}
+2   Cd u0 {1,S} {4,D} {6,S}
+3   Cs u0 {1,S} {8,S}
+4   Cd u0 {2,D} {7,S}
+5   Cd u0 {1,S} {7,D}
+6   Cd u0 {2,S} {9,D}
+7   Cd u0 {4,S} {5,D}
+8 * Cs u0 {3,S} {9,S}
+9   Cd u0 {6,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.67,-8.62,-7.99,-7,-5.42,-4.27,-2.72],'cal/(mol*K)'),
+        H298 = (2.023,'kcal/mol'),
+        S298 = (61.7232,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt21 from C10H11 library.
+""",
+)
+
+entry(
+    index = 99,
+    label = "pdt22",
+    group = 
+"""
+1   Cd u0 {2,S} {4,S} {5,D}
+2   Cs u0 {1,S} {3,S} {6,S}
+3   Cd u0 {2,S} {8,D}
+4   Cd u0 {1,S} {9,D}
+5   Cd u0 {1,D} {7,S}
+6   Cd u0 {2,S} {7,D}
+7   Cd u0 {5,S} {6,D}
+8 * Cd u0 {3,D} {9,S}
+9   Cd u0 {4,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-9.63,-9.81,-9.04,-7.82,-5.95,-4.71,-3.23],'cal/(mol*K)'),
+        H298 = (14.05,'kcal/mol'),
+        S298 = (60.39,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt22 from C10H11 library.
+""",
+)
+
+entry(
+    index = 100,
+    label = "pdt26",
+    group = 
+"""
+1    Cd u0 {2,S} {3,D} {5,S}
+2    Cd u0 {1,S} {4,S} {6,D}
+3  * Cd u0 {1,D} {8,S}
+4    Cs u0 {2,S} {10,S}
+5    Cs u0 {1,S} {9,S}
+6    Cd u0 {2,D} {7,S}
+7    Cd u0 {6,S} {9,D}
+8    Cd u0 {3,S} {10,D}
+9    Cd u0 {5,S} {7,D}
+10   Cd u0 {4,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-9.51,-10.83,-10.38,-9.04,-6.78,-5.2,-2.72],'cal/(mol*K)'),
+        H298 = (10.33,'kcal/mol'),
+        S298 = (53.47,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt26 from C10H11 library.
+""",
+)
+
+entry(
+    index = 101,
+    label = "pdt27",
+    group = 
+"""
+1   Cd u0 {2,D} {3,S} {5,S}
+2   Cd u0 {1,D} {4,S} {6,S}
+3 * Cd u0 {1,S} {7,D}
+4   Cs u0 {2,S} {8,S}
+5   Cs u0 {1,S} {9,S}
+6   Cs u0 {2,S} {7,S}
+7   Cd u0 {3,D} {6,S}
+8   Cd u0 {4,S} {9,D}
+9   Cd u0 {5,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.88,-7.18,-6.81,-6.07,-4.85,-4.06,-3.25],'cal/(mol*K)'),
+        H298 = (6.883,'kcal/mol'),
+        S298 = (58.0732,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt27 from C10H11 library.
+""",
+)
+
+entry(
+    index = 102,
+    label = "pdt27-1",
+    group = 
+"""
+1   Cd u0 {2,D} {3,S} {6,S}
+2   Cd u0 {1,D} {4,S} {5,S}
+3   Cd u0 {1,S} {9,D}
+4   Cs u0 {2,S} {8,S}
+5   Cs u0 {2,S} {7,S}
+6   Cd u0 {1,S} {7,D}
+7 * Cd u0 {5,S} {6,D}
+8   Cs u0 {4,S} {9,S}
+9   Cd u0 {3,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.57,-4.83,-4.71,-4.26,-4,-3.54,-3.01],'cal/(mol*K)'),
+        H298 = (-2.777,'kcal/mol'),
+        S298 = (59.5532,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt27 from C10H11 library.
+""",
+)
+
+entry(
+    index = 103,
+    label = "pdt29",
+    group = 
+"""
+1  * Cd u0 {2,S} {4,D} {6,S}
+2    Cs u0 {1,S} {3,S} {5,S}
+3    Cs u0 {2,S} {7,S}
+4    Cd u0 {1,D} {8,S}
+5    Cs u0 {2,S} {9,S}
+6    Cd u0 {1,S} {7,D}
+7    Cd u0 {3,S} {6,D}
+8    Cd u0 {4,S} {10,D}
+9    Cs u0 {5,S} {10,S}
+10   Cd u0 {8,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.56,-9.04,-8.6,-7.5,-5.91,-4.62,-2.75],'cal/(mol*K)'),
+        H298 = (0.693,'kcal/mol'),
+        S298 = (56.96,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt29 from C10H11 library.
+""",
+)
+
+entry(
+    index = 104,
+    label = "pdt29-1",
+    group = 
+"""
+1    Cs u0 {2,S} {5,S} {6,S}
+2    Cd u0 {1,S} {3,D} {4,S}
+3    Cd u0 {2,D} {8,S}
+4    Cd u0 {2,S} {7,D}
+5    Cs u0 {1,S} {9,S}
+6    Cs u0 {1,S} {7,S}
+7    Cd u0 {4,D} {6,S}
+8  * Cs u0 {3,S} {10,S}
+9    Cd u0 {5,S} {10,D}
+10   Cd u0 {8,S} {9,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.57,-7.23,-7.07,-6.34,-5.29,-4.34,-3.43],'cal/(mol*K)'),
+        H298 = (6.033,'kcal/mol'),
+        S298 = (53.24,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt29 from C10H11 library.
+""",
+)
+
+entry(
+    index = 105,
+    label = "pdt29-2",
+    group = 
+"""
+1  * Cs u0 {2,S} {3,S} {6,S}
+2    Cd u0 {1,S} {4,S} {5,D}
+3    Cs u0 {1,S} {8,S}
+4    Cd u0 {2,S} {9,D}
+5    Cd u0 {2,D} {7,S}
+6    Cs u0 {1,S} {7,S}
+7    Cs u0 {5,S} {6,S}
+8    Cd u0 {3,S} {10,D}
+9    Cd u0 {4,D} {10,S}
+10   Cd u0 {8,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.56,-9.04,-8.6,-7.5,-5.91,-4.62,-2.75],'cal/(mol*K)'),
+        H298 = (3.993,'kcal/mol'),
+        S298 = (56.96,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt29 from C10H11 library.
+""",
+)
+
+entry(
+    index = 106,
+    label = "pdt30",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {5,S}
+2    Cd u0 {1,S} {4,S} {6,D}
+3    Cs u0 {1,S} {8,S}
+4    Cd u0 {2,S} {9,D}
+5    Cd u0 {1,S} {7,D}
+6    Cd u0 {2,D} {7,S}
+7    Cd u0 {5,D} {6,S}
+8  * Cd u0 {3,S} {10,D}
+9    Cd u0 {4,D} {10,S}
+10   Cd u0 {8,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-10.84,-11.12,-10.33,-8.95,-6.62,-4.99,-2.8],'cal/(mol*K)'),
+        H298 = (14.29,'kcal/mol'),
+        S298 = (58.23,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt30 from C10H11 library.
+""",
+)
+
+entry(
+    index = 107,
+    label = "pdt31",
+    group = 
+"""
+1    Cs u0 {2,S} {4,S} {6,S}
+2    Cd u0 {1,S} {3,D} {5,S}
+3  * Cd u0 {2,D} {9,S}
+4    Cd u0 {1,S} {8,D}
+5    Cd u0 {2,S} {7,D}
+6    Cs u0 {1,S} {7,S}
+7    Cd u0 {5,D} {6,S}
+8    Cd u0 {4,D} {10,S}
+9    Cd u0 {3,S} {10,D}
+10   Cd u0 {8,S} {9,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-10.94,-11.19,-10.38,-8.99,-6.63,-5,-2.79],'cal/(mol*K)'),
+        H298 = (11.73,'kcal/mol'),
+        S298 = (57.98,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt31 from C10H11 library.
+""",
+)
+
+entry(
+    index = 108,
+    label = "pdt32",
+    group = 
+"""
+1   Cd u0 {2,S} {4,D} {5,S}
+2   Cs u0 {1,S} {3,S} {6,S}
+3   Cs u0 {2,S} {7,S}
+4   Cd u0 {1,D} {8,S}
+5   Cd u0 {1,S} {7,D}
+6   Cd u0 {2,S} {9,D}
+7 * Cd u0 {3,S} {5,D}
+8   Cs u0 {4,S} {9,S}
+9   Cd u0 {6,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.91,-7.09,-6.83,-6.08,-4.95,-4.08,-3.42],'cal/(mol*K)'),
+        H298 = (5.483,'kcal/mol'),
+        S298 = (58.2132,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt32 from C10H11 library.
+""",
+)
+
+entry(
+    index = 109,
+    label = "pdt32-1",
+    group = 
+"""
+1   Cs u0 {2,S} {3,S} {6,S}
+2   Cs u0 {1,S} {4,S} {5,S}
+3   Cs u0 {1,S} {7,S}
+4   Cd u0 {2,S} {8,D}
+5   Cd u0 {2,S} {7,D}
+6   Cd u0 {1,S} {9,D}
+7 * Cd u0 {3,S} {5,D}
+8   Cd u0 {4,D} {9,S}
+9   Cd u0 {6,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.78,-6.1,-4.92,-3.65,-2.41,-1.62,-0.77],'cal/(mol*K)'),
+        H298 = (-15.727,'kcal/mol'),
+        S298 = (49.8332,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt32 from C10H11 library.
+""",
+)
+
+entry(
+    index = 110,
+    label = "pdt32-2",
+    group = 
+"""
+1   Cs u0 {2,S} {4,S} {6,S}
+2   Cd u0 {1,S} {3,D} {5,S}
+3   Cd u0 {2,D} {7,S}
+4   Cs u0 {1,S} {7,S}
+5   Cd u0 {2,S} {9,D}
+6   Cd u0 {1,S} {8,D}
+7   Cs u0 {3,S} {4,S}
+8 * Cd u0 {6,D} {9,S}
+9   Cd u0 {5,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.9,-8.9,-8.26,-7.24,-5.57,-4.36,-2.74],'cal/(mol*K)'),
+        H298 = (3.693,'kcal/mol'),
+        S298 = (61.9332,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt32 from C10H11 library.
+""",
+)
+
+entry(
+    index = 111,
+    label = "pdt35",
+    group = 
+"""
+1    Cd u0 {2,D} {3,S} {6,S}
+2    Cd u0 {1,D} {4,S} {5,S}
+3  * Cs u0 {1,S} {8,S}
+4    Cd u0 {2,S} {9,D}
+5    Cd u0 {2,S} {7,D}
+6    Cs u0 {1,S} {7,S}
+7    Cd u0 {5,D} {6,S}
+8    Cd u0 {3,S} {10,D}
+9    Cd u0 {4,D} {10,S}
+10   Cd u0 {8,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.52,-7.11,-6.7,-5.92,-4.93,-4.1,-2.95],'cal/(mol*K)'),
+        H298 = (8.12,'kcal/mol'),
+        S298 = (54.6,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt35 from C10H11 library.
+""",
+)
+
+entry(
+    index = 112,
+    label = "pdt37",
+    group = 
+"""
+1    Cd u0 {2,S} {4,D} {6,S}
+2    Cs u0 {1,S} {3,S} {5,S}
+3  * Cd u0 {2,S} {10,D}
+4    Cd u0 {1,D} {7,S}
+5    Cs u0 {2,S} {8,S}
+6    Cs u0 {1,S} {9,S}
+7    Cs u0 {4,S} {10,S}
+8    Cd u0 {5,S} {9,D}
+9    Cd u0 {6,S} {8,D}
+10   Cd u0 {3,D} {7,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.74,-6.32,-5.65,-4.95,-3.99,-3.38,-2.69],'cal/(mol*K)'),
+        H298 = (2.193,'kcal/mol'),
+        S298 = (48.91,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt37 from C10H11 library.
+""",
+)
+
+entry(
+    index = 113,
+    label = "pdt38",
+    group = 
+"""
+1  * Cd u0 {2,S} {3,S} {4,D}
+2    Cd u0 {1,S} {5,D} {6,S}
+3    Cs u0 {1,S} {8,S}
+4    Cd u0 {1,D} {7,S}
+5    Cd u0 {2,D} {10,S}
+6    Cs u0 {2,S} {9,S}
+7    Cd u0 {4,S} {10,D}
+8    Cd u0 {3,S} {9,D}
+9    Cd u0 {6,S} {8,D}
+10   Cd u0 {5,S} {7,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-10.4,-11.67,-11.09,-9.63,-7.17,-5.47,-2.85],'cal/(mol*K)'),
+        H298 = (-17.82,'kcal/mol'),
+        S298 = (53.93,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt38 from C10H11 library.
+""",
+)
+
+entry(
+    index = 114,
+    label = "pdt38-1",
+    group = 
+"""
+1    Cb u0 {2,B} {4,B} {5,S}
+2    Cb u0 {1,B} {3,S} {6,B}
+3  * Cs u0 {2,S} {8,S}
+4    Cb u0 {1,B} {10,B}
+5    Cs u0 {1,S} {7,S}
+6    Cb u0 {2,B} {9,B}
+7    Cd u0 {5,S} {8,D}
+8    Cd u0 {3,S} {7,D}
+9    Cb u0 {6,B} {10,B}
+10   Cb u0 {4,B} {9,B}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-1.68,-1.73,-1.85,-1.91,-2.19,-2.39,-2.51],'cal/(mol*K)'),
+        H298 = (2.84,'kcal/mol'),
+        S298 = (35.91,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species pdt38 from C10H11 library.
+""",
+)
+
+entry(
+    index = 115,
+    label = "INDENE",
+    group = 
+"""
+1   Cd u0 {2,S} {4,S} {5,D}
+2   Cd u0 {1,S} {3,D} {6,S}
+3 * Cd u0 {2,D} {9,S}
+4   Cd u0 {1,S} {7,D}
+5   Cd u0 {1,D} {8,S}
+6   Cs u0 {2,S} {7,S}
+7   Cd u0 {4,D} {6,S}
+8   Cd u0 {5,S} {9,D}
+9   Cd u0 {3,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.18,-9.06,-8.74,-7.88,-6.6,-5.53,-4.33],'cal/(mol*K)'),
+        H298 = (-18.19,'kcal/mol'),
+        S298 = (60.02,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species INDENE from C10H11 library.
+""",
+)
+
+entry(
+    index = 116,
+    label = "INDENE-1",
+    group = 
+"""
+1   Cd u0 {2,D} {3,S} {5,S}
+2   Cd u0 {1,D} {4,S} {6,S}
+3 * Cd u0 {1,S} {8,D}
+4   Cd u0 {2,S} {9,D}
+5   Cs u0 {1,S} {7,S}
+6   Cd u0 {2,S} {7,D}
+7   Cd u0 {5,S} {6,D}
+8   Cd u0 {3,D} {9,S}
+9   Cd u0 {4,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-8.18,-9.06,-8.74,-7.88,-6.6,-5.53,-4.33],'cal/(mol*K)'),
+        H298 = (-18.19,'kcal/mol'),
+        S298 = (60.02,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species INDENE from C10H11 library.
+""",
+)
+
+entry(
+    index = 117,
+    label = "2HINDENE",
+    group = 
+"""
+1   Cd u0 {2,S} {5,S} {6,D}
+2   Cd u0 {1,S} {3,S} {4,D}
+3 * Cd u0 {2,S} {8,D}
+4   Cd u0 {2,D} {7,S}
+5   Cd u0 {1,S} {9,D}
+6   Cd u0 {1,D} {7,S}
+7   Cs u0 {4,S} {6,S}
+8   Cd u0 {3,D} {9,S}
+9   Cd u0 {5,D} {8,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.49,-4.75,-4.62,-4.45,-4.55,-4.28,-4.48],'cal/(mol*K)'),
+        H298 = (-0.61,'kcal/mol'),
+        S298 = (58.88,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species 2HINDENE from C10H11 library.
+""",
+)
+
+entry(
+    index = 118,
+    label = "prod2",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {4,S} {5,S}
+2  * Cs u0 {1,S} {8,S}
+3    Cd u0 {1,S} {6,D}
+4    Cd u0 {1,S} {9,D}
+5    Cd u0 {1,S} {7,D}
+6    Cd u0 {3,D} {10,S}
+7    Cd u0 {5,D} {9,S}
+8    Cd u0 {2,S} {10,D}
+9    Cd u0 {4,D} {7,S}
+10   Cd u0 {6,S} {8,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.54,-7.38,-7.43,-7.04,-6.22,-5.38,-3.12],'cal/(mol*K)'),
+        H298 = (3.583,'kcal/mol'),
+        S298 = (59.28,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species prod2 from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 119,
+    label = "prod2-1",
+    group = 
+"""
+1    Cs u0 {2,S} {3,S} {4,S} {5,S}
+2    Cd u0 {1,S} {7,D}
+3    Cd u0 {1,S} {9,D}
+4    Cd u0 {1,S} {8,D}
+5    Cd u0 {1,S} {6,D}
+6  * Cd u0 {5,D} {8,S}
+7    Cd u0 {2,D} {10,S}
+8    Cd u0 {4,D} {6,S}
+9    Cd u0 {3,D} {10,S}
+10   Cs u0 {7,S} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-5.98,-5.93,-5.62,-5.32,-5,-4.36,-3.36],'cal/(mol*K)'),
+        H298 = (11.133,'kcal/mol'),
+        S298 = (57.08,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species prod2 from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 120,
+    label = "prod4",
+    group = 
+"""
+1    Cd u0 {2,S} {5,D} {6,S}
+2    Cs u0 {1,S} {3,S} {4,S}
+3  * Cd u0 {2,S} {8,D}
+4    Cd u0 {2,S} {10,D}
+5    Cd u0 {1,D} {7,S}
+6    Cd u0 {1,S} {9,D}
+7    Cs u0 {5,S} {8,S}
+8    Cd u0 {3,D} {7,S}
+9    Cd u0 {6,D} {10,S}
+10   Cd u0 {4,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.57,-7.86,-7.37,-6.54,-5.25,-4.39,-3.88],'cal/(mol*K)'),
+        H298 = (-1.957,'kcal/mol'),
+        S298 = (55.67,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species prod4 from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 121,
+    label = "prod4-1",
+    group = 
+"""
+1  * Cs u0 {2,S} {3,S} {4,S}
+2    Cs u0 {1,S} {5,S} {6,S}
+3    Cd u0 {1,S} {8,D}
+4    Cd u0 {1,S} {9,D}
+5    Cd u0 {2,S} {10,D}
+6    Cd u0 {2,S} {7,D}
+7    Cd u0 {6,D} {8,S}
+8    Cd u0 {3,D} {7,S}
+9    Cd u0 {4,D} {10,S}
+10   Cd u0 {5,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-10.33,-8.08,-6.33,-4.9,-3.09,-2.2,-1.2],'cal/(mol*K)'),
+        H298 = (-22.037,'kcal/mol'),
+        S298 = (49.84,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species prod4 from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 122,
+    label = "naphthalene",
+    group = 
+"""
+1    Cd u0 {2,S} {4,D} {6,S}
+2    Cd u0 {1,S} {3,S} {5,D}
+3    Cd u0 {2,S} {7,D}
+4    Cd u0 {1,D} {9,S}
+5    Cd u0 {2,D} {8,S}
+6    Cd u0 {1,S} {10,D}
+7  * Cd u0 {3,D} {10,S}
+8    Cd u0 {5,S} {9,D}
+9    Cd u0 {4,S} {8,D}
+10   Cd u0 {6,D} {7,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.54,-8.82,-8.92,-8.3,-7.22,-5.66,-4.34],'cal/(mol*K)'),
+        H298 = (-41.44,'kcal/mol'),
+        S298 = (59.79,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species naphthalene from naphthalene_H library.
+""",
+)
+
+entry(
+    index = 123,
+    label = "naphthalene-1",
+    group = 
+"""
+1    Cbf u0 {2,B} {3,B} {4,B}
+2    Cbf u0 {1,B} {5,B} {6,B}
+3    Cb  u0 {1,B} {9,B}
+4    Cb  u0 {1,B} {8,B}
+5    Cb  u0 {2,B} {10,B}
+6  * Cb  u0 {2,B} {7,B}
+7    Cb  u0 {6,B} {8,B}
+8    Cb  u0 {4,B} {7,B}
+9    Cb  u0 {3,B} {10,B}
+10   Cb  u0 {5,B} {9,B}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.79295e-15,0,-1.35859e-14,-6.79295e-15,0,1.35859e-14,-1.35859e-14],'cal/(mol*K)'),
+        H298 = (0,'kcal/mol'),
+        S298 = (-2.75,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted from thermo library values""",
+    longDesc = 
+u"""
+Fitted from species naphthalene from naphthalene_H library.
 """,
 )
 
@@ -1854,6 +3283,56 @@ L1: PolycyclicRing
     L2: bicyclo[2.1.0]pent-1(4)-ene
     L2: bicyclo[2.1.0]pent-2-ene
     L2: tricyclo[4.4.0.0(3.9)]decane
+    L2: product1
+    L2: product3
+    L2: product23
+    L2: product25
+    L2: product29
+    L2: product34
+    L2: product36
+    L2: product42
+    L2: product45
+    L2: product46
+    L2: product46-1
+    L2: pdt8
+    L2: pdt8-1
+    L2: pdt8-2
+    L2: pdt10bis
+    L2: pdt10bis-1
+    L2: pdt11
+    L2: pdt17
+    L2: pdt17-1
+    L2: pdt19
+    L2: pdt19-1
+    L2: pdt21
+    L2: pdt21-1
+    L2: pdt21-2
+    L2: pdt21-3
+    L2: pdt22
+    L2: pdt26
+    L2: pdt27
+    L2: pdt27-1
+    L2: pdt29
+    L2: pdt29-1
+    L2: pdt29-2
+    L2: pdt30
+    L2: pdt31
+    L2: pdt32
+    L2: pdt32-1
+    L2: pdt32-2
+    L2: pdt35
+    L2: pdt37
+    L2: pdt38
+    L2: pdt38-1
+    L2: INDENE
+    L2: INDENE-1
+    L2: 2HINDENE
+    L2: prod2
+    L2: prod2-1
+    L2: prod4
+    L2: prod4-1
+    L2: naphthalene
+    L2: naphthalene-1
 """
 )
 

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -24,6 +24,7 @@ entry(
 u"""
 
 """,
+    rank = 10,
 )
 
 entry(

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -26,6 +26,53 @@ u"""
 """,
 )
 
+
+entry(
+    index = 96,
+    label = "Aromatic",
+    group = 
+"""
+1 * Cb u0
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (0,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Aromatic""",
+    longDesc = 
+u"""
+Ring correction is zero because RMG uses Cb group corrections instead in the case of a ring containing Cb bonds
+""",
+)
+
+
+entry(
+    index = 96,
+    label = "Benzene",
+    group = 
+"""
+1 Cb u0 {2,B} {6,B}
+2 Cb u0 {1,B} {3,B}
+3 Cb u0 {2,B} {4,B}
+4 Cb u0 {3,B} {5,B}
+5 Cb u0 {4,B} {6,B}
+6 Cb u0 {1,B} {5,B}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0,0,0,0,0,0,0],'cal/(mol*K)'),
+        H298 = (0,'kcal/mol'),
+        S298 = (0,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Aromatic""",
+    longDesc = 
+u"""
+Ring correction is zero because RMG uses Cb group corrections instead in the case of a ring containing Cb bonds
+""",
+)
+
 entry(
     index = 97,
     label = "ThreeMember",
@@ -3664,6 +3711,8 @@ u"""
 tree(
 """
 L1: Ring
+    L2: Aromatic
+        L3: Benzene
     L2: ThreeMember
         L3: Cyclopropane
         L3: Cyclopropene

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -24,6 +24,7 @@ entry(
 u"""
 
 """,
+    rank = 10,
 )
 
 
@@ -45,6 +46,7 @@ entry(
 u"""
 Ring correction is zero because RMG uses Cb group corrections instead in the case of a ring containing Cb bonds
 """,
+    rank = 1,
 )
 
 
@@ -71,6 +73,7 @@ entry(
 u"""
 Ring correction is zero because RMG uses Cb group corrections instead in the case of a ring containing Cb bonds
 """,
+    rank = 1,
 )
 
 entry(


### PR DESCRIPTION
- Prevent benzyl radicals from reacting in diels alder reaction family.
- Add a series of new polycyclic thermo group corrections derived from Aaron and Shamel's libraries
- Add aromatic and benzene ring groups with zero value to complement Cb bond corrections
- Give ranks to generic nodes (rank = 10 indicating very bad estimate) and aromatic nodes (rank = 1 so that RMG prioritizes it) so that they can be sorted in the thermo estimation algorithm in RMG-Py
- Training reactions from Aaron and shamel's libraries