### PR TITLE
Changed frequencies of the Nitro group (statmech groups.py)

### DIFF
--- a/input/statmech/groups/groups.py
+++ b/input/statmech/groups/groups.py
@@ -936,7 +936,6 @@ entry(
 """,
     statmech = GroupFrequencies(
         frequencies = [
-            (1545, 1555, 1),
             (1360, 1385, 1),
             (915, 1000, 1),
             (850, 920, 1),


### PR DESCRIPTION
In statmech groups.py I changed the frequencies of the Nitro (R-NO2) group. This group was originally assigned 6 frequencies, while it is only allowed a maximum of 5 (see https://dspace.mit.edu/handle/1721.1/59876). The weakest frequency range of 1545-1555 1/cm was hence removed.