### PR TITLE
Modified exportKineticsLibrarytoChemkin.py and importChemkinLibrary.py

### DIFF
--- a/scripts/exportKineticsLibraryToChemkin.py
+++ b/scripts/exportKineticsLibraryToChemkin.py
@@ -17,6 +17,7 @@ LIBRARYNAME      the libraryname of the RMG-Py format kinetics library
 import argparse
 import os
 from rmgpy.data.rmg import RMGDatabase
+from rmgpy.data.kinetics.library import LibraryReaction
 from rmgpy.chemkin import saveChemkinFile, saveSpeciesDictionary
 from rmgpy.rmg.model import Species
 from rmgpy import settings
@@ -42,7 +43,14 @@ if __name__ == '__main__':
     for index, entry in kineticLibrary.entries.iteritems():
         reaction = entry.item
         reaction.kinetics = entry.data
-        reactionList.append(reaction)
+	library_reaction = LibraryReaction(index=reaction.index,
+                     reactants=reaction.reactants,
+                     products=reaction.products,
+                     reversible=reaction.reversible,
+                     kinetics=reaction.kinetics,
+                     library=libraryName
+                     )
+        reactionList.append(library_reaction)
 
     speciesList = []
     index = 0

--- a/scripts/importChemkinLibrary.py
+++ b/scripts/importChemkinLibrary.py
@@ -62,7 +62,10 @@ if __name__ == '__main__':
                 item = reaction,
                 data = reaction.kinetics,
             )
-        entry.longDesc = reaction.kinetics.comment
+        try:
+    	    entry.longDesc = 'Originally from reaction library: ' + reaction.library + "\n" + reaction.kinetics.comment
+	except AttributeError:
+    	    entry.longDesc = reaction.kinetics.comment
         kineticsLibrary.entries[i+1] = entry
     
     # Mark as duplicates where there are mixed pressure dependent and non-pressure dependent duplicate kinetics


### PR DESCRIPTION
Modified exportKineticsLibrarytoChemkin.py and importChemkinLibrary.py scripts to print out the corresponding reaction library for each reaction

in the chem.inp Chemkin input file (as a comment for each reaction entry) in the first case (export), and
in the reactions.py library (as the "long_desc") for the second case (import).
