### PR TITLE
More concise top-level definition of Y. in H_Abstraction.

### DIFF
--- a/input/kinetics/families/H_Abstraction/groups.py
+++ b/input/kinetics/families/H_Abstraction/groups.py
@@ -26,7 +26,7 @@ entry(
 entry(
     index = 2,
     label = "Y_rad_birad_trirad_quadrad",
-    group = "OR{Y_2centeradjbirad, Y_1centerbirad, Y_rad, Y_1centertrirad, Y_1centerquadrad}",
+    group = "OR{Y_rad, Y_1centerbirad, Y_1centertrirad, Y_1centerquadrad}",
     kinetics = None,
 )
 


### PR DESCRIPTION
The Y_2centeradjbirad node is a child of Y_rad and is captured 
by the very generic Y_rad definition. Having it appear
at the start of the OR{} definition for the top-level 
Y_rad_birad_trirad_quadrad seems thus redundant, confusing,
and slower??