### PR TITLE
Add evaluateKinetics.py script to testing folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 *.pyc
 
 *.ipynb_checkpoints
+
+# evaluate kinetics folder stuff
+testing/eval/*

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/NIST/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/NIST/dictionary.txt
@@ -1,7 +1,7 @@
 C6H11-2
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3  *1 C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
 4  *5 C u0 p0 c0 {2,S} {6,S} {13,S} {14,S}
 5  *3 C u0 p0 c0 {3,S} {6,S} {15,S} {16,S}
@@ -140,7 +140,7 @@ multiplicity 2
 
 C6H11
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+1  *6  C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3  *4 C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
 4  *2 C u0 p0 c0 {2,S} {6,D} {13,S}

--- a/input/kinetics/families/R_Addition_MultipleBond/NIST/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/NIST/reactions.py
@@ -4333,7 +4333,7 @@ entry(
         Ea = (100.6, 'kJ/mol'),
         T0 = (1, 'K'),
         Tmin = (400, 'K'),
-        Tmax = (400, 'K'),
+        Tmax = (2000, 'K'),
     ),
     reference = Article(
         authors = ["Hoyermann, K.", "Olzmann, M.", "Seeba, J.", "Viskolcz, B."],

--- a/input/kinetics/families/intra_H_migration/NIST/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/NIST/dictionary.txt
@@ -25,7 +25,7 @@ multiplicity 2
 C5H11O2-2
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
-2     C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
+2  *6 C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
 3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
 4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
 5  *1 C u1 p0 c0 {1,S} {16,S} {17,S}
@@ -46,7 +46,7 @@ multiplicity 2
 C4H9O
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
-2     C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
 3  *2 C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
 4  *4 C u0 p0 c0 {2,S} {9,S} {13,S} {14,S}
 5     H u0 p0 c0 {1,S}
@@ -64,7 +64,7 @@ C7H15O
 multiplicity 2
 1  *2 C u0 p0 c0 {2,S} {5,S} {6,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
-3     C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+3  *6 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
 4  *4 C u0 p0 c0 {3,S} {7,S} {9,S} {14,S}
 5     C u0 p0 c0 {1,S} {15,S} {16,S} {17,S}
 6     C u0 p0 c0 {1,S} {18,S} {19,S} {20,S}
@@ -205,7 +205,7 @@ multiplicity 2
 
 C4H9O-2
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+1  *6  C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
 2  *4 C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
 3  *5 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
 4  *1 C u1 p0 c0 {2,S} {12,S} {13,S}
@@ -223,7 +223,7 @@ multiplicity 2
 C6H13O-10
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3     C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
 4  *4 C u0 p0 c0 {2,S} {6,S} {13,S} {14,S}
 5     C u0 p0 c0 {3,S} {15,S} {16,S} {17,S}
@@ -276,7 +276,7 @@ multiplicity 2
 
 C6H11O2-4
 multiplicity 2
-1     C u0 p0 c0 {2,S} {4,S} {7,S} {9,S}
+1  *6 C u0 p0 c0 {2,S} {4,S} {7,S} {9,S}
 2     C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
 3     C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
 4  *4 C u0 p0 c0 {1,S} {6,S} {14,S} {15,S}
@@ -320,8 +320,8 @@ multiplicity 2
 
 C6H11O2-2
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {9,S}
-2     C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+1  *7 C u0 p0 c0 {2,S} {3,S} {7,S} {9,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
 3     C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
 4  *4 C u0 p0 c0 {2,S} {6,S} {14,S} {15,S}
 5     C u0 p0 c0 {3,S} {6,S} {16,S} {17,S}
@@ -342,7 +342,7 @@ multiplicity 2
 
 C6H11O2-3
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
 3     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
 4     C u0 p0 c0 {5,S} {6,S} {14,S} {15,S}
@@ -387,7 +387,7 @@ multiplicity 2
 C5H11O-6
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
-2     C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
 3  *4 C u0 p0 c0 {2,S} {5,S} {10,S} {11,S}
 4     C u0 p0 c0 {1,S} {12,S} {13,S} {14,S}
 5  *1 C u1 p0 c0 {3,S} {15,S} {16,S}
@@ -406,7 +406,7 @@ multiplicity 2
 
 C5H11O-4
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {4,S} {7,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {4,S} {7,S}
 2  *4 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
 3  *5 C u0 p0 c0 {1,S} {6,S} {10,S} {11,S}
 4     C u0 p0 c0 {1,S} {12,S} {13,S} {14,S}
@@ -426,7 +426,7 @@ multiplicity 2
 
 C5H11O-5
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+1  *6  C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3  *4 C u0 p0 c0 {1,S} {5,S} {6,S} {11,S}
 4  *2 C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
@@ -446,7 +446,7 @@ multiplicity 2
 
 C5H11O-2
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *4 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
 3  *5 C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
 4     C u0 p0 c0 {5,S} {13,S} {14,S} {15,S}
@@ -519,7 +519,7 @@ multiplicity 2
 C6H13O-8
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
-2     C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
 3  *4 C u0 p0 c0 {2,S} {6,S} {10,S} {11,S}
 4     C u0 p0 c0 {1,S} {12,S} {13,S} {14,S}
 5     C u0 p0 c0 {1,S} {15,S} {16,S} {17,S}
@@ -607,7 +607,7 @@ multiplicity 2
 1  *2 C u0 p0 c0 {3,S} {5,S} {6,S} {10,S}
 2  *4 C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
 3  *5 C u0 p0 c0 {1,S} {4,S} {11,S} {12,S}
-4     C u0 p0 c0 {2,S} {3,S} {13,S} {14,S}
+4  *6 C u0 p0 c0 {2,S} {3,S} {13,S} {14,S}
 5     C u0 p0 c0 {1,S} {15,S} {16,S} {17,S}
 6     C u0 p0 c0 {1,S} {18,S} {19,S} {20,S}
 7     C u0 p0 c0 {2,S} {21,S} {22,S} {23,S}
@@ -665,8 +665,8 @@ multiplicity 2
 
 C6H11O2
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *7 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
 3     C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
 4  *2 C u0 p0 c0 {5,S} {6,S} {9,S} {14,S}
 5  *5 C u0 p0 c0 {2,S} {4,S} {15,S} {16,S}
@@ -783,7 +783,7 @@ multiplicity 2
 C7H15O-4
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
-2     C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
 3  *4 C u0 p0 c0 {2,S} {7,S} {11,S} {12,S}
 4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
 5     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
@@ -828,7 +828,7 @@ multiplicity 2
 
 C6H11-2
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+1   C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3  *4 C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
 4  *2 C u0 p0 c0 {2,S} {13,S} {14,S} {15,S}
@@ -851,7 +851,7 @@ multiplicity 2
 1  *2 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3     C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
-4     C u0 p0 c0 {2,S} {6,S} {13,S} {14,S}
+4  *6 C u0 p0 c0 {2,S} {6,S} {13,S} {14,S}
 5     C u0 p0 c0 {3,S} {16,S} {17,S} {18,S}
 6  *4 C u0 p0 c0 {4,S} {15,S} {19,S} {20,S}
 7  *3 H u0 p0 c0 {1,S}
@@ -872,7 +872,7 @@ multiplicity 2
 C8H17O-2
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {9,S}
-2     C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
 3  *4 C u0 p0 c0 {2,S} {8,S} {12,S} {13,S}
 4     C u0 p0 c0 {1,S} {14,S} {15,S} {16,S}
 5     C u0 p0 c0 {1,S} {17,S} {18,S} {19,S}
@@ -929,7 +929,7 @@ multiplicity 2
 C6H13O-7
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
-2     C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
 3  *5 C u0 p0 c0 {2,S} {6,S} {10,S} {11,S}
 4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
 5     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
@@ -952,7 +952,7 @@ multiplicity 2
 C5H11O2
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
-2     C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+2  *6  C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
 3  *2 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
 4     C u0 p0 c0 {1,S} {12,S} {13,S} {14,S}
 5     C u0 p0 c0 {1,S} {15,S} {16,S} {17,S}
@@ -990,7 +990,7 @@ multiplicity 2
 
 C6H13O-6
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
 2  *4 C u0 p0 c0 {1,S} {6,S} {10,S} {11,S}
 3  *5 C u0 p0 c0 {1,S} {7,S} {12,S} {13,S}
 4     C u0 p0 c0 {6,S} {14,S} {15,S} {16,S}
@@ -1013,7 +1013,7 @@ multiplicity 2
 
 C6H13O-9
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
 2  *4 C u0 p0 c0 {1,S} {4,S} {7,S} {10,S}
 3  *5 C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
 4     C u0 p0 c0 {2,S} {6,S} {13,S} {14,S}
@@ -1058,7 +1058,7 @@ C6H13O-5
 multiplicity 2
 1  *2 C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
 2  *5 C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
-3     C u0 p0 c0 {2,S} {6,S} {10,S} {11,S}
+3  *6 C u0 p0 c0 {2,S} {6,S} {10,S} {11,S}
 4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
 5     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
 6  *4 C u0 p0 c0 {3,S} {12,S} {19,S} {20,S}
@@ -1098,7 +1098,7 @@ multiplicity 2
 C6H13O-3
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
-2     C u0 p0 c0 {1,S} {4,S} {11,S} {12,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {11,S} {12,S}
 3  *2 C u0 p0 c0 {1,S} {5,S} {8,S} {13,S}
 4  *4 C u0 p0 c0 {2,S} {6,S} {7,S} {14,S}
 5     C u0 p0 c0 {3,S} {15,S} {16,S} {17,S}
@@ -1120,7 +1120,7 @@ multiplicity 2
 
 C6H13O-2
 multiplicity 2
-1     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+1  *6 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
 2  *4 C u0 p0 c0 {1,S} {6,S} {10,S} {11,S}
 3     C u0 p0 c0 {5,S} {6,S} {12,S} {13,S}
 4  *5 C u0 p0 c0 {1,S} {7,S} {14,S} {15,S}
@@ -1144,7 +1144,7 @@ multiplicity 2
 C7H15O-2
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
-2     C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
 3  *4 C u0 p0 c0 {2,S} {7,S} {12,S} {13,S}
 4     C u0 p0 c0 {1,S} {14,S} {15,S} {16,S}
 5     C u0 p0 c0 {7,S} {17,S} {18,S} {19,S}
@@ -1170,7 +1170,7 @@ multiplicity 2
 C7H15O-3
 multiplicity 2
 1  *4 C u0 p0 c0 {2,S} {5,S} {6,S} {8,S}
-2     C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
 3  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
 4  *2 C u0 p0 c0 {3,S} {7,S} {9,S} {14,S}
 5     C u0 p0 c0 {1,S} {15,S} {16,S} {17,S}
@@ -1235,7 +1235,7 @@ multiplicity 2
 
 C6H11
 multiplicity 2
-1     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+1  *6 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
 2  *5 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
 3  *4 C u0 p0 c0 {1,S} {5,S} {11,S} {12,S}
 4  *2 C u0 p0 c0 {2,S} {6,D} {13,S}
@@ -1256,7 +1256,7 @@ multiplicity 2
 C6H13O-4
 multiplicity 2
 1  *5 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
-2     C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
 3  *4 C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
 4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
 5     C u0 p0 c0 {6,S} {16,S} {17,S} {18,S}

--- a/input/kinetics/families/ketoenol/NIST/reactions.py
+++ b/input/kinetics/families/ketoenol/NIST/reactions.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "ketoenol/NIST"
+shortDesc = u""
+longDesc = u"""
+
+"""

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -259,12 +259,15 @@ def obtainKineticsFamilyStatistics(FullDatabase, trialDir):
             csvwriter.writerow(countNodes(family))
 
 
-def compareNIST(FullDatabase, trialDir):
+def compareNIST(FullDatabase, trialDir, pruneForExact=False):
     """
     Compare NIST reaction kinetics with estimates from RMG.  Creates parity plot and
     calculates the predicted root mean square error from the families.
     Note: does NOT average up the database or create any rate rules from training data.  
     If that is desired it must be done prior to entering this function.
+    
+    if pruneForExact=True, only the comparisons again exact match kinetics from RMG are returned
+    otherwise, estimated and exact matches are all included in the parity data.
     """
     trialDir=os.path.join(trialDir, 'compareNIST')
     if not os.path.exists(trialDir):
@@ -286,14 +289,16 @@ def compareNIST(FullDatabase, trialDir):
             else:
                 exactKinetics, approxKinetics = getKineticsDepository(FullDatabase, family, 'NIST')
                 
-                #prune for exact matches only
-                keysToRemove=[]
-                for key, kinetics in approxKinetics.iteritems():
-                    if not re.search('Exact', kinetics.comment):
-                        keysToRemove.append(key)
                 
-                for key in keysToRemove:
-                    del approxKinetics[key]
+                if pruneForExact:
+                    # prune for exact matches only
+                    keysToRemove=[]
+                    for key, kinetics in approxKinetics.iteritems():
+                        if not re.search('Exact', kinetics.comment):
+                            keysToRemove.append(key)
+                    
+                    for key in keysToRemove:
+                        del approxKinetics[key]
                 
                 parityData=analyzeForParity(exactKinetics, approxKinetics)
 

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -14,7 +14,6 @@ from matplotlib import pyplot as plt
 import re
 import copy
 import csv
-from time import time
 
 from rmgpy.thermo import *
 from rmgpy.kinetics import *
@@ -212,7 +211,8 @@ def obtainKineticsFamilyStatistics(FullDatabase, trialDir):
     as it would add non-exact rules to the rule count)
     """
     allFamilyNames=FullDatabase.kinetics.families.keys()
-    
+    allFamilyNames.sort()  # Perform test on families alphabetically
+
     familyCount={}
     
     for familyName in allFamilyNames: 
@@ -240,6 +240,7 @@ def compareNIST(FullDatabase, trialDir):
     
 
     allFamilyNames=FullDatabase.kinetics.families.keys()
+    allFamilyNames.sort()  # Perform test on families alphabetically
     
     QDict={}
     
@@ -305,7 +306,7 @@ def leaveOneOut(FullDatabase, trialDir):
         os.makedirs(trialDir)
     
     allFamilyNames=FullDatabase.kinetics.families.keys()
-    
+    allFamilyNames.sort()  # Perform test on families alphabetically
     QDict={}
 
     for familyName in allFamilyNames: 
@@ -314,16 +315,11 @@ def leaveOneOut(FullDatabase, trialDir):
         if len(family.rules.entries) < 2:
             print '    Skipping', familyName, ': only has one rate rule...'
         else:
-                
-            start_time = time()
             exactKinetics, approxKinetics = getKineticsLeaveOneOut(family)
-            end_time = time()
-            time_taken = end_time - start_time
-            print "Time spent: {0:.2f} minutes".format(time_taken/60.0)
             parityData=analyzeForParity(exactKinetics, approxKinetics, cutoff=8.0)
 
             if len(parityData)<2:
-                print '    Skipping', familyName, ': only one rate rule was calculated...'
+                print '    Skipping', familyName, ': {} rate rules were compared...'.format(len(parityData))
                 continue
             QDict[familyName]=calculateQ(parityData)
             createParityPlot(parityData)

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -36,7 +36,7 @@ def getKineticsDepository(FullDatabase, family, depositoryLabel):
     
     depository = None
     for tempDepository in family.depositories:
-        if re.search(depositoryLabel, tempDepository.label):
+        if re.search(re.escape(depositoryLabel), tempDepository.label):
             depository=tempDepository
             break
     else:

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -150,7 +150,7 @@ def calculateParity(exactKineticModel, approxKineticModel, T):
     return float(approx)/float(exact)
 
 
-def analyzeForParity(exactKinetics, approxKinetics, T=1000.0, cutoff=0.0):
+def analyzeForParity(exactKinetics, approxKinetics, T=1000.0):
     """
     Creates a parity plot from the exactKinetics and approxKinetics (dictionarys with 
     kineticModels are entries). Uses the median temperature of the exactKinetics to 
@@ -163,8 +163,6 @@ def analyzeForParity(exactKinetics, approxKinetics, T=1000.0, cutoff=0.0):
         exact=exactKinetics[key].getRateCoefficient(T)
         approx=approxKinetics[key].getRateCoefficient(T)
         dataPoint=[exact, approx]
-        if cutoff!=0 and math.log10((float(exact)/float(approx)))**2 > cutoff**2:
-            continue
         parityData[key]=dataPoint
 
     return parityData
@@ -297,7 +295,7 @@ def compareNIST(FullDatabase, trialDir):
                 for key in keysToRemove:
                     del approxKinetics[key]
                 
-                parityData=analyzeForParity(exactKinetics, approxKinetics, cutoff=8.0)
+                parityData=analyzeForParity(exactKinetics, approxKinetics)
 
                 if len(parityData)<2:
                     print '    Skipping', familyName, ': {} reactions were compared...'.format(len(parityData))
@@ -357,7 +355,7 @@ def leaveOneOut(FullDatabase, trialDir, averaging=True):
                     # Pre-average the family if averaging is not turned on
                     family.fillKineticsRulesByAveragingUp()
                 exactKinetics, approxKinetics = getKineticsLeaveOneOut(family, averaging)
-                parityData=analyzeForParity(exactKinetics, approxKinetics, cutoff=8.0)
+                parityData=analyzeForParity(exactKinetics, approxKinetics)
 
                 if len(parityData)<2:
                     print '    Skipping', familyName, ': {} rate rules were compared...'.format(len(parityData))

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -211,7 +211,7 @@ def obtainKineticsFamilyStatistics(FullDatabase, trialDir):
     
     for familyName in allFamilyNames: 
         family=FullDatabase.kinetics.families[familyName]
-        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' rules)'
+        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' rate rules)'
         familyCount[familyName]=countNodes(family)
 
     with open(os.path.join(trialDir, 'FamilyStatistics.csv'), 'wb') as csvfile:
@@ -239,9 +239,9 @@ def compareNIST(FullDatabase, trialDir):
     
     for familyName in allFamilyNames: 
         family=FullDatabase.kinetics.families[familyName]
-        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' nodes)'
+        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' rate rules)'
         if len(family.rules.entries) < 2:
-            print '    Skipping', familyName, ': only has one node...'
+            print '    Skipping', familyName, ': only has one rate rule...'
         else:
             exactKinetics, approxKinetics = getKineticsDepository(FullDatabase, family, 'NIST')
             
@@ -257,7 +257,7 @@ def compareNIST(FullDatabase, trialDir):
             parityData=analyzeForParity(exactKinetics, approxKinetics, cutoff=8.0)
 
             if len(parityData)<2:
-                print '    Skipping', familyName, ': only one node was calculated...'
+                print '    Skipping', familyName, ': only one rate rule was calculated...'
                 continue
             QDict[familyName]=calculateQ(parityData)
             createParityPlot(parityData)
@@ -302,15 +302,15 @@ def leaveOneOut(FullDatabase, trialDir):
 
     for familyName in allFamilyNames: 
         family=FullDatabase.kinetics.families[familyName]
-        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' nodes)'
+        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' rate rules)'
         if len(family.rules.entries) < 2:
-            print '    Skipping', familyName, ': only has one node...'
+            print '    Skipping', familyName, ': only has one rate rule...'
         else:
-            exactKinetics, approxKinetics =getKineticsLeaveOneOut(family)
+            exactKinetics, approxKinetics = getKineticsLeaveOneOut(family)
             parityData=analyzeForParity(exactKinetics, approxKinetics, cutoff=8.0)
 
             if len(parityData)<2:
-                print '    Skipping', familyName, ': only one node was calculated...'
+                print '    Skipping', familyName, ': only one rate rule was calculated...'
                 continue
             QDict[familyName]=calculateQ(parityData)
             createParityPlot(parityData)

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -29,7 +29,8 @@ from rmgpy.data.kinetics.common import UndeterminableKineticsError
 
 def getKineticsDepository(FullDatabase, family, depositoryLabel):
     """
-    Retrieve the NIST exact and approximated kinetics for those same reactions from RMG.
+    Retrieve dictionaries of exact kinetics from NIST depository and approximated kinetics 
+    for those same reactions from RMG.  
     Note: does NOT average up the database or create any rate rules from training data.  
     If that is desired it must be done prior to entering this function.
     """
@@ -85,6 +86,19 @@ def getKineticsLeaveOneOut(family, averaging=True):
     
     The original family should not contained averaged nodes when starting out.  The
     leave one out test should be performed only for original exact matches.
+    
+    There are two methods of performing the leave one out test:
+    
+    averaging=True, each exact entry is removed, and the family's trees
+    are re-averaged WITHOUT that entry and used to estimate the original entry. 
+    This method tests how the database performs to estimate data when it is
+    missing.  Speed of this test is slow.
+    
+    averaging=False, the family is pre-averaged, and then the exact entry
+    is removed, and RMG is used to re-estimate that entry.  This method
+    tests how the database averaging scheme performs, since we expect the
+    estimate to use a more general node that still incorporates the data
+    from the original exact entry. Speed of this test is fast.
     """   
     exactKinetics={}
     approxKinetics={}
@@ -153,8 +167,8 @@ def calculateParity(exactKineticModel, approxKineticModel, T):
 def analyzeForParity(exactKinetics, approxKinetics, T=1000.0):
     """
     Creates a parity plot from the exactKinetics and approxKinetics (dictionarys with 
-    kineticModels are entries). Uses the median temperature of the exactKinetics to 
-    give the best comparison. Returns the parityData in a dictionary with
+    kineticModels are entries). Uses the user specified temperature T to 
+    compare the two sets of kinetics k(T). Returns the parityData in a dictionary with
     {key: [exactCoefficient(T), approxCoefficient(T)}
     """
     parityData={}
@@ -215,7 +229,7 @@ def countNodes(family):
         else:
             # Duplicate node found at top of tree
             # eg. R_recombination: ['Y_rad', 'Y_rad']
-            assert len(forwardTemplate)==2 , 'Can currently only do symmetric trees with nothing else in them'
+            assert len(forwardTemplate)==2 , 'Duplicate entries in the top nodes must only be in symmetric trees containing exactly 2 total nodes, i.e. [Yrad, Yrad]'
             
     forwardTemplate = temporary
     

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -263,7 +263,7 @@ def compareNIST(FullDatabase, trialDir):
             parityData=analyzeForParity(exactKinetics, approxKinetics, cutoff=8.0)
 
             if len(parityData)<2:
-                print '    Skipping', familyName, ': only one rate rule was calculated...'
+                print '    Skipping', familyName, ': {} reactions were compared...'.format(len(parityData))
                 continue
             QDict[familyName]=calculateQ(parityData)
             createParityPlot(parityData)
@@ -358,7 +358,7 @@ if __name__ == '__main__':
     print 'Loading the RMG database...'
     FullDatabase=RMGDatabase()
     FullDatabase.load(settings['database.directory'], 
-                      kineticsFamilies=['Cyclic_Ether_Formation'], 
+                      kineticsFamilies='all', 
                       kineticsDepositories='all',
                       thermoLibraries=['primaryThermoLibrary'],   # Use just the primary thermo library, which contains necessary small molecular thermo
                       reactionLibraries=[],
@@ -368,17 +368,22 @@ if __name__ == '__main__':
     for family in FullDatabase.kinetics.families.values():
         family.addKineticsRulesFromTrainingSet(thermoDatabase=FullDatabase.thermo)
     
+    print '--------------------------------------------'
     print 'Obtaining statistics for the families...'
     obtainKineticsFamilyStatistics(FullDatabase, trialDir)
     
+    print '--------------------------------------------'
     print 'Performing the leave on out test on the kinetics families...'
     leaveOneOut(FullDatabase, trialDir)
     
+    print '--------------------------------------------'
+    print 'Filling up the family rate rules by averaging... Expect larger number of rate rules in subsequent tests'
     # Fill in the rate rules by averaging when we are ready to compare real kinetics
     for family in FullDatabase.kinetics.families.values():
         family.fillKineticsRulesByAveragingUp()
     
 
+    print '--------------------------------------------'
     print 'Evaluating the NIST Kinetics against the RMG estimates...'
     compareNIST(FullDatabase, trialDir)
     

--- a/testing/evaluateKinetics.py
+++ b/testing/evaluateKinetics.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+This script is meant to use statistical tests to evaluate the rate rules of RMG.
+"""
+
+import os.path
+import math
+import numpy
+import matplotlib
+matplotlib.rc('mathtext', fontset='stixsans', default='regular')
+import matplotlib.pyplot as plt
+import pylab
+import re
+import copy
+import csv
+
+from rmgpy.thermo import *
+from rmgpy.kinetics import *
+from rmgpy.data.reference import *
+from rmgpy.data.base import Entry
+from rmgpy.data.thermo import ThermoDatabase
+from rmgpy.data.kinetics import saveEntry
+from rmgpy.molecule import Molecule
+from rmgpy.species import Species
+from rmgpy.reaction import Reaction
+from rmgpy.data.rmg import RMGDatabase
+from rmgpy.data.kinetics.common import UndeterminableKineticsError
+
+
+def getKineticsDepository(family, depositoryLabel, missingGroups):
+    
+    depository = None
+    for tempDepository in family.depositories:
+        if re.search(depositoryLabel, tempDepository.label):
+            depository=tempDepository
+            
+    family.fillKineticsRulesByAveragingUp()
+    
+    exactKinetics={}
+    approxKinetics={}
+    
+    for key, entry in depository.entries.iteritems():
+        try:
+            reaction=entry.item
+            template=family.getReactionTemplate(reaction)
+            exactKinetics[key]=entry.data
+            approxKinetics[key]=family.rules.estimateKinetics(template)[0]
+
+           
+        except UndeterminableKineticsError:
+            missingGroups.append([family.label, key , 'No Template found'])
+        
+        except Exception as inst:
+            missingGroups.append([family.label, key, 'Other error, needs further investigation'])
+
+    return exactKinetics, approxKinetics, missingGroups
+        
+def getKineticsLeaveOneOut(family, missingGroups):
+    """
+    Performs the leave one out test on a family. It returns a dictionary of 
+    the original exact nodes and a dictionary of the new averaged nodes. 
+    The returned dictionary entries will be of a KineticModel class
+    """   
+
+    entryKeys=family.rules.entries.keys()
+    
+    exactKinetics={}
+    approxKinetics={}
+    index=0
+    for entryKey in entryKeys:
+        index+=1
+#         templateKeys=re.split(';', entryKey)
+#         print entryKey, templateKeys, index
+        try:
+#             print entryKey
+            template=family.getReactionTemplate(family.rules.entries[entryKey][0].item)
+
+            print entryKey, [templateEntry.label for templateEntry in template], index
+            exactKinetics[entryKey], exactKineticsEntry=family.rules.estimateKinetics(template)
+            
+            familyCopy=copy.deepcopy(family)
+            familyCopy.rules.entries.pop(entryKey)
+            familyCopy.fillKineticsRulesByAveragingUp()
+            
+            approxKinetics[entryKey], approxKineticsEntry=familyCopy.rules.estimateKinetics(template)
+        
+        except UndeterminableKineticsError:
+            missingGroups.append([family.label, re.split(';', entryKey), 'No Template found'])
+        
+        except Exception as inst:
+            missingGroups.append([family.label, re.split(';', entryKey), 'Other error, needs further investigation'])
+        
+        except AttributeError:
+#             if family.label in logicErrorNodes.keys():
+#                 logicErrorNodes[family.label].append(entryKey)
+#             else:
+#                 logicErrorNodes[family.label]=[entryKey]
+            pass #maybe add more later
+
+    return exactKinetics, approxKinetics, missingGroups
+
+#returns the average temperature for the range given by the kinetic model
+def getAverageTemp(kineticModel):
+#     try:
+#         return (kineticModel.Tmin.value + kineticModel.Tmax.value)/2
+#     except AttributeError:
+    return 1000
+        
+#calculates the parity values for each
+def calculateParity(exactKineticModel, approxKineticModel, T):
+    exact = exactKineticModel.getRateCoefficient(T)
+    approx = approxKineticModel.getRateCoefficient(T)
+    
+    return float(approx)/float(exact)
+
+
+def analyzeForParity(exactKinetics, approxKinetics, T=None, cutoff=0):
+    """
+    Creates a parity plot from the exactKinetics and approxKinetics (dictionarys with 
+    kineticModels are entries). Uses the median temperature of the exactKinetics to 
+    give the best comparison. Returns the parityData in a dictionary with
+    {key: [exactCoefficient(T), approxCoefficient(T)}
+    """
+    parityData={}
+    for key in approxKinetics:
+        if T is None:
+            T=getAverageTemp(exactKinetics[key])
+        print exactKinetics[key]
+        exact=exactKinetics[key].getRateCoefficient(T)
+        approx=approxKinetics[key].getRateCoefficient(T)
+        dataPoint=[exact, approx]
+        if cutoff!=0 and math.log10((float(exact)/float(approx)))**2 > cutoff**2:
+            continue
+        parityData[key]=dataPoint
+
+    return parityData
+
+
+def calculateQ(parityData):
+    """
+    Calculates the predicted root mean square error
+    """
+    Q=0
+    for key, value in parityData.iteritems():
+        Q+=(math.log10(value[0]/value[1]))**2
+    return (Q/len(parityData))**0.5
+
+def createParityPlot(parityData):
+    
+    #unpack the data
+    keyList=parityData.keys()
+    xAxis=[]
+    yAxis=[]
+    for key in keyList:
+        xAxis.append(parityData[key][0])
+        yAxis.append(parityData[key][1])
+    
+    plt.loglog(xAxis,yAxis, 'ks')
+    
+    minimum=min(min(xAxis), min(yAxis))
+    maximum=max(max(xAxis), max(yAxis))
+    plt.loglog([minimum/10,maximum*10], [minimum/10,maximum*10], 'k')
+    plt.loglog([minimum*10,maximum*10], [minimum/10,maximum/10], 'k--')
+    plt.loglog([minimum/10,maximum/10],[minimum*10,maximum*10], 'k--')
+    plt.xlabel('Actual rate coefficient (cm^3/mol-s)')
+    plt.ylabel('Estimated rate coefficient (cm^3/mol-s)')
+    plt.axis([minimum/10, maximum*10, minimum/10, maximum*10])
+
+def countNodes(family):
+    countList=[family.label]
+    
+    #get top nodes
+    forwardTemplate = family.groups.top[:]
+
+    temporary = []
+    symmetricTree = False
+    for entry in forwardTemplate:
+        if entry not in temporary:
+            temporary.append(entry)
+        else:
+            # duplicate node found at top of tree
+            # eg. R_recombination: ['Y_rad', 'Y_rad']
+            assert len(forwardTemplate)==2 , 'Can currently only do symmetric trees with nothing else in them'
+            symmetricTree = True
+    forwardTemplate = temporary
+    
+    for group in forwardTemplate:
+        checkList=[group]
+        childrenList=[group]
+        while len(checkList)>0:
+            childrenList.extend(checkList[0].children)
+            checkList.extend(checkList[0].children)
+            del checkList[0]
+        
+        countList.append(len(childrenList))
+    return countList
+
+
+def getKineticsFromRules(family, entryKey):
+    
+
+    family.addKineticsRulesFromTrainingSet(thermoDatabase=FullDatabase.thermo)
+    family.fillKineticsRulesByAveragingUp()
+    
+    entryKeys=re.split(';', entryKey)
+    
+    template=[]
+    for key in entryKeys:
+        template.append(family.groups.entries[key])
+    
+    return family.rules.estimateKinetics(template)
+    
+
+###########################################################################################################
+# Functions for the full Database
+
+def countNodesAll(FullDatabase, trialDir):
+    for family in FullDatabase.kinetics.families.values():
+        family.addKineticsRulesFromTrainingSet(thermoDatabase=FullDatabase.thermo)
+
+    allFamilyNames=FullDatabase.kinetics.families.keys()
+    
+    familyCount={}
+    
+    for familyName in allFamilyNames: 
+        family=FullDatabase.kinetics.families[familyName]
+        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' nodes)'
+        familyCount[familyName]=countNodes(family)
+    
+    with open(os.path.join(trialDir, 'NodeCount.csv'), 'wb') as csvfile:
+        csvwriter=csv.writer(csvfile)
+        for key, value in familyCount.iteritems():
+            csvwriter.writerow(value)
+
+
+def NISTExact(FullDatabase, trialDir):
+    
+    trialDir=os.path.join(trialDir, 'NISTExact')
+    if not os.path.exists(trialDir):
+        os.makedirs(trialDir)
+    
+    for family in FullDatabase.kinetics.families.values():
+        family.addKineticsRulesFromTrainingSet(thermoDatabase=FullDatabase.thermo)
+    
+
+    allFamilyNames=FullDatabase.kinetics.families.keys()
+#     familyName='Disproportionation'
+#     allFamilyNames=[familyName]
+    
+    missingGroups=[]
+    QDict={}
+    familiesWithErrors=[]
+    for familyName in allFamilyNames: 
+        family=FullDatabase.kinetics.families[familyName]
+        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' nodes)'
+        if len(family.rules.entries) < 2:
+            print '    Skipping', familyName, ': only has one node...'
+        else:
+            ##getKineticsDepository
+            exactKinetics, approxKinetics, missingGroups=getKineticsDepository(family, 'NIST', missingGroups)
+            
+            #prune for exact matches only
+            keysToRemove=[]
+            for key, kinetics in approxKinetics.iteritems():
+                if not re.search('Exact', kinetics.comment):
+                    keysToRemove.append(key)
+            
+            for key in keysToRemove:
+                del approxKinetics[key]
+            
+            try:
+                parityData=analyzeForParity(exactKinetics, approxKinetics, None, 8)
+            except KeyError:
+                familiesWithErrors.append(family.label)
+                continue
+            if len(parityData)<2:
+                print '    Skipping', familyName, ': only one node was calculated...'
+                continue
+            QDict[familyName]=calculateQ(parityData)
+            createParityPlot(parityData)
+            plt.title(familyName)
+            plt.savefig(os.path.join(trialDir, familyName +'.png'))
+            plt.clf()
+               
+            if not os.path.exists(os.path.join(os.path.join(trialDir, 'ParityData'))):
+                os.makedirs(os.path.join(trialDir, 'ParityData'))
+               
+            with open(os.path.join(trialDir, 'ParityData', familyName + '.csv'), 'wb') as csvfile:
+                csvwriter=csv.writer(csvfile)
+                for key, value in parityData.iteritems():
+                    csvwriter.writerow([key, value[0]/value[1], approxKinetics[key].comment]) 
+ 
+    with open(os.path.join(trialDir, 'QDict_LOO.csv'), 'wb') as csvfile:
+        csvwriter=csv.writer(csvfile)
+        for key, value in QDict.iteritems():
+            csvwriter.writerow([key, value])
+              
+    with open(os.path.join(trialDir, 'missingNodes.csv'), 'wb') as csvfile:
+        csvwriter=csv.writer(csvfile)
+        for missingNode in missingGroups:
+            csvwriter.writerow(missingNode)
+      
+    print 'These families had errors:', familiesWithErrors
+
+
+
+def leaveOneOut(FullDatabase, trialDir):
+    """
+    Performs leave one out analysis on all the kinetics families.
+    """
+    
+    trialDir=os.path.join(trialDir, 'LeaveOneOut')
+    if not os.path.exists(trialDir):
+        os.makedirs(trialDir)
+    
+    for family in FullDatabase.kinetics.families.values():
+        family.addKineticsRulesFromTrainingSet(thermoDatabase=FullDatabase.thermo)
+    
+#     familyName='intra_substitutionCS_isomerization'
+#     allFamilyNames=[familyName]
+    allFamilyNames=FullDatabase.kinetics.families.keys()
+    
+    missingGroups=[]
+    QDict={}
+    familiesWithErrors=[]
+    for familyName in allFamilyNames: 
+        family=FullDatabase.kinetics.families[familyName]
+        print "Processing", familyName + '...', '(' + str(len(family.rules.entries)) + ' nodes)'
+        if len(family.rules.entries) < 2:
+            print '    Skipping', familyName, ': only has one node...'
+        else:
+            ##getKineticsLeaveOneOut
+            exactKinetics, approxKinetics, missingGroups=getKineticsLeaveOneOut(family, missingGroups)
+            try:
+                parityData=analyzeForParity(exactKinetics, approxKinetics, None, 8)
+            except KeyError:
+                familiesWithErrors.append(family.label)
+                continue
+            if len(parityData)<2:
+                print '    Skipping', familyName, ': only one node was calculated...'
+                continue
+            QDict[familyName]=calculateQ(parityData)
+            createParityPlot(parityData)
+            plt.title(familyName)
+            plt.savefig(os.path.join(trialDir, familyName +'.png'))
+            plt.clf()
+              
+            if not os.path.exists(os.path.join(os.path.join(trialDir, 'ParityData'))):
+                os.makedirs(os.path.join(trialDir, 'ParityData'))
+              
+            with open(os.path.join(trialDir, 'ParityData', familyName + '.csv'), 'wb') as csvfile:
+                csvwriter=csv.writer(csvfile)
+                for key, value in parityData.iteritems():
+                    csvwriter.writerow([key, value[0]/value[1], approxKinetics[key].comment]) 
+
+    with open(os.path.join(trialDir, 'QDict_LOO.csv'), 'wb') as csvfile:
+        csvwriter=csv.writer(csvfile)
+        for key, value in QDict.iteritems():
+            csvwriter.writerow([key, value])
+             
+    with open(os.path.join(trialDir, 'missingNodes.csv'), 'wb') as csvfile:
+        csvwriter=csv.writer(csvfile)
+        for missingNode in missingGroups:
+            csvwriter.writerow(missingNode)
+     
+    print 'These families had errors:', familiesWithErrors
+    return
+
+
+if __name__ == '__main__':
+    from rmgpy import settings
+    print 'Loading the RMG database...'
+    FullDatabase=RMGDatabase()
+    FullDatabase.load(settings['database.directory'], 
+                      kineticsFamilies=['Disproportionation'], 
+                      kineticsDepositories='all',
+                      thermoLibraries=[],
+                      reactionLibraries=[],
+                      )
+
+    trialDir = os.path.join(settings['database.directory'],'..','testing','eval')
+    if not os.path.exists(trialDir):
+        os.makedirs(trialDir)
+
+    family=FullDatabase.kinetics.families['Disproportionation']
+    print family.depositories
+    print FullDatabase.thermo.libraries
+    entryKey='Y_1centerbirad;O_Cdrad'
+     
+    retrievedKinetics, retrievedEntry = getKineticsFromRules(family, entryKey)
+     
+    print retrievedKinetics
+    
+    NISTExact(FullDatabase, trialDir)
+    countNodesAll(FullDatabase, trialDir)
+    leaveOneOut(FullDatabase, trialDir)
+    


### PR DESCRIPTION
This is a revised and updated script of Nathan's old kinetics evaluation script containing 3 main functionalities: 

- `obtainKineticsFamilyStatistics`: gathers and saves data about families into a .csv files containing info on the number of **exact** rate rules, number of groups per tree in the groups
- `leaveOneOut`: performs a leave one out test by deleting an **exact** node (excludes averaged ones), averaging the tree and then trying to estimate that tree.  Creates parity plots for each family and creates a .csv of the root mean square error.
- `compareNIST`: compares the family estimated kinetics against the exact kinetics from the NIST depository within each family.  Also creates parity plots and .csv of error data.