### PR TITLE
"Treating N right": Fixes to forbidden groups in kinetic families

### DIFF
--- a/input/kinetics/families/Disproportionation/groups.py
+++ b/input/kinetics/families/Disproportionation/groups.py
@@ -2988,7 +2988,7 @@ forbidden(
     label = "XH_birad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p1 {2,[S,D,T]}
+1 *3 [C,Si] u0 p1 {2,[S,D,T]}
 2 *2 R!H      ux {1,[S,D,T]} {3,S}
 3 *4 H        u0 {2,S}
 """,
@@ -3003,8 +3003,23 @@ forbidden(
     label = "XH_quadrad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p2 {2,[S,D,T]}
+1 *3 [C,Si] u0 p2 {2,[S,D,T]}
 2 *2 R!H      ux {1,[S,D,T]} {3,S}
+3 *4 H        u0 {2,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "XH_N_birad_singlet",
+    group = 
+"""
+1 *3 N u0 p2 {2,[S,D]}
+2 *2 R!H      ux {1,[S,D]} {3,S}
 3 *4 H        u0 {2,S}
 """,
     shortDesc = u"""""",
@@ -3018,7 +3033,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p1
+1 *1 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *1 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -3031,7 +3059,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p2
+1 *1 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/H_Abstraction/groups.py
+++ b/input/kinetics/families/H_Abstraction/groups.py
@@ -6876,7 +6876,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p1
+1 *3 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *3 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -6976,7 +6989,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p2
+1 *3 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -2643,7 +2643,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p1
+1 *1 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *1 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -2684,7 +2697,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p2
+1 *1 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/Intra_R_Add_ExoTetCyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_ExoTetCyclic/groups.py
@@ -3172,7 +3172,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p1
+1 *1 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *1 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -3199,7 +3212,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p2
+1 *1 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
@@ -2948,7 +2948,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p1
+1 *1 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *1 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -2988,7 +3001,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p2
+1 *1 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/SubstitutionS/groups.py
+++ b/input/kinetics/families/SubstitutionS/groups.py
@@ -5367,7 +5367,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p1
+1 *3 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *3 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -5380,7 +5393,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p2
+1 *3 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/Substitution_O/groups.py
+++ b/input/kinetics/families/Substitution_O/groups.py
@@ -4578,7 +4578,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p1
+1 *3 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *3 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -4591,7 +4604,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *3 [C,N,Si] u0 p2
+1 *3 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 

--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -4263,7 +4263,20 @@ forbidden(
     label = "birad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p1
+1 *1 [C,Si] u0 p1
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "N_birad_singlet",
+    group = 
+"""
+1 *1 N u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 
@@ -5309,7 +5322,7 @@ forbidden(
     label = "quadrad_singlet",
     group = 
 """
-1 *1 [C,N,Si] u0 p2
+1 *1 [C,Si] u0 p2
 """,
     shortDesc = u"""""",
     longDesc = 


### PR DESCRIPTION
In the forbidden groups of many kinetic families N was so far treated as having similar valance as C or Si.

This was now fixed generally by deleting "N" from the "birad_singlet" and "quadrad_singlet" forbidden groups, and by adding a new “N_birad_singlet” forbidden group.

The following families were changed: Disproportionation, H_Abstraction, Intra_H_migration, Intra_R_Add_Endocyclic, Intra_R_Add_Exocyclic, Intra_R_Add_ExoTetcyclic, Substitution_O, SubstitutionS