### PR TITLE
Make polycyclic pass sibling parent testing

### DIFF
--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -8480,6 +8480,20 @@ Automated Estimation of Ring Strain Energies, Gasteiger, 1978 S, Cp copied from 
 tree(
 """
 L1: PolycyclicRing
+    L2: s2-3_5_5_5_ane
+    L2: s2-3_5d1_5_5_ene
+    L2: s2-3f0_5_5_5_ane
+    L2: s2-3f1_6_5_5_ane
+    L2: s2-3_5_5_5d1_ene
+    L2: s3-3_5_6_5_ane
+    L2: s2-4f1_5_6_7_ane
+    L2: s2-4f2_5_6_8_ane
+    L2: s2-2f1_5_5_2_ane
+    L2: s2-3f1_5_5_6_ane
+    L2: s2-4f0_5_5_6_ane
+    L2: s2-4f1_5_5_7_ane
+    L2: s4-3f1_6_6_6_ane
+    L2: s3-3f1_6_5_6_ane
     L2: s1_3_3
         L3: s1_3_3_ane
         L3: s1_3_3_ene
@@ -8581,9 +8595,9 @@ L1: PolycyclicRing
     L2: s2_3_5
         L3: s2_3_5_ane
         L3: s2_3_5_ene
-            L4: s2_3_5_ene_1
-            L4: s2_3_5_ene_side
             L4: s2_3_5_ene_1_side
+            L4: s2_3_5_ene_1
+            L4: s2_3_5_ene_side 
     L2: s2_3_6
         L3: s2_3_6_ane
         L3: s2_3_6_ene
@@ -8811,20 +8825,6 @@ L1: PolycyclicRing
             L4: s4_6_8_ene_7
         L3: s4_6_8_diene
             L4: s4_6_8_diene_7_9
-    L2: s2-3_5_5_5_ane
-    L2: s2-3_5d1_5_5_ene
-    L2: s2-3f0_5_5_5_ane
-    L2: s2-3f1_6_5_5_ane
-    L2: s2-3_5_5_5d1_ene
-    L2: s3-3_5_6_5_ane
-    L2: s2-4f1_5_6_7_ane
-    L2: s2-4f2_5_6_8_ane
-    L2: s2-2f1_5_5_2_ane
-    L2: s2-3f1_5_5_6_ane
-    L2: s2-4f0_5_5_6_ane
-    L2: s2-4f1_5_5_7_ane
-    L2: s4-3f1_6_6_6_ane
-    L2: s3-3f1_6_5_6_ane
 """
 )
 

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -323,6 +323,9 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
     def kinetics_checkSiblingsForParents(self, family_name):
         """
         This test checks that siblings in a tree are not actually parent/child
+
+        See general_checkSiblingsForParents comments for more detailed description
+        of the test.
         """
         from rmgpy.data.base import Database
         originalFamily = self.database.kinetics.families[family_name]
@@ -335,12 +338,8 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             if node in originalFamily.forwardTemplate.products: continue
             for index, child1 in enumerate(node.children):
                 for child2 in node.children[index+1:]:
-                    #Don't check a node against itself
-                    if child1 is child2: continue
                     nose.tools.assert_false(family.matchNodeToChild(child1, child2),
                                             "In family {0}, node {1} is a parent of {2}, but they are written as siblings.".format(family_name, child1, child2))
-                    nose.tools.assert_false(family.matchNodeToChild(child2, child1),
-                                            "In family {0}, node {1} is a parent of {2}, but they are written as siblings.".format(family_name, child2, child1))
 
     def kinetics_checkAdjlistsNonidentical(self, database):
         """
@@ -495,17 +494,27 @@ The following adjList may have atoms in a different ordering than the input file
 
     def general_checkSiblingsForParents(self, group_name, group):
         """
-        This test checks that siblings in a tree are not actually parent/child
+        This test checks that siblings in a tree are not actually parent/child.
+
+        For example in a tree:
+
+        L1. A
+            L2. B
+            L2. C
+
+        This tests that C is not a child of B, which would make C inaccessible because
+        we always match B first.
+
+        We do not check that B is not a child of C becausethat does not cause accessibility
+        problems and may actually be necessary in some trees. For example, in the polycyclic
+        thermo groups B might be a tricyclic and C a bicyclic parent. Currently there is no
+        way to writes a bicyclic group that excludes an analogous tricyclic.
         """
         for nodeName, node in group.entries.iteritems():
             for index, child1 in enumerate(node.children):
                 for child2 in node.children[index+1:]:
-                    #Don't check a node against itself
-                    if child1 is child2: continue
                     nose.tools.assert_false(group.matchNodeToChild(child1, child2),
                                             "In {0} group, node {1} is a parent of {2}, but they are written as siblings.".format(group_name, child1, child2))
-                    nose.tools.assert_false(group.matchNodeToChild(child2, child1),
-                                            "In {0} group, node {1} is a parent of {2}, but they are written as siblings.".format(group_name, child2, child1))
 
     def general_checkCdAtomType(self, group_name, group):
         """

--- a/testing/databaseTest.py
+++ b/testing/databaseTest.py
@@ -116,12 +116,11 @@ class TestDatabase():  # cannot inherit from unittest.TestCase if we want to use
             self.compat_func_name = test_name
             yield test, group_name
 
-            if group_name != 'polycyclic':
-                test = lambda x: self.general_checkSiblingsForParents(group_name, group)
-                test_name = "Thermo groups {0}: sibling relationships are correct?".format(group_name)
-                test.description = test_name
-                self.compat_func_name = test_name
-                yield test, group_name
+            test = lambda x: self.general_checkSiblingsForParents(group_name, group)
+            test_name = "Thermo groups {0}: sibling relationships are correct?".format(group_name)
+            test.description = test_name
+            self.compat_func_name = test_name
+            yield test, group_name
 
             test = lambda x: self.general_checkCdAtomType(group_name, group)
             test_name = "Thermo groups {0}: Cd atomtype used correctly?".format(group_name)


### PR DESCRIPTION
Previously sibling and parent checking is deactivated for polycyclics because we don't want some siblings in polycyclics to be parent-children relationship although structure-wise they are parent-children. For instance, tricyclics have more specific structures than bicyclics so current sibling parent testing will complain that tricyclics should be under bicyclics, however we don't want using tricyclics ring strains to average for bicyclics ring strains. It's more chemically more sensible to have tricyclics and bicyclics as siblings. For current testing, we should place tricyclics before bicyclics to avoid failure of sibling parent testing. This PR reorganize the tree a bit to achieve that.