### PR TITLE
More Intra_R_Add_Endocyclic training rates

### DIFF
--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -146,6 +146,36 @@ entry(
 )
 
 entry(
+    index = 180,
+    label = "R4_Cs_RR_D",
+    group = 
+"""
+1 *1 Cs       u1 {2,S}
+2 *4 Cs       u0 {1,S} {3,S} {5,S} {6,S}
+3 *2 Cd       u0 {2,S} {4,D}
+4 *3 [Cd,Cdd] u0 {3,D}
+5    R        u0 {2,S}
+6    R        u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 181,
+    label = "R4_Cs_HH_D",
+    group = 
+"""
+1 *1 Cs       u1 {2,S}
+2 *4 Cs       u0 {1,S} {3,S} {5,S} {6,S}
+3 *2 Cd       u0 {2,S} {4,D}
+4 *3 [Cd,Cdd] u0 {3,D}
+5    H        u0 {2,S}
+6    H        u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
     index = 12,
     label = "R4_S_T",
     group = 
@@ -327,6 +357,78 @@ entry(
     longDesc = 
 u"""
 The ring being formed has 5 atoms in.
+Starting at the radical site, the first two bonds are single, single.
+The multiple bond being attacked is a double bond (to another carbon).
+""",
+)
+
+entry(
+    index = 182,
+    label = "R5_CsCs_RR_D",
+    group = 
+"""
+1 *1 Cs       u1 {2,S}
+2 *4 Cs       u0 {1,S} {3,S} {6,S} {7,S}
+3 *5 Cs       u0 {2,S} {4,S} {8,S} {9,S}
+4 *2 Cd       u0 {3,S} {5,D}
+5 *3 [Cd,Cdd] u0 {4,D}
+6    R        u0 {2,S}
+7    R        u0 {2,S}
+8    R        u0 {3,S}
+9    R        u0 {3,S}
+""",
+    kinetics = None,
+    longDesc = 
+u"""
+The ring being formed has 5 carbon atoms.
+Starting at the radical site, the first two bonds are single, single.
+The multiple bond being attacked is a double bond (to another carbon).
+""",
+)
+
+entry(
+    index = 183,
+    label = "R5_CsCs_RH_D",
+    group = 
+"""
+1 *1 Cs       u1 {2,S}
+2 *4 Cs       u0 {1,S} {3,S} {6,S} {7,S}
+3 *5 Cs       u0 {2,S} {4,S} {8,S} {9,S}
+4 *2 Cd       u0 {3,S} {5,D}
+5 *3 [Cd,Cdd] u0 {4,D}
+6    R        u0 {2,S}
+7    H        u0 {2,S}
+8    R        u0 {3,S}
+9    H        u0 {3,S}
+""",
+    kinetics = None,
+    longDesc = 
+u"""
+The ring being formed has 5 carbon atoms.
+Starting at the radical site, the first two bonds are single, single.
+The multiple bond being attacked is a double bond (to another carbon).
+""",
+)
+
+entry(
+    index = 184,
+    label = "R5_CsCs_HH_D",
+    group = 
+"""
+1 *1 Cs       u1 {2,S}
+2 *4 Cs       u0 {1,S} {3,S} {6,S} {7,S}
+3 *5 Cs       u0 {2,S} {4,S} {8,S} {9,S}
+4 *2 Cd       u0 {3,S} {5,D}
+5 *3 [Cd,Cdd] u0 {4,D}
+6    H        u0 {2,S}
+7    H        u0 {2,S}
+8    H        u0 {3,S}
+9    H        u0 {3,S}
+""",
+    kinetics = None,
+    longDesc = 
+u"""
+The ring being formed has 5 carbon atoms.
 Starting at the radical site, the first two bonds are single, single.
 The multiple bond being attacked is a double bond (to another carbon).
 """,
@@ -883,6 +985,87 @@ entry(
 6 *3 [Cd,Cdd] u0 {5,D}
 """,
     kinetics = None,
+)
+
+entry(
+    index = 185,
+    label = "R6_CsCsCs_RR_D",
+    group = 
+"""
+1  *1 Cs      u1 {2,S}
+2  *4 Cs       u0 {1,S} {3,S} {7,S} {8,S}
+3  *6 Cs       u0 {2,S} {4,S} {9,S} {10,S}
+4  *5 Cs       u0 {3,S} {5,S} {11,S} {12,S}
+5  *2 Cd       u0 {4,S} {6,D}
+6  *3 [Cd,Cdd] u0 {5,D}
+7     R        u0 {2,S}
+8     R        u0 {2,S}
+9     R        u0 {3,S}
+10    R        u0 {3,S}
+11    R        u0 {4,S}
+12    R        u0 {4,S}
+""",
+    kinetics = None,
+    longDesc = 
+u"""
+The ring being formed has 6 carbon atoms.
+Starting at the radical site, the first two bonds are single, single.
+The multiple bond being attacked is a double bond (to another carbon).
+""",
+)
+
+entry(
+    index = 186,
+    label = "R6_CsCsCs_RH_D",
+    group = 
+"""
+1  *1 Cs      u1 {2,S}
+2  *4 Cs       u0 {1,S} {3,S} {7,S} {8,S}
+3  *6 Cs       u0 {2,S} {4,S} {9,S} {10,S}
+4  *5 Cs       u0 {3,S} {5,S} {11,S} {12,S}
+5  *2 Cd       u0 {4,S} {6,D}
+6  *3 [Cd,Cdd] u0 {5,D}
+7     R        u0 {2,S}
+8     H        u0 {2,S}
+9     R        u0 {3,S}
+10    H        u0 {3,S}
+11    R        u0 {4,S}
+12    H        u0 {4,S}
+""",
+    kinetics = None,
+    longDesc = 
+u"""
+The ring being formed has 6 carbon atoms.
+Starting at the radical site, the first two bonds are single, single.
+The multiple bond being attacked is a double bond (to another carbon).
+""",
+)
+
+entry(
+    index = 187,
+    label = "R6_CsCsCs_HH_D",
+    group = 
+"""
+1  *1 Cs      u1 {2,S}
+2  *4 Cs       u0 {1,S} {3,S} {7,S} {8,S}
+3  *6 Cs       u0 {2,S} {4,S} {9,S} {10,S}
+4  *5 Cs       u0 {3,S} {5,S} {11,S} {12,S}
+5  *2 Cd       u0 {4,S} {6,D}
+6  *3 [Cd,Cdd] u0 {5,D}
+7     H        u0 {2,S}
+8     H        u0 {2,S}
+9     H        u0 {3,S}
+10    H        u0 {3,S}
+11    H        u0 {4,S}
+12    H        u0 {4,S}
+""",
+    kinetics = None,
+    longDesc = 
+u"""
+The ring being formed has 6 carbon atoms.
+Starting at the radical site, the first two bonds are single, single.
+The multiple bond being attacked is a double bond (to another carbon).
+""",
 )
 
 entry(
@@ -2283,6 +2466,8 @@ L1: Rn
     L2: R4
         L3: R4_S
             L4: R4_S_D
+                L5: R4_Cs_RR_D
+                    L6: R4_Cs_HH_D
             L4: R4_S_T
             L4: R4_S_CO
         L3: R4_D
@@ -2296,6 +2481,9 @@ L1: Rn
     L2: R5
         L3: R5_SS
             L4: R5_SS_D
+                L5: R5_CsCs_RR_D
+                    L6: R5_CsCs_RH_D
+                        L7: R5_CsCs_HH_D
             L4: R5_SS_T
             L4: R5_SS_CO
             L4: R5_SS_CS
@@ -2328,6 +2516,9 @@ L1: Rn
                 L5: R6_SSR
                     L6: R6_SSS
                         L7: R6_SSS_D
+                            L8: R6_CsCsCs_RR_D
+                                L9: R6_CsCsCs_RH_D
+                                    L10: R6_CsCsCs_HH_D
                         L7: R6_SSS_T
                         L7: R6_SSS_CO
                     L6: R6_SSM

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
@@ -498,3 +498,1458 @@ multiplicity 2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {7,S}
 
+C_CCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {5,S} {6,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {7,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4  *1 C u1 p0 c0 {3,S} {10,S} {11,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+
+cyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {7,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+
+C_CCCJC
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {8,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+4  *1 C u1 p0 c0 {3,S} {5,S} {11,S}
+5     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+3-methylcyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {8,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {5,S} {11,S}
+5     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C_CCCJCC
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *1 C u1 p0 c0 {3,S} {5,S} {12,S}
+5     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+3-ethylcyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {9,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {5,S} {12,S}
+5     C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+CC_CCCJ
+multiplicity 2
+1     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {3,D} {9,S}
+3  *2 C u0 p0 c0 {2,D} {4,S} {10,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+5  *1 C u1 p0 c0 {4,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+2-methylcyclobutyl
+multiplicity 2
+1     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  *3 C u0 p0 c0 {1,S} {3,S} {5,S} {9,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {10,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+5  *1 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C_CC(C)CJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {8,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {9,S}
+4     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5  *1 C u1 p0 c0 {3,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C_C(C)CCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+4  *4 C u0 p0 c0 {2,S} {5,S} {11,S} {12,S}
+5  *1 C u1 p0 c0 {4,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+1-methylcyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+4  *4 C u0 p0 c0 {2,S} {5,S} {11,S} {12,S}
+5  *1 C u0 p0 c0 {1,S} {4,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C_CC(C)(C)CJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5     C u0 p0 c0 {3,S} {13,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {3,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+2,2-dimethylcyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {9,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5     C u0 p0 c0 {3,S} {13,S} {14,S} {15,S}
+6  *1 C u0 p0 c0 {1,S} {3,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CCCJ(C)C
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *1 C u1 p0 c0 {3,S} {5,S} {6,S}
+5     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+6     C u0 p0 c0 {4,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+3,3-dimethylcyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {9,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {5,S} {6,S}
+5     C u0 p0 c0 {4,S} {12,S} {13,S} {14,S}
+6     C u0 p0 c0 {4,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_C(C)CCJC
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {14,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+1,3-dimethylcyclobutyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
+5  *1 C u0 p0 c0 {1,S} {4,S} {6,S} {14,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+CC(C)_CCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,D}
+2     C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4  *2 C u0 p0 c0 {1,D} {5,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {8,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+5  *1 C u1 p0 c0 {4,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+cyclopentyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {8,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {11,S} {12,S}
+5  *1 C u0 p0 c0 {1,S} {4,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C_CCCCJC
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {12,S} {13,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {14,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+3-methylcyclopentyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {9,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {12,S} {13,S}
+5  *1 C u0 p0 c0 {1,S} {4,S} {6,S} {14,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CCCCJ(C)C
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     C u0 p0 c0 {5,S} {18,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+3,3-dimethylcyclopentyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *1 C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+6     C u0 p0 c0 {5,S} {15,S} {16,S} {17,S}
+7     C u0 p0 c0 {5,S} {18,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+CC_CCCCJ
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {3,D} {10,S}
+3  *2 C u0 p0 c0 {2,D} {4,S} {11,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+2-methylcyclopentyl
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *3 C u0 p0 c0 {1,S} {3,S} {6,S} {10,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {11,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u0 p0 c0 {2,S} {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CCC(C)CJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {6,S} {12,S}
+5     C u0 p0 c0 {4,S} {13,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {4,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CC(C)CCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {10,S}
+4     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {3,S} {6,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_C(C)CCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+1-methylcyclopentyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u0 p0 c0 {1,S} {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CCC(C)(C)CJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {4,S} {13,S} {14,S} {15,S}
+6     C u0 p0 c0 {4,S} {16,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {4,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CC(C)(C)CCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5     C u0 p0 c0 {3,S} {14,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {3,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+2,2-dimethylcyclopentyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5     C u0 p0 c0 {3,S} {14,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {3,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {1,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+CC(C)_CCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,D}
+2     C u0 p0 c0 {1,S} {8,S} {9,S} {10,S}
+3     C u0 p0 c0 {1,S} {11,S} {12,S} {13,S}
+4  *2 C u0 p0 c0 {1,D} {5,S} {14,S}
+5  *5 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CCCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u1 p0 c0 {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+cyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {9,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {12,S} {13,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *1 C u0 p0 c0 {1,S} {5,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C_CCCCCJC
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {17,S}
+7     C u0 p0 c0 {6,S} {18,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+3-methylcyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {6,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *1 C u0 p0 c0 {1,S} {5,S} {7,S} {17,S}
+7     C u0 p0 c0 {6,S} {18,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CCCCCJ(C)C
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     C u0 p0 c0 {6,S} {18,S} {19,S} {20,S}
+8     C u0 p0 c0 {6,S} {21,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+3,3-dimethylcyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {6,S} {9,S} {10,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+7     C u0 p0 c0 {6,S} {18,S} {19,S} {20,S}
+8     C u0 p0 c0 {6,S} {21,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+CC_CCCCCJ
+multiplicity 2
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *3 C u0 p0 c0 {1,S} {3,D} {11,S}
+3  *2 C u0 p0 c0 {2,D} {4,S} {12,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+2-methylcyclohexyl
+multiplicity 2
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *3 C u0 p0 c0 {1,S} {3,S} {7,S} {11,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {12,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {2,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CCCC(C)CJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {7,S} {15,S}
+6     C u0 p0 c0 {5,S} {16,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {5,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+4-methylcyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {7,S} {15,S}
+6     C u0 p0 c0 {5,S} {16,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {1,S} {5,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CCC(C)CCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {6,S} {13,S}
+5     C u0 p0 c0 {4,S} {14,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {4,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CC(C)CCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {11,S}
+4     C u0 p0 c0 {3,S} {12,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {3,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_C(C)CCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+1-methylcyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {1,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CCCC(C)(C)CJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+6     C u0 p0 c0 {5,S} {16,S} {17,S} {18,S}
+7     C u0 p0 c0 {5,S} {19,S} {20,S} {21,S}
+8  *1 C u1 p0 c0 {5,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+4,4-dimethylcyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+6     C u0 p0 c0 {5,S} {16,S} {17,S} {18,S}
+7     C u0 p0 c0 {5,S} {19,S} {20,S} {21,S}
+8  *1 C u0 p0 c0 {1,S} {5,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C_CCC(C)(C)CCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {4,S} {14,S} {15,S} {16,S}
+6     C u0 p0 c0 {4,S} {17,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {4,S} {8,S} {20,S} {21,S}
+8  *1 C u1 p0 c0 {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C_CC(C)(C)CCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {12,S} {13,S} {14,S}
+5     C u0 p0 c0 {3,S} {15,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {3,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u1 p0 c0 {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+2,2-dimethylcyclohexyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {12,S} {13,S} {14,S}
+5     C u0 p0 c0 {3,S} {15,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {3,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u0 p0 c0 {1,S} {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+CC(C)_CCCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,D}
+2     C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {1,S} {12,S} {13,S} {14,S}
+4  *2 C u0 p0 c0 {1,D} {5,S} {15,S}
+5  *5 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u1 p0 c0 {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C_CCCCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+cycloheptyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *1 C u0 p0 c0 {1,S} {6,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C_CCCCCCJC
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {20,S}
+8     C u0 p0 c0 {7,S} {21,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+3-methylcycloheptyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {7,S} {9,S} {10,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *1 C u0 p0 c0 {1,S} {6,S} {8,S} {20,S}
+8     C u0 p0 c0 {7,S} {21,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C_CCCCCCJ(C)C
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {12,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     C u0 p0 c0 {7,S} {21,S} {22,S} {23,S}
+9     C u0 p0 c0 {7,S} {24,S} {25,S} {26,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+24    H u0 p0 c0 {9,S}
+25    H u0 p0 c0 {9,S}
+26    H u0 p0 c0 {9,S}
+
+3,3-dimethylcycloheptyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {7,S} {10,S} {11,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {12,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+7  *1 C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
+8     C u0 p0 c0 {7,S} {21,S} {22,S} {23,S}
+9     C u0 p0 c0 {7,S} {24,S} {25,S} {26,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+24    H u0 p0 c0 {9,S}
+25    H u0 p0 c0 {9,S}
+26    H u0 p0 c0 {9,S}
+
+CC_CCCCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,D} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u0 p0 c0 {1,D} {4,S} {13,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u1 p0 c0 {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+2-methylcycloheptyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3  *2 C u1 p0 c0 {1,S} {4,S} {13,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u0 p0 c0 {1,S} {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C_C(C)CCCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u1 p0 c0 {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+1-methylcycloheptyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {18,S} {19,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {20,S} {21,S}
+8  *1 C u0 p0 c0 {1,S} {7,S} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+CC(C)_CCCCCCJ
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,D}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+4  *2 C u0 p0 c0 {1,D} {5,S} {16,S}
+5  *5 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *7 C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+7  *6 C u0 p0 c0 {6,S} {8,S} {21,S} {22,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {23,S} {24,S}
+9  *1 C u1 p0 c0 {8,S} {25,S} {26,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {8,S}
+24    H u0 p0 c0 {8,S}
+25    H u0 p0 c0 {9,S}
+26    H u0 p0 c0 {9,S}
+
+2,2-dimethylcycloheptyl
+multiplicity 2
+1  *3 C u0 p0 c0 {2,S} {3,S} {4,S} {9,S}
+2     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+3     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+4  *2 C u1 p0 c0 {1,S} {5,S} {16,S}
+5  *5 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *7 C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+7  *6 C u0 p0 c0 {6,S} {8,S} {21,S} {22,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {23,S} {24,S}
+9  *1 C u0 p0 c0 {1,S} {8,S} {25,S} {26,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {8,S}
+24    H u0 p0 c0 {8,S}
+25    H u0 p0 c0 {9,S}
+26    H u0 p0 c0 {9,S}
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -193,3 +193,1105 @@ Taken from entry: prod_29 <=> prod_30
 """,
 )
 
+entry(
+    index = 15,
+    label = "C_CCCJ <=> cyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (6.60e+07, 's^-1'),
+        n = 1.08,
+        Ea = (30.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 16,
+    label = "C_CCCJC <=> 3-methylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.02e+07, 's^-1'),
+        n = 1.34,
+        Ea = (30.1, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 17,
+    label = "C_CCCJCC <=> 3-ethylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.00e+07, 's^-1'),
+        n = 1.34,
+        Ea = (29.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 18,
+    label = "CC_CCCJ <=> 2-methylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.61e+08, 's^-1'),
+        n = 0.96,
+        Ea = (29.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling" Trans conformation of pentenyl.
+""",
+)
+
+entry(
+    index = 19,
+    label = "C_CC(C)CJ <=> 2-methylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.01e+08, 's^-1'),
+        n = 1.02,
+        Ea = (29.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 20,
+    label = "C_C(C)CCJ <=> 1-methylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.82e+08, 's^-1'),
+        n = 0.91,
+        Ea = (30.0, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 21,
+    label = "C_CC(C)(C)CJ <=> 2,2-dimethylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.41e+08, 's^-1'),
+        n = 0.96,
+        Ea = (29.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 22,
+    label = "C_CCCJ(C)C <=> 3,3-dimethylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.02e+06, 's^-1'),
+        n = 1.58,
+        Ea = (29.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 23,
+    label = "C_C(C)CCJC <=> 1,3-dimethylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.71e+08, 's^-1'),
+        n = 0.99,
+        Ea = (29.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 24,
+    label = "CC(C)_CCCJ <=> 2,2-dimethylcyclobutyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.15e+07, 's^-1'),
+        n = 1.24,
+        Ea = (30.9, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 25,
+    label = "C_CCCCJ <=> cyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.65e+07, 's^-1'),
+        n = 1.02,
+        Ea = (14.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 26,
+    label = "C_CCCCJC <=> 3-methylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (4.64e+06, 's^-1'),
+        n = 1.15,
+        Ea = (13.9, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 27,
+    label = "C_CCCCJ(C)C <=> 3,3-dimethylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.07e+06, 's^-1'),
+        n = 1.38,
+        Ea = (12.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 28,
+    label = "CC_CCCCJ <=> 2-methylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.94e+07, 's^-1'),
+        n = 0.93,
+        Ea = (13.9, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling" Trans conformation of hexenyl.
+""",
+)
+
+entry(
+    index = 29,
+    label = "C_CCC(C)CJ <=> 3-methylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (6.65e+07, 's^-1'),
+        n = 0.83,
+        Ea = (13.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 30,
+    label = "C_CC(C)CCJ <=> 2-methylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.25e+07, 's^-1'),
+        n = 0.83,
+        Ea = (14.1, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 31,
+    label = "C_C(C)CCCJ <=> 1-methylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.23e+07, 's^-1'),
+        n = 1.00,
+        Ea = (13.5, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 32,
+    label = "C_CCC(C)(C)CJ <=> 3,3-dimethylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.38e+08, 's^-1'),
+        n = 0.75,
+        Ea = (12.6, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 33,
+    label = "C_CC(C)(C)CCJ <=> 2,2-dimethylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.60e+08, 's^-1'),
+        n = 0.76,
+        Ea = (13.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 34,
+    label = "CC(C)_CCCCJ <=> 2,2-dimethylcyclopentyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (4.90e+06, 's^-1'),
+        n = 1.13,
+        Ea = (15.6, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 35,
+    label = "C_CCCCCJ <=> cyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.25e+06, 's^-1'),
+        n = 1.08,
+        Ea = (6.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 36,
+    label = "C_CCCCCJC <=> 3-methylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (4.87e+05, 's^-1'),
+        n = 1.17,
+        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 37,
+    label = "C_CCCCCJ(C)C <=> 3,3-dimethylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.30e+04, 's^-1'),
+        n = 1.42,
+        Ea = (4.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 38,
+    label = "CC_CCCCCJ <=> 2-methylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.26e+06, 's^-1'),
+        n = 1.02,
+        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling" Trans conformation of heptenyl.
+""",
+)
+
+entry(
+    index = 39,
+    label = "C_CCCC(C)CJ <=> 4-methylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.01e+06, 's^-1'),
+        n = 1.05,
+        Ea = (5.8, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 40,
+    label = "C_CCC(C)CCJ <=> 3-methylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.32e+06, 's^-1'),
+        n = 0.84,
+        Ea = (5.9, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 41,
+    label = "C_CC(C)CCCJ <=> 2-methylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.24e+07, 's^-1'),
+        n = 0.79,
+        Ea = (6.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 42,
+    label = "C_C(C)CCCCJ <=> 1-methylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.46e+06, 's^-1'),
+        n = 1.02,
+        Ea = (6.1, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 43,
+    label = "C_CCCC(C)(C)CJ <=> 4,4-dimethylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.19e+07, 's^-1'),
+        n = 0.78,
+        Ea = (6.2, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 44,
+    label = "C_CCC(C)(C)CCJ <=> 3,3-dimethylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.50e+07, 's^-1'),
+        n = 0.70,
+        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 45,
+    label = "C_CC(C)(C)CCCJ <=> 2,2-dimethylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (5.85e+07, 's^-1'),
+        n = 0.63,
+        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 46,
+    label = "CC(C)_CCCCCJ <=> 2,2-dimethylcyclohexyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.44e+05, 's^-1'),
+        n = 1.10,
+        Ea = (7.7, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 47,
+    label = "C_CCCCCCJ <=> cycloheptyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.14e+05, 's^-1'),
+        n = 1.20,
+        Ea = (6.5, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 48,
+    label = "C_CCCCCCJC <=> 3-methylcycloheptyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.11e+04, 's^-1'),
+        n = 1.34,
+        Ea = (6.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 49,
+    label = "C_CCCCCCJ(C)C <=> 3,3-dimethylcycloheptyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (5.54e+02, 's^-1'),
+        n = 1.66,
+        Ea = (4.9, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 50,
+    label = "CC_CCCCCCJ <=> 2-methylcycloheptyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.10e+05, 's^-1'),
+        n = 1.18,
+        Ea = (6.5, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 51,
+    label = "C_C(C)CCCCCJ <=> 1-methylcycloheptyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.85e+05, 's^-1'),
+        n = 1.07,
+        Ea = (6.4, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 52,
+    label = "CC(C)_CCCCCCJ <=> 2,2-dimethylcycloheptyl",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.22e+04, 's^-1'),
+        n = 1.36,
+        Ea = (8.5, 'kcal/mol', '+|-', 1),
+        T0 = (1, 'K'),
+    ),
+    reference = Article(
+        authors = ["K. Wang", "S. Villano", "A. Dean"],
+        title = u'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = "J. Phys. Chem. A",
+        volume = "119(28)",
+        pages = """7205-7221""",
+        year = "2015",
+    ),
+	rank = 3,
+    referenceType = "theory",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed TST with Eckart Tunnelling"
+""",
+)
+


### PR DESCRIPTION
I got assigned to add these rates a while ago but never got around to pushing them...

These are rates computed at the CBS-QB3 level of theory, from a 2015 paper by Wang, Villano, and Dean (http://pubs.acs.org/doi/abs/10.1021/jp511017z).

I added some nodes to the tree to prevent some of the rates from falling to the same node. However, I don't know if they way I added them are computationally or chemically optimal. Someone else should definitely review them before merging.