### PR TITLE
Add forbidden groups to Intra_R_add_Exo and Endocyclic families

### DIFF
--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -2654,3 +2654,66 @@ u"""
 """,
 )
 
+forbidden(
+    label = "2_C_rad_add_to_m_position_of_phenyl_sidegroup_res1",
+    group =
+"""
+1    C u0 {2,S} {3,[S,D,T]}
+2    C u0 {1,S} {4,D} {5,S}
+3 *1 C u1 {1,[S,D,T]}
+4    C u0 {2,D} {7,S}
+5    C u0 {2,S} {8,D}
+6 *2 C u0 {7,D} {8,S}
+7 *3 C u0 {4,S} {6,D}
+8    C u0 {5,D} {6,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid a carbon radical 2 carbons away from a phenyl side group from adding to the meta-position
+because the TS would be far too strained. Resonance form 1.
+""",
+)
+
+forbidden(
+    label = "2_C_rad_add_to_m_position_of_phenyl_sidegroup_res2",
+    group =
+"""
+1    C u0 {2,S} {3,[S,D,T]}
+2    C u0 {1,S} {4,S} {5,D}
+3 *1 C u1 {1,[S,D,T]}
+4 *2 C u0 {2,S} {7,D}
+5    C u0 {2,D} {8,S}
+6    C u0 {7,S} {8,D}
+7 *3 C u0 {4,D} {6,S}
+8    C u0 {5,S} {6,D}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid a carbon radical 2 carbons away from a phenyl side group from adding to the meta-position
+because the TS would be far too strained. Resonance form 2.
+""",
+)
+
+forbidden(
+    label = "2_C_rad_add_to_p_position_of_phenyl_sidegroup_res1",
+    group =
+"""
+1    C u0 {2,S} {3,[S,D,T]}
+2    C u0 {1,S} {4,D} {5,S}
+3 *1 C u1 {1,[S,D,T]}
+4    C u0 {2,D} {7,S}
+5    C u0 {2,S} {8,D}
+6 *3 C u0 {7,D} {8,S}
+7 *2 C u0 {4,S} {6,D}
+8    C u0 {5,D} {6,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid a carbon radical 2 carbons away from a phenyl side group from adding to the para-position
+because the TS would be far too strained. Resonance form 1.
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
@@ -2958,3 +2958,66 @@ u"""
 """,
 )
 
+forbidden(
+    label = "2_C_rad_add_to_m_position_of_phenyl_sidegroup_res1",
+    group =
+"""
+1    C u0 {2,S} {3,[S,D,T]}
+2    C u0 {1,S} {4,D} {5,S}
+3 *1 C u1 {1,[S,D,T]}
+4    C u0 {2,D} {7,S}
+5    C u0 {2,S} {8,D}
+6 *3 C u0 {7,D} {8,S}
+7 *2 C u0 {4,S} {6,D}
+8    C u0 {5,D} {6,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid a carbon radical 2 carbons away from a phenyl side group from adding to the meta-position
+because the TS would be far too strained. Resonance form 1.
+""",
+)
+
+forbidden(
+    label = "2_C_rad_add_to_m_position_of_phenyl_sidegroup_res2",
+    group =
+"""
+1    C u0 {2,S} {3,[S,D,T]}
+2    C u0 {1,S} {4,S} {5,D}
+3 *1 C u1 {1,[S,D,T]}
+4 *3 C u0 {2,S} {7,D}
+5    C u0 {2,D} {8,S}
+6    C u0 {7,S} {8,D}
+7 *2 C u0 {4,D} {6,S}
+8    C u0 {5,S} {6,D}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid a carbon radical 2 carbons away from a phenyl side group from adding to the meta-position
+because the TS would be far too strained. Resonance form 2.
+""",
+)
+
+forbidden(
+    label = "2_C_rad_add_to_p_position_of_phenyl_sidegroup_res1",
+    group =
+"""
+1    C u0 {2,S} {3,[S,D,T]}
+2    C u0 {1,S} {4,D} {5,S}
+3 *1 C u1 {1,[S,D,T]}
+4    C u0 {2,D} {7,S}
+5    C u0 {2,S} {8,D}
+6 *2 C u0 {7,D} {8,S}
+7 *3 C u0 {4,S} {6,D}
+8    C u0 {5,D} {6,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbid a carbon radical 2 carbons away from a phenyl side group from adding to the para-position
+because the TS would be far too strained. Resonance form 1.
+""",
+)
+


### PR DESCRIPTION
Added 3 forbidden groups to Intra_R_add_Exo and Endocyclic families to prevent a radical carbon located two carbons away from a phenyl side group from adding to either the meta or para positions. The TS for these reactions would be extremely strained. This is a temporary fix to RMG-Py Issue 812.