### PR TITLE
Fix the script exportKineticsLibraryToChemkin

### DIFF
--- a/scripts/exportKineticsLibraryToChemkin.py
+++ b/scripts/exportKineticsLibraryToChemkin.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     for spec in speciesDict.values():
         index = index + 1
         species = Species(molecule = spec.molecule)
-        species.generateThermoData(database)
+        species.getThermoData()
         species.index = index
         speciesList.append(species)
 


### PR DESCRIPTION
Currently run this script results in an AttributeError: 
 `AttributeError: 'Species' object has no attribute 'generateThermoData'`
Because we don't have the method species.generateThermoData() any more.
Replace this method with species.getThermoData() should fix this error.