### PR TITLE
Modified exportKineticsLibrarytoChemkin.py and importChemkinLibrary.py

### DIFF
--- a/scripts/exportKineticsLibraryToChemkin.py
+++ b/scripts/exportKineticsLibraryToChemkin.py
@@ -17,6 +17,7 @@ LIBRARYNAME      the libraryname of the RMG-Py format kinetics library
 import argparse
 import os
 from rmgpy.data.rmg import RMGDatabase
+from rmgpy.data.kinetics.library import LibraryReaction
 from rmgpy.chemkin import saveChemkinFile, saveSpeciesDictionary
 from rmgpy.rmg.model import Species
 from rmgpy import settings
@@ -42,7 +43,14 @@ if __name__ == '__main__':
     for index, entry in kineticLibrary.entries.iteritems():
         reaction = entry.item
         reaction.kinetics = entry.data
-        reactionList.append(reaction)
+	library_reaction = LibraryReaction(index=reaction.index,
+                     reactants=reaction.reactants,
+                     products=reaction.products,
+                     reversible=reaction.reversible,
+                     kinetics=reaction.kinetics,
+                     library=libraryName
+                     )
+        reactionList.append(library_reaction)
 
     speciesList = []
     index = 0

--- a/scripts/importChemkinLibrary.py
+++ b/scripts/importChemkinLibrary.py
@@ -62,7 +62,10 @@ if __name__ == '__main__':
                 item = reaction,
                 data = reaction.kinetics,
             )
-        entry.longDesc = reaction.kinetics.comment
+        try:
+    	    entry.longDesc = 'Originally from: ' + reaction.library + "\n" + reaction.kinetics.comment
+	except AttributeError:
+    	    entry.longDesc = reaction.kinetics.comment
         kineticsLibrary.entries[i+1] = entry
     
     # Mark as duplicates where there are mixed pressure dependent and non-pressure dependent duplicate kinetics


### PR DESCRIPTION
Modified exportKineticsLibrarytoChemkin.py and importChemkinLibrary.py scripts to print out the corresponding reaction library for each reaction in the chem.inp Chemkin input file (as a comment for each reaction entry) in the first case (export), and in the reactions.py library (as the "long_desc") for the second case (import). 

The utility of these changes is best shown by using the modified scripts together, in series. For example, if you have RMG kinetic libraries A and B, and you would like to merge them into one library C, you would follow these steps:

1. Use the export script above to convert both libraries A and B to separate Chemkin input files and species dictionaries. The chem.inp files will include a comment above each reaction entry noting either "Reaction Library: A" or "Reaction Library: B".

2. Use RMG-Py/script/mergeModels.py to merge the chem.inp files for A and B, and create a new chem. inp file for C, which will still have the comments mentioned above.

3. Use the import script above to convert the chem.inp file for C back to an RMG kinetic library. The reactions.py file created will now have long_desc = "Originally from: x" for each reaction, where x=A or B depending on the source of that specific reaction.

At the end of this process, anytime library C is used there will be a comment with each reaction clarifying that it's original source was either A or B.