### PR TITLE
Added the FFCM-1 library (kinetic + thermo)

### DIFF
--- a/input/kinetics/libraries/FFCM1(-)/dictionary.txt
+++ b/input/kinetics/libraries/FFCM1(-)/dictionary.txt
@@ -1,0 +1,224 @@
+Ar
+1 Ar u0 p4 c0
+
+He
+1 He u0 p1 c0
+
+N2
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+
+H2
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+H
+multiplicity 2
+1 H u1 p0 c0
+
+O
+multiplicity 3
+1 O u2 p2 c0
+
+O2
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+
+OH
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+H2O
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+HO2
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+H2O2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
+CO
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+
+CO2
+1 C u0 p0 c0 {2,D} {3,D}
+2 O u0 p2 c0 {1,D}
+3 O u0 p2 c0 {1,D}
+
+C
+multiplicity 5
+1 C u4 p0 c0
+
+CH
+multiplicity 4
+1 C u3 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+CH2
+multiplicity 3
+1 C u2 p0 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CH2(S)
+1 C u0 p1 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CH3
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+CH4
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+HCO
+multiplicity 2
+1 C u1 p0 c0 {2,D} {3,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+
+CH2O
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+CH2OH
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+
+CH3O
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+CH3OH
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+
+C2H
+multiplicity 2
+1 C u1 p0 c0 {2,T}
+2 C u0 p0 c0 {1,T} {3,S}
+3 H u0 p0 c0 {2,S}
+
+C2H2
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
+C2H3
+multiplicity 2
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u1 p0 c0 {1,D} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+
+C2H4
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+
+C2H5
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+
+C2H6
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+
+HCCO
+multiplicity 2
+1 C u0 p0 c0 {2,T} {4,S}
+2 C u0 p0 c0 {1,T} {3,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+
+CH2CO
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 O u0 p2 c0 {2,D}
+
+CH2CHO
+multiplicity 2
+1 C u0 p0 c0 {2,D} {4,S} {5,S}
+2 C u0 p0 c0 {1,D} {3,S} {6,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+
+CH3CHO
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,D} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 O u0 p2 c0 {2,D}
+7 H u0 p0 c0 {2,S}
+
+CH3CO
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 O u0 p2 c0 {2,D}
+
+H2CC
+multiplicity 3
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u2 p0 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+

--- a/input/kinetics/libraries/FFCM1(-)/reactions.py
+++ b/input/kinetics/libraries/FFCM1(-)/reactions.py
@@ -1,0 +1,2791 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "FFCM1(-)"
+shortDesc = u""
+longDesc = u"""
+Foundational Fuel Chemistry Model Version 1.0 (excited species removed)
+http://web.stanford.edu/group/haiwanglab/FFCM1/pages/FFCM1.html
+
+FFCM-1
+H2/CO/C1 reaction model - Chemkin form - version v1.0c 
+Release date: 05/31/3016.
+
+G. P. Smith, Y. Tao, and H. Wang, Foundational Fuel Chemistry Model Version 1.0 (FFCM-1),
+http://nanoenergy.stanford.edu/ffcm1, 2016.
+
+Reactions that were not included:
+CH+O2<=>CO+OH*                                     1.800E+11    0.000        0.00
+C2H+O<=>CO+CH*                                     2.500E+12    0.000        0.00
+C2H+O2<=>CO2+CH*                                   3.200E+11    0.000     1600.00
+H+O+M=>OH*+M                                       5.450E+12    0.000        0.00
+2OH+H=>OH*+H2O                                     1.450E+15    0.000        0.00
+CH*=>CH                                            1.850E+06    0.000        0.00
+CH*+N2<=>CH+N2                                     3.030E+02    3.400     -381.00
+CH*+O2<=>CH+O2                                     2.400E+06    2.140    -1720.00
+CH*+H2O<=>CH+H2O                                   5.300E+13    0.000        0.00
+CH*+H2<=>CH+H2                                     1.470E+14    0.000     1361.00
+CH*+CO2<=>CH+CO2                                   2.410E-01    4.300    -1694.00
+CH*+CO<=>CH+CO                                     2.440E+12    0.500        0.00
+CH*+CH4<=>CH+CH4                                   1.730E+13    0.000      167.00
+CH*+AR<=>CH+AR                                     1.250E+10    0.500        0.00
+CH*+HE<=>CH+HE                                     1.950E+09    0.500        0.00
+OH*=>OH                                            1.450E+06    0.000        0.00
+OH*+N2<=>OH+N2                                     1.080E+11    0.500    -1238.00
+OH*+O2<=>OH+O2                                     2.100E+12    0.500     -482.00
+OH*+H2O<=>OH+H2O                                   5.920E+12    0.500     -861.00
+OH*+H2<=>OH+H2                                     2.950E+12    0.500     -444.00
+OH*+CO2<=>OH+CO2                                   2.750E+12    0.500     -968.00
+OH*+CO<=>OH+CO                                     3.230E+12    0.500     -787.00
+OH*+CH4<=>OH+CH4                                   3.360E+12    0.500     -635.00
+OH*+AR<=>OH+AR                                     1.250E+10    0.500        0.00
+OH*+HE<=>OH+HE                                     1.950E+09    0.500        0.00
+"""
+
+entry(
+    index = 1,
+    label = "H + O2 <=> O + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (9.841e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (15310, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 2,
+    label = "O + H2 <=> H + OH",
+    degeneracy = 1,
+    kinetics = MultiArrhenius(
+        arrhenius = [
+            Arrhenius(
+                A = (3.848e+12, 'cm^3/(mol*s)'),
+                n = 0,
+                Ea = (7950, 'cal/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (6.687e+14, 'cm^3/(mol*s)'),
+                n = 0,
+                Ea = (19180, 'cal/mol'),
+                T0 = (1, 'K'),
+            ),
+        ],
+    ),
+)
+
+entry(
+    index = 3,
+    label = "OH + H2 <=> H + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.256e+08, 'cm^3/(mol*s)'),
+        n = 1.51,
+        Ea = (3437, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 4,
+    label = "OH + OH <=> O + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (31610, 'cm^3/(mol*s)'),
+        n = 2.42,
+        Ea = (-1928, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 5,
+    label = "H2 <=> H + H",
+    degeneracy = 1,
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(
+            A = (4.58e+19, 'cm^3/(mol*s)'),
+            n = -1.4,
+            Ea = (104390, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 0, '[He]': 0, 'N#N': 1.01, '[H][H]': 2.55, 'O': 12.02, '[C-]#[O+]': 1.95, 'O=C=O': 3.83, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 6,
+    label = "H2 + Ar <=> H + H + Ar",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (5.176e+18, 'cm^3/(mol*s)'),
+        n = -1.1,
+        Ea = (104390, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 7,
+    label = "H2 + He <=> H + H + He",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (5.84e+18, 'cm^3/(mol*s)'),
+        n = -1.1,
+        Ea = (104390, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 8,
+    label = "O + O <=> O2",
+    degeneracy = 1,
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(
+            A = (6.16e+15, 'cm^6/(mol^2*s)'),
+            n = -0.5,
+            Ea = (0, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 0, '[He]': 0, '[H][H]': 2.50, 'O': 12.00, '[C-]#[O+]': 1.90, 'O=C=O': 3.80, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 9,
+    label = "O + O + Ar <=> O2 + Ar",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.89e+13, 'cm^6/(mol^2*s)'),
+        n = 0,
+        Ea = (-1788, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 10,
+    label = "O + O + He <=> O2 + He",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.89e+13, 'cm^6/(mol^2*s)'),
+        n = 0,
+        Ea = (-1788, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 11,
+    label = "O + H <=> OH",
+    degeneracy = 1,
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(A=(4.71e+18, 'cm^6/(mol^2*s)'), n=-1, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        efficiencies = {'[Ar]': 0.75, '[He]': 0.75, 'N#N': 1.32, '[H][H]': 2.50, 'O': 15.80, '[C-]#[O+]': 2.52, 'O=C=O': 5.01, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 12,
+    label = "H2O <=> H + OH",
+    degeneracy = 1,
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(
+            A = (6.06e+27, 'cm^3/(mol*s)'),
+            n = -3.322,
+            Ea = (120800, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 1.23, '[He]': 1.33, 'N#N': 2.46, '[H][H]': 3.77, '[O][O]': 1.50, 'O': 0.00, '[C-]#[O+]': 2.40, 'O=C=O': 4.67, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 13,
+    label = "H2O + H2O <=> H + OH + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.528e+25, 'cm^3/(mol*s)'),
+        n = -2.44,
+        Ea = (120200, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 14,
+    label = "H + O2 <=> HO2",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (4.565e+12, 'cm^3/(mol*s)'),
+            n = 0.44,
+            Ea = (0, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (6.37e+20, 'cm^6/(mol^2*s)'),
+            n = -1.72,
+            Ea = (525, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.5,
+        T3 = (30, 'K'),
+        T1 = (90000, 'K'),
+        T2 = (90000, 'K'),
+        efficiencies = {'[Ar]': 0.6, '[He]': 0.71, 'N#N': 0.96, '[H][H]': 1.87, '[O][O]': 0.75, 'O': 15.81, '[C-]#[O+]': 1.90, 'O=C=O': 3.45, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 15,
+    label = "HO2 + H <=> H2 + O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.945e+06, 'cm^3/(mol*s)'),
+        n = 2.087,
+        Ea = (-1455, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 16,
+    label = "HO2 + H <=> OH + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.888e+13, 'cm^3/(mol*s)'), n=0, Ea=(300, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 17,
+    label = "HO2 + H <=> O + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.632e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 18,
+    label = "HO2 + O <=> OH + O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.609e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-445, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 19,
+    label = "HO2 + OH <=> H2O + O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.347e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-1093, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 20,
+    label = "HO2 + HO2 <=> H2O2 + O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.958e+11, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-1409, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 21,
+    label = "H2O2 <=> OH + OH",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(2.187e+12, 's^-1'), n=0.9, Ea=(48750, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (2.49e+24, 'cm^3/(mol*s)'),
+            n = -2.3,
+            Ea = (48750, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.58,
+        T3 = (30, 'K'),
+        T1 = (90000, 'K'),
+        T2 = (90000, 'K'),
+        efficiencies = {'[Ar]': 0.85, '[He]': 0.65, 'N#N': 1.33, '[H][H]': 3.27, '[O][O]': 1.20, 'O': 6.63, 'OO': 6.61, '[C-]#[O+]': 2.80, 'O=C=O': 1.60, 'C': 2.00, 'C=O': 2.33, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 22,
+    label = "H2O2 + H <=> OH + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.045e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (3970, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 23,
+    label = "H2O2 + H <=> HO2 + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (5.856e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (7950, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 24,
+    label = "H2O2 + O <=> OH + HO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.513e+06, 'cm^3/(mol*s)'),
+        n = 2,
+        Ea = (3970, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 25,
+    label = "H2O2 + OH <=> H2O + HO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.565e+12, 'cm^3/(mol*s)'), n=0, Ea=(318, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 26,
+    label = "CO + O <=> CO2",
+    degeneracy = 1,
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(1.88e+11, 'cm^3/(mol*s)'), n=0, Ea=(2430, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (1.4e+21, 'cm^6/(mol^2*s)'),
+            n = -2.1,
+            Ea = (5500, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 0.87, '[He]': 2.50, 'O': 12.00, '[C-]#[O+]': 1.90, 'O=C=O': 3.80, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 27,
+    label = "CO + O2 <=> O + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.533e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (47700, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 28,
+    label = "CO + OH <=> H + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (61870, 'cm^3/(mol*s)'),
+        n = 2.053,
+        Ea = (-356, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 29,
+    label = "CO + HO2 <=> OH + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (157000, 'cm^3/(mol*s)'),
+        n = 2.18,
+        Ea = (17944, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 30,
+    label = "HCO <=> H + CO",
+    degeneracy = 1,
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(
+            A = (4.8e+17, 'cm^3/(mol*s)'),
+            n = -1.2,
+            Ea = (17734, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 1.40, '[He]': 1.31, 'N#N': 1.31, '[H][H]': 1.31, '[O][O]': 1.32, 'O': 15.31, '[C-]#[O+]': 2.40, 'O=C=O': 2.00, 'C': 2.60, 'C=O': 3.29, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 31,
+    label = "HCO + H <=> H2 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(8.482e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 32,
+    label = "HCO + O <=> OH + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.01e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 33,
+    label = "HCO + O <=> H + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.001e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 34,
+    label = "HCO + OH <=> H2O + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.199e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 35,
+    label = "HCO + O2 <=> HO2 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.562e+10, 'cm^3/(mol*s)'),
+        n = 0.521,
+        Ea = (-521, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 36,
+    label = "C + OH <=> H + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 37,
+    label = "C + O2 <=> O + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.62e+13, 'cm^3/(mol*s)'), n=0, Ea=(636, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 38,
+    label = "CH + H <=> C + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.089e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 39,
+    label = "CH + O <=> H + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.7e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 40,
+    label = "CH + OH <=> H + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 41,
+    label = "CH + H2 <=> H + CH2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.612e+14, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (3320, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 42,
+    label = "CH + H2 <=> CH3",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(5.13e+13, 'cm^3/(mol*s)'), n=0.15, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (2.43e+22, 'cm^6/(mol^2*s)'),
+            n = -1.6,
+            Ea = (0, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.514,
+        T3 = (152, 'K'),
+        T1 = (22850, 'K'),
+        T2 = (10350, 'K'),
+        efficiencies = {'[Ar]': 0.71, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 43,
+    label = "CH + H2O <=> H + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.43e+12, 'cm^3/(mol*s)'), n=0, Ea=(-884, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 44,
+    label = "CH + O2 <=> O + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.84e+08, 'cm^3/(mol*s)'),
+        n = 1.43,
+        Ea = (1200, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 45,
+    label = "CH + O2 <=> CO2 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.781e+08, 'cm^3/(mol*s)'),
+        n = 1.43,
+        Ea = (1200, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 46,
+    label = "CH + O2 <=> CO + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.84e+08, 'cm^3/(mol*s)'),
+        n = 1.43,
+        Ea = (1200, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 47,
+    label = "CH + O2 => O + H + CO",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(
+        A = (2.789e+08, 'cm^3/(mol*s)'),
+        n = 1.43,
+        Ea = (1200, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 48,
+    label = "CH + CO <=> HCCO",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(1.02e+15, 'cm^3/(mol*s)'), n=-0.4, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (3.26e+24, 'cm^6/(mol^2*s)'),
+            n = -2.5,
+            Ea = (0, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.4,
+        T3 = (30, 'K'),
+        T1 = (90000, 'K'),
+        T2 = (90000, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 49,
+    label = "CH + CO2 <=> HCO + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (6.38e+07, 'cm^3/(mol*s)'),
+        n = 1.51,
+        Ea = (-715, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 50,
+    label = "CH2 + H <=> CH3",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(2.13e+13, 'cm^3/(mol*s)'), n=0.32, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (1.39e+34, 'cm^6/(mol^2*s)'),
+            n = -5.04,
+            Ea = (7400, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.405,
+        T3 = (258, 'K'),
+        T1 = (2811, 'K'),
+        T2 = (9908, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 51,
+    label = "CH2 + O => H + H + CO",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(8e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 52,
+    label = "CH2 + OH <=> H + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.899e+13, 'cm^3/(mol*s)'),
+        n = 0.12,
+        Ea = (-162, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 53,
+    label = "CH2 + OH <=> CH + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (863000, 'cm^3/(mol*s)'),
+        n = 2.02,
+        Ea = (6776, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 54,
+    label = "CH2 + HO2 <=> OH + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 55,
+    label = "CH2 + H2 <=> H + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.265e+06, 'cm^3/(mol*s)'),
+        n = 2,
+        Ea = (7230, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 56,
+    label = "CH2 + O2 => OH + H + CO",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(
+        A = (2.643e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (1000, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 57,
+    label = "CH2 + O2 => H + H + CO2",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(
+        A = (1.844e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (1000, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 58,
+    label = "CH2 + O2 <=> O + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.6e+12, 'cm^3/(mol*s)'), n=0, Ea=(1000, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 59,
+    label = "CH2 + O2 <=> H2 + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.836e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (1000, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 60,
+    label = "CH2 + O2 <=> H2O + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.2e+11, 'cm^3/(mol*s)'), n=0, Ea=(1000, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 61,
+    label = "CH2 + C <=> H + C2H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 62,
+    label = "CH2 + CH <=> H + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 63,
+    label = "CH2 + CH2 => H + H + C2H2",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(2e+14, 'cm^3/(mol*s)'), n=0, Ea=(10989, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 64,
+    label = "CH2 + CH2 <=> H2 + H2CC",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.6e+15, 'cm^3/(mol*s)'), n=0, Ea=(11944, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 65,
+    label = "CH2(S) + N2 <=> CH2 + N2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.2e+13, 'cm^3/(mol*s)'), n=0, Ea=(471, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 66,
+    label = "CH2(S) + Ar <=> CH2 + Ar",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9e+12, 'cm^3/(mol*s)'), n=0, Ea=(600, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 67,
+    label = "CH2(S) + He <=> CH2 + He",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.62e+12, 'cm^3/(mol*s)'), n=0, Ea=(755, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 68,
+    label = "CH2(S) + H <=> CH + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 69,
+    label = "CH2(S) + O => H + H + CO",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 70,
+    label = "CH2(S) + OH <=> H + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 71,
+    label = "CH2(S) + H2 <=> CH3 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(8.291e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 72,
+    label = "CH2(S) + O2 <=> CH2 + O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.13e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 73,
+    label = "CH2(S) + H2O <=> CH3OH",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (2.94e+12, 'cm^3/(mol*s)'),
+            n = 0.053,
+            Ea = (-1897, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (1.68e+41, 'cm^6/(mol^2*s)'),
+            n = -7.192,
+            Ea = (5777, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.992,
+        T3 = (943, 'K'),
+        T1 = (47310, 'K'),
+        T2 = (47110, 'K'),
+        efficiencies = {'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 74,
+    label = "CH2(S) + H2O <=> CH2 + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.51e+13, 'cm^3/(mol*s)'), n=0, Ea=(-431, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 75,
+    label = "CH2(S) + H2O <=> H2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (6.67e+21, 'cm^3/(mol*s)'),
+        n = -3.134,
+        Ea = (3300, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 76,
+    label = "CH2(S) + H2O2 <=> OH + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.29e+14, 'cm^3/(mol*s)'),
+        n = -0.138,
+        Ea = (0, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 77,
+    label = "CH2(S) + CO <=> CH2 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 78,
+    label = "CH2(S) + CO2 <=> CH2 + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.33e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 79,
+    label = "CH2(S) + CO2 <=> CO + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.62e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 80,
+    label = "HCO + H <=> CH2O",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (1.913e+14, 'cm^3/(mol*s)'),
+            n = -0.033,
+            Ea = (-142, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (4.19e+34, 'cm^6/(mol^2*s)'),
+            n = -5.533,
+            Ea = (6128, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.782,
+        T3 = (271, 'K'),
+        T1 = (2755, 'K'),
+        T2 = (6570, 'K'),
+        efficiencies = {'[Ar]': 0.79, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.84, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 81,
+    label = "CH2O <=> H2 + CO",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(3.7e+13, 's^-1'), n=0, Ea=(71976, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (4.4e+38, 'cm^3/(mol*s)'),
+            n = -6.1,
+            Ea = (94000, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.932,
+        T3 = (197, 'K'),
+        T1 = (1540, 'K'),
+        T2 = (10300, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 82,
+    label = "CH2O + H <=> HCO + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.149e+07, 'cm^3/(mol*s)'),
+        n = 1.9,
+        Ea = (2742, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 83,
+    label = "CH2O + O <=> OH + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (4.244e+11, 'cm^3/(mol*s)'),
+        n = 0.57,
+        Ea = (2762, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 84,
+    label = "CH2O + OH <=> HCO + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.338e+07, 'cm^3/(mol*s)'),
+        n = 1.63,
+        Ea = (-1055, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 85,
+    label = "CH2O + O2 <=> HO2 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (329700, 'cm^3/(mol*s)'),
+        n = 2.5,
+        Ea = (36460, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 86,
+    label = "CH2O + HO2 <=> HCO + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(71110, 'cm^3/(mol*s)'), n=2.5, Ea=(10210, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 87,
+    label = "CH2O + CH <=> H + CH2CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.64e+13, 'cm^3/(mol*s)'), n=0, Ea=(-517, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 88,
+    label = "CH2O + CH2 <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(0.074, 'cm^3/(mol*s)'), n=4.21, Ea=(1120, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 89,
+    label = "CH2O + CH2(S) <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.33e+13, 'cm^3/(mol*s)'), n=0, Ea=(-550, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 90,
+    label = "CH2O + C2H <=> C2H2 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5400, 'cm^3/(mol*s)'), n=2.81, Ea=(5862, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 91,
+    label = "CH2O + C2H3 <=> C2H4 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5400, 'cm^3/(mol*s)'), n=2.81, Ea=(5862, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 92,
+    label = "CH3 + H <=> CH4",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(1.801e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (7.93e+24, 'cm^6/(mol^2*s)'),
+            n = -2.17,
+            Ea = (0, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.124,
+        T3 = (1801, 'K'),
+        T1 = (33.1, 'K'),
+        T2 = (90000, 'K'),
+        efficiencies = {'[Ar]': 0.36, '[He]': 0.42, 'N#N': 0.59, '[O][O]': 0.59, 'O': 3.42, '[C-]#[O+]': 0.89, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 93,
+    label = "CH3 + O <=> H + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.722e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 94,
+    label = "CH3 + O => H + H2 + CO",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(2.384e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 95,
+    label = "CH3 + OH <=> CH3OH",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (6.21e+13, 'cm^3/(mol*s)'),
+            n = -0.018,
+            Ea = (-33, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (7.24e+36, 'cm^6/(mol^2*s)'),
+            n = -6,
+            Ea = (3226, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.1855,
+        T3 = (156, 'K'),
+        T1 = (1675, 'K'),
+        T2 = (4530, 'K'),
+        efficiencies = {'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 96,
+    label = "CH3 + OH <=> CH2 + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(44640, 'cm^3/(mol*s)'), n=2.57, Ea=(3998, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 97,
+    label = "CH3 + OH <=> CH2(S) + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.81e+15, 'cm^3/(mol*s)'),
+        n = -0.91,
+        Ea = (546, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 98,
+    label = "CH3 + OH <=> H2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.735e+09, 'cm^3/(mol*s)'),
+        n = 0.734,
+        Ea = (-2177, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 99,
+    label = "CH3 + HO2 <=> O2 + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (126900, 'cm^3/(mol*s)'),
+        n = 2.228,
+        Ea = (-3022, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 100,
+    label = "CH3 + HO2 <=> OH + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.821e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-590, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 101,
+    label = "CH3 + O2 <=> O + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.104e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (28297, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 102,
+    label = "CH3 + O2 <=> OH + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(99.77, 'cm^3/(mol*s)'), n=2.86, Ea=(9768, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 103,
+    label = "CH3 + C <=> H + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 104,
+    label = "CH3 + CH <=> H + C2H3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.062e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 105,
+    label = "CH3 + CH2 <=> H + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.824e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 106,
+    label = "CH3 + CH2(S) <=> H + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(-497, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 107,
+    label = "CH3 + CH3 <=> C2H6",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (1.844e+16, 'cm^3/(mol*s)'),
+            n = -0.97,
+            Ea = (620, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (1.77e+50, 'cm^6/(mol^2*s)'),
+            n = -9.67,
+            Ea = (6220, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.5325,
+        T3 = (151, 'K'),
+        T1 = (1038, 'K'),
+        T2 = (4970, 'K'),
+        efficiencies = {'[Ar]': 0.69, '[He]': 0.70, '[O][O]': 1.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 1.99, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 108,
+    label = "CH3 + CH3 <=> H + C2H5",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.621e+12, 'cm^3/(mol*s)'),
+        n = 0.1,
+        Ea = (10600, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 109,
+    label = "CH3 + HCO <=> CH4 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.3e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 110,
+    label = "CH3 + CH2O <=> HCO + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(32.13, 'cm^3/(mol*s)'), n=3.36, Ea=(4310, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 111,
+    label = "CH3O <=> H + CH2O",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(1.13e+10, 's^-1'), n=1.21, Ea=(24075, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (6.02e+16, 'cm^3/(mol*s)'),
+            n = -0.547,
+            Ea = (18024, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.341,
+        T3 = (28, 'K'),
+        T1 = (1000, 'K'),
+        T2 = (2339, 'K'),
+        efficiencies = {'[Ar]': 0.85, '[He]': 0.67, '[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00},
+    ),
+)
+
+entry(
+    index = 112,
+    label = "CH3O + H <=> CH3OH",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(2.44e+11, 'cm^3/(mol*s)'), n=0.76, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (6.7e+40, 'cm^6/(mol^2*s)'),
+            n = -7.38,
+            Ea = (9177, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.684,
+        T3 = (37050, 'K'),
+        T1 = (41490, 'K'),
+        T2 = (3980, 'K'),
+        efficiencies = {'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 113,
+    label = "CH3O + H <=> H + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.29e+07, 'cm^3/(mol*s)'),
+        n = 1.82,
+        Ea = (-703, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 114,
+    label = "CH3O + H <=> H2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.79e+13, 'cm^3/(mol*s)'), n=0, Ea=(596, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 115,
+    label = "CH3O + H <=> OH + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.88e+14, 'cm^3/(mol*s)'),
+        n = -0.264,
+        Ea = (-26, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 116,
+    label = "CH3O + H <=> CH2(S) + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.97e+11, 'cm^3/(mol*s)'),
+        n = 0.414,
+        Ea = (243, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 117,
+    label = "CH3O + O <=> OH + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.78e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 118,
+    label = "CH3O + OH <=> H2O + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.81e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 119,
+    label = "CH3O + O2 <=> HO2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.32e+10, 'cm^3/(mol*s)'), n=0, Ea=(2603, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 120,
+    label = "CH3O + CH3 <=> CH4 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 121,
+    label = "CH3O + CO <=> CH3 + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6e+12, 'cm^3/(mol*s)'), n=0, Ea=(11000, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 122,
+    label = "CH2OH <=> H + CH2O",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(7.37e+10, 's^-1'), n=0.811, Ea=(39580, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (3.01e+13, 'cm^3/(mol*s)'),
+            n = 0.184,
+            Ea = (17230, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.001,
+        T3 = (50, 'K'),
+        T1 = (600, 'K'),
+        T2 = (2780, 'K'),
+        efficiencies = {'[Ar]': 0.85, '[He]': 0.67, '[H][H]': 2.00, 'O': 5.97, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00},
+    ),
+)
+
+entry(
+    index = 123,
+    label = "CH2OH + H <=> CH3OH",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(6.67e+10, 'cm^3/(mol*s)'), n=0.96, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (1.34e+41, 'cm^6/(mol^2*s)'),
+            n = -7.38,
+            Ea = (9177, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.684,
+        T3 = (37050, 'K'),
+        T1 = (41490, 'K'),
+        T2 = (3980, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 124,
+    label = "CH2OH + H <=> H2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.44e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 125,
+    label = "CH2OH + H <=> OH + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.006e+13, 'cm^3/(mol*s)'),
+        n = 0.198,
+        Ea = (-241, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 126,
+    label = "CH2OH + H <=> CH2(S) + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.28e+11, 'cm^3/(mol*s)'),
+        n = 0.516,
+        Ea = (215, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 127,
+    label = "CH2OH + O <=> OH + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.03e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 128,
+    label = "CH2OH + OH <=> H2O + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.41e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 129,
+    label = "CH2OH + O2 <=> HO2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.298e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (3736, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 130,
+    label = "CH2OH + CH3 <=> CH4 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 131,
+    label = "CH4 + H <=> CH3 + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(478100, 'cm^3/(mol*s)'), n=2.5, Ea=(9588, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 132,
+    label = "CH4 + O <=> OH + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (6.786e+08, 'cm^3/(mol*s)'),
+        n = 1.56,
+        Ea = (8485, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 133,
+    label = "CH4 + OH <=> CH3 + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (983900, 'cm^3/(mol*s)'),
+        n = 2.182,
+        Ea = (2446, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 134,
+    label = "CH4 + HO2 <=> CH3 + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(47780, 'cm^3/(mol*s)'), n=2.5, Ea=(21000, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 135,
+    label = "CH4 + CH <=> H + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(-397, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 136,
+    label = "CH4 + CH2 <=> CH3 + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.483e+06, 'cm^3/(mol*s)'),
+        n = 2,
+        Ea = (8270, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 137,
+    label = "CH4 + CH2(S) <=> CH3 + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.867e+13, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-497, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 138,
+    label = "CH4 + C2H <=> CH3 + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.3e+13, 'cm^3/(mol*s)'), n=0, Ea=(600, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 139,
+    label = "CH3OH + H <=> CH2OH + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.55e+06, 'cm^3/(mol*s)'),
+        n = 2.351,
+        Ea = (5912, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 140,
+    label = "CH3OH + H <=> CH3O + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (5.49e+06, 'cm^3/(mol*s)'),
+        n = 2.147,
+        Ea = (11134, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 141,
+    label = "CH3OH + O <=> OH + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.47e+13, 'cm^3/(mol*s)'), n=0, Ea=(5306, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 142,
+    label = "CH3OH + O <=> OH + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(8.2e+12, 'cm^3/(mol*s)'), n=0, Ea=(9040, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 143,
+    label = "CH3OH + OH <=> CH2OH + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (142000, 'cm^3/(mol*s)'),
+        n = 2.37,
+        Ea = (-965.2, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 144,
+    label = "CH3OH + OH <=> CH3O + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(16000, 'cm^3/(mol*s)'), n=2.7, Ea=(53.3, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 145,
+    label = "CH3OH + O2 <=> CH2OH + HO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (358000, 'cm^3/(mol*s)'),
+        n = 2.27,
+        Ea = (42760, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 146,
+    label = "CH3OH + HO2 <=> CH2OH + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.28e-05, 'cm^3/(mol*s)'),
+        n = 5.06,
+        Ea = (10213, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 147,
+    label = "CH3OH + HO2 <=> CH3O + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (0.0334, 'cm^3/(mol*s)'),
+        n = 4.12,
+        Ea = (16233, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 148,
+    label = "CH3OH + CH <=> CH3 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (9.04e+18, 'cm^3/(mol*s)'),
+        n = -1.93,
+        Ea = (0, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 149,
+    label = "CH3OH + CH2 <=> CH3 + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(32, 'cm^3/(mol*s)'), n=3.2, Ea=(7175, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 150,
+    label = "CH3OH + CH2 <=> CH3 + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(14.5, 'cm^3/(mol*s)'), n=3.1, Ea=(6940, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 151,
+    label = "CH3OH + CH2(S) <=> CH3 + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(7e+12, 'cm^3/(mol*s)'), n=0, Ea=(-550, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 152,
+    label = "CH3OH + CH2(S) <=> CH3 + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2e+13, 'cm^3/(mol*s)'), n=0, Ea=(-550, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 153,
+    label = "CH3OH + CH3 <=> CH2OH + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(665, 'cm^3/(mol*s)'), n=3.03, Ea=(8720, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 154,
+    label = "CH3OH + CH3 <=> CH3O + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(21500, 'cm^3/(mol*s)'), n=2.27, Ea=(8710, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 155,
+    label = "CH3OH + C2H <=> C2H2 + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 156,
+    label = "CH3OH + C2H <=> C2H2 + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.2e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 157,
+    label = "CH3OH + C2H3 <=> C2H4 + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(32, 'cm^3/(mol*s)'), n=3.2, Ea=(7175, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 158,
+    label = "CH3OH + C2H3 <=> C2H4 + CH3O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(14.5, 'cm^3/(mol*s)'), n=3.1, Ea=(6940, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 159,
+    label = "C2H + H <=> C2H2",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(2.25e+13, 'cm^3/(mol*s)'), n=0.32, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (3.75e+33, 'cm^6/(mol^2*s)'),
+            n = -4.8,
+            Ea = (1900, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.646,
+        T3 = (132, 'K'),
+        T1 = (1315, 'K'),
+        T2 = (5566, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 160,
+    label = "C2H + O <=> CH + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 161,
+    label = "C2H + OH <=> H + HCCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 162,
+    label = "C2H + H2 <=> H + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.11e+06, 'cm^3/(mol*s)'),
+        n = 2.32,
+        Ea = (882, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 163,
+    label = "C2H + O2 <=> HCO + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.63e+14, 'cm^3/(mol*s)'),
+        n = -0.35,
+        Ea = (0, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 164,
+    label = "HCCO + H <=> CH2(S) + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.32e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 165,
+    label = "HCCO + O <=> H + CO + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.73e+14, 'cm^3/(mol*s)'),
+        n = -0.112,
+        Ea = (0, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 166,
+    label = "HCCO + O <=> CH + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.95e+13, 'cm^3/(mol*s)'), n=0, Ea=(1113, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 167,
+    label = "HCCO + O2 <=> OH + CO + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.567e+12, 'cm^3/(mol*s)'), n=0, Ea=(854, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 168,
+    label = "HCCO + CH <=> CO + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 169,
+    label = "HCCO + CH2 <=> C2H3 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 170,
+    label = "HCCO + HCCO <=> CO + CO + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 171,
+    label = "C2H2 <=> H2CC",
+    degeneracy = 1,
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(8e+14, 's^-1'), n=-0.52, Ea=(50750, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (2.45e+15, 'cm^3/(mol*s)'),
+            n = -0.64,
+            Ea = (49700, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 0.69, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 172,
+    label = "C2H2 + H <=> C2H3",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (5.54e+08, 'cm^3/(mol*s)'),
+            n = 1.64,
+            Ea = (2096, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (3.63e+27, 'cm^6/(mol^2*s)'),
+            n = -3.38,
+            Ea = (847, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.215,
+        T3 = (10.7, 'K'),
+        T1 = (1043, 'K'),
+        T2 = (2341, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 173,
+    label = "C2H2 + O <=> H + HCCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.679e+08, 'cm^3/(mol*s)'),
+        n = 1.4,
+        Ea = (2206, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 174,
+    label = "C2H2 + O <=> CO + CH2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.304e+08, 'cm^3/(mol*s)'),
+        n = 1.4,
+        Ea = (2206, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 175,
+    label = "C2H2 + OH <=> H + CH2CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (0.867, 'cm^3/(mol*s)'),
+        n = 3.566,
+        Ea = (-2370, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 176,
+    label = "C2H2 + OH <=> C2H + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.63e+06, 'cm^3/(mol*s)'),
+        n = 2.14,
+        Ea = (17060, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 177,
+    label = "C2H2 + OH <=> CH3 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (614000, 'cm^3/(mol*s)'),
+        n = 1.62,
+        Ea = (-731, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 178,
+    label = "H2CC + H <=> C2H2 + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 179,
+    label = "H2CC + OH <=> CH2CO + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 180,
+    label = "H2CC + O2 <=> HCO + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.124e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 181,
+    label = "CH2 + CO <=> CH2CO",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (8.1e+11, 'cm^3/(mol*s)'),
+            n = 0.5,
+            Ea = (4510, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (2.69e+33, 'cm^6/(mol^2*s)'),
+            n = -5.11,
+            Ea = (7095, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.591,
+        T3 = (275, 'K'),
+        T1 = (1226, 'K'),
+        T2 = (5185, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 182,
+    label = "CH2CO + H <=> HCCO + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (4.2e+07, 'cm^3/(mol*s)'),
+        n = 1.9,
+        Ea = (11850, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 183,
+    label = "CH2CO + H <=> CH3 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (7.676e+08, 'cm^3/(mol*s)'),
+        n = 1.45,
+        Ea = (2780, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 184,
+    label = "CH2CO + O <=> OH + HCCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1e+13, 'cm^3/(mol*s)'), n=0, Ea=(10300, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 185,
+    label = "CH2CO + O <=> CH2 + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.08e+12, 'cm^3/(mol*s)'), n=0, Ea=(1351, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 186,
+    label = "CH2CO + O <=> HCO + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.61e+11, 'cm^3/(mol*s)'), n=0, Ea=(1351, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 187,
+    label = "CH2CO + O <=> CO + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.61e+11, 'cm^3/(mol*s)'), n=0, Ea=(1351, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 188,
+    label = "CH2CO + OH <=> HCCO + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(11200, 'cm^3/(mol*s)'), n=2.74, Ea=(2220, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 189,
+    label = "CH2CO + OH <=> CH3 + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.8e+11, 'cm^3/(mol*s)'), n=0, Ea=(-1013, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 190,
+    label = "CH2CO + OH <=> CH2OH + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.01e+12, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-1013, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 191,
+    label = "CH2CO + CH <=> C2H3 + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.45e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 192,
+    label = "C2H3 + H <=> C2H4",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(3.88e+13, 'cm^3/(mol*s)'), n=0.2, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (1.4e+30, 'cm^6/(mol^2*s)'),
+            n = -3.86,
+            Ea = (3320, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.782,
+        T3 = (207.5, 'K'),
+        T1 = (2663, 'K'),
+        T2 = (6095, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 193,
+    label = "C2H3 + H <=> H2 + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.21e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 194,
+    label = "C2H3 + H <=> H2CC + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.893e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 195,
+    label = "C2H3 + O <=> H + CH2CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.01e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 196,
+    label = "C2H3 + OH <=> H2O + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 197,
+    label = "C2H3 + OH <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 198,
+    label = "C2H3 + OH <=> CH3CO + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 199,
+    label = "C2H3 + O2 <=> HCO + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.936e+15, 'cm^3/(mol*s)'),
+        n = -0.959,
+        Ea = (580, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 200,
+    label = "C2H3 + O2 <=> CH2CHO + O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.849e+09, 'cm^3/(mol*s)'),
+        n = 0.923,
+        Ea = (226, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 201,
+    label = "C2H3 + O2 <=> C2H2 + HO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(44, 'cm^3/(mol*s)'), n=2.95, Ea=(186, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 202,
+    label = "C2H3 + CH3 <=> CH4 + C2H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9e+12, 'cm^3/(mol*s)'), n=0, Ea=(-765, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 203,
+    label = "CH2CHO <=> CH2CO + H",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(1.43e+15, 's^-1'), n=-0.15, Ea=(45606, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (2.44e+29, 'cm^3/(mol*s)'),
+            n = -3.79,
+            Ea = (43577, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.796,
+        T3 = (100, 'K'),
+        T1 = (50000, 'K'),
+        T2 = (34204, 'K'),
+        efficiencies = {'[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'C#C': 3.00, 'C=C': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 204,
+    label = "CH2CHO <=> CH3 + CO",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(2.93e+12, 's^-1'), n=0.29, Ea=(40326, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (2.34e+27, 'cm^3/(mol*s)'),
+            n = -3.18,
+            Ea = (33445, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.211,
+        T3 = (199, 'K'),
+        T1 = (2032, 'K'),
+        T2 = (111702, 'K'),
+        efficiencies = {'[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'C#C': 3.00, 'C=C': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 205,
+    label = "CH2CHO + H <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 206,
+    label = "CH2CHO + H <=> CH2CO + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 207,
+    label = "CH2CHO + H <=> CH3CO + H",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 208,
+    label = "CH2CHO + O => H + CH2 + CO2",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(1.58e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 209,
+    label = "CH2CHO + OH <=> H2O + CH2CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 210,
+    label = "CH2CHO + OH <=> HCO + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.01e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 211,
+    label = "CH2CHO + O2 => OH + CO + CH2O",
+    degeneracy = 1,
+    reversible = False,
+    kinetics = Arrhenius(A=(2.3e+10, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 212,
+    label = "CH3CO <=> CH3 + CO",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(1.07e+12, 's^-1'), n=0.63, Ea=(16895, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (5.65e+18, 'cm^3/(mol*s)'),
+            n = -0.97,
+            Ea = (14585, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.36,
+        T3 = (122, 'K'),
+        T1 = (50000, 'K'),
+        T2 = (16935, 'K'),
+        efficiencies = {'[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'C#C': 3.00, 'C=C': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 213,
+    label = "CH3CO + H <=> CH3CHO",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(9.6e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (3.85e+44, 'cm^6/(mol^2*s)'),
+            n = -8.569,
+            Ea = (5500, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 1,
+        T3 = (2900, 'K'),
+        T1 = (2900, 'K'),
+        T2 = (5132, 'K'),
+        efficiencies = {'[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'C#C': 3.00, 'C=C': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 214,
+    label = "CH3CO + H <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.6e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 215,
+    label = "CH3CO + O <=> CH2CO + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.27e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 216,
+    label = "CH3CO + O <=> CH3 + CO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.58e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 217,
+    label = "CH3CO + OH <=> CH2CO + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.2e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 218,
+    label = "CH3CO + OH <=> CH3 + CO + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 219,
+    label = "CH3CO + HO2 <=> CH3 + CO2 + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 220,
+    label = "CH3CO + O2 <=> HO2 + CH2CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.3e+10, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 221,
+    label = "CH3CO + CH3 <=> CH4 + CH2CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(6.08e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 222,
+    label = "CH3CHO <=> CH4 + CO",
+    degeneracy = 1,
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(5.44e+21, 's^-1'), n=-1.74, Ea=(86364, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (2.29e+58, 'cm^3/(mol*s)'),
+            n = -11.3,
+            Ea = (95922, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'C#C': 3.00, 'C=C': 3.00, 'CC': 3.00},
+        comment = 'Warning: SRI parameters from chemkin file ignored on import.',
+    ),
+    longDesc = 
+u"""
+Warning: SRI parameters from chemkin file ignored on import.
+""",
+)
+
+entry(
+    index = 223,
+    label = "CH3CHO <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(2.18e+22, 's^-1'), n=-1.74, Ea=(86364, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (9.15e+58, 'cm^3/(mol*s)'),
+            n = -11.3,
+            Ea = (95922, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[H][H]': 2.00, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'C#C': 3.00, 'C=C': 3.00, 'CC': 3.00},
+        comment = 'Warning: SRI parameters from chemkin file ignored on import.',
+    ),
+    longDesc = 
+u"""
+Warning: SRI parameters from chemkin file ignored on import.
+""",
+)
+
+entry(
+    index = 224,
+    label = "CH3CHO + H <=> CH2CHO + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.05e+09, 'cm^3/(mol*s)'),
+        n = 1.16,
+        Ea = (2405, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 225,
+    label = "CH3CHO + H <=> CH3CO + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.05e+09, 'cm^3/(mol*s)'),
+        n = 1.16,
+        Ea = (2405, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 226,
+    label = "CH3CHO + O <=> OH + CH2CHO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.92e+12, 'cm^3/(mol*s)'), n=0, Ea=(1808, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 227,
+    label = "CH3CHO + O <=> OH + CH3CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.92e+12, 'cm^3/(mol*s)'), n=0, Ea=(1808, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 228,
+    label = "CH3CHO + OH <=> CH3CO + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.69e+08, 'cm^3/(mol*s)'),
+        n = 1.35,
+        Ea = (-1574, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 229,
+    label = "CH3CHO + O2 <=> HO2 + CH3CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (120000, 'cm^3/(mol*s)'),
+        n = 2.5,
+        Ea = (37560, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 230,
+    label = "CH3CHO + HO2 <=> CH3CO + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(41000, 'cm^3/(mol*s)'), n=2.5, Ea=(10200, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 231,
+    label = "CH3CHO + CH3 <=> CH3CO + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (2.72e+06, 'cm^3/(mol*s)'),
+        n = 1.77,
+        Ea = (5920, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 232,
+    label = "C2H4 <=> H2 + H2CC",
+    degeneracy = 1,
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(3.985e+15, 's^-1'), n=0, Ea=(87060, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(
+            A = (3.71e+16, 'cm^3/(mol*s)'),
+            n = 0,
+            Ea = (67816, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.01, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 233,
+    label = "C2H4 + H <=> C2H5",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (1.232e+09, 'cm^3/(mol*s)'),
+            n = 1.463,
+            Ea = (1355, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (2.9e+39, 'cm^6/(mol^2*s)'),
+            n = -6.642,
+            Ea = (5769, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 1.569,
+        T3 = (-9147, 'K'),
+        T1 = (299, 'K'),
+        T2 = (152.4, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'N#N': 0.86, 'O': 4.92, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 234,
+    label = "C2H4 + H <=> C2H3 + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (220.1, 'cm^3/(mol*s)'),
+        n = 3.62,
+        Ea = (11270, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 235,
+    label = "C2H4 + O <=> CH3 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (8.355e+06, 'cm^3/(mol*s)'),
+        n = 1.88,
+        Ea = (183, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 236,
+    label = "C2H4 + O <=> H + CH2CHO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (3.7e+09, 'cm^3/(mol*s)'),
+        n = 0.907,
+        Ea = (839, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 237,
+    label = "C2H4 + O <=> CH2 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(14000, 'cm^3/(mol*s)'), n=2.62, Ea=(459, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 238,
+    label = "C2H4 + OH <=> C2H3 + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (21440, 'cm^3/(mol*s)'),
+        n = 2.745,
+        Ea = (2216, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 239,
+    label = "C2H4 + OH <=> CH2O + CH3",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (178000, 'cm^3/(mol*s)'),
+        n = 1.68,
+        Ea = (2060, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 240,
+    label = "C2H4 + OH <=> H + CH3CHO",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (0.0238, 'cm^3/(mol*s)'),
+        n = 3.91,
+        Ea = (1723, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 241,
+    label = "C2H4 + CH3 <=> C2H3 + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (6.02e+07, 'cm^3/(mol*s)'),
+        n = 1.56,
+        Ea = (16630, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 242,
+    label = "C2H4 + O2 <=> HO2 + C2H3",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(7.1e+13, 'cm^3/(mol*s)'), n=0, Ea=(60010, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 243,
+    label = "C2H5 + H <=> C2H6",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(
+            A = (5.21e+17, 'cm^3/(mol*s)'),
+            n = -0.99,
+            Ea = (1580, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        arrheniusLow = Arrhenius(
+            A = (1.99e+41, 'cm^6/(mol^2*s)'),
+            n = -7.08,
+            Ea = (6685, 'cal/mol'),
+            T0 = (1, 'K'),
+        ),
+        alpha = 0.842,
+        T3 = (125, 'K'),
+        T1 = (2219, 'K'),
+        T2 = (6882, 'K'),
+        efficiencies = {'[Ar]': 0.70, '[He]': 0.70, 'O': 6.00, '[C-]#[O+]': 1.50, 'O=C=O': 2.00, 'C': 2.00, 'C=O': 2.50, 'CO': 3.00, 'CC': 3.00},
+    ),
+)
+
+entry(
+    index = 244,
+    label = "C2H5 + H <=> H2 + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.81e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 245,
+    label = "C2H5 + O <=> CH3 + CH2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.42e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 246,
+    label = "C2H5 + O <=> H + CH3CHO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.89e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 247,
+    label = "C2H5 + O <=> OH + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.94e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 248,
+    label = "C2H5 + O2 <=> HO2 + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.355e+07, 'cm^3/(mol*s)'),
+        n = 1.09,
+        Ea = (-1975, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 249,
+    label = "C2H5 + CH3 <=> CH4 + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9e+11, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 250,
+    label = "C2H5 + CH2O <=> C2H6 + HCO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5500, 'cm^3/(mol*s)'), n=2.81, Ea=(5860, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 251,
+    label = "C2H5 + CH3OH <=> C2H6 + CH2OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(32, 'cm^3/(mol*s)'), n=3.2, Ea=(7175, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 252,
+    label = "C2H6 + H <=> C2H5 + H2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.133e+08, 'cm^3/(mol*s)'),
+        n = 1.9,
+        Ea = (7530, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 253,
+    label = "C2H6 + O <=> OH + C2H5",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(176300, 'cm^3/(mol*s)'), n=2.8, Ea=(5803, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 254,
+    label = "C2H6 + OH <=> C2H5 + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.463e+06, 'cm^3/(mol*s)'), n=2, Ea=(994, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 255,
+    label = "C2H6 + CH <=> CH3 + C2H4",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (1.077e+14, 'cm^3/(mol*s)'),
+        n = 0,
+        Ea = (-262, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 256,
+    label = "C2H6 + CH2(S) <=> CH3 + C2H5",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(3.3e+13, 'cm^3/(mol*s)'), n=0, Ea=(-660, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 257,
+    label = "C2H6 + CH3 <=> C2H5 + CH4",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(5.6e+10, 'cm^3/(mol*s)'), n=0, Ea=(9420, 'cal/mol'), T0=(1, 'K')),
+)
+
+entry(
+    index = 258,
+    label = "C2H6 + O2 <=> C2H5 + HO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (729000, 'cm^3/(mol*s)'),
+        n = 2.5,
+        Ea = (49160, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 259,
+    label = "C2H6 + HO2 <=> C2H5 + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (110000, 'cm^3/(mol*s)'),
+        n = 2.5,
+        Ea = (16850, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+

--- a/input/thermo/libraries/FFCM1(-).py
+++ b/input/thermo/libraries/FFCM1(-).py
@@ -1,0 +1,1101 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "FFCM1(-)"
+shortDesc = u""
+longDesc = u"""
+Foundational Fuel Chemistry Model Version 1.0 (excited species removed)
+http://web.stanford.edu/group/haiwanglab/FFCM1/pages/FFCM1.html
+
+FFCM-1
+H2/CO/C1 reaction model - Chemkin form - version v1.0c 
+Release date: 05/31/3016.
+
+G. P. Smith, Y. Tao, and H. Wang, Foundational Fuel Chemistry Model Version 1.0 (FFCM-1),
+http://nanoenergy.stanford.edu/ffcm1, 2016.
+
+Species that were not included:
+OH*               ATcT AO   1H   1    0    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 2.75582920E+00 1.39848756E-03-4.19428493E-07 6.33453282E-11-3.56042218E-15    2! OH A 2Sigma+ (excited)
+ 5.09751756E+04 5.62581429E+00 3.46084428E+00 5.01872172E-04-2.00254474E-06    3! CAS: 3352-57-6 (?)
+ 3.18901984E-09-1.35451838E-12 5.07349466E+04 1.73976415E+00 5.17770741E+04    4! Uncertainty unknown => -1.0
+CH*               EG4/09C   1H   1    0    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 2.78220752E+00 1.47246754E-03-4.63436227E-07 7.32736021E-11-4.19705404E-15    2! CH A2Delta  excited state only
+ 1.04547060E+05 5.17421018E+00 3.47250101E+00 4.26443626E-04-1.95181794E-06    3! CAS: 3315-37-5
+ 3.51755043E-09-1.60436174E-12 1.04334869E+05 1.44799533E+00 1.05378099E+05    4! Uncertainty unknown => -1.0
+CH2*              IU3/03C   1H   2    0    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 3.13501686E+00 2.89593926E-03-8.16668090E-07 1.13572697E-10-6.36262835E-15    2! Methylene radical excited 
+ 5.05040504E+04 4.06030621E+00 4.19331325E+00-2.33105184E-03 8.15676451E-06    3! CAS 2465-56-7
+-6.62985981E-09 1.93233199E-12 5.03662246E+04-7.46734310E-01 5.15724919E+04    4! 429.039 +- 0.14 kJ/mol ATcT 31.01.2011 
+HOCO              ATcT/AC   1O   2H   1    0G   200.000  6000.000              1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 5.39206152E+00 4.11221455E-03-1.48194900E-06 2.39875460E-10-1.43903104E-14    2! Carboxyl radical 
+-2.38606717E+04-2.23529091E+00 2.92207919E+00 7.62453859E-03 3.29884437E-06    3! CAS 2564-86-5
+-1.07135205E-08 5.11587057E-12-2.30281524E+04 1.12925886E+01-2.18076591E+04    4! -181.32+/-2.3 kJ/mol ATcT 31.01.201111
+CH3O2             T04/10C   1H   3O   2    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 5.55530486E+00 9.12236137E-03-3.23851661E-06 5.18713798E-10-3.08834151E-14    2! Methylperoxide radical
+-1.03569402E+03-3.99158547E+00 4.97169544E+00-5.29356557E-03 4.77334149E-05    3! CAS: 2143-58-0
+-5.77065617E-08 2.22219969E-11-1.29022161E+02 2.81501182E+00 1.43618036E+03    4! 12.055 +- 0.9 kJ/mol AtcT 10-05-2012
+CH3O2H            A 7/05C   1H   4O   2    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 7.76538058E+00 8.61499712E-03-2.98006935E-06 4.68638071E-10-2.75339255E-14    2! Methylperoxide
+-1.82979984E+04-1.43992663E+01 2.90540897E+00 1.74994735E-02 5.28243630E-06    3! CAS: 3031-73-0
+-2.52827275E-08 1.34368212E-11-1.68894632E+04 1.13741987E+01-1.52423685E+04    4! 12.055 +- 0.9 kJ/mol AtcT 10-05-2012
+C2H5OH            L 8/88C   2H   6O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012  
+ 0.65624365E+01 0.15204222E-01-0.53896795E-05 0.86225011E-09-0.51289787E-13    2! Ethanol
+-0.31525621E+05-0.94730202E+01 0.48586957E+01-0.37401726E-02 0.69555378E-04    3! CAS: 64-17-5
+-0.88654796E-07 0.35168835E-10-0.29996132E+05 0.48018545E+01-0.28257829E+05    4! -234.56 +- 0.2 kJ/mol ATcT 10.05.2012
+CH3OCH3           T03/10C   2H   6O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 5.64844274E+00 1.63381875E-02-5.86802189E-06 9.46836384E-10-5.66504295E-14    2! Dimethyl ether
+-2.50864216E+04-5.96267354E+00 5.30562273E+00-2.14253958E-03 5.30873092E-05    3! CAS: 115-10-6
+-6.23146897E-08 2.30730916E-11-2.39655820E+04 7.13244569E-01-2.21221696E+04    4! -184.02 +-0.43 kJ/mol ATcT 10.05.2012
+CH2CH2OH          T05/11C   2H   5O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 7.01348674E+00 1.20204391E-02-4.21992012E-06 6.70675981E-10-3.97135273E-14    2! 2-Hydroxylethyl
+-6.16161779E+03-8.62052409E+00 4.20954137E+00 9.12964578E-03 2.47462263E-05    3! CAS: 4422-54-2
+-3.92945764E-08 1.66541312E-11-4.91511371E+03 8.30445413E+00-3.10541451E+03    4! -25.82+- 0.6 kJ/mol ATcT 10.05.2012
+CH3CHOH           T06/11C   2H   5O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 6.35842302E+00 1.24356276E-02-4.33096839E-06 6.84530381E-10-4.03713238E-14    2! 1-Hydroxylethyl
+-9.53018581E+03-6.05106112E+00 4.22283250E+00 5.12174798E-03 3.48386522E-05    3! CAS: 2348-46-1
+-4.91943637E-08 2.01183723E-11-8.35622088E+03 8.01675700E+00-6.64945980E+03    4! -54.03 +- 4.0 kJ/mol ATcT 10.05.2012
+CH3CH2O           T06/11C   2H   5O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 6.55053877E+00 1.32525511E-02-4.74726060E-06 7.64699226E-10-4.57008357E-14    2! Ethyl oxide radical
+-4.47191998E+03-9.61231141E+00 3.26905655E+00 9.33562904E-03 2.96317166E-05    3! CAS: 2154-50-9
+-4.53411341E-08 1.88795595E-11-2.95022955E+03 1.04200942E+01-1.37951605E+03    4! -13.6 +-4.0 kJ/mol ATcT 10.05.2012
+CH3OCH2           A10/04C   2H   5O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 5.94067593E+00 1.29906358E-02-4.56921036E-06 7.26888932E-10-4.30599587E-14    2! CH2-O-CH3 radical   
+-2.58503562E+03-4.52841964E+00 4.53195381E+00 7.81884271E-03 1.94968539E-05    3! CAS: 16520-04-0
+-2.74538336E-08 1.06521135E-11-1.70629244E+03 5.06122980E+00 1.15460803E+02    4! -2.8 +- 1.2 kcal/mol ATcT 10.05.2012 (from MacMillen Golden 1982)
+CH2OCH2           L 8/88C   2H   4O   1    0G   200.000  6000.000  1000.       1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 0.54887641E+01 0.12046190E-01-0.43336931E-05 0.70028311E-09-0.41949088E-13    2! Oxirane, cyc-(CH2)2O, Ethylene oxide
+-0.91804251E+04-0.70799605E+01 0.37590532E+01-0.94412180E-02 0.80309721E-04    3! CAS: 75-21-8
+-0.10080788E-06 0.40039921E-10-0.75608143E+04 0.78497475E+01 0.425             4! -52.681 +- 0.425 kJ/mol ATcT 31.01.2011
+C2H3OH            T03/10C   2H   4O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 7.49818166E+00 1.03957000E-02-3.66891058E-06 5.85205827E-10-3.47373827E-14    2! Vinyl Alcohol 
+-1.81643092E+04-1.38388104E+01 2.28758479E+00 1.97013262E-02 1.96382662E-06    3! CAS: 557-75-5
+-1.94389758E-08 1.02616778E-11-1.65373421E+04 1.41333462E+01-1.49958566E+04    4! -28.85+/-2. kcal/mol ATcT 10.05.2012 
+C2H3O             A 1/05C   2H   3O   1    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 5.60158035E+00 9.17613962E-03-3.28028902E-06 5.27903888E-10-3.15362241E-14    2! Oxirane (ethylene oxide) radical 
+ 1.71446252E+04-5.47228512E+00 3.58349017E+00-6.02275805E-03 6.32426867E-05    3! 31586-84-2
+-8.18540707E-08 3.30444505E-11 1.85681353E+04 9.59725926E+00 1.97814471E+04    4! No ATcT value, G3B3 +- 8 kJ/mol
+HCCOH             T12/09C   2H   2O   1    0G   200.000  6000.000   1000.0     1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 6.37509678E+00 5.49429011E-03-1.88136576E-06 2.93803536E-10-1.71771901E-14    2! Ethynol, Hydroxyacetylene
+ 8.93277676E+03-8.24498007E+00 2.05541154E+00 2.52003372E-02-3.80821654E-05    3! CAS: 32038-79-2
+ 3.09890632E-08-9.89799902E-12 9.76872113E+03 1.22271534E+01 1.33              4! 92.7 +- 1.33 kJ/mol ATcT 31.01.2011
+C2O               T 8/11C   2O   1    0    0G   200.000  6000.000   1000.0     1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 5.42468378E+00 1.85393945E-03-5.17932956E-07 6.77646230E-11-3.53315237E-15    2! Carbon oxide
+ 4.37161379E+04-3.69608405E+00 2.86278214E+00 1.19701204E-02-1.80851222E-05    3! 12071-23-7 
+ 1.52777730E-08-5.20063163E-12 4.43125964E+04 8.89759099E+00 1.2               4! 378.86 +/- 1.2 kJ/mol ATcT 31.01.2011
+"""
+entry(
+    index = 1,
+    label = "Ar",
+    molecule = 
+"""
+1 Ar u0 p4 c0
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,4.37967], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,4.37967], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Argon
+CAS: 7440-37-1
+Reference element
+""",
+)
+
+entry(
+    index = 2,
+    label = "He",
+    molecule = 
+"""
+1 He u0 p1 c0
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,0.928724], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,0.928724], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Helium
+CAS: 7440-59-7
+Reference element""",
+)
+
+entry(
+    index = 3,
+    label = "N2",
+    molecule = 
+"""
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.53101,-0.000123661,-5.02999e-07,2.43531e-09,-1.40881e-12,-1046.98,2.96747], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.95258,0.0013969,-4.92632e-07,7.8601e-11,-4.60755e-15,-923.949,5.87189], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Nitrogen
+CAS:7727-37-9
+Reference element
+""",
+)
+
+entry(
+    index = 4,
+    label = "H2",
+    molecule = 
+"""
+1 H u0 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.34433,0.00798052,-1.94782e-05,2.01572e-08,-7.37612e-12,-917.935,0.68301], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.93287,0.000826608,-1.46402e-07,1.541e-11,-6.88805e-16,-813.066,-1.02433], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Hydrogen
+CAS: 1333-74-0
+Reference element
+""",
+)
+
+entry(
+    index = 5,
+    label = "H",
+    molecule = 
+"""
+multiplicity 2
+1 H u1 p0 c0
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.5,0,0,0,0,25473.7,-0.446683], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.5,0,0,0,0,25473.7,-0.446683], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Atomic hydrogen
+CAS: 12385-13-6
+217.997805 +- 0.000008 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 6,
+    label = "O",
+    molecule = 
+"""
+multiplicity 3
+1 O u2 p2 c0
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.16827,-0.00327932,6.64306e-06,-6.12807e-09,2.11266e-12,29122.3,2.05193], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.54364,-2.73162e-05,-4.1903e-09,4.95482e-12,-4.79554e-16,29226,4.92229], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Atomic oxygen
+CAS:17778-80-2
+249.22916 +- 0.00203 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 7,
+    label = "O2",
+    molecule = 
+"""
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 O u1 p2 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.78246,-0.00299673,9.8473e-06,-9.6813e-09,3.24373e-12,-1063.94,3.65768], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.66096,0.000656366,-1.4115e-07,2.05798e-11,-1.29913e-15,-1215.98,3.41536], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Molecular oxygen
+CAS: 7782-44-7
+Reference element
+""",
+)
+
+entry(
+    index = 8,
+    label = "OH",
+    molecule = 
+"""
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.99198,-0.00240107,4.61664e-06,-3.87916e-09,1.3632e-12,3368.9,-0.103998], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.83853,0.00110741,-2.94e-07,4.20699e-11,-2.4229e-15,3697.81,5.84495], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Hydroxyl radical
+CAS: 3352-57-6
+37.5011 +- 0.0259 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 9,
+    label = "H2O",
+    molecule = 
+"""
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.19864,-0.0020364,6.52034e-06,-5.48793e-09,1.77197e-12,-30293.7,-0.849009], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.67704,0.00297318,-7.73769e-07,9.44335e-11,-4.269e-15,-29885.9,6.88255], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Water(v)
+CAS: 7732-18-5
+-241.8222 +- 0.0259 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 10,
+    label = "HO2",
+    molecule = 
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.3018,-0.00474912,2.11583e-05,-2.42764e-08,9.29225e-12,264.018,3.71666], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.17229,0.00188118,-3.46277e-07,1.94658e-11,1.76257e-16,31.0207,2.95768], Tmin=(1000,'K'), Tmax=(5000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (5000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Perhydroxyl radical 
+CAS: 3170-83-0
+12.271 +- 0.157 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 11,
+    label = "H2O2",
+    molecule = 
+"""
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.31515,-0.000847391,1.76404e-05,-2.26763e-08,9.0895e-12,-17706.7,3.27373], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.57977,0.00405326,-1.29845e-06,1.98211e-10,-1.13969e-14,-18007.2,0.664971], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""T 8/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Hydrogen peroxide
+CAS 7722-84-1
+-135.4416 +- 0.0622 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 12,
+    label = "CO",
+    molecule = 
+"""
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.57953,-0.000610354,1.01681e-06,9.07006e-10,-9.04424e-13,-14344.1,3.50841], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.04849,0.00135173,-4.85794e-07,7.88536e-11,-4.69807e-15,-14266.1,6.0171], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""RUS 79""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Carbon monoxide
+CAS 630-08-0
+-110.525 +- 0.0251 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 13,
+    label = "CO2",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,D} {3,D}
+2 O u0 p2 c0 {1,D}
+3 O u0 p2 c0 {1,D}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.35681,0.00898413,-7.12206e-06,2.4573e-09,-1.42885e-13,-48372,9.9009], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.63651,0.00274146,-9.95898e-07,1.60387e-10,-9.16199e-15,-49024.9,-1.9349], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""L 7/88""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Carbon dioxide
+CAS 124-38-9
+-393.4743 +- 0.014 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 14,
+    label = "C",
+    molecule = 
+"""
+multiplicity 5
+1 C u4 p0 c0
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.55424,-0.000321538,7.33792e-07,-7.32235e-10,2.66521e-13,85442.7,4.53131], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.60558,-0.000195934,1.06737e-07,-1.64239e-11,8.18706e-16,85411.7,4.19239], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""L 7/88""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Carbon atom
+CAS 7440-44-0
+716.8734 +- 0.0555 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 15,
+    label = "CH",
+    molecule = 
+"""
+multiplicity 4
+1 C u3 p0 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.48976,0.000324322,-1.68998e-06,3.16284e-09,-1.40618e-12,70612.6,2.08428], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.52094,0.00176536,-4.61477e-07,5.92897e-11,-3.34745e-15,70946.8,7.40518], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU3/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methylidyne
+CAS 3315-37-5
+596.173 +- 0.124 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 16,
+    label = "CH2",
+    molecule = 
+"""
+multiplicity 3
+1 C u2 p0 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.71758,0.00127391,2.17347e-06,-3.48858e-09,1.65209e-12,45872.4,1.75298], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.14632,0.00303671,-9.96474e-07,1.50484e-10,-8.57336e-15,46041.3,4.72342], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU3/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methylene radical 
+CAS 2465-56-7
+391.458 +- 0.133 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 17,
+    label = "CH2(S)",
+    molecule = 
+"""
+1 C u0 p1 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.19331,-0.00233105,8.15676e-06,-6.62986e-09,1.93233e-12,50366.2,-0.746734], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.13502,0.00289594,-8.16668e-07,1.13573e-10,-6.36263e-15,50504.1,4.06031], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU3/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methylene radical excited
+CAS 2465-56-7
+429.039 +- 0.14 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 18,
+    label = "CH3",
+    molecule = 
+"""
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.65718,0.0021266,5.45839e-06,-6.6181e-09,2.46571e-12,16422.7,1.67354], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[2.97812,0.00579785,-1.97558e-06,3.07298e-10,-1.79174e-14,16509.5,4.72248], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU0702""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methyl radical
+CAS 2229-07-4
+146.4941 +- 0.079 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 19,
+    label = "CH4",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[5.14911,-0.0136622,4.91454e-05,-4.84247e-08,1.66603e-11,-10246.6,-4.63849], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[1.65326,0.0100263,-3.31661e-06,5.36483e-10,-3.14697e-14,-10009.6,9.90506], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""g 8/99""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methane 
+CAS 74-82-8
+-74.5335 +- 0.0554 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 20,
+    label = "HCO",
+    molecule = 
+"""
+multiplicity 2
+1 C u1 p0 c0 {2,D} {3,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.23755,-0.00332075,1.4003e-05,-1.3424e-08,4.37416e-12,3872.41,3.30835], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.92002,0.00252279,-6.71004e-07,1.05616e-10,-7.43798e-15,3653.43,3.58077], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""T 5/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Formyl radical  HC=O
+CAS 2597-44-6
+41.827 +- 0.101 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 21,
+    label = "CH2O",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.79372,-0.00990833,3.7322e-05,-3.79285e-08,1.31773e-11,-14379.2,0.602798], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.16953,0.00619321,-2.25056e-06,3.65976e-10,-2.20149e-14,-14548.7,6.04208], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""g 8/88""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Formaldehyde
+CAS 50-00-0
+-109.164 +- 0.101 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 22,
+    label = "CH2OH",
+    molecule = 
+"""
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.47834,-0.0013507,2.78485e-05,-3.64869e-08,1.47907e-11,-3500.73,3.30913], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.09314,0.00594761,-2.06497e-06,3.23008e-10,-1.88126e-14,-4034.1,-1.84691], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU2/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Hydroxymethyl radical
+CAS 2597-43-5
+-16.097 +- 0.422 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 23,
+    label = "CH3O",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.71181,-0.00280463,3.76551e-05,-4.73072e-08,1.86588e-11,1295.7,6.57241], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.75779,0.00744142,-2.69705e-06,4.38091e-10,-2.63537e-14,378.112,-1.9668], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU1/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methoxy radical
+CAS 2143-68-2
+21.845 +- 0.35 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 24,
+    label = "CH3OH",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[5.65851,-0.0162983,6.91938e-05,-7.58373e-08,2.80428e-11,-25612,-0.897331], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.52727,0.0103179,-3.62893e-06,5.77448e-10,-3.42183e-14,-26002.9,5.16759], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""T06/02""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Methanol
+CAS 67-56-1
+-200.702 +- 0.169 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 25,
+    label = "C2H",
+    molecule = 
+"""
+multiplicity 2
+1 C u1 p0 c0 {2,T}
+2 C u0 p0 c0 {1,T} {3,S}
+3 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.89868,0.0132988,-2.80733e-05,2.89485e-08,-1.07502e-11,67061.6,6.18548], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.6627,0.00382492,-1.36633e-06,2.13455e-10,-1.23217e-14,67168.4,3.92206], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""T 5/10""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ethynyl radical
+CAS 2122-48-7
+567.905 +- 0.163 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 26,
+    label = "C2H2",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[0.80868,0.0233616,-3.55172e-05,2.80153e-08,-8.50075e-12,26429,13.9397], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.65878,0.00488397,-1.60829e-06,2.46975e-10,-1.38606e-14,25759.4,-3.99838], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""g 1/91""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ethyne, Acetylene
+CAS: 74-86-2
+228.324 +- 0.142 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 27,
+    label = "C2H3",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u1 p0 c0 {1,D} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.36378,0.000265766,2.79621e-05,-3.72987e-08,1.5159e-11,34475,7.9151], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.15027,0.00754021,-2.62998e-06,4.15974e-10,-2.45408e-14,33856.6,1.72812], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""ATcT/A""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Vinyl radical H2C=CH*
+CAS: 2669-89-8
+297.272 +- 0.454 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 28,
+    label = "C2H4",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.9592,-0.00757051,5.7099e-05,-6.91588e-08,2.69884e-11,5089.78,4.0973], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[3.99183,0.0104834,-3.71721e-06,5.94628e-10,-3.5363e-14,4268.66,-0.269082], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""g 1/00""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ethene, ethylene
+CAS: 74-85-1
+52.555 +- 0.142 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 29,
+    label = "C2H5",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.24186,-0.00356905,4.82667e-05,-5.85401e-08,2.25805e-11,12969,4.44704], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.32196,0.0123931,-4.39681e-06,7.0352e-10,-4.18435e-14,12175.9,0.171104], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU1/07""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ethyl radical CH3CH2
+CAS:2025-56-1
+119.7 +- 0.7 kJ/mol ATcT 10.05.2012
+""",
+)
+
+entry(
+    index = 30,
+    label = "C2H6",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.29143,-0.00550155,5.99438e-05,-7.08466e-08,2.68686e-11,-11522.2,2.66679], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.04666,0.0153539,-5.47039e-06,8.77827e-10,-5.23168e-14,-12447.3,-0.968698], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""g 8/88""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ethane
+CAS: 74-84-0
+-83.775 +- 0.159 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 31,
+    label = "HCCO",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,T} {4,S}
+2 C u0 p0 c0 {1,T} {3,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[1.87608,0.0221205,-3.58869e-05,3.05403e-08,-1.01281e-11,20163.4,13.6968], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.91479,0.00371409,-1.30137e-06,2.06473e-10,-1.21477e-14,19359.6,-5.50567], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""T 4/09""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ketenyl radical
+CAS: 51095-15-9
+177.966 +- 0.585 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 32,
+    label = "CH2CO",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 O u0 p2 c0 {2,D}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.13241,0.0181319,-1.74093e-05,9.35336e-09,-2.01725e-12,-7148.09,13.3808], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.75871,0.00635124,-2.25955e-06,3.62322e-10,-2.15856e-14,-8085.33,-4.9649], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""g 4/02""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Ketene H2C=C=O
+CAS: 463-51-4
+-48.569 +- 0.144 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 33,
+    label = "CH2CHO",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,D} {4,S} {5,S}
+2 C u0 p0 c0 {1,D} {3,S} {6,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.66874,0.0096233,1.60617e-05,-2.87682e-08,1.2503e-11,219.438,12.5694], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.91637,0.0088465,-3.14955e-06,5.05413e-10,-3.01305e-14,-1047.8,-6.1065], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""T04/06""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Vinoxy radical, CH2=CH-O
+CAS: 6912-06-7
+No ATcT value, G3B3 +- 8 kJ/mol
+""",
+)
+
+entry(
+    index = 34,
+    label = "CH3CHO",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,D} {7,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 O u0 p2 c0 {2,D}
+7 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.72946,-0.00319329,4.75349e-05,-5.74586e-08,2.19311e-11,-21572.9,4.10302], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.40411,0.0117231,-4.22631e-06,6.83725e-10,-4.09849e-14,-22593.1,-3.48079], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""L 8/88""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012 
+Acetaldehyde
+CAS: 75-07-0
+-165.374 +- 0.307 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 35,
+    label = "CH3CO",
+    molecule = 
+"""
+multiplicity 2
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u1 p0 c0 {1,S} {6,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 O u0 p2 c0 {2,D}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.03587,0.000877295,3.071e-05,-3.92476e-08,1.52969e-11,-2682.07,7.86177], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.31372,0.00917378,-3.32204e-06,5.39475e-10,-3.24524e-14,-3645.04,-1.67576], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""IU2/03""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+Acetyl radical   CH3-C=O
+CAS: 3170-69-2
+-9.678+- 0.385 kJ/mol ATcT 31.01.2011
+""",
+)
+
+entry(
+    index = 36,
+    label = "H2CC",
+    molecule = 
+"""
+multiplicity 3
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u2 p0 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.28155,0.00697643,-2.38528e-06,-1.21078e-09,9.82042e-13,48319.2,5.92036], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[4.27807,0.00475623,-1.63007e-06,2.54623e-10,-1.4886e-14,48014,0.639979], Tmin=(1000,'K'), Tmax=(6000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (6000,'K'),
+    ),
+    shortDesc = u"""L12/89""",
+    longDesc = 
+u"""
+Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012 no newer NASA polynom
+Vinylidene
+CAS: 2143-69-3
+kk:1
+""",
+)
+


### PR DESCRIPTION
This PR includes the kinetics + thermo libraries of the Foundational Fuel Chemistry Model Version 1.0
Note: Excited species (OH, CH, CH2) were removed.
Also, thermo data of species not in this mechanism were commented out.

http://web.stanford.edu/group/haiwanglab/FFCM1/pages/FFCM1.html