### PR TITLE
Added P-dependent kinetic libraries for 3 small molecule surfaces

### DIFF
--- a/input/kinetics/libraries/1989_Stewart_2CH3_to_C2H5_H/dictionary.txt
+++ b/input/kinetics/libraries/1989_Stewart_2CH3_to_C2H5_H/dictionary.txt
@@ -1,0 +1,21 @@
+H
+multiplicity 2
+1 H u1 p0 c0
+
+C2H5
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5 H u0 p0 c0 {4,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {4,S}
+
+CH3
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+

--- a/input/kinetics/libraries/1989_Stewart_2CH3_to_C2H5_H/reactions.py
+++ b/input/kinetics/libraries/1989_Stewart_2CH3_to_C2H5_H/reactions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "1989_Stewart_2CH3_to_C2H5_H"
+shortDesc = u"Chemically Activated Methyl Recombination to Ethyl + H from 1989 Stewart Calculations"
+longDesc = u"""
+Chebyshev fit to the T,P-dependent k for 2CH3 = C2H5 + H from:
+P.H. Stewart, et al.,
+"Pressure and Temperature Dependence of Reactions Proceeding Via A Bound Complex. 2. Application to 2CH3 -> C2H5 + H",
+Combustion and Flame 75: 25-31 (1989)
+The k computed by Stewart that we fit was for a "strong collider" because "weak collider" correction they provide is only valid to 900 K
+"""
+entry(
+    index = 1,
+    label = "CH3 + CH3 <=> C2H5 + H",
+    degeneracy = 1,
+    kinetics = Chebyshev(
+        coeffs = [
+            [8.267, -0.5559, -0.2081, -0.02475],
+            [3.774, 0.482, 0.1485, -0.005274],
+            [0.06503, 0.08914, 0.05444, 0.01846],
+            [-0.01057, -0.01794, 0.005877, 0.0101],
+            [-0.006027, -0.01206, -0.002669, 0.002541],
+            [-0.002256, -0.006865, -0.005809, -0.002549],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+        Pmin = (0.001, 'atm'),
+        Pmax = (10, 'atm'),
+    ),
+)
+

--- a/input/kinetics/libraries/2005_Senosiain_OH_C2H2/dictionary.txt
+++ b/input/kinetics/libraries/2005_Senosiain_OH_C2H2/dictionary.txt
@@ -1,0 +1,60 @@
+CH2CO
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 O u0 p2 c0 {2,D}
+
+CO
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+
+HCCOH
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 O u0 p2 c0 {1,S} {5,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+
+OH
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+H
+multiplicity 2
+1 H u1 p0 c0
+
+HOC2H2
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,D}
+2 H u0 p0 c0 {1,S}
+3 C u0 p0 c0 {1,D} {4,S} {5,S}
+4 O u0 p2 c0 {3,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+
+H2O
+1 O u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+
+CH3
+multiplicity 2
+1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+C2H
+multiplicity 2
+1 C u1 p0 c0 {2,T}
+2 C u0 p0 c0 {1,T} {3,S}
+3 H u0 p0 c0 {2,S}
+
+C2H2
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+

--- a/input/kinetics/libraries/2005_Senosiain_OH_C2H2/reactions.py
+++ b/input/kinetics/libraries/2005_Senosiain_OH_C2H2/reactions.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "2005_Senosiain_OH_C2H2"
+shortDesc = u"Calculated T,P-dependent rates for significant pathways on the OH + acetylene surface of 2005 Senosiain"
+longDesc = u"""
+T,P-dependent k's for the significant pathways on the OH + acetylene surface computed with RQCISD(T)/CBS//UB3LYP/6-311++G(d,p) by:
+J. P. Senosiain, et al.,
+"The Reaction of Acetylene with Hydroxyl Radicals",
+J. Phys. Chem. A 2005, 109, 6045-6055
+PLog rates taken directly from Table 6 of this paper.
+Rates are for an Argon bath gas
+"""
+entry(
+    index = 1,
+    label = "OH + C2H2 <=> H2O + C2H",
+    degeneracy = 1,
+    kinetics = Arrhenius(
+        A = (4.37e-18, 'cm^3/(molecule*s)'),
+        n = 2.14,
+        Ea = (71388.1, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+)
+
+entry(
+    index = 2,
+    label = "OH + C2H2 <=> HCCOH + H",
+    degeneracy = 1,
+    kinetics = PDepArrhenius(
+        pressures = ([0.01, 0.025, 0.1, 1, 10, 100], 'atm'),
+        arrhenius = [
+            Arrhenius(
+                A = (4.65e-19, 'cm^3/(molecule*s)'),
+                n = 2.28,
+                Ea = (51965.5, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (1.24e-18, 'cm^3/(molecule*s)'),
+                n = 2.16,
+                Ea = (52505.9, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (2.95e-18, 'cm^3/(molecule*s)'),
+                n = 2.04,
+                Ea = (53013.1, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (4.01e-18, 'cm^3/(molecule*s)'),
+                n = 2,
+                Ea = (53196, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (5.33e-18, 'cm^3/(molecule*s)'),
+                n = 1.97,
+                Ea = (53603.4, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (1.22e-17, 'cm^3/(molecule*s)'),
+                n = 1.89,
+                Ea = (56920.9, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+        ],
+    ),
+)
+
+entry(
+    index = 3,
+    label = "OH + C2H2 <=> CH2CO + H",
+    degeneracy = 1,
+    kinetics = PDepArrhenius(
+        pressures = ([0.01, 0.025, 0.1, 1, 10, 100], 'atm'),
+        arrhenius = [
+            Arrhenius(
+                A = (2.62e-21, 'cm^3/(molecule*s)'),
+                n = 2.56,
+                Ea = (-3533.65, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (2.52e-20, 'cm^3/(molecule*s)'),
+                n = 2.28,
+                Ea = (-1222.23, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (5.01e-19, 'cm^3/(molecule*s)'),
+                n = 1.92,
+                Ea = (2502.66, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (1.25e-17, 'cm^3/(molecule*s)'),
+                n = 1.55,
+                Ea = (8813.34, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (8.47e-18, 'cm^3/(molecule*s)'),
+                n = 1.65,
+                Ea = (14226.1, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (2.42e-20, 'cm^3/(molecule*s)'),
+                n = 2.45,
+                Ea = (18732.5, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+        ],
+    ),
+)
+
+entry(
+    index = 4,
+    label = "OH + C2H2 <=> CO + CH3",
+    degeneracy = 1,
+    kinetics = PDepArrhenius(
+        pressures = ([0.01, 0.025, 0.1, 1, 10, 100], 'atm'),
+        arrhenius = [
+            Arrhenius(
+                A = (7.9e-19, 'cm^3/(molecule*s)'),
+                n = 1.68,
+                Ea = (-1380.2, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (7.26e-18, 'cm^3/(molecule*s)'),
+                n = 1.4,
+                Ea = (947.85, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (1.27e-16, 'cm^3/(molecule*s)'),
+                n = 1.05,
+                Ea = (4664.42, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (2.12e-15, 'cm^3/(molecule*s)'),
+                n = 0.73,
+                Ea = (10792.2, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (7.16e-16, 'cm^3/(molecule*s)'),
+                n = 0.92,
+                Ea = (15631.2, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (1.37e-18, 'cm^3/(molecule*s)'),
+                n = 1.77,
+                Ea = (19655.4, 'J/mol'),
+                T0 = (1, 'K'),
+            ),
+        ],
+    ),
+)
+
+entry(
+    index = 5,
+    label = "OH + C2H2 <=> HOC2H2",
+    degeneracy = 1,
+    kinetics = PDepArrhenius(
+        pressures = ([0.01, 0.025, 0.1, 1, 10, 100], 'atm'),
+        arrhenius = [
+            MultiArrhenius(
+                arrhenius = [
+                    Arrhenius(
+                        A = (4.77e+40, 'cm^3/(molecule*s)'),
+                        n = -18.57,
+                        Ea = (41880, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                    Arrhenius(
+                        A = (4.38e+09, 'cm^3/(molecule*s)'),
+                        n = -7.36,
+                        Ea = (26747.7, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                ],
+            ),
+            MultiArrhenius(
+                arrhenius = [
+                    Arrhenius(
+                        A = (7.79e+35, 'cm^3/(molecule*s)'),
+                        n = -16.87,
+                        Ea = (38022.1, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                    Arrhenius(
+                        A = (7.27e+08, 'cm^3/(molecule*s)'),
+                        n = -7.02,
+                        Ea = (24827, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                ],
+            ),
+            MultiArrhenius(
+                arrhenius = [
+                    Arrhenius(
+                        A = (20600, 'cm^3/(molecule*s)'),
+                        n = -5.56,
+                        Ea = (15581.3, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                    Arrhenius(
+                        A = (1.06e+19, 'cm^3/(molecule*s)'),
+                        n = -9.96,
+                        Ea = (49113.6, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                ],
+            ),
+            MultiArrhenius(
+                arrhenius = [
+                    Arrhenius(
+                        A = (3.16e+20, 'cm^3/(molecule*s)'),
+                        n = -11.38,
+                        Ea = (26356.9, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                    Arrhenius(
+                        A = (5.79e+07, 'cm^3/(molecule*s)'),
+                        n = -6.2,
+                        Ea = (27762, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                ],
+            ),
+            MultiArrhenius(
+                arrhenius = [
+                    Arrhenius(
+                        A = (2.47, 'cm^3/(molecule*s)'),
+                        n = -4.06,
+                        Ea = (13644, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                    Arrhenius(
+                        A = (7.48e+07, 'cm^3/(molecule*s)'),
+                        n = -5.92,
+                        Ea = (36658.5, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                ],
+            ),
+            MultiArrhenius(
+                arrhenius = [
+                    Arrhenius(
+                        A = (0.00103, 'cm^3/(molecule*s)'),
+                        n = -2.8,
+                        Ea = (11848.1, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                    Arrhenius(
+                        A = (266000, 'cm^3/(molecule*s)'),
+                        n = -4.91,
+                        Ea = (40732.6, 'J/mol'),
+                        T0 = (1, 'K'),
+                    ),
+                ],
+            ),
+        ],
+    ),
+)
+

--- a/input/kinetics/libraries/2006_Joshi_OH_CO/dictionary.txt
+++ b/input/kinetics/libraries/2006_Joshi_OH_CO/dictionary.txt
@@ -1,0 +1,25 @@
+HOCO
+multiplicity 2
+1 O u0 p2 c0 {2,D}
+2 C u1 p0 c0 {1,D} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 H u0 p0 c0 {3,S}
+
+CO2
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 O u0 p2 c0 {2,D}
+
+CO
+1 C u0 p1 c-1 {2,T}
+2 O u0 p1 c+1 {1,T}
+
+H
+multiplicity 2
+1 H u1 p0 c0
+
+OH
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+

--- a/input/kinetics/libraries/2006_Joshi_OH_CO/reactions.py
+++ b/input/kinetics/libraries/2006_Joshi_OH_CO/reactions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "2006_Joshi_OH_CO"
+shortDesc = u"Computed rates on OH + CO = HOCO = H + CO2 surface"
+longDesc = u"""
+Chebyshev fit to T,P-dependent k's calculated with CCSD(T)/cc-pvTZ for the small OH + CO surface by:
+A.V. Joshi and H. Wang,
+"Master equation modeling of wide range temperature and pressure dependence of CO + OH -> Products'
+Int. J. Chem. Kin., Vol. 38, Iss. 1, January 2006, Pages 57-73
+The surface includes OH+CO, HOCO and H+CO2 only.
+Calculated for an N2/Ar bath gas
+"""
+entry(
+    index = 1,
+    label = "OH + CO <=> HOCO",
+    degeneracy = 1,
+    kinetics = Chebyshev(
+        coeffs = [
+            [9.415, 2.41, -0.2151, -0.05592],
+            [-1.187, 0.4925, 0.226, 0.03057],
+            [-0.4109, -0.01515, 0.0145, 0.02892],
+            [-0.141, -0.0386, -0.01717, 0.004195],
+            [-0.03786, -0.02215, -0.01361, 0.00278],
+            [-0.03699, 0.01123, 0.0004769, -0.01677],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+        Pmin = (0.001, 'atm'),
+        Pmax = (641.5, 'atm'),
+    ),
+)
+
+entry(
+    index = 2,
+    label = "OH + CO <=> H + CO2",
+    degeneracy = 1,
+    kinetics = Chebyshev(
+        coeffs = [
+            [10.89, -0.4346, -0.2152, -0.05574],
+            [0.6535, 0.4928, 0.2262, 0.03006],
+            [0.2008, -0.01527, 0.01434, 0.02917],
+            [0.07196, -0.03864, -0.01717, 0.00435],
+            [0.02016, -0.02204, -0.01345, 0.002451],
+            [0.01154, 0.01113, 0.0004633, -0.01646],
+        ],
+        kunits = 'cm^3/(mol*s)',
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+        Pmin = (0.001, 'atm'),
+        Pmax = (641.5, 'atm'),
+    ),
+)
+


### PR DESCRIPTION
Added P-dependent kinetic libraries for the 3 following small molecule surfaces:

1. 2CH3 = C2H5 + H from 1989 Stewart calculations
2. OH + C2H2 from 2005 Senosiain calculations
3. OH + CO from 2006 Joshi calculations

The comments in each library indicate for which bath gas the calculations were done ("strong collider" for 1, and Ar/N2 for 2 and 3). For most combustion relevant conditions the P-dep of these reactions are negligible, so for most RMG jobs these libraries will not be much of an improvement over FFCM, which includes all of the above reactions without P-dep.