### PR TITLE
refactored reaction recipes

### DIFF
--- a/input/kinetics/families/1+2_Cycloaddition/groups.py
+++ b/input/kinetics/families/1+2_Cycloaddition/groups.py
@@ -12,9 +12,9 @@ template(reactants=["multiplebond", "elec_def"], products=["cycle"], ownReverse=
 reverse = "Three_Ring_Cleavage"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*3'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*3'],
     ['LOSE_PAIR', '*3', '1'],
 ])
 

--- a/input/kinetics/families/1,2-Birad_to_alkene/groups.py
+++ b/input/kinetics/families/1,2-Birad_to_alkene/groups.py
@@ -12,7 +12,7 @@ template(reactants=["Y_12birad"], products=["Y_alkene"], ownReverse=False)
 reverse = "Alkene_to_1,2-birad"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '1', '*2'],
+    ['CHANGE_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*2', '1'],
 ])

--- a/input/kinetics/families/1,2_Insertion_CO/groups.py
+++ b/input/kinetics/families/1,2_Insertion_CO/groups.py
@@ -12,11 +12,11 @@ template(reactants=["CO_birad", "RR'"], products=["R_CO_R'"], ownReverse=False)
 reverse = "1,1_Elimination"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*4'],
+    ['CHANGE_BOND', '*1', -1, '*4'],
     ['GAIN_PAIR', '*4', '1'],
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['LOSE_PAIR', '*1', '1'],
 ])
 

--- a/input/kinetics/families/1,2_Insertion_carbene/groups.py
+++ b/input/kinetics/families/1,2_Insertion_carbene/groups.py
@@ -12,9 +12,9 @@ template(reactants=["carbene", "RR'"], products=["R_CO_R'"], ownReverse=False)
 reverse = "1,1_Elimination"
 
 recipe(actions=[
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['LOSE_PAIR', '*1', '1'],
 ])
 

--- a/input/kinetics/families/1,2_shiftS/groups.py
+++ b/input/kinetics/families/1,2_shiftS/groups.py
@@ -12,8 +12,8 @@ template(reactants=["XSYJ"], products=["XYSJ"], ownReverse=False)
 reverse = "1,2_S_radical_shift"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/1,3_Insertion_CO2/groups.py
+++ b/input/kinetics/families/1,3_Insertion_CO2/groups.py
@@ -12,10 +12,10 @@ template(reactants=["CO2", "RR'"], products=["R_(CO2)_R'"], ownReverse=False)
 reverse = "1,2_Elimination_CO2"
 
 recipe(actions=[
-    ['BREAK_BOND', '*3', 'S', '*4'],
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['BREAK_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/1,3_Insertion_ROR/groups.py
+++ b/input/kinetics/families/1,3_Insertion_ROR/groups.py
@@ -12,10 +12,10 @@ template(reactants=["doublebond", "R_OR"], products=["R_doublebond_OR"], ownReve
 reverse = "1,2_Elimination_ROR"
 
 recipe(actions=[
-    ['BREAK_BOND', '*3', 'S', '*4'],
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['BREAK_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/1,3_Insertion_RSR/groups.py
+++ b/input/kinetics/families/1,3_Insertion_RSR/groups.py
@@ -12,10 +12,10 @@ template(reactants=["doublebond", "R_SR"], products=["R_singlebond_SR"], ownReve
 reverse = "1,2_Elimination_RSR"
 
 recipe(actions=[
-    ['BREAK_BOND', '*3', 'S', '*4'],
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['BREAK_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/1,4_Cyclic_birad_scission/groups.py
+++ b/input/kinetics/families/1,4_Cyclic_birad_scission/groups.py
@@ -12,11 +12,11 @@ template(reactants=["RJJ"], products=["diene"], ownReverse=False)
 reverse = "none"
 
 recipe(actions=[
-    ['BREAK_BOND', '*2', 'S', '*3'],
+    ['BREAK_BOND', '*2', 1, '*3'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*4', '1'],
-    ['CHANGE_BOND', '*1', '1', '*2'],
-    ['CHANGE_BOND', '*3', '1', '*4'],
+    ['CHANGE_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*3', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/1,4_Linear_birad_scission/groups.py
+++ b/input/kinetics/families/1,4_Linear_birad_scission/groups.py
@@ -14,9 +14,9 @@ reverse = "none"
 recipe(actions=[
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*4', '1'],
-    ['CHANGE_BOND', '*1', '1', '*2'],
-    ['CHANGE_BOND', '*3', '1', '*4'],
-    ['BREAK_BOND', '*2', 'S', '*3'],
+    ['CHANGE_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*3', 1, '*4'],
+    ['BREAK_BOND', '*2', 1, '*3'],
 ])
 
 entry(

--- a/input/kinetics/families/2+2_cycloaddition_CCO/groups.py
+++ b/input/kinetics/families/2+2_cycloaddition_CCO/groups.py
@@ -12,10 +12,10 @@ template(reactants=["CCO", "doublebond"], products=["four_ring"], ownReverse=Fal
 reverse = "Four_Ring_Cleavage_CCO"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['CHANGE_BOND', '*3', '-1', '*4'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['CHANGE_BOND', '*3', -1, '*4'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/2+2_cycloaddition_CO/groups.py
+++ b/input/kinetics/families/2+2_cycloaddition_CO/groups.py
@@ -12,10 +12,10 @@ template(reactants=["CO", "doublebond"], products=["four_ring"], ownReverse=Fals
 reverse = "Four_Ring_Cleavage_CO"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['CHANGE_BOND', '*3', '-1', '*4'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['CHANGE_BOND', '*3', -1, '*4'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/2+2_cycloaddition_Cd/groups.py
+++ b/input/kinetics/families/2+2_cycloaddition_Cd/groups.py
@@ -12,10 +12,10 @@ template(reactants=["db", "doublebond"], products=["four_ring"], ownReverse=Fals
 reverse = "Four_Ring_Cleavage_Cd"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['CHANGE_BOND', '*3', '-1', '*4'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['CHANGE_BOND', '*3', -1, '*4'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/Birad_recombination/groups.py
+++ b/input/kinetics/families/Birad_recombination/groups.py
@@ -12,7 +12,7 @@ template(reactants=["Rn"], products=["Rncycle"], ownReverse=False)
 reverse = "Ring_Open"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*2', '1'],
 ])

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups.py
@@ -12,8 +12,8 @@ template(reactants=["RnOO"], products=["RO", "OR"], ownReverse=False)
 reverse = "OH+CyclicEther_Form_Alkyl-hydroperoxyl"
 
 recipe(actions=[
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['GAIN_RADICAL', '*3', '1'],
     ['LOSE_RADICAL', '*1', '1'],
 ])

--- a/input/kinetics/families/Diels_alder_addition/groups.py
+++ b/input/kinetics/families/Diels_alder_addition/groups.py
@@ -12,12 +12,12 @@ template(reactants=["{ene,yne}", "diene_out"], products=["Six_Ring"], ownReverse
 reverse = "Retro_Diels_Alder_Addition"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['CHANGE_BOND', '*3', '-1', '*4'],
-    ['CHANGE_BOND', '*4', '1', '*5'],
-    ['CHANGE_BOND', '*5', '-1', '*6'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*6'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['CHANGE_BOND', '*3', -1, '*4'],
+    ['CHANGE_BOND', '*4', 1, '*5'],
+    ['CHANGE_BOND', '*5', -1, '*6'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*6'],
 ])
 
 entry(

--- a/input/kinetics/families/Disproportionation/groups.py
+++ b/input/kinetics/families/Disproportionation/groups.py
@@ -14,9 +14,9 @@ template(reactants=["Y_rad_birad_trirad_quadrad", "XH_Rrad_birad"], products=["Y
 reverse = "Molecular_Addition"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 'S', '*4'],
-    ['BREAK_BOND', '*2', 'S', '*4'],
-    ['CHANGE_BOND', '*2', '1', '*3'],
+    ['FORM_BOND', '*1', 1, '*4'],
+    ['BREAK_BOND', '*2', 1, '*4'],
+    ['CHANGE_BOND', '*2', 1, '*3'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/HO2_Elimination_from_PeroxyRadical/groups.py
+++ b/input/kinetics/families/HO2_Elimination_from_PeroxyRadical/groups.py
@@ -12,10 +12,10 @@ template(reactants=["R2OO"], products=["R=R", "OOH"], ownReverse=False)
 reverse = "HO2_concerted_addition"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*5'],
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['CHANGE_BOND', '*1', '1', '*2'],
-    ['FORM_BOND', '*4', 'S', '*5'],
+    ['BREAK_BOND', '*1', 1, '*5'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['CHANGE_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*4', 1, '*5'],
     ['GAIN_RADICAL', '*3', '1'],
     ['LOSE_RADICAL', '*4', '1'],
 ])

--- a/input/kinetics/families/H_Abstraction/groups.py
+++ b/input/kinetics/families/H_Abstraction/groups.py
@@ -10,8 +10,8 @@ The reaction site *3 needs a lone pair in order to react. It cannot be 2S or 4S.
 template(reactants=["X_H_or_Xrad_H_Xbirad_H_Xtrirad_H", "Y_rad_birad_trirad_quadrad"], products=["X_H_or_Xrad_H_Xbirad_H_Xtrirad_H", "Y_rad_birad_trirad_quadrad"], ownReverse=True)
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*2', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*2', 1, '*3'],
     ['GAIN_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/H_shift_cyclopentadiene/groups.py
+++ b/input/kinetics/families/H_shift_cyclopentadiene/groups.py
@@ -10,12 +10,12 @@ longDesc = u"""
 template(reactants=["cyclopentadiene"], products=["cyclopentadiene"], ownReverse=True)
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*6'],
-    ['FORM_BOND', '*2', 'S', '*6'],
-    ['CHANGE_BOND', '*2', '-1', '*3'],
-    ['CHANGE_BOND', '*4', '-1', '*5'],
-    ['CHANGE_BOND', '*1', '1', '*5'],
-    ['CHANGE_BOND', '*4', '1', '*3'],
+    ['BREAK_BOND', '*1', 1, '*6'],
+    ['FORM_BOND', '*2', 1, '*6'],
+    ['CHANGE_BOND', '*2', -1, '*3'],
+    ['CHANGE_BOND', '*4', -1, '*5'],
+    ['CHANGE_BOND', '*1', 1, '*5'],
+    ['CHANGE_BOND', '*4', 1, '*3'],
 ])
 
 entry(

--- a/input/kinetics/families/Intra_Diels_alder/groups.py
+++ b/input/kinetics/families/Intra_Diels_alder/groups.py
@@ -12,12 +12,12 @@ template(reactants=["cyclohexene"], products=["open"], ownReverse=False)
 reverse = "ringopening"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '1', '*2'],
-    ['CHANGE_BOND', '*3', '1', '*4'],
-    ['CHANGE_BOND', '*2', '-1', '*3'],
-    ['CHANGE_BOND', '*5', '1', '*6'],
-    ['BREAK_BOND', '*1', 'S', '*6'],
-    ['BREAK_BOND', '*4', 'S', '*5'],
+    ['CHANGE_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*2', -1, '*3'],
+    ['CHANGE_BOND', '*5', 1, '*6'],
+    ['BREAK_BOND', '*1', 1, '*6'],
+    ['BREAK_BOND', '*4', 1, '*5'],
 ])
 
 entry(

--- a/input/kinetics/families/Intra_Disproportionation/groups.py
+++ b/input/kinetics/families/Intra_Disproportionation/groups.py
@@ -12,9 +12,9 @@ template(reactants=["Rn"], products=["Y"], ownReverse=False)
 reverse = "BiradFromMultipleBond"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 'S', '*4'],
-    ['BREAK_BOND', '*2', 'S', '*4'],
-    ['CHANGE_BOND', '*2', '1', '*3'],
+    ['FORM_BOND', '*1', 1, '*4'],
+    ['BREAK_BOND', '*2', 1, '*4'],
+    ['CHANGE_BOND', '*2', 1, '*3'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/Intra_RH_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_RH_Add_Endocyclic/groups.py
@@ -12,9 +12,9 @@ template(reactants=["Rn"], products=["RnCycle"], ownReverse=False)
 reverse = "Ring_Open+H_Migration"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*4'],
-    ['FORM_BOND', '*1', 'S', '*3'],
-    ['FORM_BOND', '*2', 'S', '*4'],
+    ['BREAK_BOND', '*1', 1, '*4'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['FORM_BOND', '*2', 1, '*4'],
     ['CHANGE_BOND', '*2', '-1', '*3'],
 ])
 

--- a/input/kinetics/families/Intra_RH_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_RH_Add_Exocyclic/groups.py
@@ -12,10 +12,10 @@ template(reactants=["Rn"], products=["RnCycle"], ownReverse=False)
 reverse = "Ring_Open+H_Migration"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*4'],
-    ['FORM_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*3', 'S', '*4'],
-    ['CHANGE_BOND', '*2', '-1', '*3'],
+    ['BREAK_BOND', '*1', 1, '*4'],
+    ['FORM_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*2', -1, '*3'],
 ])
 
 entry(

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -12,8 +12,8 @@ template(reactants=["Rn"], products=["RnCyclic"], ownReverse=False)
 reverse = "Ring_Open_Endo_Cycli_Radical"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*2', '-1', '*3'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['CHANGE_BOND', '*2', -1, '*3'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*1', '1'],
 ])

--- a/input/kinetics/families/Intra_R_Add_ExoTetCyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_ExoTetCyclic/groups.py
@@ -12,8 +12,8 @@ template(reactants=["R1_rad_R2_R3"], products=["R1_R2_Cycle", "R3_rad"], ownReve
 reverse = "Ring_Open_Rad_Addition"
 
 recipe(actions=[
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*1', '1'],
     ['GAIN_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
@@ -12,8 +12,8 @@ template(reactants=["Rn"], products=["RnCycle"], ownReverse=False)
 reverse = "Ring_Open_Exo_Cycli_Radical"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*2', '-1', '*3'],
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['CHANGE_BOND', '*2', -1, '*3'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*1', '1'],
     ['GAIN_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/Korcek_step1/groups.py
+++ b/input/kinetics/families/Korcek_step1/groups.py
@@ -12,10 +12,10 @@ template(reactants=["RCH(OOH)CH2C(O)R'"], products=["cyclic_peroxide"], ownRever
 reverse = "cyclic_peroxide_ringopening"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['CHANGE_BOND', '*3', '-1', '*4'],
-    ['FORM_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*4'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['CHANGE_BOND', '*3', -1, '*4'],
+    ['FORM_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*4'],
 ])
 
 entry(

--- a/input/kinetics/families/Korcek_step2/groups.py
+++ b/input/kinetics/families/Korcek_step2/groups.py
@@ -12,12 +12,12 @@ template(reactants=["C1(R)(H)(O(OC3(OH)(R'))C2)"], products=["C1(R)(O)(C2)", "C3
 reverse = "none"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*6'],
-    ['BREAK_BOND', '*4', 'S', '*5'],
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['CHANGE_BOND', '*3', '1', '*4'],
-    ['CHANGE_BOND', '*1', '1', '*5'],
-    ['FORM_BOND', '*2', 'S', '*6'],
+    ['BREAK_BOND', '*1', 1, '*6'],
+    ['BREAK_BOND', '*4', 1, '*5'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['CHANGE_BOND', '*3', 1, '*4'],
+    ['CHANGE_BOND', '*1', 1, '*5'],
+    ['FORM_BOND', '*2', 1, '*6'],
 ])
 
 entry(

--- a/input/kinetics/families/Oa_R_Recombination/groups.py
+++ b/input/kinetics/families/Oa_R_Recombination/groups.py
@@ -13,7 +13,7 @@ template(reactants=["Y_rad", "Oa"], products=["YO."], ownReverse=False)
 reverse = "RO_Bond_Dissociation"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*2', '1'],
 ])

--- a/input/kinetics/families/R_Addition_COm/groups.py
+++ b/input/kinetics/families/R_Addition_COm/groups.py
@@ -13,10 +13,10 @@ reverse = "COM_Elimination_From_Carbonyl"
 
 recipe(actions=[
     ['LOSE_PAIR', '*1', '1'],
-    ['CHANGE_BOND', '*1', '-1', '*3'],
+    ['CHANGE_BOND', '*1', -1, '*3'],
     ['GAIN_RADICAL', '*1', '1'],
     ['GAIN_PAIR', '*3', '1'],
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*2', '1'],
 ])
 

--- a/input/kinetics/families/R_Addition_CSm/groups.py
+++ b/input/kinetics/families/R_Addition_CSm/groups.py
@@ -13,10 +13,10 @@ reverse = "CSM_Elimination_From_Thiocarbonyl"
 
 recipe(actions=[
     ['LOSE_PAIR', '*1', '1'],
-    ['CHANGE_BOND', '*1', '-1', '*3'],
+    ['CHANGE_BOND', '*1', -1, '*3'],
     ['GAIN_RADICAL', '*1', '1'],
     ['GAIN_PAIR', '*3', '1'],
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*2', '1'],
 ])
 

--- a/input/kinetics/families/R_Addition_MultipleBond/groups.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/groups.py
@@ -12,8 +12,8 @@ template(reactants=["R_R", "YJ"], products=["RJ_R_Y"], ownReverse=False)
 reverse = "Beta_Scission"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/R_Recombination/groups.py
+++ b/input/kinetics/families/R_Recombination/groups.py
@@ -12,7 +12,7 @@ template(reactants=["Y_rad", "Y_rad"], products=["Y_Y"], ownReverse=False)
 reverse = "Bond_Dissociation"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*2', '1'],
 ])

--- a/input/kinetics/families/Substitution_O/groups.py
+++ b/input/kinetics/families/Substitution_O/groups.py
@@ -10,8 +10,8 @@ The reacting site *3 must be a triplet for this reaction family.
 template(reactants=["O-RR_or_RRrad", "YJ"], products=["O-RR_or_RRrad", "YJ"], ownReverse=True)
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -10,8 +10,8 @@ longDesc = u"""
 template(reactants=["RnH"], products=["RnH"], ownReverse=True)
 
 recipe(actions=[
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*1', '1'],
 ])

--- a/input/kinetics/families/intra_NO2_ONO_conversion/groups.py
+++ b/input/kinetics/families/intra_NO2_ONO_conversion/groups.py
@@ -12,8 +12,8 @@ template(reactants=["RNO2"], products=["RONO"], ownReverse=False)
 reverse = "intra_ONO_NO2_migration"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['LOSE_PAIR', '*3', '1'],
     ['GAIN_PAIR', '*2', '1'],
 ])

--- a/input/kinetics/families/intra_OH_migration/groups.py
+++ b/input/kinetics/families/intra_OH_migration/groups.py
@@ -12,8 +12,8 @@ template(reactants=["RnOOH"], products=["HORO."], ownReverse=False)
 reverse = "none"
 
 recipe(actions=[
-    ['BREAK_BOND', '*2', 'S', '*3'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*1', '1'],
 ])

--- a/input/kinetics/families/intra_substitutionCS_cyclization/groups.py
+++ b/input/kinetics/families/intra_substitutionCS_cyclization/groups.py
@@ -12,8 +12,8 @@ template(reactants=["XSYJ"], products=["SY", "XJ"], ownReverse=False)
 reverse = "Ring_Opening_bySradical"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/intra_substitutionCS_isomerization/groups.py
+++ b/input/kinetics/families/intra_substitutionCS_isomerization/groups.py
@@ -12,8 +12,8 @@ template(reactants=["XSYJ"], products=["XYSJ"], ownReverse=False)
 reverse = "Ring_Opening_bySradical"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/intra_substitutionS_cyclization/groups.py
+++ b/input/kinetics/families/intra_substitutionS_cyclization/groups.py
@@ -12,8 +12,8 @@ template(reactants=["XSYJ"], products=["SY", "XJ"], ownReverse=False)
 reverse = "Ring_OpeningS"
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/intra_substitutionS_isomerization/groups.py
+++ b/input/kinetics/families/intra_substitutionS_isomerization/groups.py
@@ -10,8 +10,8 @@ longDesc = u"""
 template(reactants=["XSYJ"], products=["XSYJ"], ownReverse=True)
 
 recipe(actions=[
-    ['BREAK_BOND', '*1', 'S', '*2'],
-    ['FORM_BOND', '*1', 'S', '*3'],
+    ['BREAK_BOND', '*1', 1, '*2'],
+    ['FORM_BOND', '*1', 1, '*3'],
     ['GAIN_RADICAL', '*2', '1'],
     ['LOSE_RADICAL', '*3', '1'],
 ])

--- a/input/kinetics/families/ketoenol/groups.py
+++ b/input/kinetics/families/ketoenol/groups.py
@@ -12,10 +12,10 @@ template(reactants=["R_ROR"], products=["keton"], ownReverse=False)
 reverse = "none"
 
 recipe(actions=[
-    ['CHANGE_BOND', '*1', '-1', '*2'],
-    ['CHANGE_BOND', '*2', '1', '*3'],
-    ['BREAK_BOND', '*3', 'S', '*4'],
-    ['FORM_BOND', '*4', 'S', '*1'],
+    ['CHANGE_BOND', '*1', -1, '*2'],
+    ['CHANGE_BOND', '*2', 1, '*3'],
+    ['BREAK_BOND', '*3', 1, '*4'],
+    ['FORM_BOND', '*4', 1, '*1'],
 ])
 
 entry(

--- a/input/kinetics/families/lone_electron_pair_bond/groups.py
+++ b/input/kinetics/families/lone_electron_pair_bond/groups.py
@@ -12,7 +12,7 @@ template(reactants=["N3sRRR", "O_atom_singlet"], products=["N3sRRRO"], ownRevers
 reverse = "Bond_Dissociation"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 'S', '*2'],
+    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_PAIR', '*1', '1'],
 ])
 


### PR DESCRIPTION
Along with the pull request to change bond representation to floats, the recipe actions FORM_BOND, CHANGE_BOND and
BREAK_BOND were changed to use numbers instead of strings. This pull request for RMG-database changes the reaction recipes for all reaction families to use numbers for actions FORM_BOND, CHANGE_BOND, and BREAK_BOND instead of strings. 

This pull request needs to go along with the branch `bond_doubles` in RMG-Py. 