### PR TITLE
Ban square brackets in kinetics group names

### DIFF
--- a/input/kinetics/families/Korcek_step2/groups.py
+++ b/input/kinetics/families/Korcek_step2/groups.py
@@ -7,7 +7,7 @@ longDesc = u"""
 
 """
 
-template(reactants=["C1(R)(H)(O[OC3(OH)(R')]C2)"], products=["C1(R)(O)(C2)", "C3(OH)(O)(R')"], ownReverse=False)
+template(reactants=["C1(R)(H)(O(OC3(OH)(R'))C2)"], products=["C1(R)(O)(C2)", "C3(OH)(O)(R')"], ownReverse=False)
 
 reverse = "none"
 
@@ -22,7 +22,7 @@ recipe(actions=[
 
 entry(
     index = 1,
-    label = "C1(R)(H)(O[OC3(OH)(R')]C2)",
+    label = "C1(R)(H)(O(OC3(OH)(R'))C2)",
     group = 
 """
 1  *1 C u0 {2,S} {4,S} {7,S} {9,S}
@@ -43,7 +43,7 @@ entry(
 
 tree(
 """
-L1: C1(R)(H)(O[OC3(OH)(R')]C2)
+L1: C1(R)(H)(O(OC3(OH)(R'))C2)
 """
 )
 

--- a/input/kinetics/families/Korcek_step2/rules.py
+++ b/input/kinetics/families/Korcek_step2/rules.py
@@ -8,7 +8,7 @@ longDesc = u"""
 """
 entry(
     index = 1,
-    label = "C1(R)(H)(O[OC3(OH)(R')]C2)",
+    label = "C1(R)(H)(O(OC3(OH)(R'))C2)",
     kinetics = ArrheniusEP(
         A = (3e+09, 's^-1'),
         n = 1.38,

--- a/input/kinetics/families/R_Addition_COm/groups.py
+++ b/input/kinetics/families/R_Addition_COm/groups.py
@@ -403,7 +403,7 @@ entry(
 
 entry(
     index = 32,
-    label = "CH[CH3]2",
+    label = "CH(CH3)2",
     group = 
 """
 1  *2 C  u1 {2,S} {3,S} {4,S}
@@ -741,7 +741,7 @@ L1: Y_rad
             L4: C_rad/H2/O
         L3: C_sec_rad
             L4: C_rad/H/NonDeC
-                L5: CH[CH3]2
+                L5: CH(CH3)2
             L4: C_rad/H/NonDeO
                 L5: C_rad/H/CsO
                 L5: C_rad/H/O2

--- a/input/kinetics/families/R_Addition_COm/rules.py
+++ b/input/kinetics/families/R_Addition_COm/rules.py
@@ -426,7 +426,7 @@ CH3CH2CH2CO (doublet): EXTSYM = 1, three hindered rotors (methyl group, symmetry
 
 entry(
     index = 427,
-    label = "COm;CH[CH3]2",
+    label = "COm;CH(CH3)2",
     kinetics = ArrheniusEP(
         A = (8.61e+07, 'cm^3/(mol*s)', '*|/', 3),
         n = 1.36,

--- a/input/kinetics/families/R_Addition_CSm/groups.py
+++ b/input/kinetics/families/R_Addition_CSm/groups.py
@@ -403,7 +403,7 @@ entry(
 
 entry(
     index = 32,
-    label = "CH[CH3]2",
+    label = "CH(CH3)2",
     group = 
 """
 1  *2 Cs u1 {2,S} {3,S} {4,S}
@@ -687,7 +687,7 @@ L1: Y_rad
             L4: C_rad/H2/O
         L3: C_sec_rad
             L4: C_rad/H/NonDeC
-                L5: CH[CH3]2
+                L5: CH(CH3)2
             L4: C_rad/H/NonDeO
                 L5: C_rad/H/CsO
                 L5: C_rad/H/O2

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -265,6 +265,7 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
         """
         family = self.database.kinetics.families[family_name]
         for nodeName, nodeGroup in family.groups.entries.iteritems():
+            nose.tools.assert_false('[' in nodeName or ']' in nodeName, "Group {group} in {family} family contains square brackets [ ] in the label, which are not allowed.".format(group=nodeName, family=family_name))
             ascendParent = nodeGroup
             # Check whether the node has proper parents unless it is the top reactant or product node
             while ascendParent not in family.groups.top and ascendParent not in family.forwardTemplate.products:


### PR DESCRIPTION
We will now be using square brackets in comments describing kinetics. Banning them in group labels will make them easier to parse.