### PR TITLE
fix anaconda in .travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ addons:
 
 before_install:
   # Set up anaconda
-  - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/anaconda/bin:$PATH
+  - ./miniconda.sh -b -p $HOME/miniconda
+  - export PATH=$HOME/miniconda/bin:$PATH
   # Update conda itself
   - conda update --yes conda
   - cd ..


### PR DESCRIPTION
This PR fixes the outdated miniconda URL and updates `.travis.yaml` file the repository.