### PR TITLE
Delete comments and fix typo in Srad Disproportionation and R_Recombination rate rules

### DIFF
--- a/input/kinetics/families/Disproportionation/rules.py
+++ b/input/kinetics/families/Disproportionation/rules.py
@@ -855,8 +855,8 @@ entry(
     label = "S_rad/NonDeS;C/H2/Nd_Csrad/H/Cd",
     kinetics = ArrheniusEP(
         A = (6.44e+08, 'cm^3/(mol*s)'),
-        n = 0,
-        alpha = 1.19,
+        n = 1.19,
+        alpha = 0.0,
         E0 = (0.51, 'kcal/mol'),
         Tmin = (300, 'K'),
         Tmax = (1500, 'K'),
@@ -865,15 +865,7 @@ entry(
     shortDesc = u"""Very rough based on R_Recomb #491""",
     longDesc = 
 u"""
-[91] Tsang, W.; Journal of Physical and Chemical Reference Data (1988), 17(2), 887-951.
-Literature review.  C2H3 + n-C3H7 --> C3H6 + C2H4
 
-pg. 922: Discussion on evaluated data
-
-Entry 41,19 (a): No data available at the time.  Author estimates the rate coefficient
-
-based on the rxn C2H5+n-C3H7=C3H6=C2H6.
-MRH 30-Aug-2009
 """,
 )
 
@@ -910,8 +902,8 @@ entry(
     label = "S_rad/NonDeS;S_Csrad",
     kinetics = ArrheniusEP(
         A = (6.44e+08, 'cm^3/(mol*s)'),
-        n = 0,
-        alpha = 1.19,
+        n = 1.19,
+        alpha = 0.0,
         E0 = (0.51, 'kcal/mol'),
         Tmin = (300, 'K'),
         Tmax = (1500, 'K'),
@@ -920,16 +912,6 @@ entry(
     shortDesc = u"""Very rough based on R_Recomb #491""",
     longDesc = 
 u"""
-[91] Tsang, W.; Journal of Physical and Chemical Reference Data (1988), 17(2), 887-951.
-Literature review.  C2H + n-C3H7 --> C3H6 + C2H2
-
-pg. 923: Discussion on evaluated data
-
-Entry 41,21 (a): No data available at the time.  Author notes that the rxn is more exothermic
-
-than the rxn CH3+n-C3H7=C3H6+CH4 and suggests a rate coefficient 3x larger,
-namely 1.0x10^-11 cm3/molecule/s.
-MRH 30-Aug-2009
 """,
 )
 

--- a/input/kinetics/families/R_Recombination/rules.py
+++ b/input/kinetics/families/R_Recombination/rules.py
@@ -2156,22 +2156,6 @@ entry(
     shortDesc = u"""A.G. Vandeputte""",
     longDesc = 
 u"""
-MRH estimate
-
-A reasonable estimate for the total k_inf(T) for the recombination of H radical with a heavy atom
-is a temperature-independent 1e+14 cm3 mol-1 s-1.  HOWEVER, the value I choose to store in the database
-is 1e+13 cm3 mol-1 s-1, because this is the single-event value.  Not knowing what species RMG will find
-in trying this estimate, I want to fail on the low side.
-
-Using a hydrogen on a primary carbon as an example: Ethane has a multiplicity of six, iso-butane has a
-multiplicity of nine, and neo-pentane has a multiplicity of 12.  Using the 1e+13 cm3 mol-1 s-1 with any
-of these multiplicities will not result in ridiculously fast kinetics.  The purpose of adding entries
-491 and 492 are to reduce the chance RMG sends ridiculously fast high-P-limit kinetics to fame, thereby
-giving us ridiculously fast k(T,P) in our chem.inp files and causing stiffness issues in flame solvers.
-
-NOTE TO RMG USERS: If your model proves to be sensitive to the kinetics of the H+R(+M)=H-R(+M), I would
-encourage you to run a fame job separately, with the 1e+14 cm3 mol-1 s-1 as the total k(T) (if no better
-estimate is known).
 """,
 )
 


### PR DESCRIPTION
Found bug after getting Ea = -50, causing system to
be too stiff and crash.  We found that the alpha and n
kinetics values in Disproportionation were switched
due to a typo. The form of the kinetics should not be
Evans-Polanyi.  We also found that the MRH comments in the
kinetics descriptions are no longer relevant as it
corresponds to a previous version of the rate rule.
The rate rule in the database was constructed by
AG Vandeputte.