### PR TITLE
move deploy key decryption into deploy.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
   - export PATH=/home/travis/anaconda/bin:$PATH
   # Update conda itself
   - conda update --yes conda
-  - openssl aes-256-cbc -K $encrypted_02f40ca58e32_key -iv $encrypted_02f40ca58e32_iv -in deploy_key.enc -out deploy_key -d
   - cd ..
   # this is the RMG-database project, so need to fetch RMG-Py
   - git clone https://github.com/ReactionMechanismGenerator/RMG-Py.git
@@ -36,4 +35,6 @@ install:
 script:
   - make test-database
   - cd $TRAVIS_BUILD_DIR
+
+after_success:
   - bash ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,8 @@
 
 set -e # exit with nonzero exit code if anything fails
 
+openssl aes-256-cbc -K $encrypted_02f40ca58e32_key -iv $encrypted_02f40ca58e32_iv -in deploy_key.enc -out deploy_key -d
+
 echo 'Travis Build Dir: '$TRAVIS_BUILD_DIR
 
 if $TRAVIS_PULL_REQUEST


### PR DESCRIPTION
This PR implements the [same solution as for RMG-Py](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/625) to deal with pull requests from users external of the RMG organization.

In summary: their PR's will not trigger a RMG-tests rebuild, but they won't crash the current travis build neither.