### PR TITLE
Unimol kinetics part2

### DIFF
--- a/input/kinetics/families/1,2_shiftS/groups.py
+++ b/input/kinetics/families/1,2_shiftS/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*3"]
+
 entry(
     index = 1,
     label = "XSYJ",

--- a/input/kinetics/families/Birad_recombination/groups.py
+++ b/input/kinetics/families/Birad_recombination/groups.py
@@ -24,6 +24,8 @@ entry(
     kinetics = None,
 )
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 2,
     label = "Y_rad_out",

--- a/input/kinetics/families/Birad_recombination/groups.py
+++ b/input/kinetics/families/Birad_recombination/groups.py
@@ -49,9 +49,9 @@ entry(
     label = "R3",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+1 *1 R!H u1 {2,[S,D]}
 2 *3 [Cs,Cd,CO,Os,Ss,N3s] u0 {1,[S,D]} {3,[S,D]}
-3 *2 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+3 *2 R!H u1 {2,[S,D]}
 """,
     kinetics = None,
 )
@@ -61,9 +61,9 @@ entry(
     label = "R3_SS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3 *2 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+3 *2 R!H u1 {2,S}
 """,
     kinetics = None,
 )
@@ -73,9 +73,9 @@ entry(
     label = "R3_SD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 Cd               u0 {1,S} {3,D}
-3 *2 Cd               u1 {2,D}
+3 *2 R!H              u1 {2,D}
 """,
     kinetics = None,
 )
@@ -85,10 +85,10 @@ entry(
     label = "R4",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+1 *1 R!H u1 {2,[S,D]}
 2 *3 [Cs,Cd,CO,Os,Ss,N3s] u0 {1,[S,D]} {3,[S,D]}
 3 *4 [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
-4 *2 [Cs,Cd,CO,Os,Ss,N3s] u1 {3,[S,D]}
+4 *2 R!H u1 {3,[S,D]}
 """,
     kinetics = None,
 )
@@ -98,10 +98,10 @@ entry(
     label = "R4_SSS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
 3 *4 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
-4 *2 [Cs,Cd,CO,Os,Ss] u1 {3,S}
+4 *2 R!H u1 {3,S}
 """,
     kinetics = None,
 )
@@ -111,10 +111,10 @@ entry(
     label = "R4_SSD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
 3 *4 Cd               u0 {2,S} {4,D}
-4 *2 Cd               u1 {3,D}
+4 *2 R!H              u1 {3,D}
 """,
     kinetics = None,
 )
@@ -124,10 +124,10 @@ entry(
     label = "R4_SDS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 Cd               u0 {1,S} {3,D}
 3 *4 Cd               u0 {2,D} {4,S}
-4 *2 [Cs,Cd,CO,Os,Ss] u1 {3,S}
+4 *2 R!H u1 {3,S}
 """,
     kinetics = None,
 )
@@ -137,10 +137,10 @@ entry(
     label = "R4_DSD",
     group = 
 """
-1 *1 Cd u1 {2,D}
+1 *1 R!H u1 {2,D}
 2 *3 Cd u0 {1,D} {3,S}
 3 *4 Cd u0 {2,S} {4,D}
-4 *2 Cd u1 {3,D}
+4 *2 R!H u1 {3,D}
 """,
     kinetics = None,
 )
@@ -150,11 +150,11 @@ entry(
     label = "R5",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+1 *1 R!H u1 {2,[S,D]}
 2 *3 [Cs,Cd,CO,Os,Ss,N3s] u0 {1,[S,D]} {3,[S,D]}
-3    [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
+3 *5 [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
 4 *4 [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
-5 *2 [Cs,Cd,CO,Os,Ss,N3s] u1 {4,[S,D]}
+5 *2 R!H u1 {4,[S,D]}
 """,
     kinetics = None,
 )
@@ -164,11 +164,11 @@ entry(
     label = "R5_SSSS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
 4 *4 [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
-5 *2 [Cs,Cd,CO,Os,Ss] u1 {4,S}
+5 *2 R!H u1 {4,S}
 """,
     kinetics = None,
 )
@@ -178,11 +178,11 @@ entry(
     label = "R5_SSSD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
 4 *4 Cd               u0 {3,S} {5,D}
-5 *2 Cd               u1 {4,D}
+5 *2 R!H              u1 {4,D}
 """,
     kinetics = None,
 )
@@ -192,11 +192,11 @@ entry(
     label = "R5_SSDS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    Cd               u0 {2,S} {4,D}
+3 *5 Cd               u0 {2,S} {4,D}
 4 *4 Cd               u0 {3,D} {5,S}
-5 *2 [Cs,Cd,CO,Os,Ss] u1 {4,S}
+5 *2 R!H u1 {4,S}
 """,
     kinetics = None,
 )
@@ -206,11 +206,11 @@ entry(
     label = "R5_SDSD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 Cd               u0 {1,S} {3,D}
-3    Cd               u0 {2,D} {4,S}
+3 *5 Cd               u0 {2,D} {4,S}
 4 *4 Cd               u0 {3,S} {5,D}
-5 *2 Cd               u1 {4,D}
+5 *2 R!H              u1 {4,D}
 """,
     kinetics = None,
 )
@@ -220,11 +220,11 @@ entry(
     label = "R5_DSSD",
     group = 
 """
-1 *1 Cd               u1 {2,D}
+1 *1 R!H              u1 {2,D}
 2 *3 Cd               u0 {1,D} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
 4 *4 Cd               u0 {3,S} {5,D}
-5 *2 Cd               u1 {4,D}
+5 *2 R!H              u1 {4,D}
 """,
     kinetics = None,
 )
@@ -234,12 +234,12 @@ entry(
     label = "R6",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+1 *1 R!H u1 {2,[S,D]}
 2 *3 [Cs,Cd,CO,Os,Ss,N3s] u0 {1,[S,D]} {3,[S,D]}
-3    [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
-4    [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
+3 *5 [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
+4 *6 [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
 5 *4 [Cs,Cd,CO,Os,Ss,N3s] u0 {4,[S,D]} {6,[S,D]}
-6 *2 [Cs,Cd,CO,Os,Ss,N3s] u1 {5,[S,D]}
+6 *2 R!H u1 {5,[S,D]}
 """,
     kinetics = None,
 )
@@ -249,12 +249,12 @@ entry(
     label = "R6_SSSSS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
-4    [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+4 *6 [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
 5 *4 [Cs,Cd,CO,Os,Ss] u0 {4,S} {6,S}
-6 *2 [Cs,Cd,CO,Os,Ss] u1 {5,S}
+6 *2 R!H u1 {5,S}
 """,
     kinetics = None,
 )
@@ -264,12 +264,12 @@ entry(
     label = "R6_SSSSD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
-4    [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+4 *6 [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
 5 *4 Cd               u0 {4,S} {6,D}
-6 *2 Cd               u1 {5,D}
+6 *2 R!H              u1 {5,D}
 """,
     kinetics = None,
 )
@@ -279,12 +279,12 @@ entry(
     label = "R6_SSSDS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
-4    Cd               u0 {3,S} {5,D}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+4 *6 Cd               u0 {3,S} {5,D}
 5 *4 Cd               u0 {4,D} {6,S}
-6 *2 [Cs,Cd,CO,Os,Ss] u1 {5,S}
+6 *2 R!H u1 {5,S}
 """,
     kinetics = None,
 )
@@ -294,12 +294,12 @@ entry(
     label = "R6_SSDSS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    Cd               u0 {2,S} {4,D}
-4    Cd               u0 {3,D} {5,S}
+3 *5 Cd               u0 {2,S} {4,D}
+4 *6 Cd               u0 {3,D} {5,S}
 5 *4 [Cs,Cd,CO,Os,Ss] u0 {4,S} {6,S}
-6 *2 [Cs,Cd,CO,Os,Ss] u1 {5,S}
+6 *2 R!H u1 {5,S}
 """,
     kinetics = None,
 )
@@ -309,12 +309,12 @@ entry(
     label = "R6_SSDSD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    Cd               u0 {2,S} {4,D}
-4    Cd               u0 {3,D} {5,S}
+3 *5 Cd               u0 {2,S} {4,D}
+4 *6 Cd               u0 {3,D} {5,S}
 5 *4 Cd               u0 {4,S} {6,D}
-6 *2 Cd               u1 {5,D}
+6 *2 R!H              u1 {5,D}
 """,
     kinetics = None,
 )
@@ -324,12 +324,12 @@ entry(
     label = "R6_SDSDS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 Cd               u0 {1,S} {3,D}
-3    Cd               u0 {2,D} {4,S}
-4    Cd               u0 {3,S} {5,D}
+3 *5 Cd               u0 {2,D} {4,S}
+4 *6 Cd               u0 {3,S} {5,D}
 5 *4 Cd               u0 {4,D} {6,S}
-6 *2 [Cs,Cd,CO,Os,Ss] u1 {5,S}
+6 *2 R!H u1 {5,S}
 """,
     kinetics = None,
 )
@@ -339,12 +339,12 @@ entry(
     label = "R6_SDSSD",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 Cd               u0 {1,S} {3,D}
-3    Cd               u0 {2,D} {4,S}
-4    [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
+3 *5 Cd               u0 {2,D} {4,S}
+4 *6 [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
 5 *4 Cd               u0 {4,S} {6,D}
-6 *2 Cd               u1 {5,D}
+6 *2 R!H              u1 {5,D}
 """,
     kinetics = None,
 )
@@ -354,12 +354,12 @@ entry(
     label = "R6_DSSSD",
     group = 
 """
-1 *1 Cd               u1 {2,D}
+1 *1 R!H              u1 {2,D}
 2 *3 Cd               u0 {1,D} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
-4    [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+4 *6 [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
 5 *4 Cd               u0 {4,S} {6,D}
-6 *2 Cd               u1 {5,D}
+6 *2 R!H              u1 {5,D}
 """,
     kinetics = None,
 )
@@ -369,12 +369,12 @@ entry(
     label = "R6_DSDSD",
     group = 
 """
-1 *1 Cd u1 {2,D}
+1 *1 R!H u1 {2,D}
 2 *3 Cd u0 {1,D} {3,S}
-3    Cd u0 {2,S} {4,D}
-4    Cd u0 {3,D} {5,S}
+3 *5 Cd u0 {2,S} {4,D}
+4 *6 Cd u0 {3,D} {5,S}
 5 *4 Cd u0 {4,S} {6,D}
-6 *2 Cd u1 {5,D}
+6 *2 R!H u1 {5,D}
 """,
     kinetics = None,
 )
@@ -384,13 +384,13 @@ entry(
     label = "R7",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+1 *1 R!H u1 {2,[S,D]}
 2 *3 [Cs,Cd,CO,Os,Ss,N3s] u0 {1,[S,D]} {3,[S,D]}
-3    [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
-4    [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
-5    [Cs,Cd,CO,Os,Ss,N3s] u0 {4,[S,D]} {6,[S,D]}
+3 *5 [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
+4 *6 [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
+5 *7 [Cs,Cd,CO,Os,Ss,N3s] u0 {4,[S,D]} {6,[S,D]}
 6 *4 [Cs,Cd,CO,Os,Ss,N3s] u0 {5,[S,D]} {7,[S,D]}
-7 *2 [Cs,Cd,CO,Os,Ss,N3s] u1 {6,[S,D]}
+7 *2 R!H u1 {6,[S,D]}
 """,
     kinetics = None,
 )
@@ -400,14 +400,14 @@ entry(
     label = "R8",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss,N3s] u1 {2,[S,D]}
+1 *1 R!H u1 {2,[S,D]}
 2 *3 [Cs,Cd,CO,Os,Ss,N3s] u0 {1,[S,D]} {3,[S,D]}
-3    [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
-4    [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
-5    [Cs,Cd,CO,Os,Ss,N3s] u0 {4,[S,D]} {6,[S,D]}
-6    [Cs,Cd,CO,Os,Ss,N3s] u0 {5,[S,D]} {7,[S,D]}
+3 *5 [Cs,Cd,CO,Os,Ss,N3s] u0 {2,[S,D]} {4,[S,D]}
+4 *6 [Cs,Cd,CO,Os,Ss,N3s] u0 {3,[S,D]} {5,[S,D]}
+5 *7 [Cs,Cd,CO,Os,Ss,N3s] u0 {4,[S,D]} {6,[S,D]}
+6 *8 [Cs,Cd,CO,Os,Ss,N3s] u0 {5,[S,D]} {7,[S,D]}
 7 *4 [Cs,Cd,CO,Os,Ss,N3s] u0 {6,[S,D]} {8,[S,D]}
-8 *2 [Cs,Cd,CO,Os,Ss,N3s] u1 {7,[S,D]}
+8 *2 R!H u1 {7,[S,D]}
 """,
     kinetics = None,
 )
@@ -417,14 +417,14 @@ entry(
     label = "R8_SSSSSSS",
     group = 
 """
-1 *1 [Cs,Cd,CO,Os,Ss] u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *3 [Cs,Cd,CO,Os,Ss] u0 {1,S} {3,S}
-3    [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
-4    [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
-5    [Cs,Cd,CO,Os,Ss] u0 {4,S} {6,S}
-6    [Cs,Cd,CO,Os,Ss] u0 {5,S} {7,S}
+3 *5 [Cs,Cd,CO,Os,Ss] u0 {2,S} {4,S}
+4 *6 [Cs,Cd,CO,Os,Ss] u0 {3,S} {5,S}
+5 *7 [Cs,Cd,CO,Os,Ss] u0 {4,S} {6,S}
+6 *8 [Cs,Cd,CO,Os,Ss] u0 {5,S} {7,S}
 7 *4 [Cs,Cd,CO,Os,Ss] u0 {6,S} {8,S}
-8 *2 [Cs,Cd,CO,Os,Ss] u1 {7,S}
+8 *2 R!H u1 {7,S}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups.py
@@ -53,7 +53,7 @@ entry(
     label = "R2OO_S",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 [Cd,Cs,CO] u0 {1,S} {3,S}
 3 *2 Os         u0 {2,S} {4,S}
 4 *3 Os         ux {3,S}
@@ -66,10 +66,10 @@ entry(
     label = "R2OO_SCO",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 CO      u0 {1,S} {3,S}
-3 *2 Os      u0 {2,S} {4,S}
-4 *3 Os      ux {3,S}
+1 *1 R!H u1 {2,S}
+2 *4 CO  u0 {1,S} {3,S}
+3 *2 Os  u0 {2,S} {4,S}
+4 *3 Os  ux {3,S}
 """,
     kinetics = None,
 )
@@ -79,10 +79,10 @@ entry(
     label = "R2OO_D",
     group = 
 """
-1 *1 Cd u1 {2,D}
-2 *4 Cd u0 {1,D} {3,S}
-3 *2 Os u0 {2,S} {4,S}
-4 *3 Os ux {3,S}
+1 *1 R!H u1 {2,D}
+2 *4 Cd  u0 {1,D} {3,S}
+3 *2 Os  u0 {2,S} {4,S}
+4 *3 Os  ux {3,S}
 """,
     kinetics = None,
 )
@@ -106,7 +106,7 @@ entry(
     label = "R3OO_SS",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
 3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 Os         u0 {3,S} {5,S}
@@ -120,7 +120,7 @@ entry(
     label = "R3OO_SSCO",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
+1 *1 R!H     u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
 3 *5 CO      u0 {2,S} {4,S}
 4 *2 Os      u0 {3,S} {5,S}
@@ -134,7 +134,7 @@ entry(
     label = "R3OO_SD",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
+1 *1 R!H     u1 {2,S}
 2 *4 Cd      u0 {1,S} {3,D}
 3 *5 Cd      u0 {2,D} {4,S}
 4 *2 Os      u0 {3,S} {5,S}
@@ -148,7 +148,7 @@ entry(
     label = "R3OO_DS",
     group = 
 """
-1 *1 Cd         u1 {2,D}
+1 *1 R!H        u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
 3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 Os         u0 {3,S} {5,S}
@@ -177,7 +177,7 @@ entry(
     label = "R4OO_SSS",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
 3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
@@ -192,7 +192,7 @@ entry(
     label = "R4OO_SSSCO",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
+1 *1 R!H     u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
 3 *6 [Cd,Cs] u0 {2,S} {4,S}
 4 *5 CO      u0 {3,S} {5,S}
@@ -207,7 +207,7 @@ entry(
     label = "R4OO_SSD",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
+1 *1 R!H     u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
 3 *6 Cd      u0 {2,S} {4,D}
 4 *5 Cd      u0 {3,D} {5,S}
@@ -222,7 +222,7 @@ entry(
     label = "R4OO_SDS",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 Cd         u0 {1,S} {3,D}
 3 *6 Cd         u0 {2,D} {4,S}
 4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
@@ -237,7 +237,7 @@ entry(
     label = "R4OO_DSS",
     group = 
 """
-1 *1 Cd         u1 {2,D}
+1 *1 R!H        u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
 3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
@@ -252,12 +252,12 @@ entry(
     label = "R4OO_DSD",
     group = 
 """
-1 *1 Cd u1 {2,D}
-2 *4 Cd u0 {1,D} {3,S}
-3 *6 Cd u0 {2,S} {4,D}
-4 *5 Cd u0 {3,D} {5,S}
-5 *2 Os u0 {4,S} {6,S}
-6 *3 Os ux {5,S}
+1 *1 R!H u1 {2,D}
+2 *4 Cd  u0 {1,D} {3,S}
+3 *6 Cd  u0 {2,S} {4,D}
+4 *5 Cd  u0 {3,D} {5,S}
+5 *2 Os  u0 {4,S} {6,S}
+6 *3 Os  ux {5,S}
 """,
     kinetics = None,
 )
@@ -283,7 +283,7 @@ entry(
     label = "R5OO_SSSS",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
 3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
@@ -299,7 +299,7 @@ entry(
     label = "R5OO_SSSSCO",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
+1 *1 R!H     u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
 3 *6 [Cd,Cs] u0 {2,S} {4,S}
 4 *7 [Cd,Cs] u0 {3,S} {5,S}
@@ -315,7 +315,7 @@ entry(
     label = "R5OO_SSSD",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
 3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *7 Cd         u0 {3,S} {5,D}
@@ -331,7 +331,7 @@ entry(
     label = "R5OO_SSDS",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
 3 *6 Cd         u0 {2,S} {4,D}
 4 *7 Cd         u0 {3,D} {5,S}
@@ -347,7 +347,7 @@ entry(
     label = "R5OO_SDSS",
     group = 
 """
-1 *1 [Cd,Cs]    u1 {2,S}
+1 *1 R!H        u1 {2,S}
 2 *4 Cd         u0 {1,S} {3,D}
 3 *6 Cd         u0 {2,D} {4,S}
 4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
@@ -363,7 +363,7 @@ entry(
     label = "R5OO_DSSS",
     group = 
 """
-1 *1 Cd         u1 {2,D}
+1 *1 R!H        u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
 3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
@@ -379,13 +379,13 @@ entry(
     label = "R5OO_SDSD",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 Cd      u0 {1,S} {3,D}
-3 *6 Cd      u0 {2,D} {4,S}
-4 *7 Cd      u0 {3,S} {5,D}
-5 *5 Cd      u0 {4,D} {6,S}
-6 *2 Os      u0 {5,S} {7,S}
-7 *3 Os      ux {6,S}
+1 *1 R!H u1 {2,S}
+2 *4 Cd  u0 {1,S} {3,D}
+3 *6 Cd  u0 {2,D} {4,S}
+4 *7 Cd  u0 {3,S} {5,D}
+5 *5 Cd  u0 {4,D} {6,S}
+6 *2 Os  u0 {5,S} {7,S}
+7 *3 Os  ux {6,S}
 """,
     kinetics = None,
 )
@@ -395,13 +395,13 @@ entry(
     label = "R5OO_DSDS",
     group = 
 """
-1 *1 Cd u1 {2,D}
-2 *4 Cd u0 {1,D} {3,S}
-3 *6 Cd u0 {2,S} {4,D}
-4 *7 Cd u0 {3,D} {5,S}
-5 *5 Cd u0 {4,S} {6,S}
-6 *2 Os u0 {5,S} {7,S}
-7 *3 Os ux {6,S}
+1 *1 R!H u1 {2,D}
+2 *4 Cd  u0 {1,D} {3,S}
+3 *6 Cd  u0 {2,S} {4,D}
+4 *7 Cd  u0 {3,D} {5,S}
+5 *5 Cd  u0 {4,S} {6,S}
+6 *2 Os  u0 {5,S} {7,S}
+7 *3 Os  ux {6,S}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups.py
@@ -38,144 +38,51 @@ entry(
 entry(
     index = 3,
     label = "R2OO",
-    group = "OR{R2OOH, R2OOR, R2OOJ}",
-    kinetics = None,
-)
-
-entry(
-    index = 4,
-    label = "R2OOJ",
     group = 
 """
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,S}
-3 *2 O                    u0 {2,S} {4,S}
-4 *3 O                    u1 {3,S}
+1 *1 R!H u1 {2,[S,D]}
+2 *5 R!H u0 {1,[S,D]} {3,S}
+3 *2 Os  u0 {2,S} {4,S}
+4 *3 Os  ux {3,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 5,
-    label = "R2OOJ_S",
+    label = "R2OO_S",
     group = 
 """
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *2 O       u0 {2,S} {4,S}
-4 *3 O       u1 {3,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 6,
-    label = "R2OOH",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,S}
-3 *2 O                    u0 {2,S} {4,S}
-4 *3 O                    u0 {3,S} {5,S}
-5    H                    u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 7,
-    label = "R2OOH_S",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *2 O       u0 {2,S} {4,S}
-4 *3 O       u0 {3,S} {5,S}
-5    H       u0 {4,S}
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *5 [Cd,Cs,CO] u0 {1,S} {3,S}
+3 *2 Os         u0 {2,S} {4,S}
+4 *3 Os         ux {3,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 5,
-    label = "R2OOH_SCO",
+    label = "R2OO_SCO",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 CO      u0 {1,S} {3,S}
-3 *2 O       u0 {2,S} {4,S}
-4 *3 O       u0 {3,S} {5,S}
-5    H       u0 {4,S}
+2 *5 CO      u0 {1,S} {3,S}
+3 *2 Os      u0 {2,S} {4,S}
+4 *3 Os      ux {3,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 6,
-    label = "R2OOH_D",
+    label = "R2OO_D",
     group = 
 """
 1 *1 Cd u1 {2,D}
-2 *4 Cd u0 {1,D} {3,S}
-3 *2 O  u0 {2,S} {4,S}
-4 *3 O  u0 {3,S} {5,S}
-5    H  u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 7,
-    label = "R2OOR",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,S}
-3 *2 O                    u0 {2,S} {4,S}
-4 *3 O                    u0 {3,S} {5,S}
-5    R!H                  u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 8,
-    label = "R2OOR_S",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *2 O       u0 {2,S} {4,S}
-4 *3 O       u0 {3,S} {5,S}
-5    R!H     u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 9,
-    label = "R2OOR_SCO",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 CO      u0 {1,S} {3,S}
-3 *2 O       u0 {2,S} {4,S}
-4 *3 O       u0 {3,S} {5,S}
-5    R!H     u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 10,
-    label = "R2OOR_D",
-    group = 
-"""
-1 *1 Cd  u1 {2,D}
-2 *4 Cd  u0 {1,D} {3,S}
-3 *2 O   u0 {2,S} {4,S}
-4 *3 O   u0 {3,S} {5,S}
-5    R!H u0 {4,S}
+2 *5 Cd u0 {1,D} {3,S}
+3 *2 Os u0 {2,S} {4,S}
+4 *3 Os ux {3,S}
 """,
     kinetics = None,
 )
@@ -183,170 +90,69 @@ entry(
 entry(
     index = 14,
     label = "R3OO",
-    group = "OR{R3OOH, R3OOR, R3OOJ}",
-    kinetics = None,
-)
-
-entry(
-    index = 15,
-    label = "R3OOJ",
-    group = 
+    group =
 """
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
-4 *2 O                    u0 {3,S} {5,S}
-5 *3 O                    u1 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 16,
-    label = "R3OOH",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
-4 *2 O                    u0 {3,S} {5,S}
-5 *3 O                    u0 {4,S} {6,S}
-6    H                    u0 {5,S}
+1 *1 R!H u1 {2,[S,D]}
+2 *5 R!H u0 {1,[S,D]} {3,[S,D]}
+3 *6 R!H u0 {2,[S,D]} {4,S}
+4 *2 Os  u0 {3,S} {5,S}
+5 *3 Os  ux {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 17,
-    label = "R3OOH_SS",
+    label = "R3OO_SS",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *2 O          u0 {3,S} {5,S}
-5 *3 O          u0 {4,S} {6,S}
-6    H          u0 {5,S}
+2 *5 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *2 Os         u0 {3,S} {5,S}
+5 *3 Os         ux {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 13,
-    label = "R3OOH_SSCO",
+    label = "R3OO_SSCO",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *5 CO      u0 {2,S} {4,S}
-4 *2 O       u0 {3,S} {5,S}
-5 *3 O       u0 {4,S} {6,S}
-6    H       u0 {5,S}
+2 *5 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 CO      u0 {2,S} {4,S}
+4 *2 Os      u0 {3,S} {5,S}
+5 *3 Os      ux {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 14,
-    label = "R3OOH_SD",
+    label = "R3OO_SD",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 Cd      u0 {1,S} {3,D}
-3 *5 Cd      u0 {2,D} {4,S}
-4 *2 O       u0 {3,S} {5,S}
-5 *3 O       u0 {4,S} {6,S}
-6    H       u0 {5,S}
+2 *5 Cd      u0 {1,S} {3,D}
+3 *6 Cd      u0 {2,D} {4,S}
+4 *2 Os      u0 {3,S} {5,S}
+5 *3 Os      ux {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 15,
-    label = "R3OOH_DS",
+    label = "R3OO_DS",
     group = 
 """
 1 *1 Cd         u1 {2,D}
-2 *4 Cd         u0 {1,D} {3,S}
-3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *2 O          u0 {3,S} {5,S}
-5 *3 O          u0 {4,S} {6,S}
-6    H          u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 16,
-    label = "R3OOR",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
-4 *2 O                    u0 {3,S} {5,S}
-5 *3 O                    u0 {4,S} {6,S}
-6    R!H                  u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 17,
-    label = "R3OOR_SS",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *2 O          u0 {3,S} {5,S}
-5 *3 O          u0 {4,S} {6,S}
-6    R!H        u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 18,
-    label = "R3OOR_SSCO",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *5 CO      u0 {2,S} {4,S}
-4 *2 O       u0 {3,S} {5,S}
-5 *3 O       u0 {4,S} {6,S}
-6    R!H     u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 19,
-    label = "R3OOR_SD",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 Cd      u0 {1,S} {3,D}
-3 *5 Cd      u0 {2,D} {4,S}
-4 *2 O       u0 {3,S} {5,S}
-5 *3 O       u0 {4,S} {6,S}
-6    R!H     u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 20,
-    label = "R3OOR_DS",
-    group = 
-"""
-1 *1 Cd         u1 {2,D}
-2 *4 Cd         u0 {1,D} {3,S}
-3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *2 O          u0 {3,S} {5,S}
-5 *3 O          u0 {4,S} {6,S}
-6    R!H        u0 {5,S}
+2 *5 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *2 Os         u0 {3,S} {5,S}
+5 *3 Os         ux {4,S}
 """,
     kinetics = None,
 )
@@ -354,245 +160,104 @@ entry(
 entry(
     index = 26,
     label = "R4OO",
-    group = "OR{R4OOH, R4OOR, R4OOJ}",
-    kinetics = None,
-)
-
-entry(
-    index = 27,
-    label = "R4OOJ",
     group = 
 """
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
-5 *2 O                    u0 {4,S} {6,S}
-6 *3 O                    u1 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 28,
-    label = "R4OOH",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
-5 *2 O                    u0 {4,S} {6,S}
-6 *3 O                    u0 {5,S} {7,S}
-7    H                    u0 {6,S}
+1 *1 R!H u1 {2,[S,D]}
+2 *5 R!H u0 {1,[S,D]} {3,[S,D]}
+3 *7 R!H u0 {2,[S,D]} {4,[S,D]}
+4 *6 R!H u0 {3,[S,D]} {5,S}
+5 *2 Os  u0 {4,S} {6,S}
+6 *3 Os  ux {5,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 29,
-    label = "R4OOH_SSS",
+    label = "R4OO_SSS",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *2 O          u0 {4,S} {6,S}
-6 *3 O          u0 {5,S} {7,S}
-7    H          u0 {6,S}
+2 *5 [Cd,Cs]    u0 {1,S} {3,S}
+3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *6 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 Os         u0 {4,S} {6,S}
+6 *3 Os         ux {5,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 23,
-    label = "R4OOH_SSSCO",
+    label = "R4OO_SSSCO",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 [Cd,Cs] u0 {2,S} {4,S}
-4 *5 CO      u0 {3,S} {5,S}
-5 *2 O       u0 {4,S} {6,S}
-6 *3 O       u0 {5,S} {7,S}
-7    H       u0 {6,S}
+2 *5 [Cd,Cs] u0 {1,S} {3,S}
+3 *7 [Cd,Cs] u0 {2,S} {4,S}
+4 *6 CO      u0 {3,S} {5,S}
+5 *2 Os      u0 {4,S} {6,S}
+6 *3 Os      ux {5,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 24,
-    label = "R4OOH_SSD",
+    label = "R4OO_SSD",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 Cd      u0 {2,S} {4,D}
-4 *5 Cd      u0 {3,D} {5,S}
-5 *2 O       u0 {4,S} {6,S}
-6 *3 O       u0 {5,S} {7,S}
-7    H       u0 {6,S}
+2 *5 [Cd,Cs] u0 {1,S} {3,S}
+3 *7 Cd      u0 {2,S} {4,D}
+4 *6 Cd      u0 {3,D} {5,S}
+5 *2 Os      u0 {4,S} {6,S}
+6 *3 Os      ux {5,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 25,
-    label = "R4OOH_SDS",
+    label = "R4OO_SDS",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 Cd         u0 {1,S} {3,D}
-3 *6 Cd         u0 {2,D} {4,S}
-4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *2 O          u0 {4,S} {6,S}
-6 *3 O          u0 {5,S} {7,S}
-7    H          u0 {6,S}
+2 *5 Cd         u0 {1,S} {3,D}
+3 *7 Cd         u0 {2,D} {4,S}
+4 *6 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 Os         u0 {4,S} {6,S}
+6 *3 Os         ux {5,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 26,
-    label = "R4OOH_DSS",
+    label = "R4OO_DSS",
     group = 
 """
 1 *1 Cd         u1 {2,D}
-2 *4 Cd         u0 {1,D} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *2 O          u0 {4,S} {6,S}
-6 *3 O          u0 {5,S} {7,S}
-7    H          u0 {6,S}
+2 *5 Cd         u0 {1,D} {3,S}
+3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *6 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 Os         u0 {4,S} {6,S}
+6 *3 Os         ux {5,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 27,
-    label = "R4OOH_DSD",
+    label = "R4OO_DSD",
     group = 
 """
 1 *1 Cd u1 {2,D}
-2 *4 Cd u0 {1,D} {3,S}
-3 *6 Cd u0 {2,S} {4,D}
-4 *5 Cd u0 {3,D} {5,S}
-5 *2 O  u0 {4,S} {6,S}
-6 *3 O  u0 {5,S} {7,S}
-7    H  u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 28,
-    label = "R4OOR",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
-5 *2 O                    u0 {4,S} {6,S}
-6 *3 O                    u0 {5,S} {7,S}
-7    R!H                  u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 29,
-    label = "R4OOR_SSS",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *2 O          u0 {4,S} {6,S}
-6 *3 O          u0 {5,S} {7,S}
-7    R!H        u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 30,
-    label = "R4OOR_SSSCO",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 [Cd,Cs] u0 {2,S} {4,S}
-4 *5 CO      u0 {3,S} {5,S}
-5 *2 O       u0 {4,S} {6,S}
-6 *3 O       u0 {5,S} {7,S}
-7    R!H     u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 31,
-    label = "R4OOR_SSD",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 Cd      u0 {2,S} {4,D}
-4 *5 Cd      u0 {3,D} {5,S}
-5 *2 O       u0 {4,S} {6,S}
-6 *3 O       u0 {5,S} {7,S}
-7    R!H     u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 32,
-    label = "R4OOR_SDS",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 Cd         u0 {1,S} {3,D}
-3 *6 Cd         u0 {2,D} {4,S}
-4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *2 O          u0 {4,S} {6,S}
-6 *3 O          u0 {5,S} {7,S}
-7    R!H        u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 33,
-    label = "R4OOR_DSS",
-    group = 
-"""
-1 *1 Cd         u1 {2,D}
-2 *4 Cd         u0 {1,D} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *2 O          u0 {4,S} {6,S}
-6 *3 O          u0 {5,S} {7,S}
-7    R!H        u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 34,
-    label = "R4OOR_DSD",
-    group = 
-"""
-1 *1 Cd  u1 {2,D}
-2 *4 Cd  u0 {1,D} {3,S}
-3 *6 Cd  u0 {2,S} {4,D}
-4 *5 Cd  u0 {3,D} {5,S}
-5 *2 O   u0 {4,S} {6,S}
-6 *3 O   u0 {5,S} {7,S}
-7    R!H u0 {6,S}
+2 *5 Cd u0 {1,D} {3,S}
+3 *7 Cd u0 {2,S} {4,D}
+4 *6 Cd u0 {3,D} {5,S}
+5 *2 Os u0 {4,S} {6,S}
+6 *3 Os ux {5,S}
 """,
     kinetics = None,
 )
@@ -600,328 +265,143 @@ entry(
 entry(
     index = 42,
     label = "R5OO",
-    group = "OR{R5OOH, R5OOR, R5OOJ}",
-    kinetics = None,
-)
-
-entry(
-    index = 43,
-    label = "R5OOJ",
-    group = 
+    group =
 """
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
-5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
-6 *2 O                    u0 {5,S} {7,S}
-7 *3 O                    u1 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 44,
-    label = "R5OOH",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
-5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
-6 *2 O                    u0 {5,S} {7,S}
-7 *3 O                    u0 {6,S} {8,S}
-8    H                    u0 {7,S}
+1 *1 R!H u1 {2,[S,D]}
+2 *5 R!H u0 {1,[S,D]} {3,[S,D]}
+3 *7 R!H u0 {2,[S,D]} {4,[S,D]}
+4 *8 R!H u0 {3,[S,D]} {5,[S,D]}
+5 *6 R!H u0 {4,[S,D]} {6,S}
+6 *2 Os  u0 {5,S} {7,S}
+7 *3 Os  ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 45,
-    label = "R5OOH_SSSS",
+    label = "R5OO_SSSS",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    H          u0 {7,S}
+2 *5 [Cd,Cs]    u0 {1,S} {3,S}
+3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *8 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 Os         u0 {5,S} {7,S}
+7 *3 Os         ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 37,
-    label = "R5OOH_SSSSCO",
+    label = "R5OO_SSSSCO",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 [Cd,Cs] u0 {2,S} {4,S}
-4 *7 [Cd,Cs] u0 {3,S} {5,S}
-5 *5 CO      u0 {4,S} {6,S}
-6 *2 O       u0 {5,S} {7,S}
-7 *3 O       u0 {6,S} {8,S}
-8    H       u0 {7,S}
+2 *5 [Cd,Cs] u0 {1,S} {3,S}
+3 *7 [Cd,Cs] u0 {2,S} {4,S}
+4 *8 [Cd,Cs] u0 {3,S} {5,S}
+5 *6 CO      u0 {4,S} {6,S}
+6 *2 Os      u0 {5,S} {7,S}
+7 *3 Os      ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 38,
-    label = "R5OOH_SSSD",
+    label = "R5OO_SSSD",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *7 Cd         u0 {3,S} {5,D}
-5 *5 Cd         u0 {4,D} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    H          u0 {7,S}
+2 *5 [Cd,Cs]    u0 {1,S} {3,S}
+3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *8 Cd         u0 {3,S} {5,D}
+5 *6 Cd         u0 {4,D} {6,S}
+6 *2 Os         u0 {5,S} {7,S}
+7 *3 Os         ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 39,
-    label = "R5OOH_SSDS",
+    label = "R5OO_SSDS",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 Cd         u0 {2,S} {4,D}
-4 *7 Cd         u0 {3,D} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    H          u0 {7,S}
+2 *5 [Cd,Cs]    u0 {1,S} {3,S}
+3 *7 Cd         u0 {2,S} {4,D}
+4 *8 Cd         u0 {3,D} {5,S}
+5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 Os         u0 {5,S} {7,S}
+7 *3 Os         ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 40,
-    label = "R5OOH_SDSS",
+    label = "R5OO_SDSS",
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 Cd         u0 {1,S} {3,D}
-3 *6 Cd         u0 {2,D} {4,S}
-4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    H          u0 {7,S}
+2 *5 Cd         u0 {1,S} {3,D}
+3 *7 Cd         u0 {2,D} {4,S}
+4 *8 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 Os         u0 {5,S} {7,S}
+7 *3 Os         ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 41,
-    label = "R5OOH_DSSS",
+    label = "R5OO_DSSS",
     group = 
 """
 1 *1 Cd         u1 {2,D}
-2 *4 Cd         u0 {1,D} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    H          u0 {7,S}
+2 *5 Cd         u0 {1,D} {3,S}
+3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *8 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 Os         u0 {5,S} {7,S}
+7 *3 Os         ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 42,
-    label = "R5OOH_SDSD",
+    label = "R5OO_SDSD",
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *4 Cd      u0 {1,S} {3,D}
-3 *6 Cd      u0 {2,D} {4,S}
-4 *7 Cd      u0 {3,S} {5,D}
-5 *5 Cd      u0 {4,D} {6,S}
-6 *2 O       u0 {5,S} {7,S}
-7 *3 O       u0 {6,S} {8,S}
-8    H       u0 {7,S}
+2 *5 Cd      u0 {1,S} {3,D}
+3 *7 Cd      u0 {2,D} {4,S}
+4 *8 Cd      u0 {3,S} {5,D}
+5 *6 Cd      u0 {4,D} {6,S}
+6 *2 Os      u0 {5,S} {7,S}
+7 *3 Os      ux {6,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 43,
-    label = "R5OOH_DSDS",
+    label = "R5OO_DSDS",
     group = 
 """
 1 *1 Cd u1 {2,D}
-2 *4 Cd u0 {1,D} {3,S}
-3 *6 Cd u0 {2,S} {4,D}
-4 *7 Cd u0 {3,D} {5,S}
-5 *5 Cd u0 {4,S} {6,S}
-6 *2 O  u0 {5,S} {7,S}
-7 *3 O  u0 {6,S} {8,S}
-8    H  u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 44,
-    label = "R5OOR",
-    group = 
-"""
-1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
-2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
-5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
-6 *2 O                    u0 {5,S} {7,S}
-7 *3 O                    u0 {6,S} {8,S}
-8    R!H                  u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 45,
-    label = "R5OOR_SSSS",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    R!H        u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 46,
-    label = "R5OOR_SSSSCO",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 [Cd,Cs] u0 {2,S} {4,S}
-4 *7 [Cd,Cs] u0 {3,S} {5,S}
-5 *5 CO      u0 {4,S} {6,S}
-6 *2 O       u0 {5,S} {7,S}
-7 *3 O       u0 {6,S} {8,S}
-8    R!H     u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 47,
-    label = "R5OOR_SSSD",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *7 Cd         u0 {3,S} {5,D}
-5 *5 Cd         u0 {4,D} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    R!H        u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 48,
-    label = "R5OOR_SSDS",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 Cd         u0 {2,S} {4,D}
-4 *7 Cd         u0 {3,D} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    R!H        u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 49,
-    label = "R5OOR_SDSS",
-    group = 
-"""
-1 *1 [Cd,Cs]    u1 {2,S}
-2 *4 Cd         u0 {1,S} {3,D}
-3 *6 Cd         u0 {2,D} {4,S}
-4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    R!H        u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 50,
-    label = "R5OOR_DSSS",
-    group = 
-"""
-1 *1 Cd         u1 {2,D}
-2 *4 Cd         u0 {1,D} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
-6 *2 O          u0 {5,S} {7,S}
-7 *3 O          u0 {6,S} {8,S}
-8    R!H        u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 51,
-    label = "R5OOR_SDSD",
-    group = 
-"""
-1 *1 [Cd,Cs] u1 {2,S}
-2 *4 Cd      u0 {1,S} {3,D}
-3 *6 Cd      u0 {2,D} {4,S}
-4 *7 Cd      u0 {3,S} {5,D}
-5 *5 Cd      u0 {4,D} {6,S}
-6 *2 O       u0 {5,S} {7,S}
-7 *3 O       u0 {6,S} {8,S}
-8    R!H     u0 {7,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 52,
-    label = "R5OOR_DSDS",
-    group = 
-"""
-1 *1 Cd  u1 {2,D}
-2 *4 Cd  u0 {1,D} {3,S}
-3 *6 Cd  u0 {2,S} {4,D}
-4 *7 Cd  u0 {3,D} {5,S}
-5 *5 Cd  u0 {4,S} {6,S}
-6 *2 O   u0 {5,S} {7,S}
-7 *3 O   u0 {6,S} {8,S}
-8    R!H u0 {7,S}
+2 *5 Cd u0 {1,D} {3,S}
+3 *7 Cd u0 {2,S} {4,D}
+4 *8 Cd u0 {3,D} {5,S}
+5 *6 Cd u0 {4,S} {6,S}
+6 *2 Os u0 {5,S} {7,S}
+7 *3 Os ux {6,S}
 """,
     kinetics = None,
 )
@@ -932,7 +412,7 @@ entry(
     group = 
 """
 1 *1 C u1 {2,D} {3,S}
-2 *4 C u0 {1,D}
+2 *5 C u0 {1,D}
 3    R u0 {1,S}
 """,
     kinetics = None,
@@ -944,7 +424,7 @@ entry(
     group = 
 """
 1 *1 C u1 {2,D} {3,S}
-2 *4 C u0 {1,D}
+2 *5 C u0 {1,D}
 3    H u0 {1,S}
 """,
     kinetics = None,
@@ -956,7 +436,7 @@ entry(
     group = 
 """
 1 *1 C   u1 {2,D} {3,S}
-2 *4 C   u0 {1,D}
+2 *5 C   u0 {1,D}
 3    R!H u0 {1,S}
 """,
     kinetics = None,
@@ -968,7 +448,7 @@ entry(
     group = 
 """
 1 *1 C  u1 {2,D} {3,S}
-2 *4 C  u0 {1,D}
+2 *5 C  u0 {1,D}
 3    Cs u0 {1,S}
 """,
     kinetics = None,
@@ -980,7 +460,7 @@ entry(
     group = 
 """
 1 *1 C u1 {2,D} {3,S}
-2 *4 C u0 {1,D}
+2 *5 C u0 {1,D}
 3    O u0 {1,S}
 """,
     kinetics = None,
@@ -992,7 +472,7 @@ entry(
     group = 
 """
 1 *1 C   u1 {2,D} {3,S}
-2 *4 C   u0 {1,D}
+2 *5 C   u0 {1,D}
 3    N3s u0 {1,S}
 """,
     kinetics = None,
@@ -1004,7 +484,7 @@ entry(
     group = 
 """
 1 *1 C             u1 {2,D} {3,S}
-2 *4 C             u0 {1,D}
+2 *5 C             u0 {1,D}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
 """,
     kinetics = None,
@@ -1016,7 +496,7 @@ entry(
     group = 
 """
 1 *1 C  u1 {2,S} {3,D}
-2 *4 C  u0 {1,S}
+2 *5 C  u0 {1,S}
 3    Cd u0 {1,D}
 """,
     kinetics = None,
@@ -1028,7 +508,7 @@ entry(
     group = 
 """
 1 *1 C u1 {2,S} {3,S} {4,S}
-2 *4 C u0 {1,S}
+2 *5 C u0 {1,S}
 3    R u0 {1,S}
 4    R u0 {1,S}
 """,
@@ -1043,7 +523,7 @@ entry(
 1 *1 C u1 {2,S} {3,S} {4,S}
 2    H u0 {1,S}
 3    H u0 {1,S}
-4 *4 C u0 {1,S}
+4 *5 C u0 {1,S}
 """,
     kinetics = None,
 )
@@ -1055,7 +535,7 @@ entry(
 """
 1 *1 C   u1 {2,S} {3,S} {4,S}
 2    H   u0 {1,S}
-3 *4 C   u0 {1,S}
+3 *5 C   u0 {1,S}
 4    R!H u0 {1,S}
 """,
     kinetics = None,
@@ -1068,7 +548,7 @@ entry(
 """
 1 *1 C  u1 {2,S} {3,S} {4,S}
 2    H  u0 {1,S}
-3 *4 C  u0 {1,S}
+3 *5 C  u0 {1,S}
 4    Cs u0 {1,S}
 """,
     kinetics = None,
@@ -1081,7 +561,7 @@ entry(
 """
 1 *1 C u1 {2,S} {3,S} {4,S}
 2    H u0 {1,S}
-3 *4 C u0 {1,S}
+3 *5 C u0 {1,S}
 4    O u0 {1,S}
 """,
     kinetics = None,
@@ -1094,7 +574,7 @@ entry(
 """
 1 *1 C   u1 {2,S} {3,S} {4,S}
 2    H   u0 {1,S}
-3 *4 C   u0 {1,S}
+3 *5 C   u0 {1,S}
 4    N3s u0 {1,S}
 """,
     kinetics = None,
@@ -1108,7 +588,7 @@ entry(
 1 *1 C             u1 {2,S} {3,S} {4,S}
 2    H             u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
-4 *4 C             u0 {1,S}
+4 *5 C             u0 {1,S}
 """,
     kinetics = None,
 )
@@ -1119,7 +599,7 @@ entry(
     group = 
 """
 1 *1 C   u1 {2,S} {3,S} {4,S}
-2 *4 C   u0 {1,S}
+2 *5 C   u0 {1,S}
 3    R!H u0 {1,S}
 4    R!H u0 {1,S}
 """,
@@ -1132,7 +612,7 @@ entry(
     group = 
 """
 1 *1 C      u1 {2,S} {3,S} {4,S}
-2 *4 C      u0 {1,S}
+2 *5 C      u0 {1,S}
 3    [Cs,O] u0 {1,S}
 4    [Cs,O] u0 {1,S}
 """,
@@ -1145,7 +625,7 @@ entry(
     group = 
 """
 1 *1 C  u1 {2,S} {3,S} {4,S}
-2 *4 C  u0 {1,S}
+2 *5 C  u0 {1,S}
 3    Cs u0 {1,S}
 4    Cs u0 {1,S}
 """,
@@ -1158,7 +638,7 @@ entry(
     group = 
 """
 1 *1 C      u1 {2,S} {3,S} {4,S}
-2 *4 C      u0 {1,S}
+2 *5 C      u0 {1,S}
 3    O      u0 {1,S}
 4    [Cs,O] u0 {1,S}
 """,
@@ -1172,7 +652,7 @@ entry(
 """
 1 *1 C             u1 {2,S} {3,S} {4,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
-3 *4 C             u0 {1,S}
+3 *5 C             u0 {1,S}
 4    [Cs,O]        u0 {1,S}
 """,
     kinetics = None,
@@ -1185,7 +665,7 @@ entry(
 """
 1 *1 C             u1 {2,S} {3,S} {4,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
-3 *4 C             u0 {1,S}
+3 *5 C             u0 {1,S}
 4    Cs            u0 {1,S}
 """,
     kinetics = None,
@@ -1198,7 +678,7 @@ entry(
 """
 1 *1 C             u1 {2,S} {3,S} {4,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
-3 *4 C             u0 {1,S}
+3 *5 C             u0 {1,S}
 4    O             u0 {1,S}
 """,
     kinetics = None,
@@ -1212,7 +692,7 @@ entry(
 1 *1 C             u1 {2,S} {3,S} {4,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
-4 *4 C             u0 {1,S}
+4 *5 C             u0 {1,S}
 """,
     kinetics = None,
 )
@@ -1227,68 +707,80 @@ entry(
     kinetics = None,
 )
 
+entry(
+    index = 75,
+    label = "OO_intra",
+    group = 
+"""
+1 *2 Os u0 {2,S}
+2 *3 Os ux {1,S}  
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 76,
+    label = "OOJ",
+    group = 
+"""
+1 *2 Os u0 {2,S}
+2 *3 Os u1 {1,S}  
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 77,
+    label = "OOH",
+    group = 
+"""
+1 *2 Os u0 {2,S}
+2 *3 Os u0 {1,S} {3,S}
+3 *4 H  u0 {2,S}  
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 78,
+    label = "OOR",
+    group = 
+"""
+1 *2 Os  u0 {2,S}
+2 *3 Os  u0 {1,S} {3,S}
+3 *4 R!H u0 {2,S}  
+""",
+    kinetics = None,
+)
+
 tree(
 """
 L1: RnOO
     L2: R2OO
-        L3: R2OOJ
-            L4: R2OOJ_S
-        L3: R2OOH
-            L4: R2OOH_S
-            L4: R2OOH_SCO
-            L4: R2OOH_D
-        L3: R2OOR
-            L4: R2OOR_S
-            L4: R2OOR_SCO
-            L4: R2OOR_D
+        L3: R2OO_S
+            L4: R2OO_SCO
+        L3: R2OO_D
     L2: R3OO
-        L3: R3OOJ
-        L3: R3OOH
-            L4: R3OOH_SS
-                L5: R3OOH_SSCO
-            L4: R3OOH_SD
-            L4: R3OOH_DS
-        L3: R3OOR
-            L4: R3OOR_SS
-                L5: R3OOR_SSCO
-            L4: R3OOR_SD
-            L4: R3OOR_DS
+        L3: R3OO_SS
+            L4: R3OO_SSCO
+        L3: R3OO_SD
+        L3: R3OO_DS
     L2: R4OO
-        L3: R4OOJ
-        L3: R4OOH
-            L4: R4OOH_SSS
-                L5: R4OOH_SSSCO
-            L4: R4OOH_SSD
-            L4: R4OOH_SDS
-            L4: R4OOH_DSS
-            L4: R4OOH_DSD
-        L3: R4OOR
-            L4: R4OOR_SSS
-                L5: R4OOR_SSSCO
-            L4: R4OOR_SSD
-            L4: R4OOR_SDS
-            L4: R4OOR_DSS
-            L4: R4OOR_DSD
+        L3: R4OO_SSS
+            L4: R4OO_SSSCO
+        L3: R4OO_SSD
+        L3: R4OO_SDS
+        L3: R4OO_DSS
+        L3: R4OO_DSD
     L2: R5OO
-        L3: R5OOJ
-        L3: R5OOH
-            L4: R5OOH_SSSS
-                L5: R5OOH_SSSSCO
-            L4: R5OOH_SSSD
-            L4: R5OOH_SSDS
-            L4: R5OOH_SDSS
-            L4: R5OOH_DSSS
-            L4: R5OOH_SDSD
-            L4: R5OOH_DSDS
-        L3: R5OOR
-            L4: R5OOR_SSSS
-                L5: R5OOR_SSSSCO
-            L4: R5OOR_SSSD
-            L4: R5OOR_SSDS
-            L4: R5OOR_SDSS
-            L4: R5OOR_DSSS
-            L4: R5OOR_SDSD
-            L4: R5OOR_DSDS
+        L3: R5OO_SSSS
+            L4: R5OO_SSSSCO
+        L3: R5OO_SSSD
+        L3: R5OO_SSDS
+        L3: R5OO_SDSS
+        L3: R5OO_DSSS
+        L3: R5OO_SDSD
+        L3: R5OO_DSDS
 L1: Y_rad_intra
     L2: Cd_rad_in
         L3: Cd_pri_rad_in
@@ -1314,6 +806,10 @@ L1: Y_rad_intra
                 L5: C_rad/ODMustO_intra
             L4: C_rad/TwoDe_intra
     L2: N_rad
+L1: OO_intra
+    L2: OOJ
+    L2: OOH
+    L2: OOR
 """
 )
 

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups.py
@@ -30,7 +30,7 @@ entry(
     label = "Y_rad_intra",
     group = 
 """
-1 *1 R u1
+1 *1 R!H u1
 """,
     kinetics = None,
 )
@@ -194,7 +194,7 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
+3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
 4 *2 O                    u0 {3,S} {5,S}
 5 *3 O                    u1 {4,S}
 """,
@@ -208,7 +208,7 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
+3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
 4 *2 O                    u0 {3,S} {5,S}
 5 *3 O                    u0 {4,S} {6,S}
 6    H                    u0 {5,S}
@@ -223,7 +223,7 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 O          u0 {3,S} {5,S}
 5 *3 O          u0 {4,S} {6,S}
 6    H          u0 {5,S}
@@ -238,7 +238,7 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    CO      u0 {2,S} {4,S}
+3 *5 CO      u0 {2,S} {4,S}
 4 *2 O       u0 {3,S} {5,S}
 5 *3 O       u0 {4,S} {6,S}
 6    H       u0 {5,S}
@@ -253,7 +253,7 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 Cd      u0 {1,S} {3,D}
-3    Cd      u0 {2,D} {4,S}
+3 *5 Cd      u0 {2,D} {4,S}
 4 *2 O       u0 {3,S} {5,S}
 5 *3 O       u0 {4,S} {6,S}
 6    H       u0 {5,S}
@@ -268,7 +268,7 @@ entry(
 """
 1 *1 Cd         u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 O          u0 {3,S} {5,S}
 5 *3 O          u0 {4,S} {6,S}
 6    H          u0 {5,S}
@@ -283,7 +283,7 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
+3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
 4 *2 O                    u0 {3,S} {5,S}
 5 *3 O                    u0 {4,S} {6,S}
 6    R!H                  u0 {5,S}
@@ -298,7 +298,7 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 O          u0 {3,S} {5,S}
 5 *3 O          u0 {4,S} {6,S}
 6    R!H        u0 {5,S}
@@ -313,7 +313,7 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    CO      u0 {2,S} {4,S}
+3 *5 CO      u0 {2,S} {4,S}
 4 *2 O       u0 {3,S} {5,S}
 5 *3 O       u0 {4,S} {6,S}
 6    R!H     u0 {5,S}
@@ -328,7 +328,7 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 Cd      u0 {1,S} {3,D}
-3    Cd      u0 {2,D} {4,S}
+3 *5 Cd      u0 {2,D} {4,S}
 4 *2 O       u0 {3,S} {5,S}
 5 *3 O       u0 {4,S} {6,S}
 6    R!H     u0 {5,S}
@@ -343,7 +343,7 @@ entry(
 """
 1 *1 Cd         u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 O          u0 {3,S} {5,S}
 5 *3 O          u0 {4,S} {6,S}
 6    R!H        u0 {5,S}
@@ -365,8 +365,8 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4    [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
 5 *2 O                    u0 {4,S} {6,S}
 6 *3 O                    u1 {5,S}
 """,
@@ -380,8 +380,8 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4    [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
 5 *2 O                    u0 {4,S} {6,S}
 6 *3 O                    u0 {5,S} {7,S}
 7    H                    u0 {6,S}
@@ -396,8 +396,8 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 O          u0 {4,S} {6,S}
 6 *3 O          u0 {5,S} {7,S}
 7    H          u0 {6,S}
@@ -412,8 +412,8 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    [Cd,Cs] u0 {2,S} {4,S}
-4    CO      u0 {3,S} {5,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *5 CO      u0 {3,S} {5,S}
 5 *2 O       u0 {4,S} {6,S}
 6 *3 O       u0 {5,S} {7,S}
 7    H       u0 {6,S}
@@ -428,8 +428,8 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    Cd      u0 {2,S} {4,D}
-4    Cd      u0 {3,D} {5,S}
+3 *6 Cd      u0 {2,S} {4,D}
+4 *5 Cd      u0 {3,D} {5,S}
 5 *2 O       u0 {4,S} {6,S}
 6 *3 O       u0 {5,S} {7,S}
 7    H       u0 {6,S}
@@ -444,8 +444,8 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 Cd         u0 {1,S} {3,D}
-3    Cd         u0 {2,D} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 O          u0 {4,S} {6,S}
 6 *3 O          u0 {5,S} {7,S}
 7    H          u0 {6,S}
@@ -460,8 +460,8 @@ entry(
 """
 1 *1 Cd         u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 O          u0 {4,S} {6,S}
 6 *3 O          u0 {5,S} {7,S}
 7    H          u0 {6,S}
@@ -476,8 +476,8 @@ entry(
 """
 1 *1 Cd u1 {2,D}
 2 *4 Cd u0 {1,D} {3,S}
-3    Cd u0 {2,S} {4,D}
-4    Cd u0 {3,D} {5,S}
+3 *6 Cd u0 {2,S} {4,D}
+4 *5 Cd u0 {3,D} {5,S}
 5 *2 O  u0 {4,S} {6,S}
 6 *3 O  u0 {5,S} {7,S}
 7    H  u0 {6,S}
@@ -492,8 +492,8 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4    [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
 5 *2 O                    u0 {4,S} {6,S}
 6 *3 O                    u0 {5,S} {7,S}
 7    R!H                  u0 {6,S}
@@ -508,8 +508,8 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 O          u0 {4,S} {6,S}
 6 *3 O          u0 {5,S} {7,S}
 7    R!H        u0 {6,S}
@@ -524,8 +524,8 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    [Cd,Cs] u0 {2,S} {4,S}
-4    CO      u0 {3,S} {5,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *5 CO      u0 {3,S} {5,S}
 5 *2 O       u0 {4,S} {6,S}
 6 *3 O       u0 {5,S} {7,S}
 7    R!H     u0 {6,S}
@@ -540,8 +540,8 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    Cd      u0 {2,S} {4,D}
-4    Cd      u0 {3,D} {5,S}
+3 *6 Cd      u0 {2,S} {4,D}
+4 *5 Cd      u0 {3,D} {5,S}
 5 *2 O       u0 {4,S} {6,S}
 6 *3 O       u0 {5,S} {7,S}
 7    R!H     u0 {6,S}
@@ -556,8 +556,8 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 Cd         u0 {1,S} {3,D}
-3    Cd         u0 {2,D} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 O          u0 {4,S} {6,S}
 6 *3 O          u0 {5,S} {7,S}
 7    R!H        u0 {6,S}
@@ -572,8 +572,8 @@ entry(
 """
 1 *1 Cd         u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 O          u0 {4,S} {6,S}
 6 *3 O          u0 {5,S} {7,S}
 7    R!H        u0 {6,S}
@@ -588,8 +588,8 @@ entry(
 """
 1 *1 Cd  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
-3    Cd  u0 {2,S} {4,D}
-4    Cd  u0 {3,D} {5,S}
+3 *6 Cd  u0 {2,S} {4,D}
+4 *5 Cd  u0 {3,D} {5,S}
 5 *2 O   u0 {4,S} {6,S}
 6 *3 O   u0 {5,S} {7,S}
 7    R!H u0 {6,S}
@@ -611,9 +611,9 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4    [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
-5    [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
+5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
 6 *2 O                    u0 {5,S} {7,S}
 7 *3 O                    u1 {6,S}
 """,
@@ -627,9 +627,9 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4    [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
-5    [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
+5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
 6 *2 O                    u0 {5,S} {7,S}
 7 *3 O                    u0 {6,S} {8,S}
 8    H                    u0 {7,S}
@@ -644,9 +644,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    H          u0 {7,S}
@@ -661,9 +661,9 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    [Cd,Cs] u0 {2,S} {4,S}
-4    [Cd,Cs] u0 {3,S} {5,S}
-5    CO      u0 {4,S} {6,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *7 [Cd,Cs] u0 {3,S} {5,S}
+5 *5 CO      u0 {4,S} {6,S}
 6 *2 O       u0 {5,S} {7,S}
 7 *3 O       u0 {6,S} {8,S}
 8    H       u0 {7,S}
@@ -678,9 +678,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    Cd         u0 {3,S} {5,D}
-5    Cd         u0 {4,D} {6,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 Cd         u0 {3,S} {5,D}
+5 *5 Cd         u0 {4,D} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    H          u0 {7,S}
@@ -695,9 +695,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    Cd         u0 {2,S} {4,D}
-4    Cd         u0 {3,D} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 Cd         u0 {2,S} {4,D}
+4 *7 Cd         u0 {3,D} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    H          u0 {7,S}
@@ -712,9 +712,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 Cd         u0 {1,S} {3,D}
-3    Cd         u0 {2,D} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    H          u0 {7,S}
@@ -729,9 +729,9 @@ entry(
 """
 1 *1 Cd         u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    H          u0 {7,S}
@@ -746,9 +746,9 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 Cd      u0 {1,S} {3,D}
-3    Cd      u0 {2,D} {4,S}
-4    Cd      u0 {3,S} {5,D}
-5    Cd      u0 {4,D} {6,S}
+3 *6 Cd      u0 {2,D} {4,S}
+4 *7 Cd      u0 {3,S} {5,D}
+5 *5 Cd      u0 {4,D} {6,S}
 6 *2 O       u0 {5,S} {7,S}
 7 *3 O       u0 {6,S} {8,S}
 8    H       u0 {7,S}
@@ -763,9 +763,9 @@ entry(
 """
 1 *1 Cd u1 {2,D}
 2 *4 Cd u0 {1,D} {3,S}
-3    Cd u0 {2,S} {4,D}
-4    Cd u0 {3,D} {5,S}
-5    Cd u0 {4,S} {6,S}
+3 *6 Cd u0 {2,S} {4,D}
+4 *7 Cd u0 {3,D} {5,S}
+5 *5 Cd u0 {4,S} {6,S}
 6 *2 O  u0 {5,S} {7,S}
 7 *3 O  u0 {6,S} {8,S}
 8    H  u0 {7,S}
@@ -780,9 +780,9 @@ entry(
 """
 1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
 2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
-3    [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
-4    [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
-5    [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
+5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
 6 *2 O                    u0 {5,S} {7,S}
 7 *3 O                    u0 {6,S} {8,S}
 8    R!H                  u0 {7,S}
@@ -797,9 +797,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    R!H        u0 {7,S}
@@ -814,9 +814,9 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 [Cd,Cs] u0 {1,S} {3,S}
-3    [Cd,Cs] u0 {2,S} {4,S}
-4    [Cd,Cs] u0 {3,S} {5,S}
-5    CO      u0 {4,S} {6,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *7 [Cd,Cs] u0 {3,S} {5,S}
+5 *5 CO      u0 {4,S} {6,S}
 6 *2 O       u0 {5,S} {7,S}
 7 *3 O       u0 {6,S} {8,S}
 8    R!H     u0 {7,S}
@@ -831,9 +831,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    Cd         u0 {3,S} {5,D}
-5    Cd         u0 {4,D} {6,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 Cd         u0 {3,S} {5,D}
+5 *5 Cd         u0 {4,D} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    R!H        u0 {7,S}
@@ -848,9 +848,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 [Cd,Cs]    u0 {1,S} {3,S}
-3    Cd         u0 {2,S} {4,D}
-4    Cd         u0 {3,D} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 Cd         u0 {2,S} {4,D}
+4 *7 Cd         u0 {3,D} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    R!H        u0 {7,S}
@@ -865,9 +865,9 @@ entry(
 """
 1 *1 [Cd,Cs]    u1 {2,S}
 2 *4 Cd         u0 {1,S} {3,D}
-3    Cd         u0 {2,D} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    R!H        u0 {7,S}
@@ -882,9 +882,9 @@ entry(
 """
 1 *1 Cd         u1 {2,D}
 2 *4 Cd         u0 {1,D} {3,S}
-3    [Cd,Cs,CO] u0 {2,S} {4,S}
-4    [Cd,Cs,CO] u0 {3,S} {5,S}
-5    [Cd,Cs,CO] u0 {4,S} {6,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 O          u0 {5,S} {7,S}
 7 *3 O          u0 {6,S} {8,S}
 8    R!H        u0 {7,S}
@@ -899,9 +899,9 @@ entry(
 """
 1 *1 [Cd,Cs] u1 {2,S}
 2 *4 Cd      u0 {1,S} {3,D}
-3    Cd      u0 {2,D} {4,S}
-4    Cd      u0 {3,S} {5,D}
-5    Cd      u0 {4,D} {6,S}
+3 *6 Cd      u0 {2,D} {4,S}
+4 *7 Cd      u0 {3,S} {5,D}
+5 *5 Cd      u0 {4,D} {6,S}
 6 *2 O       u0 {5,S} {7,S}
 7 *3 O       u0 {6,S} {8,S}
 8    R!H     u0 {7,S}
@@ -916,9 +916,9 @@ entry(
 """
 1 *1 Cd  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
-3    Cd  u0 {2,S} {4,D}
-4    Cd  u0 {3,D} {5,S}
-5    Cd  u0 {4,S} {6,S}
+3 *6 Cd  u0 {2,S} {4,D}
+4 *7 Cd  u0 {3,D} {5,S}
+5 *5 Cd  u0 {4,S} {6,S}
 6 *2 O   u0 {5,S} {7,S}
 7 *3 O   u0 {6,S} {8,S}
 8    R!H u0 {7,S}

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*1', '1'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "RnOO",

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups.py
@@ -41,7 +41,7 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D]}
-2 *5 R!H u0 {1,[S,D]} {3,S}
+2 *4 R!H u0 {1,[S,D]} {3,S}
 3 *2 Os  u0 {2,S} {4,S}
 4 *3 Os  ux {3,S}
 """,
@@ -54,7 +54,7 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 [Cd,Cs,CO] u0 {1,S} {3,S}
+2 *4 [Cd,Cs,CO] u0 {1,S} {3,S}
 3 *2 Os         u0 {2,S} {4,S}
 4 *3 Os         ux {3,S}
 """,
@@ -67,7 +67,7 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 CO      u0 {1,S} {3,S}
+2 *4 CO      u0 {1,S} {3,S}
 3 *2 Os      u0 {2,S} {4,S}
 4 *3 Os      ux {3,S}
 """,
@@ -80,7 +80,7 @@ entry(
     group = 
 """
 1 *1 Cd u1 {2,D}
-2 *5 Cd u0 {1,D} {3,S}
+2 *4 Cd u0 {1,D} {3,S}
 3 *2 Os u0 {2,S} {4,S}
 4 *3 Os ux {3,S}
 """,
@@ -93,8 +93,8 @@ entry(
     group =
 """
 1 *1 R!H u1 {2,[S,D]}
-2 *5 R!H u0 {1,[S,D]} {3,[S,D]}
-3 *6 R!H u0 {2,[S,D]} {4,S}
+2 *4 R!H u0 {1,[S,D]} {3,[S,D]}
+3 *5 R!H u0 {2,[S,D]} {4,S}
 4 *2 Os  u0 {3,S} {5,S}
 5 *3 Os  ux {4,S}
 """,
@@ -107,8 +107,8 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 [Cd,Cs]    u0 {1,S} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 Os         u0 {3,S} {5,S}
 5 *3 Os         ux {4,S}
 """,
@@ -121,8 +121,8 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 [Cd,Cs] u0 {1,S} {3,S}
-3 *6 CO      u0 {2,S} {4,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *5 CO      u0 {2,S} {4,S}
 4 *2 Os      u0 {3,S} {5,S}
 5 *3 Os      ux {4,S}
 """,
@@ -135,8 +135,8 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 Cd      u0 {1,S} {3,D}
-3 *6 Cd      u0 {2,D} {4,S}
+2 *4 Cd      u0 {1,S} {3,D}
+3 *5 Cd      u0 {2,D} {4,S}
 4 *2 Os      u0 {3,S} {5,S}
 5 *3 Os      ux {4,S}
 """,
@@ -149,8 +149,8 @@ entry(
     group = 
 """
 1 *1 Cd         u1 {2,D}
-2 *5 Cd         u0 {1,D} {3,S}
-3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
 4 *2 Os         u0 {3,S} {5,S}
 5 *3 Os         ux {4,S}
 """,
@@ -163,9 +163,9 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D]}
-2 *5 R!H u0 {1,[S,D]} {3,[S,D]}
-3 *7 R!H u0 {2,[S,D]} {4,[S,D]}
-4 *6 R!H u0 {3,[S,D]} {5,S}
+2 *4 R!H u0 {1,[S,D]} {3,[S,D]}
+3 *6 R!H u0 {2,[S,D]} {4,[S,D]}
+4 *5 R!H u0 {3,[S,D]} {5,S}
 5 *2 Os  u0 {4,S} {6,S}
 6 *3 Os  ux {5,S}
 """,
@@ -178,9 +178,9 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 [Cd,Cs]    u0 {1,S} {3,S}
-3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *6 [Cd,Cs,CO] u0 {3,S} {5,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 Os         u0 {4,S} {6,S}
 6 *3 Os         ux {5,S}
 """,
@@ -193,9 +193,9 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 [Cd,Cs] u0 {1,S} {3,S}
-3 *7 [Cd,Cs] u0 {2,S} {4,S}
-4 *6 CO      u0 {3,S} {5,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *5 CO      u0 {3,S} {5,S}
 5 *2 Os      u0 {4,S} {6,S}
 6 *3 Os      ux {5,S}
 """,
@@ -208,9 +208,9 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 [Cd,Cs] u0 {1,S} {3,S}
-3 *7 Cd      u0 {2,S} {4,D}
-4 *6 Cd      u0 {3,D} {5,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 Cd      u0 {2,S} {4,D}
+4 *5 Cd      u0 {3,D} {5,S}
 5 *2 Os      u0 {4,S} {6,S}
 6 *3 Os      ux {5,S}
 """,
@@ -223,9 +223,9 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 Cd         u0 {1,S} {3,D}
-3 *7 Cd         u0 {2,D} {4,S}
-4 *6 [Cd,Cs,CO] u0 {3,S} {5,S}
+2 *4 Cd         u0 {1,S} {3,D}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 Os         u0 {4,S} {6,S}
 6 *3 Os         ux {5,S}
 """,
@@ -238,9 +238,9 @@ entry(
     group = 
 """
 1 *1 Cd         u1 {2,D}
-2 *5 Cd         u0 {1,D} {3,S}
-3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *6 [Cd,Cs,CO] u0 {3,S} {5,S}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
 5 *2 Os         u0 {4,S} {6,S}
 6 *3 Os         ux {5,S}
 """,
@@ -253,9 +253,9 @@ entry(
     group = 
 """
 1 *1 Cd u1 {2,D}
-2 *5 Cd u0 {1,D} {3,S}
-3 *7 Cd u0 {2,S} {4,D}
-4 *6 Cd u0 {3,D} {5,S}
+2 *4 Cd u0 {1,D} {3,S}
+3 *6 Cd u0 {2,S} {4,D}
+4 *5 Cd u0 {3,D} {5,S}
 5 *2 Os u0 {4,S} {6,S}
 6 *3 Os ux {5,S}
 """,
@@ -268,10 +268,10 @@ entry(
     group =
 """
 1 *1 R!H u1 {2,[S,D]}
-2 *5 R!H u0 {1,[S,D]} {3,[S,D]}
-3 *7 R!H u0 {2,[S,D]} {4,[S,D]}
-4 *8 R!H u0 {3,[S,D]} {5,[S,D]}
-5 *6 R!H u0 {4,[S,D]} {6,S}
+2 *4 R!H u0 {1,[S,D]} {3,[S,D]}
+3 *6 R!H u0 {2,[S,D]} {4,[S,D]}
+4 *7 R!H u0 {3,[S,D]} {5,[S,D]}
+5 *5 R!H u0 {4,[S,D]} {6,S}
 6 *2 Os  u0 {5,S} {7,S}
 7 *3 Os  ux {6,S}
 """,
@@ -284,10 +284,10 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 [Cd,Cs]    u0 {1,S} {3,S}
-3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *8 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 Os         u0 {5,S} {7,S}
 7 *3 Os         ux {6,S}
 """,
@@ -300,10 +300,10 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 [Cd,Cs] u0 {1,S} {3,S}
-3 *7 [Cd,Cs] u0 {2,S} {4,S}
-4 *8 [Cd,Cs] u0 {3,S} {5,S}
-5 *6 CO      u0 {4,S} {6,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *7 [Cd,Cs] u0 {3,S} {5,S}
+5 *5 CO      u0 {4,S} {6,S}
 6 *2 Os      u0 {5,S} {7,S}
 7 *3 Os      ux {6,S}
 """,
@@ -316,10 +316,10 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 [Cd,Cs]    u0 {1,S} {3,S}
-3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *8 Cd         u0 {3,S} {5,D}
-5 *6 Cd         u0 {4,D} {6,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 Cd         u0 {3,S} {5,D}
+5 *5 Cd         u0 {4,D} {6,S}
 6 *2 Os         u0 {5,S} {7,S}
 7 *3 Os         ux {6,S}
 """,
@@ -332,10 +332,10 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 [Cd,Cs]    u0 {1,S} {3,S}
-3 *7 Cd         u0 {2,S} {4,D}
-4 *8 Cd         u0 {3,D} {5,S}
-5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 Cd         u0 {2,S} {4,D}
+4 *7 Cd         u0 {3,D} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 Os         u0 {5,S} {7,S}
 7 *3 Os         ux {6,S}
 """,
@@ -348,10 +348,10 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs]    u1 {2,S}
-2 *5 Cd         u0 {1,S} {3,D}
-3 *7 Cd         u0 {2,D} {4,S}
-4 *8 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+2 *4 Cd         u0 {1,S} {3,D}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 Os         u0 {5,S} {7,S}
 7 *3 Os         ux {6,S}
 """,
@@ -364,10 +364,10 @@ entry(
     group = 
 """
 1 *1 Cd         u1 {2,D}
-2 *5 Cd         u0 {1,D} {3,S}
-3 *7 [Cd,Cs,CO] u0 {2,S} {4,S}
-4 *8 [Cd,Cs,CO] u0 {3,S} {5,S}
-5 *6 [Cd,Cs,CO] u0 {4,S} {6,S}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
 6 *2 Os         u0 {5,S} {7,S}
 7 *3 Os         ux {6,S}
 """,
@@ -380,10 +380,10 @@ entry(
     group = 
 """
 1 *1 [Cd,Cs] u1 {2,S}
-2 *5 Cd      u0 {1,S} {3,D}
-3 *7 Cd      u0 {2,D} {4,S}
-4 *8 Cd      u0 {3,S} {5,D}
-5 *6 Cd      u0 {4,D} {6,S}
+2 *4 Cd      u0 {1,S} {3,D}
+3 *6 Cd      u0 {2,D} {4,S}
+4 *7 Cd      u0 {3,S} {5,D}
+5 *5 Cd      u0 {4,D} {6,S}
 6 *2 Os      u0 {5,S} {7,S}
 7 *3 Os      ux {6,S}
 """,
@@ -396,10 +396,10 @@ entry(
     group = 
 """
 1 *1 Cd u1 {2,D}
-2 *5 Cd u0 {1,D} {3,S}
-3 *7 Cd u0 {2,S} {4,D}
-4 *8 Cd u0 {3,D} {5,S}
-5 *6 Cd u0 {4,S} {6,S}
+2 *4 Cd u0 {1,D} {3,S}
+3 *6 Cd u0 {2,S} {4,D}
+4 *7 Cd u0 {3,D} {5,S}
+5 *5 Cd u0 {4,S} {6,S}
 6 *2 Os u0 {5,S} {7,S}
 7 *3 Os ux {6,S}
 """,
@@ -411,9 +411,8 @@ entry(
     label = "Cd_rad_in",
     group = 
 """
-1 *1 C u1 {2,D} {3,S}
-2 *5 C u0 {1,D}
-3    R u0 {1,S}
+1 *1 Cd u1 {2,S}
+2    R  u0 {1,S}
 """,
     kinetics = None,
 )
@@ -423,9 +422,8 @@ entry(
     label = "Cd_pri_rad_in",
     group = 
 """
-1 *1 C u1 {2,D} {3,S}
-2 *5 C u0 {1,D}
-3    H u0 {1,S}
+1 *1 Cd u1 {2,S}
+2    H  u0 {1,S}
 """,
     kinetics = None,
 )
@@ -435,9 +433,8 @@ entry(
     label = "Cd_sec_rad_in",
     group = 
 """
-1 *1 C   u1 {2,D} {3,S}
-2 *5 C   u0 {1,D}
-3    R!H u0 {1,S}
+1 *1 Cd   u1 {2,S}
+2    R!H  u0 {1,S}
 """,
     kinetics = None,
 )
@@ -447,9 +444,8 @@ entry(
     label = "Cd_rad_in/NonDeC",
     group = 
 """
-1 *1 C  u1 {2,D} {3,S}
-2 *5 C  u0 {1,D}
-3    Cs u0 {1,S}
+1 *1 Cd u1 {2,S}
+2    Cs u0 {1,S}
 """,
     kinetics = None,
 )
@@ -459,9 +455,8 @@ entry(
     label = "Cd_rad_in/NonDeO",
     group = 
 """
-1 *1 C u1 {2,D} {3,S}
-2 *5 C u0 {1,D}
-3    O u0 {1,S}
+1 *1 Cd u1 {2,S}
+2    O  u0 {1,S}
 """,
     kinetics = None,
 )
@@ -471,9 +466,8 @@ entry(
     label = "Cd_rad_in/NonDeN",
     group = 
 """
-1 *1 C   u1 {2,D} {3,S}
-2 *5 C   u0 {1,D}
-3    N3s u0 {1,S}
+1 *1 Cd  u1 {2,S}
+2    N3s u0 {1,S}
 """,
     kinetics = None,
 )
@@ -483,9 +477,8 @@ entry(
     label = "Cd_rad_in/OneDe",
     group = 
 """
-1 *1 C             u1 {2,D} {3,S}
-2 *5 C             u0 {1,D}
-3    [Cd,Ct,Cb,CO] u0 {1,S}
+1 *1 Cd            u1 {2,S}
+2    [Cd,Ct,Cb,CO] u0 {1,S}
 """,
     kinetics = None,
 )
@@ -495,9 +488,8 @@ entry(
     label = "Cd_rad_out",
     group = 
 """
-1 *1 C  u1 {2,S} {3,D}
-2 *5 C  u0 {1,S}
-3    Cd u0 {1,D}
+1 *1 Cd u1 {2,D}
+2    Cd u0 {1,D}
 """,
     kinetics = None,
 )
@@ -507,10 +499,9 @@ entry(
     label = "Cs_rad_intra",
     group = 
 """
-1 *1 C u1 {2,S} {3,S} {4,S}
-2 *5 C u0 {1,S}
-3    R u0 {1,S}
-4    R u0 {1,S}
+1 *1 Cs u1 {2,S} {3,S}
+2    R  u0 {1,S}
+3    R  u0 {1,S}
 """,
     kinetics = None,
 )
@@ -520,10 +511,9 @@ entry(
     label = "C_pri_rad_intra",
     group = 
 """
-1 *1 C u1 {2,S} {3,S} {4,S}
-2    H u0 {1,S}
-3    H u0 {1,S}
-4 *5 C u0 {1,S}
+1 *1 Cs u1 {2,S} {3,S}
+2    H  u0 {1,S}
+3    H  u0 {1,S}
 """,
     kinetics = None,
 )
@@ -533,10 +523,9 @@ entry(
     label = "C_sec_rad_intra",
     group = 
 """
-1 *1 C   u1 {2,S} {3,S} {4,S}
+1 *1 Cs  u1 {2,S} {3,S}
 2    H   u0 {1,S}
-3 *5 C   u0 {1,S}
-4    R!H u0 {1,S}
+3    R!H u0 {1,S}
 """,
     kinetics = None,
 )
@@ -546,10 +535,9 @@ entry(
     label = "C_rad/H/NonDeC_intra",
     group = 
 """
-1 *1 C  u1 {2,S} {3,S} {4,S}
+1 *1 Cs u1 {2,S} {3,S}
 2    H  u0 {1,S}
-3 *5 C  u0 {1,S}
-4    Cs u0 {1,S}
+3    Cs u0 {1,S}
 """,
     kinetics = None,
 )
@@ -559,10 +547,9 @@ entry(
     label = "C_rad/H/NonDeO_intra",
     group = 
 """
-1 *1 C u1 {2,S} {3,S} {4,S}
-2    H u0 {1,S}
-3 *5 C u0 {1,S}
-4    O u0 {1,S}
+1 *1 Cs u1 {2,S} {3,S}
+2    H  u0 {1,S}
+3    Os u0 {1,S}
 """,
     kinetics = None,
 )
@@ -572,10 +559,9 @@ entry(
     label = "C_rad/H/NonDeN_intra",
     group = 
 """
-1 *1 C   u1 {2,S} {3,S} {4,S}
+1 *1 Cs  u1 {2,S} {3,S}
 2    H   u0 {1,S}
-3 *5 C   u0 {1,S}
-4    N3s u0 {1,S}
+3    N3s u0 {1,S}
 """,
     kinetics = None,
 )
@@ -585,10 +571,9 @@ entry(
     label = "C_rad/H/OneDe_intra",
     group = 
 """
-1 *1 C             u1 {2,S} {3,S} {4,S}
+1 *1 Cs            u1 {2,S} {3,S}
 2    H             u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
-4 *5 C             u0 {1,S}
 """,
     kinetics = None,
 )
@@ -598,10 +583,9 @@ entry(
     label = "C_ter_rad_intra",
     group = 
 """
-1 *1 C   u1 {2,S} {3,S} {4,S}
-2 *5 C   u0 {1,S}
+1 *1 Cs  u1 {2,S} {3,S}
+2    R!H u0 {1,S}
 3    R!H u0 {1,S}
-4    R!H u0 {1,S}
 """,
     kinetics = None,
 )
@@ -611,10 +595,9 @@ entry(
     label = "C_rad/NonDeC_intra",
     group = 
 """
-1 *1 C      u1 {2,S} {3,S} {4,S}
-2 *5 C      u0 {1,S}
+1 *1 Cs     u1 {2,S} {3,S}
+2    [Cs,O] u0 {1,S}
 3    [Cs,O] u0 {1,S}
-4    [Cs,O] u0 {1,S}
 """,
     kinetics = None,
 )
@@ -624,10 +607,9 @@ entry(
     label = "C_rad/Cs3_intra",
     group = 
 """
-1 *1 C  u1 {2,S} {3,S} {4,S}
-2 *5 C  u0 {1,S}
+1 *1 Cs u1 {2,S} {3,S}
+2    Cs u0 {1,S}
 3    Cs u0 {1,S}
-4    Cs u0 {1,S}
 """,
     kinetics = None,
 )
@@ -637,10 +619,9 @@ entry(
     label = "C_rad/NDMustO_intra",
     group = 
 """
-1 *1 C      u1 {2,S} {3,S} {4,S}
-2 *5 C      u0 {1,S}
-3    O      u0 {1,S}
-4    [Cs,O] u0 {1,S}
+1 *1 Cs     u1 {2,S} {3,S}
+2    O      u0 {1,S}
+3    [Cs,O] u0 {1,S}
 """,
     kinetics = None,
 )
@@ -650,10 +631,9 @@ entry(
     label = "C_rad/OneDe_intra",
     group = 
 """
-1 *1 C             u1 {2,S} {3,S} {4,S}
+1 *1 Cs            u1 {2,S} {3,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
-3 *5 C             u0 {1,S}
-4    [Cs,O]        u0 {1,S}
+3    [Cs,O]        u0 {1,S}
 """,
     kinetics = None,
 )
@@ -663,10 +643,9 @@ entry(
     label = "C_rad/Cs2_intra",
     group = 
 """
-1 *1 C             u1 {2,S} {3,S} {4,S}
+1 *1 Cs            u1 {2,S} {3,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
-3 *5 C             u0 {1,S}
-4    Cs            u0 {1,S}
+3    Cs            u0 {1,S}
 """,
     kinetics = None,
 )
@@ -676,10 +655,9 @@ entry(
     label = "C_rad/ODMustO_intra",
     group = 
 """
-1 *1 C             u1 {2,S} {3,S} {4,S}
+1 *1 Cs            u1 {2,S} {3,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
-3 *5 C             u0 {1,S}
-4    O             u0 {1,S}
+3    O             u0 {1,S}
 """,
     kinetics = None,
 )
@@ -689,10 +667,9 @@ entry(
     label = "C_rad/TwoDe_intra",
     group = 
 """
-1 *1 C             u1 {2,S} {3,S} {4,S}
+1 *1 Cs            u1 {2,S} {3,S}
 2    [Cd,Ct,Cb,CO] u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
-4 *5 C             u0 {1,S}
 """,
     kinetics = None,
 )
@@ -736,7 +713,7 @@ entry(
 """
 1 *2 Os u0 {2,S}
 2 *3 Os u0 {1,S} {3,S}
-3 *4 H  u0 {2,S}  
+3    H  u0 {2,S}  
 """,
     kinetics = None,
 )
@@ -748,7 +725,7 @@ entry(
 """
 1 *2 Os  u0 {2,S}
 2 *3 Os  u0 {1,S} {3,S}
-3 *4 R!H u0 {2,S}  
+3    R!H u0 {2,S}  
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Cyclic_Ether_Formation/groups_OLD.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/groups_OLD.py
@@ -1,0 +1,1319 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Cyclic_Ether_Formation/groups"
+shortDesc = u""
+longDesc = u"""
+
+"""
+
+template(reactants=["RnOO"], products=["RO", "OR"], ownReverse=False)
+
+reverse = "OH+CyclicEther_Form_Alkyl-hydroperoxyl"
+
+recipe(actions=[
+    ['BREAK_BOND', '*2', 'S', '*3'],
+    ['FORM_BOND', '*1', 'S', '*2'],
+    ['GAIN_RADICAL', '*3', '1'],
+    ['LOSE_RADICAL', '*1', '1'],
+])
+
+entry(
+    index = 1,
+    label = "RnOO",
+    group = "OR{R2OO, R3OO, R4OO, R5OO}",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "Y_rad_intra",
+    group = 
+"""
+1 *1 R!H u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
+    label = "R2OO",
+    group = "OR{R2OOH, R2OOR, R2OOJ}",
+    kinetics = None,
+)
+
+entry(
+    index = 4,
+    label = "R2OOJ",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,S}
+3 *2 O                    u0 {2,S} {4,S}
+4 *3 O                    u1 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
+    label = "R2OOJ_S",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *2 O       u0 {2,S} {4,S}
+4 *3 O       u1 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 6,
+    label = "R2OOH",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,S}
+3 *2 O                    u0 {2,S} {4,S}
+4 *3 O                    u0 {3,S} {5,S}
+5    H                    u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 7,
+    label = "R2OOH_S",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *2 O       u0 {2,S} {4,S}
+4 *3 O       u0 {3,S} {5,S}
+5    H       u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
+    label = "R2OOH_SCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 CO      u0 {1,S} {3,S}
+3 *2 O       u0 {2,S} {4,S}
+4 *3 O       u0 {3,S} {5,S}
+5    H       u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 6,
+    label = "R2OOH_D",
+    group = 
+"""
+1 *1 Cd u1 {2,D}
+2 *4 Cd u0 {1,D} {3,S}
+3 *2 O  u0 {2,S} {4,S}
+4 *3 O  u0 {3,S} {5,S}
+5    H  u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 7,
+    label = "R2OOR",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,S}
+3 *2 O                    u0 {2,S} {4,S}
+4 *3 O                    u0 {3,S} {5,S}
+5    R!H                  u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 8,
+    label = "R2OOR_S",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *2 O       u0 {2,S} {4,S}
+4 *3 O       u0 {3,S} {5,S}
+5    R!H     u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 9,
+    label = "R2OOR_SCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 CO      u0 {1,S} {3,S}
+3 *2 O       u0 {2,S} {4,S}
+4 *3 O       u0 {3,S} {5,S}
+5    R!H     u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 10,
+    label = "R2OOR_D",
+    group = 
+"""
+1 *1 Cd  u1 {2,D}
+2 *4 Cd  u0 {1,D} {3,S}
+3 *2 O   u0 {2,S} {4,S}
+4 *3 O   u0 {3,S} {5,S}
+5    R!H u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "R3OO",
+    group = "OR{R3OOH, R3OOR, R3OOJ}",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "R3OOJ",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
+4 *2 O                    u0 {3,S} {5,S}
+5 *3 O                    u1 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "R3OOH",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
+4 *2 O                    u0 {3,S} {5,S}
+5 *3 O                    u0 {4,S} {6,S}
+6    H                    u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "R3OOH_SS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *2 O          u0 {3,S} {5,S}
+5 *3 O          u0 {4,S} {6,S}
+6    H          u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 13,
+    label = "R3OOH_SSCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *5 CO      u0 {2,S} {4,S}
+4 *2 O       u0 {3,S} {5,S}
+5 *3 O       u0 {4,S} {6,S}
+6    H       u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "R3OOH_SD",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 Cd      u0 {1,S} {3,D}
+3 *5 Cd      u0 {2,D} {4,S}
+4 *2 O       u0 {3,S} {5,S}
+5 *3 O       u0 {4,S} {6,S}
+6    H       u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "R3OOH_DS",
+    group = 
+"""
+1 *1 Cd         u1 {2,D}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *2 O          u0 {3,S} {5,S}
+5 *3 O          u0 {4,S} {6,S}
+6    H          u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "R3OOR",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,S}
+4 *2 O                    u0 {3,S} {5,S}
+5 *3 O                    u0 {4,S} {6,S}
+6    R!H                  u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "R3OOR_SS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *2 O          u0 {3,S} {5,S}
+5 *3 O          u0 {4,S} {6,S}
+6    R!H        u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 18,
+    label = "R3OOR_SSCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *5 CO      u0 {2,S} {4,S}
+4 *2 O       u0 {3,S} {5,S}
+5 *3 O       u0 {4,S} {6,S}
+6    R!H     u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 19,
+    label = "R3OOR_SD",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 Cd      u0 {1,S} {3,D}
+3 *5 Cd      u0 {2,D} {4,S}
+4 *2 O       u0 {3,S} {5,S}
+5 *3 O       u0 {4,S} {6,S}
+6    R!H     u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 20,
+    label = "R3OOR_DS",
+    group = 
+"""
+1 *1 Cd         u1 {2,D}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *5 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *2 O          u0 {3,S} {5,S}
+5 *3 O          u0 {4,S} {6,S}
+6    R!H        u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 26,
+    label = "R4OO",
+    group = "OR{R4OOH, R4OOR, R4OOJ}",
+    kinetics = None,
+)
+
+entry(
+    index = 27,
+    label = "R4OOJ",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
+5 *2 O                    u0 {4,S} {6,S}
+6 *3 O                    u1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 28,
+    label = "R4OOH",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
+5 *2 O                    u0 {4,S} {6,S}
+6 *3 O                    u0 {5,S} {7,S}
+7    H                    u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 29,
+    label = "R4OOH_SSS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 O          u0 {4,S} {6,S}
+6 *3 O          u0 {5,S} {7,S}
+7    H          u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 23,
+    label = "R4OOH_SSSCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *5 CO      u0 {3,S} {5,S}
+5 *2 O       u0 {4,S} {6,S}
+6 *3 O       u0 {5,S} {7,S}
+7    H       u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 24,
+    label = "R4OOH_SSD",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 Cd      u0 {2,S} {4,D}
+4 *5 Cd      u0 {3,D} {5,S}
+5 *2 O       u0 {4,S} {6,S}
+6 *3 O       u0 {5,S} {7,S}
+7    H       u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 25,
+    label = "R4OOH_SDS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 Cd         u0 {1,S} {3,D}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 O          u0 {4,S} {6,S}
+6 *3 O          u0 {5,S} {7,S}
+7    H          u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 26,
+    label = "R4OOH_DSS",
+    group = 
+"""
+1 *1 Cd         u1 {2,D}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 O          u0 {4,S} {6,S}
+6 *3 O          u0 {5,S} {7,S}
+7    H          u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 27,
+    label = "R4OOH_DSD",
+    group = 
+"""
+1 *1 Cd u1 {2,D}
+2 *4 Cd u0 {1,D} {3,S}
+3 *6 Cd u0 {2,S} {4,D}
+4 *5 Cd u0 {3,D} {5,S}
+5 *2 O  u0 {4,S} {6,S}
+6 *3 O  u0 {5,S} {7,S}
+7    H  u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 28,
+    label = "R4OOR",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,S}
+5 *2 O                    u0 {4,S} {6,S}
+6 *3 O                    u0 {5,S} {7,S}
+7    R!H                  u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 29,
+    label = "R4OOR_SSS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 O          u0 {4,S} {6,S}
+6 *3 O          u0 {5,S} {7,S}
+7    R!H        u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 30,
+    label = "R4OOR_SSSCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *5 CO      u0 {3,S} {5,S}
+5 *2 O       u0 {4,S} {6,S}
+6 *3 O       u0 {5,S} {7,S}
+7    R!H     u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 31,
+    label = "R4OOR_SSD",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 Cd      u0 {2,S} {4,D}
+4 *5 Cd      u0 {3,D} {5,S}
+5 *2 O       u0 {4,S} {6,S}
+6 *3 O       u0 {5,S} {7,S}
+7    R!H     u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 32,
+    label = "R4OOR_SDS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 Cd         u0 {1,S} {3,D}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 O          u0 {4,S} {6,S}
+6 *3 O          u0 {5,S} {7,S}
+7    R!H        u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 33,
+    label = "R4OOR_DSS",
+    group = 
+"""
+1 *1 Cd         u1 {2,D}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *5 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *2 O          u0 {4,S} {6,S}
+6 *3 O          u0 {5,S} {7,S}
+7    R!H        u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 34,
+    label = "R4OOR_DSD",
+    group = 
+"""
+1 *1 Cd  u1 {2,D}
+2 *4 Cd  u0 {1,D} {3,S}
+3 *6 Cd  u0 {2,S} {4,D}
+4 *5 Cd  u0 {3,D} {5,S}
+5 *2 O   u0 {4,S} {6,S}
+6 *3 O   u0 {5,S} {7,S}
+7    R!H u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 42,
+    label = "R5OO",
+    group = "OR{R5OOH, R5OOR, R5OOJ}",
+    kinetics = None,
+)
+
+entry(
+    index = 43,
+    label = "R5OOJ",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
+5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
+6 *2 O                    u0 {5,S} {7,S}
+7 *3 O                    u1 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 44,
+    label = "R5OOH",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
+5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
+6 *2 O                    u0 {5,S} {7,S}
+7 *3 O                    u0 {6,S} {8,S}
+8    H                    u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 45,
+    label = "R5OOH_SSSS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    H          u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 37,
+    label = "R5OOH_SSSSCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *7 [Cd,Cs] u0 {3,S} {5,S}
+5 *5 CO      u0 {4,S} {6,S}
+6 *2 O       u0 {5,S} {7,S}
+7 *3 O       u0 {6,S} {8,S}
+8    H       u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 38,
+    label = "R5OOH_SSSD",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 Cd         u0 {3,S} {5,D}
+5 *5 Cd         u0 {4,D} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    H          u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 39,
+    label = "R5OOH_SSDS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 Cd         u0 {2,S} {4,D}
+4 *7 Cd         u0 {3,D} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    H          u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 40,
+    label = "R5OOH_SDSS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 Cd         u0 {1,S} {3,D}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    H          u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 41,
+    label = "R5OOH_DSSS",
+    group = 
+"""
+1 *1 Cd         u1 {2,D}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    H          u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 42,
+    label = "R5OOH_SDSD",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 Cd      u0 {1,S} {3,D}
+3 *6 Cd      u0 {2,D} {4,S}
+4 *7 Cd      u0 {3,S} {5,D}
+5 *5 Cd      u0 {4,D} {6,S}
+6 *2 O       u0 {5,S} {7,S}
+7 *3 O       u0 {6,S} {8,S}
+8    H       u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 43,
+    label = "R5OOH_DSDS",
+    group = 
+"""
+1 *1 Cd u1 {2,D}
+2 *4 Cd u0 {1,D} {3,S}
+3 *6 Cd u0 {2,S} {4,D}
+4 *7 Cd u0 {3,D} {5,S}
+5 *5 Cd u0 {4,S} {6,S}
+6 *2 O  u0 {5,S} {7,S}
+7 *3 O  u0 {6,S} {8,S}
+8    H  u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 44,
+    label = "R5OOR",
+    group = 
+"""
+1 *1 [CO,Cd,Cs,Sid,Sis,N] u1 {2,[S,D]}
+2 *4 [CO,Cd,Cs,Sid,Sis,N] u0 {1,[S,D]} {3,[S,D]}
+3 *6 [CO,Cd,Cs,Sid,Sis,N] u0 {2,[S,D]} {4,[S,D]}
+4 *7 [CO,Cd,Cs,Sid,Sis,N] u0 {3,[S,D]} {5,[S,D]}
+5 *5 [CO,Cd,Cs,Sid,Sis,N] u0 {4,[S,D]} {6,S}
+6 *2 O                    u0 {5,S} {7,S}
+7 *3 O                    u0 {6,S} {8,S}
+8    R!H                  u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 45,
+    label = "R5OOR_SSSS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    R!H        u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 46,
+    label = "R5OOR_SSSSCO",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 [Cd,Cs] u0 {1,S} {3,S}
+3 *6 [Cd,Cs] u0 {2,S} {4,S}
+4 *7 [Cd,Cs] u0 {3,S} {5,S}
+5 *5 CO      u0 {4,S} {6,S}
+6 *2 O       u0 {5,S} {7,S}
+7 *3 O       u0 {6,S} {8,S}
+8    R!H     u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 47,
+    label = "R5OOR_SSSD",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 Cd         u0 {3,S} {5,D}
+5 *5 Cd         u0 {4,D} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    R!H        u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 48,
+    label = "R5OOR_SSDS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 [Cd,Cs]    u0 {1,S} {3,S}
+3 *6 Cd         u0 {2,S} {4,D}
+4 *7 Cd         u0 {3,D} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    R!H        u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 49,
+    label = "R5OOR_SDSS",
+    group = 
+"""
+1 *1 [Cd,Cs]    u1 {2,S}
+2 *4 Cd         u0 {1,S} {3,D}
+3 *6 Cd         u0 {2,D} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    R!H        u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 50,
+    label = "R5OOR_DSSS",
+    group = 
+"""
+1 *1 Cd         u1 {2,D}
+2 *4 Cd         u0 {1,D} {3,S}
+3 *6 [Cd,Cs,CO] u0 {2,S} {4,S}
+4 *7 [Cd,Cs,CO] u0 {3,S} {5,S}
+5 *5 [Cd,Cs,CO] u0 {4,S} {6,S}
+6 *2 O          u0 {5,S} {7,S}
+7 *3 O          u0 {6,S} {8,S}
+8    R!H        u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 51,
+    label = "R5OOR_SDSD",
+    group = 
+"""
+1 *1 [Cd,Cs] u1 {2,S}
+2 *4 Cd      u0 {1,S} {3,D}
+3 *6 Cd      u0 {2,D} {4,S}
+4 *7 Cd      u0 {3,S} {5,D}
+5 *5 Cd      u0 {4,D} {6,S}
+6 *2 O       u0 {5,S} {7,S}
+7 *3 O       u0 {6,S} {8,S}
+8    R!H     u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 52,
+    label = "R5OOR_DSDS",
+    group = 
+"""
+1 *1 Cd  u1 {2,D}
+2 *4 Cd  u0 {1,D} {3,S}
+3 *6 Cd  u0 {2,S} {4,D}
+4 *7 Cd  u0 {3,D} {5,S}
+5 *5 Cd  u0 {4,S} {6,S}
+6 *2 O   u0 {5,S} {7,S}
+7 *3 O   u0 {6,S} {8,S}
+8    R!H u0 {7,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 53,
+    label = "Cd_rad_in",
+    group = 
+"""
+1 *1 C u1 {2,D} {3,S}
+2 *4 C u0 {1,D}
+3    R u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 54,
+    label = "Cd_pri_rad_in",
+    group = 
+"""
+1 *1 C u1 {2,D} {3,S}
+2 *4 C u0 {1,D}
+3    H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 55,
+    label = "Cd_sec_rad_in",
+    group = 
+"""
+1 *1 C   u1 {2,D} {3,S}
+2 *4 C   u0 {1,D}
+3    R!H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 56,
+    label = "Cd_rad_in/NonDeC",
+    group = 
+"""
+1 *1 C  u1 {2,D} {3,S}
+2 *4 C  u0 {1,D}
+3    Cs u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 57,
+    label = "Cd_rad_in/NonDeO",
+    group = 
+"""
+1 *1 C u1 {2,D} {3,S}
+2 *4 C u0 {1,D}
+3    O u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 75,
+    label = "Cd_rad_in/NonDeN",
+    group = 
+"""
+1 *1 C   u1 {2,D} {3,S}
+2 *4 C   u0 {1,D}
+3    N3s u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 58,
+    label = "Cd_rad_in/OneDe",
+    group = 
+"""
+1 *1 C             u1 {2,D} {3,S}
+2 *4 C             u0 {1,D}
+3    [Cd,Ct,Cb,CO] u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 59,
+    label = "Cd_rad_out",
+    group = 
+"""
+1 *1 C  u1 {2,S} {3,D}
+2 *4 C  u0 {1,S}
+3    Cd u0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 60,
+    label = "Cs_rad_intra",
+    group = 
+"""
+1 *1 C u1 {2,S} {3,S} {4,S}
+2 *4 C u0 {1,S}
+3    R u0 {1,S}
+4    R u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 61,
+    label = "C_pri_rad_intra",
+    group = 
+"""
+1 *1 C u1 {2,S} {3,S} {4,S}
+2    H u0 {1,S}
+3    H u0 {1,S}
+4 *4 C u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 62,
+    label = "C_sec_rad_intra",
+    group = 
+"""
+1 *1 C   u1 {2,S} {3,S} {4,S}
+2    H   u0 {1,S}
+3 *4 C   u0 {1,S}
+4    R!H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 63,
+    label = "C_rad/H/NonDeC_intra",
+    group = 
+"""
+1 *1 C  u1 {2,S} {3,S} {4,S}
+2    H  u0 {1,S}
+3 *4 C  u0 {1,S}
+4    Cs u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 64,
+    label = "C_rad/H/NonDeO_intra",
+    group = 
+"""
+1 *1 C u1 {2,S} {3,S} {4,S}
+2    H u0 {1,S}
+3 *4 C u0 {1,S}
+4    O u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 76,
+    label = "C_rad/H/NonDeN_intra",
+    group = 
+"""
+1 *1 C   u1 {2,S} {3,S} {4,S}
+2    H   u0 {1,S}
+3 *4 C   u0 {1,S}
+4    N3s u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 65,
+    label = "C_rad/H/OneDe_intra",
+    group = 
+"""
+1 *1 C             u1 {2,S} {3,S} {4,S}
+2    H             u0 {1,S}
+3    [Cd,Ct,Cb,CO] u0 {1,S}
+4 *4 C             u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 66,
+    label = "C_ter_rad_intra",
+    group = 
+"""
+1 *1 C   u1 {2,S} {3,S} {4,S}
+2 *4 C   u0 {1,S}
+3    R!H u0 {1,S}
+4    R!H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 67,
+    label = "C_rad/NonDeC_intra",
+    group = 
+"""
+1 *1 C      u1 {2,S} {3,S} {4,S}
+2 *4 C      u0 {1,S}
+3    [Cs,O] u0 {1,S}
+4    [Cs,O] u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 68,
+    label = "C_rad/Cs3_intra",
+    group = 
+"""
+1 *1 C  u1 {2,S} {3,S} {4,S}
+2 *4 C  u0 {1,S}
+3    Cs u0 {1,S}
+4    Cs u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 69,
+    label = "C_rad/NDMustO_intra",
+    group = 
+"""
+1 *1 C      u1 {2,S} {3,S} {4,S}
+2 *4 C      u0 {1,S}
+3    O      u0 {1,S}
+4    [Cs,O] u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 70,
+    label = "C_rad/OneDe_intra",
+    group = 
+"""
+1 *1 C             u1 {2,S} {3,S} {4,S}
+2    [Cd,Ct,Cb,CO] u0 {1,S}
+3 *4 C             u0 {1,S}
+4    [Cs,O]        u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 71,
+    label = "C_rad/Cs2_intra",
+    group = 
+"""
+1 *1 C             u1 {2,S} {3,S} {4,S}
+2    [Cd,Ct,Cb,CO] u0 {1,S}
+3 *4 C             u0 {1,S}
+4    Cs            u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 72,
+    label = "C_rad/ODMustO_intra",
+    group = 
+"""
+1 *1 C             u1 {2,S} {3,S} {4,S}
+2    [Cd,Ct,Cb,CO] u0 {1,S}
+3 *4 C             u0 {1,S}
+4    O             u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 73,
+    label = "C_rad/TwoDe_intra",
+    group = 
+"""
+1 *1 C             u1 {2,S} {3,S} {4,S}
+2    [Cd,Ct,Cb,CO] u0 {1,S}
+3    [Cd,Ct,Cb,CO] u0 {1,S}
+4 *4 C             u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 74,
+    label = "N_rad",
+    group = 
+"""
+1 *1 N u1
+""",
+    kinetics = None,
+)
+
+tree(
+"""
+L1: RnOO
+    L2: R2OO
+        L3: R2OOJ
+            L4: R2OOJ_S
+        L3: R2OOH
+            L4: R2OOH_S
+            L4: R2OOH_SCO
+            L4: R2OOH_D
+        L3: R2OOR
+            L4: R2OOR_S
+            L4: R2OOR_SCO
+            L4: R2OOR_D
+    L2: R3OO
+        L3: R3OOJ
+        L3: R3OOH
+            L4: R3OOH_SS
+                L5: R3OOH_SSCO
+            L4: R3OOH_SD
+            L4: R3OOH_DS
+        L3: R3OOR
+            L4: R3OOR_SS
+                L5: R3OOR_SSCO
+            L4: R3OOR_SD
+            L4: R3OOR_DS
+    L2: R4OO
+        L3: R4OOJ
+        L3: R4OOH
+            L4: R4OOH_SSS
+                L5: R4OOH_SSSCO
+            L4: R4OOH_SSD
+            L4: R4OOH_SDS
+            L4: R4OOH_DSS
+            L4: R4OOH_DSD
+        L3: R4OOR
+            L4: R4OOR_SSS
+                L5: R4OOR_SSSCO
+            L4: R4OOR_SSD
+            L4: R4OOR_SDS
+            L4: R4OOR_DSS
+            L4: R4OOR_DSD
+    L2: R5OO
+        L3: R5OOJ
+        L3: R5OOH
+            L4: R5OOH_SSSS
+                L5: R5OOH_SSSSCO
+            L4: R5OOH_SSSD
+            L4: R5OOH_SSDS
+            L4: R5OOH_SDSS
+            L4: R5OOH_DSSS
+            L4: R5OOH_SDSD
+            L4: R5OOH_DSDS
+        L3: R5OOR
+            L4: R5OOR_SSSS
+                L5: R5OOR_SSSSCO
+            L4: R5OOR_SSSD
+            L4: R5OOR_SSDS
+            L4: R5OOR_SDSS
+            L4: R5OOR_DSSS
+            L4: R5OOR_SDSD
+            L4: R5OOR_DSDS
+L1: Y_rad_intra
+    L2: Cd_rad_in
+        L3: Cd_pri_rad_in
+        L3: Cd_sec_rad_in
+            L4: Cd_rad_in/NonDeC
+            L4: Cd_rad_in/NonDeO
+            L4: Cd_rad_in/NonDeN
+            L4: Cd_rad_in/OneDe
+    L2: Cd_rad_out
+    L2: Cs_rad_intra
+        L3: C_pri_rad_intra
+        L3: C_sec_rad_intra
+            L4: C_rad/H/NonDeC_intra
+            L4: C_rad/H/NonDeO_intra
+            L4: C_rad/H/NonDeN_intra
+            L4: C_rad/H/OneDe_intra
+        L3: C_ter_rad_intra
+            L4: C_rad/NonDeC_intra
+                L5: C_rad/Cs3_intra
+                L5: C_rad/NDMustO_intra
+            L4: C_rad/OneDe_intra
+                L5: C_rad/Cs2_intra
+                L5: C_rad/ODMustO_intra
+            L4: C_rad/TwoDe_intra
+    L2: N_rad
+"""
+)
+

--- a/input/kinetics/families/Cyclic_Ether_Formation/rules.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/rules.py
@@ -8,7 +8,7 @@ longDesc = u"""
 """
 entry(
     index = 812,
-    label = "RnOO;Y_rad_intra",
+    label = "RnOO;Y_rad_intra;OO_intra",
     kinetics = ArrheniusEP(
         A = (1e+11, 's^-1'),
         n = 0,
@@ -22,7 +22,7 @@ entry(
 
 entry(
     index = 813,
-    label = "R2OOH_S;C_pri_rad_intra",
+    label = "R2OO_S;C_pri_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (3.98e+12, 's^-1', '*|/', 1.2),
         n = 0,
@@ -37,7 +37,7 @@ entry(
 
 entry(
     index = 813,
-    label = "R2OOR_S;C_pri_rad_intra",
+    label = "R2OO_S;C_pri_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (3.98e+12, 's^-1', '*|/', 1.2),
         n = 0,
@@ -52,7 +52,7 @@ entry(
 
 entry(
     index = 814,
-    label = "R2OOH_S;C_sec_rad_intra",
+    label = "R2OO_S;C_sec_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (1.38e+12, 's^-1', '*|/', 1.2),
         n = 0,
@@ -67,7 +67,7 @@ entry(
 
 entry(
     index = 814,
-    label = "R2OOR_S;C_sec_rad_intra",
+    label = "R2OO_S;C_sec_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (1.38e+12, 's^-1', '*|/', 1.2),
         n = 0,
@@ -82,7 +82,7 @@ entry(
 
 entry(
     index = 815,
-    label = "R2OOR_S;C_ter_rad_intra",
+    label = "R2OO_S;C_ter_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (3.09e+12, 's^-1', '*|/', 1.2),
         n = 0,
@@ -97,7 +97,7 @@ entry(
 
 entry(
     index = 815,
-    label = "R2OOH_S;C_ter_rad_intra",
+    label = "R2OO_S;C_ter_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (3.09e+12, 's^-1', '*|/', 1.2),
         n = 0,
@@ -112,7 +112,7 @@ entry(
 
 entry(
     index = 816,
-    label = "R3OOH_SS;C_pri_rad_intra",
+    label = "R3OO_SS;C_pri_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (4.47e+11, 's^-1', '*|/', 1.74),
         n = 0,
@@ -127,7 +127,7 @@ entry(
 
 entry(
     index = 816,
-    label = "R3OOR_SS;C_pri_rad_intra",
+    label = "R3OO_SS;C_pri_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (4.47e+11, 's^-1', '*|/', 1.74),
         n = 0,
@@ -142,7 +142,7 @@ entry(
 
 entry(
     index = 817,
-    label = "R3OOH_SS;C_sec_rad_intra",
+    label = "R3OO_SS;C_sec_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (2.04e+11, 's^-1', '*|/', 1.74),
         n = 0,
@@ -157,7 +157,7 @@ entry(
 
 entry(
     index = 817,
-    label = "R3OOR_SS;C_sec_rad_intra",
+    label = "R3OO_SS;C_sec_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (2.04e+11, 's^-1', '*|/', 1.74),
         n = 0,
@@ -172,7 +172,7 @@ entry(
 
 entry(
     index = 818,
-    label = "R3OOR_SS;C_ter_rad_intra",
+    label = "R3OO_SS;C_ter_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (3.31e+11, 's^-1', '*|/', 1.74),
         n = 0,
@@ -187,7 +187,7 @@ entry(
 
 entry(
     index = 818,
-    label = "R3OOH_SS;C_ter_rad_intra",
+    label = "R3OO_SS;C_ter_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (3.31e+11, 's^-1', '*|/', 1.74),
         n = 0,
@@ -202,7 +202,7 @@ entry(
 
 entry(
     index = 819,
-    label = "R4OOR_SSS;C_pri_rad_intra",
+    label = "R4OO_SSS;C_pri_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (5.13e+10, 's^-1', '*|/', 1.41),
         n = 0,
@@ -217,7 +217,7 @@ entry(
 
 entry(
     index = 819,
-    label = "R4OOH_SSS;C_pri_rad_intra",
+    label = "R4OO_SSS;C_pri_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (5.13e+10, 's^-1', '*|/', 1.41),
         n = 0,
@@ -232,7 +232,7 @@ entry(
 
 entry(
     index = 820,
-    label = "R4OOR_SSS;C_sec_rad_intra",
+    label = "R4OO_SSS;C_sec_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (3.63e+10, 's^-1', '*|/', 1.41),
         n = 0,
@@ -247,7 +247,7 @@ entry(
 
 entry(
     index = 820,
-    label = "R4OOH_SSS;C_sec_rad_intra",
+    label = "R4OO_SSS;C_sec_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (3.63e+10, 's^-1', '*|/', 1.41),
         n = 0,
@@ -262,7 +262,7 @@ entry(
 
 entry(
     index = 821,
-    label = "R4OOR_SSS;C_ter_rad_intra",
+    label = "R4OO_SSS;C_ter_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (2.57e+10, 's^-1', '*|/', 1.41),
         n = 0,
@@ -277,7 +277,7 @@ entry(
 
 entry(
     index = 821,
-    label = "R4OOH_SSS;C_ter_rad_intra",
+    label = "R4OO_SSS;C_ter_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (2.57e+10, 's^-1', '*|/', 1.41),
         n = 0,
@@ -292,7 +292,7 @@ entry(
 
 entry(
     index = 822,
-    label = "R2OOR_S;Cs_rad_intra",
+    label = "R2OO_S;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (6e+11, 's^-1'),
         n = 0,
@@ -307,7 +307,7 @@ entry(
 
 entry(
     index = 822,
-    label = "R2OOH_S;Cs_rad_intra",
+    label = "R2OO_S;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (6e+11, 's^-1'),
         n = 0,
@@ -322,7 +322,7 @@ entry(
 
 entry(
     index = 823,
-    label = "R3OOR_SS;Cs_rad_intra",
+    label = "R3OO_SS;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (7.5e+10, 's^-1'),
         n = 0,
@@ -337,7 +337,7 @@ entry(
 
 entry(
     index = 823,
-    label = "R3OOH_SS;Cs_rad_intra",
+    label = "R3OO_SS;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (7.5e+10, 's^-1'),
         n = 0,
@@ -352,7 +352,7 @@ entry(
 
 entry(
     index = 824,
-    label = "R4OOR_SSS;Cs_rad_intra",
+    label = "R4OO_SSS;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (9.38e+09, 's^-1'),
         n = 0,
@@ -367,7 +367,7 @@ entry(
 
 entry(
     index = 824,
-    label = "R4OOH_SSS;Cs_rad_intra",
+    label = "R4OO_SSS;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (9.38e+09, 's^-1'),
         n = 0,
@@ -382,7 +382,7 @@ entry(
 
 entry(
     index = 825,
-    label = "R5OOH_SSSS;Cs_rad_intra",
+    label = "R5OO_SSSS;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (1.17e+09, 's^-1'),
         n = 0,
@@ -397,7 +397,7 @@ entry(
 
 entry(
     index = 825,
-    label = "R5OOR_SSSS;Cs_rad_intra",
+    label = "R5OO_SSSS;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (1.17e+09, 's^-1'),
         n = 0,
@@ -412,7 +412,7 @@ entry(
 
 entry(
     index = 826,
-    label = "R5OOR_SSSSCO;Cs_rad_intra",
+    label = "R5OO_SSSSCO;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (1.27e+08, 's^-1'),
         n = 0.77,
@@ -427,7 +427,7 @@ entry(
 
 entry(
     index = 826,
-    label = "R5OOH_SSSSCO;Cs_rad_intra",
+    label = "R5OO_SSSSCO;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (1.27e+08, 's^-1'),
         n = 0.77,
@@ -442,7 +442,7 @@ entry(
 
 entry(
     index = 827,
-    label = "R2OOR_SCO;Cs_rad_intra",
+    label = "R2OO_SCO;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (6.92e+15, 's^-1'),
         n = -0.53,
@@ -457,7 +457,7 @@ entry(
 
 entry(
     index = 827,
-    label = "R2OOH_SCO;Cs_rad_intra",
+    label = "R2OO_SCO;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (6.92e+15, 's^-1'),
         n = -0.53,
@@ -472,7 +472,7 @@ entry(
 
 entry(
     index = 828,
-    label = "R4OOR_SSSCO;Cs_rad_intra",
+    label = "R4OO_SSSCO;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (1.27e+08, 's^-1'),
         n = 0.77,
@@ -487,7 +487,7 @@ entry(
 
 entry(
     index = 828,
-    label = "R4OOH_SSSCO;Cs_rad_intra",
+    label = "R4OO_SSSCO;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (1.27e+08, 's^-1'),
         n = 0.77,
@@ -502,7 +502,7 @@ entry(
 
 entry(
     index = 829,
-    label = "R3OOH_SSCO;Cs_rad_intra",
+    label = "R3OO_SSCO;Cs_rad_intra;OOH",
     kinetics = ArrheniusEP(
         A = (1.27e+08, 's^-1'),
         n = 0.77,
@@ -517,7 +517,7 @@ entry(
 
 entry(
     index = 829,
-    label = "R3OOR_SSCO;Cs_rad_intra",
+    label = "R3OO_SSCO;Cs_rad_intra;OOR",
     kinetics = ArrheniusEP(
         A = (1.27e+08, 's^-1'),
         n = 0.77,
@@ -532,7 +532,7 @@ entry(
 
 entry(
     index = 830,
-    label = "R2OOJ_S;C_pri_rad_intra",
+    label = "R2OO_S;C_pri_rad_intra;OOJ",
     kinetics = ArrheniusEP(
         A = (1.62e+09, 's^-1'),
         n = 1.1,
@@ -547,7 +547,7 @@ entry(
 
 entry(
     index = 831,
-    label = "R2OOJ_S;C_pri_rad_intra",
+    label = "R2OO_S;C_pri_rad_intra;OOJ",
     kinetics = ArrheniusEP(
         A = (1.61e+09, 's^-1'),
         n = 1.09,
@@ -562,7 +562,7 @@ entry(
 
 entry(
     index = 832,
-    label = "R2OOJ_S;C_rad/H/NonDeC_intra",
+    label = "R2OO_S;C_rad/H/NonDeC_intra;OOJ",
     kinetics = ArrheniusEP(
         A = (3.27e+09, 's^-1'),
         n = 1.06,

--- a/input/kinetics/families/Cyclic_Ether_Formation/rules_old.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/rules_old.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Cyclic_Ether_Formation/rules"
+shortDesc = u""
+longDesc = u"""
+
+"""
+entry(
+    index = 812,
+    label = "RnOO;Y_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1e+11, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (10, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+)
+
+entry(
+    index = 813,
+    label = "R2OOH_S;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.98e+12, 's^-1', '*|/', 1.2),
+        n = 0,
+        alpha = (1.3, '', '+|-', 0.3),
+        E0 = (37, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 813,
+    label = "R2OOR_S;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.98e+12, 's^-1', '*|/', 1.2),
+        n = 0,
+        alpha = (1.3, '', '+|-', 0.3),
+        E0 = (37, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 814,
+    label = "R2OOH_S;C_sec_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.38e+12, 's^-1', '*|/', 1.2),
+        n = 0,
+        alpha = (1.3, '', '+|-', 0.3),
+        E0 = (37, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 814,
+    label = "R2OOR_S;C_sec_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.38e+12, 's^-1', '*|/', 1.2),
+        n = 0,
+        alpha = (1.3, '', '+|-', 0.3),
+        E0 = (37, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 815,
+    label = "R2OOR_S;C_ter_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.09e+12, 's^-1', '*|/', 1.2),
+        n = 0,
+        alpha = (1.3, '', '+|-', 0.3),
+        E0 = (37, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 815,
+    label = "R2OOH_S;C_ter_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.09e+12, 's^-1', '*|/', 1.2),
+        n = 0,
+        alpha = (1.3, '', '+|-', 0.3),
+        E0 = (37, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 816,
+    label = "R3OOH_SS;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (4.47e+11, 's^-1', '*|/', 1.74),
+        n = 0,
+        alpha = (1, '', '+|-', 0.1),
+        E0 = (38.2, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 816,
+    label = "R3OOR_SS;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (4.47e+11, 's^-1', '*|/', 1.74),
+        n = 0,
+        alpha = (1, '', '+|-', 0.1),
+        E0 = (38.2, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 817,
+    label = "R3OOH_SS;C_sec_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (2.04e+11, 's^-1', '*|/', 1.74),
+        n = 0,
+        alpha = (1, '', '+|-', 0.1),
+        E0 = (38.2, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 817,
+    label = "R3OOR_SS;C_sec_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (2.04e+11, 's^-1', '*|/', 1.74),
+        n = 0,
+        alpha = (1, '', '+|-', 0.1),
+        E0 = (38.2, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 818,
+    label = "R3OOR_SS;C_ter_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.31e+11, 's^-1', '*|/', 1.74),
+        n = 0,
+        alpha = (1, '', '+|-', 0.1),
+        E0 = (38.2, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 818,
+    label = "R3OOH_SS;C_ter_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.31e+11, 's^-1', '*|/', 1.74),
+        n = 0,
+        alpha = (1, '', '+|-', 0.1),
+        E0 = (38.2, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 819,
+    label = "R4OOR_SSS;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (5.13e+10, 's^-1', '*|/', 1.41),
+        n = 0,
+        alpha = 0,
+        E0 = (14.8, 'kcal/mol', '+|-', 2),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 819,
+    label = "R4OOH_SSS;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (5.13e+10, 's^-1', '*|/', 1.41),
+        n = 0,
+        alpha = 0,
+        E0 = (14.8, 'kcal/mol', '+|-', 2),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 820,
+    label = "R4OOR_SSS;C_sec_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.63e+10, 's^-1', '*|/', 1.41),
+        n = 0,
+        alpha = 0,
+        E0 = (13, 'kcal/mol', '+|-', 2.5),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 820,
+    label = "R4OOH_SSS;C_sec_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (3.63e+10, 's^-1', '*|/', 1.41),
+        n = 0,
+        alpha = 0,
+        E0 = (13, 'kcal/mol', '+|-', 2.5),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 821,
+    label = "R4OOR_SSS;C_ter_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (2.57e+10, 's^-1', '*|/', 1.41),
+        n = 0,
+        alpha = 0,
+        E0 = (11.5, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 821,
+    label = "R4OOH_SSS;C_ter_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (2.57e+10, 's^-1', '*|/', 1.41),
+        n = 0,
+        alpha = 0,
+        E0 = (11.5, 'kcal/mol', '+|-', 3),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 2,
+    shortDesc = u"""CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including treatment of hindered rotor.""",
+)
+
+entry(
+    index = 822,
+    label = "R2OOR_S;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (6e+11, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (22, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 822,
+    label = "R2OOH_S;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (6e+11, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (22, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 823,
+    label = "R3OOR_SS;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (7.5e+10, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (15.25, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 823,
+    label = "R3OOH_SS;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (7.5e+10, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (15.25, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 824,
+    label = "R4OOR_SSS;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (9.38e+09, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (7, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 824,
+    label = "R4OOH_SSS;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (9.38e+09, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (7, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 825,
+    label = "R5OOH_SSSS;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.17e+09, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (1.8, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 825,
+    label = "R5OOR_SSSS;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.17e+09, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (1.8, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Curran's [8] estimation in reaction type 19, QOOH = cyclic ether + OH""",
+)
+
+entry(
+    index = 826,
+    label = "R5OOR_SSSSCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.27e+08, 's^-1'),
+        n = 0.77,
+        alpha = 0,
+        E0 = (18.73, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""CBS-QB3 Including treatment of hindered rotor (SSM)""",
+)
+
+entry(
+    index = 826,
+    label = "R5OOH_SSSSCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.27e+08, 's^-1'),
+        n = 0.77,
+        alpha = 0,
+        E0 = (18.73, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""CBS-QB3 Including treatment of hindered rotor (SSM)""",
+)
+
+entry(
+    index = 827,
+    label = "R2OOR_SCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (6.92e+15, 's^-1'),
+        n = -0.53,
+        alpha = 0,
+        E0 = (24.34, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""CBS-QB3 Including treatment for hindered rotor, QTST Calculation (CFG & JWA)""",
+)
+
+entry(
+    index = 827,
+    label = "R2OOH_SCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (6.92e+15, 's^-1'),
+        n = -0.53,
+        alpha = 0,
+        E0 = (24.34, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""CBS-QB3 Including treatment for hindered rotor, QTST Calculation (CFG & JWA)""",
+)
+
+entry(
+    index = 828,
+    label = "R4OOR_SSSCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.27e+08, 's^-1'),
+        n = 0.77,
+        alpha = 0,
+        E0 = (18.73, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""Estimate (Same as 5 memebered ring)""",
+)
+
+entry(
+    index = 828,
+    label = "R4OOH_SSSCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.27e+08, 's^-1'),
+        n = 0.77,
+        alpha = 0,
+        E0 = (18.73, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""Estimate (Same as 5 memebered ring)""",
+)
+
+entry(
+    index = 829,
+    label = "R3OOH_SSCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.27e+08, 's^-1'),
+        n = 0.77,
+        alpha = 0,
+        E0 = (18.73, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""Estimate (Same as 5 memebered ring)""",
+)
+
+entry(
+    index = 829,
+    label = "R3OOR_SSCO;Cs_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.27e+08, 's^-1'),
+        n = 0.77,
+        alpha = 0,
+        E0 = (18.73, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""Estimate (Same as 5 memebered ring)""",
+)
+
+entry(
+    index = 830,
+    label = "R2OOJ_S;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.62e+09, 's^-1'),
+        n = 1.1,
+        alpha = 0,
+        E0 = (31.9, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""AG Vandeputte, BMK/cbsb7""",
+)
+
+entry(
+    index = 831,
+    label = "R2OOJ_S;C_pri_rad_intra",
+    kinetics = ArrheniusEP(
+        A = (1.61e+09, 's^-1'),
+        n = 1.09,
+        alpha = 0,
+        E0 = (29.9, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""AG Vandeputte, BMK/cbsb7""",
+)
+
+entry(
+    index = 832,
+    label = "R2OOJ_S;C_rad/H/NonDeC_intra",
+    kinetics = ArrheniusEP(
+        A = (3.27e+09, 's^-1'),
+        n = 1.06,
+        alpha = 0,
+        E0 = (31, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""AG Vandeputte, BMK/cbsb7""",
+)
+

--- a/input/kinetics/families/Intra_Disproportionation/groups.py
+++ b/input/kinetics/families/Intra_Disproportionation/groups.py
@@ -19,6 +19,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*3"]
+
 entry(
     index = 1,
     label = "Rn",

--- a/input/kinetics/families/Intra_Disproportionation/groups.py
+++ b/input/kinetics/families/Intra_Disproportionation/groups.py
@@ -72,7 +72,7 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B]}
 3 *2 R!H u0 {2,[S,D,B]} {4,S} {5,S}
 4 *3 R!H u1 {3,S}
 5 *4 H   u0 {3,S}
@@ -93,7 +93,7 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
 3 *3 R!H u1 {2,[S,D,B,T]} {4,S}
 4 *2 R!H u0 {3,S} {5,S}
 5 *4 H   u0 {4,S}
@@ -107,8 +107,8 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *6 R!H u0 {2,[S,D,B,T]} {4,[S,D,B]}
 4 *2 R!H u0 {3,[S,D,B]} {5,S} {6,S}
 5 *3 R!H u1 {4,S}
 6 *4 H   u0 {4,S}
@@ -129,8 +129,8 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *6 R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
 4 *3 R!H u1 {3,[S,D,B,T]} {5,S}
 5 *2 R!H u0 {4,S} {6,S}
 6 *4 H   u0 {5,S}
@@ -144,9 +144,9 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
-4    R!H u0 {3,[S,D,B,T]} {5,[S,D,B]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *7 R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
+4 *6 R!H u0 {3,[S,D,B,T]} {5,[S,D,B]}
 5 *2 R!H u0 {4,[S,D,B]} {6,S} {7,S}
 6 *3 R!H u1 {5,S}
 7 *4 H   u0 {5,S}
@@ -167,9 +167,9 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
-4    R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *7 R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
+4 *6 R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
 5 *3 R!H u1 {4,[S,D,B,T]} {6,S}
 6 *2 R!H u0 {5,S} {7,S}
 7 *4 H   u0 {6,S}
@@ -183,10 +183,10 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
-4    R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
-5    R!H u0 {4,[S,D,B,T]} {6,[S,D,B]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *7 R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
+4 *8 R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
+5 *6 R!H u0 {4,[S,D,B,T]} {6,[S,D,B]}
 6 *2 R!H u0 {5,[S,D,B]} {7,S} {8,S}
 7 *3 R!H u1 {6,S}
 8 *4 H   u0 {6,S}
@@ -207,10 +207,10 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
-4    R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
-5    R!H u0 {4,[S,D,B,T]} {6,[S,D,B,T]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *7 R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
+4 *8 R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
+5 *6 R!H u0 {4,[S,D,B,T]} {6,[S,D,B,T]}
 6 *3 R!H u1 {5,[S,D,B,T]} {7,S}
 7 *2 R!H u0 {6,S} {8,S}
 8 *4 H   u0 {7,S}
@@ -224,11 +224,11 @@ entry(
     group = 
 """
 1 *1 R!H u1 {2,[S,D,B,T]}
-2    R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
-3    R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
-4    R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
-5    R!H u0 {4,[S,D,B,T]} {6,[S,D,B,T]}
-6    R!H u0 {5,[S,D,B,T]} {7,[S,D,B]}
+2 *5 R!H u0 {1,[S,D,B,T]} {3,[S,D,B,T]}
+3 *7 R!H u0 {2,[S,D,B,T]} {4,[S,D,B,T]}
+4 *8 R!H u0 {3,[S,D,B,T]} {5,[S,D,B,T]}
+5 *9 R!H u0 {4,[S,D,B,T]} {6,[S,D,B,T]}
+6 *6 R!H u0 {5,[S,D,B,T]} {7,[S,D,B]}
 7 *2 R!H u0 {6,[S,D,B]} {8,S} {9,S}
 8 *3 R!H u1 {7,S}
 9 *4 H   u0 {7,S}

--- a/input/kinetics/families/Intra_RH_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_RH_Add_Endocyclic/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['CHANGE_BOND', '*2', '-1', '*3'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "Rn",

--- a/input/kinetics/families/Intra_RH_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_RH_Add_Exocyclic/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['CHANGE_BOND', '*2', -1, '*3'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "Rn",

--- a/input/kinetics/families/Intra_RH_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_RH_Add_Exocyclic/groups.py
@@ -75,39 +75,11 @@ entry(
 )
 
 entry(
-    index = 6,
-    label = "R4_S_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 R!H     u0 {1,S} {4,S}
-4 *2 Cd      u0 {3,S} {5,D}
-5 *3 [Cd,Od] u0 {4,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 7,
-    label = "R4_S_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 R!H u0 {1,S} {4,S}
-4 *2 Ct  u0 {3,S} {5,T}
-5 *3 Ct  u0 {4,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 8,
     label = "R4_D",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *2 C     u0 {3,S} {5,[D,T]}
@@ -117,39 +89,11 @@ entry(
 )
 
 entry(
-    index = 9,
-    label = "R4_D_D",
-    group = 
-"""
-1 *1 Cd      u0 {2,S} {3,D}
-2 *4 H       u0 {1,S}
-3 *5 Cd      u0 {1,D} {4,S}
-4 *2 Cd      u0 {3,S} {5,[D,T]}
-5 *3 [Cd,Od] u0 {4,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 10,
-    label = "R4_D_T",
-    group = 
-"""
-1 *1 Cd u0 {2,S} {3,D}
-2 *4 H  u0 {1,S}
-3 *5 Cd u0 {1,D} {4,S}
-4 *2 Ct u0 {3,S} {5,T}
-5 *3 Ct u0 {4,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 11,
     label = "R4_T",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *2 C     u0 {3,S} {5,[D,T]}
@@ -159,71 +103,15 @@ entry(
 )
 
 entry(
-    index = 12,
-    label = "R4_T_D",
-    group = 
-"""
-1 *1 Ct      u0 {2,S} {3,T}
-2 *4 H       u0 {1,S}
-3 *5 Ct      u0 {1,T} {4,S}
-4 *2 Cd      u0 {3,S} {5,D}
-5 *3 [Cd,Od] u0 {4,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 13,
-    label = "R4_T_T",
-    group = 
-"""
-1 *1 Ct u0 {2,S} {3,T}
-2 *4 H  u0 {1,S}
-3 *5 Ct u0 {1,T} {4,S}
-4 *2 Ct u0 {3,S} {5,T}
-5 *3 Ct u0 {4,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 14,
     label = "R4_B",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *2 C     u0 {3,S} {5,[D,T]}
 5 *3 [C,O] u0 {4,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 15,
-    label = "R4_B_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,B} {4,S}
-4 *2 Cd      u0 {3,S} {5,D}
-5 *3 [Cd,Od] u0 {4,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 16,
-    label = "R4_B_T",
-    group = 
-"""
-1 *1 Cb u0 {2,S} {3,B}
-2 *4 H  u0 {1,S}
-3 *5 Cb u0 {1,B} {4,S}
-4 *2 Ct u0 {3,S} {5,T}
-5 *3 Ct u0 {4,T}
 """,
     kinetics = None,
 )
@@ -251,36 +139,6 @@ entry(
 )
 
 entry(
-    index = 19,
-    label = "R5_SS_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 R!H     u0 {1,S} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *2 Cd      u0 {4,S} {6,D}
-6 *3 [Cd,Od] u0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 20,
-    label = "R5_SS_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 R!H u0 {1,S} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 20,
     label = "R5_SD",
     group = 
@@ -296,76 +154,16 @@ entry(
 )
 
 entry(
-    index = 21,
-    label = "R5_SD_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 R!H     u0 {1,S} {4,D}
-4 *6 R!H     u0 {3,D} {5,S}
-5 *2 Cd      u0 {4,S} {6,D}
-6 *3 [Cd,Od] u0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 22,
-    label = "R5_SD_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 R!H u0 {1,S} {4,D}
-4 *6 R!H u0 {3,D} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 23,
     label = "R5_DS",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
 5 *2 C     u0 {4,S} {6,[D,T]}
 6 *3 [C,O] u0 {5,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 24,
-    label = "R5_DS_D",
-    group = 
-"""
-1 *1 Cd      u0 {2,S} {3,D}
-2 *4 H       u0 {1,S}
-3 *5 Cd      u0 {1,D} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *2 Cd      u0 {4,S} {6,D}
-6 *3 [Cd,Od] u0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 25,
-    label = "R5_DS_T",
-    group = 
-"""
-1 *1 Cd  u0 {2,S} {3,D}
-2 *4 H   u0 {1,S}
-3 *5 Cd  u0 {1,D} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
 """,
     kinetics = None,
 )
@@ -386,76 +184,16 @@ entry(
 )
 
 entry(
-    index = 27,
-    label = "R5_ST_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 Ct      u0 {1,S} {4,T}
-4 *6 Ct      u0 {3,T} {5,S}
-5 *2 Cd      u0 {4,S} {6,D}
-6 *3 [Cd,Od] u0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 28,
-    label = "R5_ST_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 Ct  u0 {1,S} {4,T}
-4 *6 Ct  u0 {3,T} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 29,
     label = "R5_TS",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
 5 *2 C     u0 {4,S} {6,[D,T]}
 6 *3 [C,O] u0 {5,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 30,
-    label = "R5_TS_D",
-    group = 
-"""
-1 *1 Ct      u0 {2,S} {3,T}
-2 *4 H       u0 {1,S}
-3 *5 Ct      u0 {1,T} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *2 Cd      u0 {4,S} {6,D}
-6 *3 [Cd,Od] u0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 31,
-    label = "R5_TS_T",
-    group = 
-"""
-1 *1 Ct  u0 {2,S} {3,T}
-2 *4 H   u0 {1,S}
-3 *5 Ct  u0 {1,T} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
 """,
     kinetics = None,
 )
@@ -476,76 +214,16 @@ entry(
 )
 
 entry(
-    index = 33,
-    label = "R5_SB_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,S} {4,B}
-4 *6 Cb      u0 {3,B} {5,S}
-5 *2 Cd      u0 {4,S} {6,D}
-6 *3 [Cd,Od] u0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 34,
-    label = "R5_SB_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,S} {4,B}
-4 *6 Cb  u0 {3,B} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 35,
     label = "R5_BS",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
 5 *2 C     u0 {4,S} {6,[D,T]}
 6 *3 [C,O] u0 {5,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 36,
-    label = "R5_BS_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,B} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *2 Cd      u0 {4,S} {6,[D,T]}
-6 *3 [Cd,Od] u0 {5,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 37,
-    label = "R5_BS_T",
-    group = 
-"""
-1 *1 Cb  u0 {2,S} {3,B}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,B} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *2 Ct  u0 {4,S} {6,T}
-6 *3 Ct  u0 {5,T}
 """,
     kinetics = None,
 )
@@ -606,38 +284,6 @@ entry(
 )
 
 entry(
-    index = 42,
-    label = "R6_SSS_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 R!H     u0 {1,S} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *7 R!H     u0 {4,S} {6,S}
-6 *2 Cd      u0 {5,S} {7,D}
-7 *3 [Cd,Od] u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 43,
-    label = "R6_SSS_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 R!H u0 {1,S} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *7 R!H u0 {4,S} {6,S}
-6 *2 Ct  u0 {5,S} {7,T}
-7 *3 Ct  u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 44,
     label = "R6_SSM",
     group = 
@@ -654,43 +300,11 @@ entry(
 )
 
 entry(
-    index = 45,
-    label = "R6_SSM_D",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 R!H        u0 {1,S} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[S,D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[S,D,T,B]} {6,S}
-6 *2 Cd         u0 {5,S} {7,D}
-7 *3 [Cd,Od]    u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 46,
-    label = "R6_SSM_T",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 R!H        u0 {1,S} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[S,D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[S,D,T,B]} {6,S}
-6 *2 Ct         u0 {5,S} {7,T}
-7 *3 Ct         u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 47,
     label = "R6_DSR",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *6 R!H   u0 {3,S} {5,[S,D,T,B]}
@@ -706,7 +320,7 @@ entry(
     label = "R6_DSS",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -718,43 +332,11 @@ entry(
 )
 
 entry(
-    index = 49,
-    label = "R6_DSS_D",
-    group = 
-"""
-1 *1 Cd      u0 {2,S} {3,D}
-2 *4 H       u0 {1,S}
-3 *5 Cd      u0 {1,D} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *7 R!H     u0 {4,S} {6,S}
-6 *2 Cd      u0 {5,S} {7,D}
-7 *3 [Cd,Od] u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 50,
-    label = "R6_DSS_T",
-    group = 
-"""
-1 *1 Cd  u0 {2,S} {3,D}
-2 *4 H   u0 {1,S}
-3 *5 Cd  u0 {1,D} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *7 R!H u0 {4,S} {6,S}
-6 *2 Ct  u0 {5,S} {7,T}
-7 *3 Ct  u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 51,
     label = "R6_DSM",
     group = 
 """
-1 *1 Cd         u0 {2,S} {3,D}
+1 *1 R!H         u0 {2,S} {3,D}
 2 *4 H          u0 {1,S}
 3 *5 Cd         u0 {1,D} {4,S}
 4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
@@ -766,43 +348,11 @@ entry(
 )
 
 entry(
-    index = 52,
-    label = "R6_DSM_D",
-    group = 
-"""
-1 *1 Cd         u0 {2,S} {3,D}
-2 *4 H          u0 {1,S}
-3 *5 Cd         u0 {1,D} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *2 Cd         u0 {5,S} {7,D}
-7 *3 [Cd,Od]    u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 53,
-    label = "R6_DSM_T",
-    group = 
-"""
-1 *1 Cd         u0 {2,S} {3,D}
-2 *4 H          u0 {1,S}
-3 *5 Cd         u0 {1,D} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *2 Ct         u0 {5,S} {7,T}
-7 *3 Ct         u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 54,
     label = "R6_TSR",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *6 R!H   u0 {3,S} {5,[S,D,T,B]}
@@ -818,7 +368,7 @@ entry(
     label = "R6_TSS",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -830,43 +380,11 @@ entry(
 )
 
 entry(
-    index = 56,
-    label = "R6_TSS_D",
-    group = 
-"""
-1 *1 Ct      u0 {2,S} {3,T}
-2 *4 H       u0 {1,S}
-3 *5 Ct      u0 {1,T} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *7 R!H     u0 {4,S} {6,S}
-6 *2 Cd      u0 {5,S} {7,D}
-7 *3 [Cd,Cd] u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 57,
-    label = "R6_TSS_T",
-    group = 
-"""
-1 *1 Ct  u0 {2,S} {3,T}
-2 *4 H   u0 {1,S}
-3 *5 Ct  u0 {1,T} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *7 R!H u0 {4,S} {6,S}
-6 *2 Ct  u0 {5,S} {7,T}
-7 *3 Ct  u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 58,
     label = "R6_TSM",
     group = 
 """
-1 *1 Ct         u0 {2,S} {3,T}
+1 *1 R!H         u0 {2,S} {3,T}
 2 *4 H          u0 {1,S}
 3 *5 Ct         u0 {1,T} {4,S}
 4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
@@ -878,43 +396,11 @@ entry(
 )
 
 entry(
-    index = 59,
-    label = "R6_TSM_D",
-    group = 
-"""
-1 *1 Ct         u0 {2,S} {3,T}
-2 *4 H          u0 {1,S}
-3 *5 Ct         u0 {1,T} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *2 Cd         u0 {5,S} {7,D}
-7 *3 [Cd,Od]    u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 60,
-    label = "R6_TSM_T",
-    group = 
-"""
-1 *1 Ct         u0 {2,S} {3,T}
-2 *4 H          u0 {1,S}
-3 *5 Ct         u0 {1,T} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *2 Ct         u0 {5,S} {7,T}
-7 *3 Ct         u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 61,
     label = "R6_BSR",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *6 R!H   u0 {3,S} {5,[S,D,T,B]}
@@ -930,7 +416,7 @@ entry(
     label = "R6_BSS",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -942,81 +428,17 @@ entry(
 )
 
 entry(
-    index = 63,
-    label = "R6_BSS_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,B} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *7 R!H     u0 {4,S} {6,S}
-6 *2 Cd      u0 {5,S} {7,D}
-7 *3 [Cd,Od] u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 64,
-    label = "R6_BSS_T",
-    group = 
-"""
-1 *1 Cb  u0 {2,S} {3,B}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,B} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *7 R!H u0 {4,S} {6,S}
-6 *2 Ct  u0 {5,S} {7,T}
-7 *3 Ct  u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 65,
     label = "R6_BSM",
     group = 
 """
-1 *1 Cb         u0 {2,S} {3,B}
+1 *1 R!H         u0 {2,S} {3,B}
 2 *4 H          u0 {1,S}
 3 *5 Cb         u0 {1,B} {4,S}
 4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
 5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
 6 *2 C          u0 {5,S} {7,[D,T]}
 7 *3 [C,O]      u0 {6,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 66,
-    label = "R6_BSM_D",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cb         u0 {1,B} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *2 Cd         u0 {5,S} {7,D}
-7 *3 [Cd,Od]    u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 67,
-    label = "R6_BSM_T",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cb         u0 {1,B} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *7 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *2 Ct         u0 {5,S} {7,T}
-7 *3 Ct         u0 {6,T}
 """,
     kinetics = None,
 )
@@ -1038,38 +460,6 @@ entry(
 )
 
 entry(
-    index = 69,
-    label = "R6_SMS_D",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 [Cd,Ct,Cb] u0 {1,S} {4,[D,T,B]}
-4 *6 [Cd,Ct,Cb] u0 {3,[D,T,B]} {5,S}
-5 *7 R!H        u0 {4,S} {6,S}
-6 *2 Cd         u0 {5,S} {7,D}
-7 *3 [Cd,Od]    u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 70,
-    label = "R6_SMS_T",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 [Cd,Ct,Cb] u0 {1,S} {4,[D,T,B]}
-4 *6 [Cd,Ct,Cb] u0 {3,[D,T,B]} {5,S}
-5 *7 R!H        u0 {4,S} {6,S}
-6 *2 Ct         u0 {5,S} {7,T}
-7 *3 Ct         u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 71,
     label = "R6_SBB",
     group = 
@@ -1086,81 +476,17 @@ entry(
 )
 
 entry(
-    index = 72,
-    label = "R6_SBB_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,S} {4,B}
-4 *6 Cbf     u0 {3,B} {5,B}
-5 *7 Cb      u0 {4,B} {6,S}
-6 *2 Cd      u0 {5,S} {7,D}
-7 *3 [Cd,Od] u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 73,
-    label = "R6_SBB_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,S} {4,B}
-4 *6 Cbf u0 {3,B} {5,B}
-5 *7 Cb  u0 {4,B} {6,S}
-6 *2 Ct  u0 {5,S} {7,T}
-7 *3 Ct  u0 {6,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 74,
     label = "R6_BBS",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cbf   u0 {1,B} {4,B}
 4 *6 Cb    u0 {3,B} {5,S}
 5 *7 R!H   u0 {4,S} {6,S}
 6 *2 C     u0 {5,S} {7,[D,T]}
 7 *3 [C,O] u0 {6,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 75,
-    label = "R6_BBS_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cbf     u0 {1,B} {4,B}
-4 *6 Cb      u0 {3,B} {5,S}
-5 *7 R!H     u0 {4,S} {6,S}
-6 *2 Cd      u0 {5,S} {7,D}
-7 *3 [Cd,Od] u0 {6,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 76,
-    label = "R6_BBS_T",
-    group = 
-"""
-1 *1 Cb  u0 {2,S} {3,B}
-2 *4 H   u0 {1,S}
-3 *5 Cbf u0 {1,B} {4,B}
-4 *6 Cb  u0 {3,B} {5,S}
-5 *7 R!H u0 {4,S} {6,S}
-6 *2 Ct  u0 {5,S} {7,T}
-7 *3 Ct  u0 {6,T}
 """,
     kinetics = None,
 )
@@ -1224,40 +550,6 @@ entry(
 )
 
 entry(
-    index = 81,
-    label = "R7_SSSS_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 R!H     u0 {1,S} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *8 R!H     u0 {4,S} {6,S}
-6 *7 R!H     u0 {5,S} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 82,
-    label = "R7_SSSS_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 R!H u0 {1,S} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *8 R!H u0 {4,S} {6,S}
-6 *7 R!H u0 {5,S} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 83,
     label = "R7_SSSM",
     group = 
@@ -1275,45 +567,11 @@ entry(
 )
 
 entry(
-    index = 84,
-    label = "R7_SSSM_D",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 R!H        u0 {1,S} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 85,
-    label = "R7_SSSM_T",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 R!H        u0 {1,S} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 86,
     label = "R7_DSSR",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -1330,7 +588,7 @@ entry(
     label = "R7_DSSS",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -1343,45 +601,11 @@ entry(
 )
 
 entry(
-    index = 88,
-    label = "R7_DSSS_D",
-    group = 
-"""
-1 *1 Cd      u0 {2,S} {3,D}
-2 *4 H       u0 {1,S}
-3 *5 Cd      u0 {1,D} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *8 R!H     u0 {4,S} {6,S}
-6 *7 R!H     u0 {5,S} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 89,
-    label = "R7_DSSS_T",
-    group = 
-"""
-1 *1 Cd  u0 {2,S} {3,D}
-2 *4 H   u0 {1,S}
-3 *5 Cd  u0 {1,D} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *8 R!H u0 {4,S} {6,S}
-6 *7 R!H u0 {5,S} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 90,
     label = "R7_DSSM",
     group = 
 """
-1 *1 Cd         u0 {2,S} {3,D}
+1 *1 R!H         u0 {2,S} {3,D}
 2 *4 H          u0 {1,S}
 3 *5 Cd         u0 {1,D} {4,S}
 4 *6 R!H        u0 {3,S} {5,S}
@@ -1394,45 +618,11 @@ entry(
 )
 
 entry(
-    index = 91,
-    label = "R7_DSSM_D",
-    group = 
-"""
-1 *1 Cd         u0 {2,S} {3,D}
-2 *4 H          u0 {1,S}
-3 *5 Cd         u0 {1,D} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 92,
-    label = "R7_DSSM_T",
-    group = 
-"""
-1 *1 Cd         u0 {2,S} {3,D}
-2 *4 H          u0 {1,S}
-3 *5 Cd         u0 {1,D} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 93,
     label = "R7_TSSR",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -1449,7 +639,7 @@ entry(
     label = "R7_TSSS",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -1462,45 +652,11 @@ entry(
 )
 
 entry(
-    index = 95,
-    label = "R7_TSSS_D",
-    group = 
-"""
-1 *1 Ct      u0 {2,S} {3,T}
-2 *4 H       u0 {1,S}
-3 *5 Ct      u0 {1,T} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *8 R!H     u0 {4,S} {6,S}
-6 *7 R!H     u0 {5,S} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 96,
-    label = "R7_TSSS_T",
-    group = 
-"""
-1 *1 Ct  u0 {2,S} {3,T}
-2 *4 H   u0 {1,S}
-3 *5 Ct  u0 {1,T} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *8 R!H u0 {4,S} {6,S}
-6 *7 R!H u0 {5,S} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 97,
     label = "R7_TSSM",
     group = 
 """
-1 *1 Ct         u0 {2,S} {3,T}
+1 *1 R!H         u0 {2,S} {3,T}
 2 *4 H          u0 {1,S}
 3 *5 Ct         u0 {1,T} {4,S}
 4 *6 R!H        u0 {3,S} {5,S}
@@ -1513,45 +669,11 @@ entry(
 )
 
 entry(
-    index = 98,
-    label = "R7_TSSM_D",
-    group = 
-"""
-1 *1 Ct         u0 {2,S} {3,T}
-2 *4 H          u0 {1,S}
-3 *5 Ct         u0 {1,T} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 99,
-    label = "R7_TSSM_T",
-    group = 
-"""
-1 *1 Ct         u0 {2,S} {3,T}
-2 *4 H          u0 {1,S}
-3 *5 Ct         u0 {1,T} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,T}
-8 *3 [Cd,Od]    u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 197,
     label = "R7_BSSR",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -1568,7 +690,7 @@ entry(
     label = "R7_BSSS",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *6 R!H   u0 {3,S} {5,S}
@@ -1581,45 +703,11 @@ entry(
 )
 
 entry(
-    index = 101,
-    label = "R7_BSSS_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,B} {4,S}
-4 *6 R!H     u0 {3,S} {5,S}
-5 *8 R!H     u0 {4,S} {6,S}
-6 *7 R!H     u0 {5,S} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 102,
-    label = "R7_BSSS_T",
-    group = 
-"""
-1 *1 Cb  u0 {2,S} {3,B}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,B} {4,S}
-4 *6 R!H u0 {3,S} {5,S}
-5 *8 R!H u0 {4,S} {6,S}
-6 *7 R!H u0 {5,S} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 103,
     label = "R7_BSSM",
     group = 
 """
-1 *1 Cb         u0 {2,S} {3,B}
+1 *1 R!H         u0 {2,S} {3,B}
 2 *4 H          u0 {1,S}
 3 *5 Cb         u0 {1,B} {4,S}
 4 *6 R!H        u0 {3,S} {5,S}
@@ -1627,40 +715,6 @@ entry(
 6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
 7 *2 C          u0 {6,S} {8,[D,T]}
 8 *3 [C,O]      u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 104,
-    label = "R7_BSSM_D",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cb         u0 {1,B} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 105,
-    label = "R7_BSSM_T",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cb         u0 {1,B} {4,S}
-4 *6 R!H        u0 {3,S} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
 """,
     kinetics = None,
 )
@@ -1700,45 +754,11 @@ entry(
 )
 
 entry(
-    index = 108,
-    label = "R7_SSMS_D",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 R!H        u0 {1,S} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 109,
-    label = "R7_SSMS_T",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 R!H        u0 {1,S} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 110,
     label = "R7_DSMS",
     group = 
 """
-1 *1 Cd         u0 {2,S} {3,D}
+1 *1 R!H         u0 {2,S} {3,D}
 2 *4 H          u0 {1,S}
 3 *5 Cd         u0 {1,D} {4,S}
 4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
@@ -1746,40 +766,6 @@ entry(
 6 *7 R!H        u0 {5,S} {7,S}
 7 *2 C          u0 {6,S} {8,[D,T]}
 8 *3 [C,O]      u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 111,
-    label = "R7_DSMS_D",
-    group = 
-"""
-1 *1 Cd         u0 {2,S} {3,D}
-2 *4 H          u0 {1,S}
-3 *5 Cd         u0 {1,D} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 112,
-    label = "R7_DSMS_T",
-    group = 
-"""
-1 *1 Cd         u0 {2,S} {3,D}
-2 *4 H          u0 {1,S}
-3 *5 Cd         u0 {1,D} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
 """,
     kinetics = None,
 )
@@ -1789,7 +775,7 @@ entry(
     label = "R7_TSMS",
     group = 
 """
-1 *1 Ct         u0 {2,S} {3,T}
+1 *1 R!H         u0 {2,S} {3,T}
 2 *4 H          u0 {1,S}
 3 *5 Ct         u0 {1,T} {4,S}
 4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
@@ -1797,40 +783,6 @@ entry(
 6 *7 R!H        u0 {5,S} {7,S}
 7 *2 C          u0 {6,S} {8,[D,T]}
 8 *3 [C,O]      u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 114,
-    label = "R7_TSMS_D",
-    group = 
-"""
-1 *1 Ct         u0 {2,S} {3,T}
-2 *4 H          u0 {1,S}
-3 *5 Ct         u0 {1,T} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 115,
-    label = "R7_TSMS_T",
-    group = 
-"""
-1 *1 Ct         u0 {2,S} {3,T}
-2 *4 H          u0 {1,S}
-3 *5 Ct         u0 {1,T} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
 """,
     kinetics = None,
 )
@@ -1840,7 +792,7 @@ entry(
     label = "R7_BSMS",
     group = 
 """
-1 *1 Cb         u0 {2,S} {3,B}
+1 *1 R!H         u0 {2,S} {3,B}
 2 *4 H          u0 {1,S}
 3 *5 Cb         u0 {1,B} {4,S}
 4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
@@ -1848,40 +800,6 @@ entry(
 6 *7 R!H        u0 {5,S} {7,S}
 7 *2 C          u0 {6,S} {8,[D,T]}
 8 *3 [C,O]      u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 117,
-    label = "R7_BSMS_D",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cb         u0 {1,B} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 118,
-    label = "R7_BSMS_T",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cb         u0 {1,B} {4,S}
-4 *6 [Cd,Ct,Cb] u0 {3,S} {5,[D,T,B]}
-5 *8 [Cd,Ct,Cb] u0 {4,[D,T,B]} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
 """,
     kinetics = None,
 )
@@ -1921,40 +839,6 @@ entry(
 )
 
 entry(
-    index = 121,
-    label = "R7_SMSS_D",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 [Cd,Ct,Cb] u0 {1,S} {4,[D,T,B]}
-4 *6 [Cd,Ct,Cb] u0 {3,[D,T,B]} {5,S}
-5 *8 R!H        u0 {4,S} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 122,
-    label = "R7_SMSS_T",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 [Cd,Ct,Cb] u0 {1,S} {4,[D,T,B]}
-4 *6 [Cd,Ct,Cb] u0 {3,[D,T,B]} {5,S}
-5 *8 R!H        u0 {4,S} {6,S}
-6 *7 R!H        u0 {5,S} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 123,
     label = "R7_SMSM",
     group = 
@@ -1972,45 +856,11 @@ entry(
 )
 
 entry(
-    index = 124,
-    label = "R7_SMSM_D",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 [Cd,Ct,Cb] u0 {1,S} {4,[D,T,B]}
-4 *6 [Cd,Ct,Cb] u0 {3,[D,T,B]} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 125,
-    label = "R7_SMSM_T",
-    group = 
-"""
-1 *1 R!H        u0 {2,S} {3,S}
-2 *4 H          u0 {1,S}
-3 *5 [Cd,Ct,Cb] u0 {1,S} {4,[D,T,B]}
-4 *6 [Cd,Ct,Cb] u0 {3,[D,T,B]} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 126,
     label = "R7_BBSR",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cbf   u0 {1,B} {4,B}
 4 *6 Cb    u0 {3,B} {5,S}
@@ -2027,7 +877,7 @@ entry(
     label = "R7_BBSS",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cbf   u0 {1,B} {4,B}
 4 *6 Cb    u0 {3,B} {5,S}
@@ -2040,45 +890,11 @@ entry(
 )
 
 entry(
-    index = 128,
-    label = "R7_BBSS_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cbf     u0 {1,B} {4,B}
-4 *6 Cb      u0 {3,B} {5,S}
-5 *8 R!H     u0 {4,S} {6,S}
-6 *7 R!H     u0 {5,S} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 129,
-    label = "R7_BBSS_T",
-    group = 
-"""
-1 *1 Cb  u0 {2,S} {3,B}
-2 *4 H   u0 {1,S}
-3 *5 Cbf u0 {1,B} {4,B}
-4 *6 Cb  u0 {3,B} {5,S}
-5 *8 R!H u0 {4,S} {6,S}
-6 *7 R!H u0 {5,S} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 130,
     label = "R7_BBSM",
     group = 
 """
-1 *1 Cb         u0 {2,S} {3,B}
+1 *1 R!H         u0 {2,S} {3,B}
 2 *4 H          u0 {1,S}
 3 *5 Cbf        u0 {1,B} {4,B}
 4 *6 Cb         u0 {3,B} {5,S}
@@ -2086,40 +902,6 @@ entry(
 6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
 7 *2 C          u0 {6,S} {8,[D,T]}
 8 *3 [C,O]      u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 131,
-    label = "R7_BBSM_D",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cbf        u0 {1,B} {4,B}
-4 *6 Cb         u0 {3,B} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Cd         u0 {6,S} {8,D}
-8 *3 [Cd,Od]    u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 132,
-    label = "R7_BBSM_T",
-    group = 
-"""
-1 *1 Cb         u0 {2,S} {3,B}
-2 *4 H          u0 {1,S}
-3 *5 Cbf        u0 {1,B} {4,B}
-4 *6 Cb         u0 {3,B} {5,S}
-5 *8 [Cd,Ct,Cb] u0 {4,S} {6,[D,T,B]}
-6 *7 [Cd,Ct,Cb] u0 {5,[D,T,B]} {7,S}
-7 *2 Ct         u0 {6,S} {8,T}
-8 *3 Ct         u0 {7,T}
 """,
     kinetics = None,
 )
@@ -2159,45 +941,11 @@ entry(
 )
 
 entry(
-    index = 135,
-    label = "R7_SSBB_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 R!H     u0 {1,S} {4,S}
-4 *6 Cb      u0 {3,S} {5,B}
-5 *8 Cbf     u0 {4,B} {6,B}
-6 *7 Cb      u0 {5,B} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 136,
-    label = "R7_SSBB_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 R!H u0 {1,S} {4,S}
-4 *6 Cb  u0 {3,S} {5,B}
-5 *8 Cbf u0 {4,B} {6,B}
-6 *7 Cb  u0 {5,B} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 137,
     label = "R7_DSBB",
     group = 
 """
-1 *1 Cd    u0 {2,S} {3,D}
+1 *1 R!H    u0 {2,S} {3,D}
 2 *4 H     u0 {1,S}
 3 *5 Cd    u0 {1,D} {4,S}
 4 *6 Cb    u0 {3,S} {5,B}
@@ -2210,45 +958,11 @@ entry(
 )
 
 entry(
-    index = 138,
-    label = "R7_DSBB_D",
-    group = 
-"""
-1 *1 Cd      u0 {2,S} {3,D}
-2 *4 H       u0 {1,S}
-3 *5 Cd      u0 {1,D} {4,S}
-4 *6 Cb      u0 {3,S} {5,B}
-5 *8 Cbf     u0 {4,B} {6,B}
-6 *7 Cb      u0 {5,B} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 139,
-    label = "R7_DSBB_T",
-    group = 
-"""
-1 *1 Cd  u0 {2,S} {3,D}
-2 *4 H   u0 {1,S}
-3 *5 Cd  u0 {1,D} {4,S}
-4 *6 Cb  u0 {3,S} {5,B}
-5 *8 Cbf u0 {4,B} {6,B}
-6 *7 Cb  u0 {5,B} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 140,
     label = "R7_TSBB",
     group = 
 """
-1 *1 Ct    u0 {2,S} {3,T}
+1 *1 R!H    u0 {2,S} {3,T}
 2 *4 H     u0 {1,S}
 3 *5 Ct    u0 {1,T} {4,S}
 4 *6 Cb    u0 {3,S} {5,B}
@@ -2261,45 +975,11 @@ entry(
 )
 
 entry(
-    index = 141,
-    label = "R7_TSBB_D",
-    group = 
-"""
-1 *1 Ct      u0 {2,S} {3,T}
-2 *4 H       u0 {1,S}
-3 *5 Ct      u0 {1,T} {4,S}
-4 *6 Cb      u0 {3,S} {5,B}
-5 *8 Cbf     u0 {4,B} {6,B}
-6 *7 Cb      u0 {5,B} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 142,
-    label = "R7_TSBB_T",
-    group = 
-"""
-1 *1 Ct  u0 {2,S} {3,T}
-2 *4 H   u0 {1,S}
-3 *5 Ct  u0 {1,T} {4,S}
-4 *6 Cb  u0 {3,S} {5,B}
-5 *8 Cbf u0 {4,B} {6,B}
-6 *7 Cb  u0 {5,B} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 143,
     label = "R7_BSBB",
     group = 
 """
-1 *1 Cb    u0 {2,S} {3,B}
+1 *1 R!H    u0 {2,S} {3,B}
 2 *4 H     u0 {1,S}
 3 *5 Cb    u0 {1,B} {4,S}
 4 *6 Cb    u0 {3,S} {5,B}
@@ -2307,40 +987,6 @@ entry(
 6 *7 Cb    u0 {5,B} {7,S}
 7 *2 C     u0 {6,S} {8,[D,T]}
 8 *3 [C,O] u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 144,
-    label = "R7_BSBB_D",
-    group = 
-"""
-1 *1 Cb      u0 {2,S} {3,B}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,B} {4,S}
-4 *6 Cb      u0 {3,S} {5,B}
-5 *8 Cbf     u0 {4,B} {6,B}
-6 *7 Cb      u0 {5,B} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 145,
-    label = "R7_BSBB_T",
-    group = 
-"""
-1 *1 Cb  u0 {2,S} {3,B}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,B} {4,S}
-4 *6 Cb  u0 {3,S} {5,B}
-5 *8 Cbf u0 {4,B} {6,B}
-6 *7 Cb  u0 {5,B} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
 """,
     kinetics = None,
 )
@@ -2358,40 +1004,6 @@ entry(
 6 *7 R!H   u0 {5,S} {7,S}
 7 *2 C     u0 {6,S} {8,[D,T]}
 8 *3 [C,O] u0 {7,[D,T]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 147,
-    label = "R7_SBBS_D",
-    group = 
-"""
-1 *1 R!H     u0 {2,S} {3,S}
-2 *4 H       u0 {1,S}
-3 *5 Cb      u0 {1,S} {4,B}
-4 *6 Cbf     u0 {3,B} {5,B}
-5 *8 Cb      u0 {4,B} {6,S}
-6 *7 R!H     u0 {5,S} {7,S}
-7 *2 Cd      u0 {6,S} {8,D}
-8 *3 [Cd,Od] u0 {7,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 148,
-    label = "R7_SBBS_T",
-    group = 
-"""
-1 *1 R!H u0 {2,S} {3,S}
-2 *4 H   u0 {1,S}
-3 *5 Cb  u0 {1,S} {4,B}
-4 *6 Cbf u0 {3,B} {5,B}
-5 *8 Cb  u0 {4,B} {6,S}
-6 *7 R!H u0 {5,S} {7,S}
-7 *2 Ct  u0 {6,S} {8,T}
-8 *3 Ct  u0 {7,T}
 """,
     kinetics = None,
 )
@@ -2548,7 +1160,7 @@ entry(
     group = 
 """
 1 *1 Cs u0 {2,S} {3,S}
-2 *4 H  u0 {1,S}
+2    H  u0 {1,S}
 3    H  u0 {1,S}
 """,
     kinetics = None,
@@ -2560,7 +1172,7 @@ entry(
     group = 
 """
 1 *1 Cs     u0 {2,S} {3,S} {4,S}
-2 *4 H      u0 {1,S}
+2    H      u0 {1,S}
 3    [Cs,O] u0 {1,S}
 4    H      u0 {1,S}
 """,
@@ -2573,7 +1185,7 @@ entry(
     group = 
 """
 1 *1 Cs            u0 {2,S} {3,S} {4,S}
-2 *4 H             u0 {1,S}
+2    H             u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
 4    H             u0 {1,S}
 """,
@@ -2586,7 +1198,7 @@ entry(
     group = 
 """
 1 *1 Cs     u0 {2,S} {3,S} {4,S}
-2 *4 H      u0 {1,S}
+2    H      u0 {1,S}
 3    [Cs,O] u0 {1,S}
 4    [Cs,O] u0 {1,S}
 """,
@@ -2599,7 +1211,7 @@ entry(
     group = 
 """
 1 *1 Cs            u0 {2,S} {3,S} {4,S}
-2 *4 H             u0 {1,S}
+2    H             u0 {1,S}
 3    [Cs,O]        u0 {1,S}
 4    [Cd,Ct,Cb,CO] u0 {1,S}
 """,
@@ -2612,7 +1224,7 @@ entry(
     group = 
 """
 1 *1 Cs            u0 {2,S} {3,S} {4,S}
-2 *4 H             u0 {1,S}
+2    H             u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
 4    [Cd,Ct,Cb,CO] u0 {1,S}
 """,
@@ -2645,7 +1257,7 @@ entry(
     group = 
 """
 1 *1 Cd u0 {2,S} {3,S}
-2 *4 H  u0 {1,S}
+2    H  u0 {1,S}
 3    R  u0 {1,S}
 """,
     kinetics = None,
@@ -2657,7 +1269,7 @@ entry(
     group = 
 """
 1 *1 Cd u0 {2,S} {3,S}
-2 *4 H  u0 {1,S}
+2    H  u0 {1,S}
 3    H  u0 {1,S}
 """,
     kinetics = None,
@@ -2669,7 +1281,7 @@ entry(
     group = 
 """
 1 *1 Cd     u0 {2,S} {3,S}
-2 *4 H      u0 {1,S}
+2    H      u0 {1,S}
 3    [Cs,O] u0 {1,S}
 """,
     kinetics = None,
@@ -2681,7 +1293,7 @@ entry(
     group = 
 """
 1 *1 Cd            u0 {2,S} {3,S}
-2 *4 H             u0 {1,S}
+2    H             u0 {1,S}
 3    [Cd,Ct,Cb,CO] u0 {1,S}
 """,
     kinetics = None,
@@ -2693,7 +1305,7 @@ entry(
     group = 
 """
 1 *1 Cd u0 {2,S} {3,D}
-2 *4 H  u0 {1,S}
+2    H  u0 {1,S}
 3    Cd u0 {1,D}
 """,
     kinetics = None,
@@ -2705,7 +1317,7 @@ entry(
     group = 
 """
 1 *1 CO u0 {2,S} {3,D}
-2 *4 H  u0 {1,S}
+2    H  u0 {1,S}
 3    O  u0 {1,D}
 """,
     kinetics = None,
@@ -2717,7 +1329,7 @@ entry(
     group = 
 """
 1 *1 Ct u0 {2,S} {3,T}
-2 *4 H  u0 {1,S}
+2    H  u0 {1,S}
 3    Ct u0 {1,T}
 """,
     kinetics = None,
@@ -2728,151 +1340,65 @@ tree(
 L1: Rn
     L2: R4
         L3: R4_S
-            L4: R4_S_D
-            L4: R4_S_T
         L3: R4_D
-            L4: R4_D_D
-            L4: R4_D_T
         L3: R4_T
-            L4: R4_T_D
-            L4: R4_T_T
         L3: R4_B
-            L4: R4_B_D
-            L4: R4_B_T
     L2: R5
         L3: R5_SS
-            L4: R5_SS_D
-            L4: R5_SS_T
         L3: R5_SD
-            L4: R5_SD_D
-            L4: R5_SD_T
         L3: R5_DS
-            L4: R5_DS_D
-            L4: R5_DS_T
         L3: R5_ST
-            L4: R5_ST_D
-            L4: R5_ST_T
         L3: R5_TS
-            L4: R5_TS_D
-            L4: R5_TS_T
         L3: R5_SB
-            L4: R5_SB_D
-            L4: R5_SB_T
         L3: R5_BS
-            L4: R5_BS_D
-            L4: R5_BS_T
     L2: R6
         L3: R6_RSR
             L4: R6_SSR
                 L5: R6_SSS
-                    L6: R6_SSS_D
-                    L6: R6_SSS_T
                 L5: R6_SSM
-                    L6: R6_SSM_D
-                    L6: R6_SSM_T
             L4: R6_DSR
                 L5: R6_DSS
-                    L6: R6_DSS_D
-                    L6: R6_DSS_T
                 L5: R6_DSM
-                    L6: R6_DSM_D
-                    L6: R6_DSM_T
             L4: R6_TSR
                 L5: R6_TSS
-                    L6: R6_TSS_D
-                    L6: R6_TSS_T
                 L5: R6_TSM
-                    L6: R6_TSM_D
-                    L6: R6_TSM_T
             L4: R6_BSR
                 L5: R6_BSS
-                    L6: R6_BSS_D
-                    L6: R6_BSS_T
                 L5: R6_BSM
-                    L6: R6_BSM_D
-                    L6: R6_BSM_T
         L3: R6_SMS
-            L4: R6_SMS_D
-            L4: R6_SMS_T
         L3: R6_SBB
-            L4: R6_SBB_D
-            L4: R6_SBB_T
         L3: R6_BBS
-            L4: R6_BBS_D
-            L4: R6_BBS_T
     L2: R7
         L3: R7_RSSR
             L4: R7_SSSR
                 L5: R7_SSSS
-                    L6: R7_SSSS_D
-                    L6: R7_SSSS_T
                 L5: R7_SSSM
-                    L6: R7_SSSM_D
-                    L6: R7_SSSM_T
             L4: R7_DSSR
                 L5: R7_DSSS
-                    L6: R7_DSSS_D
-                    L6: R7_DSSS_T
                 L5: R7_DSSM
-                    L6: R7_DSSM_D
-                    L6: R7_DSSM_T
             L4: R7_TSSR
                 L5: R7_TSSS
-                    L6: R7_TSSS_D
-                    L6: R7_TSSS_T
                 L5: R7_TSSM
-                    L6: R7_TSSM_D
-                    L6: R7_TSSM_T
             L4: R7_BSSR
                 L5: R7_BSSS
-                    L6: R7_BSSS_D
-                    L6: R7_BSSS_T
                 L5: R7_BSSM
-                    L6: R7_BSSM_D
-                    L6: R7_BSSM_T
         L3: R7_RSMS
             L4: R7_SSMS
-                L5: R7_SSMS_D
-                L5: R7_SSMS_T
             L4: R7_DSMS
-                L5: R7_DSMS_D
-                L5: R7_DSMS_T
             L4: R7_TSMS
-                L5: R7_TSMS_D
-                L5: R7_TSMS_T
             L4: R7_BSMS
-                L5: R7_BSMS_D
-                L5: R7_BSMS_T
         L3: R7_SMSR
             L4: R7_SMSS
-                L5: R7_SMSS_D
-                L5: R7_SMSS_T
             L4: R7_SMSM
-                L5: R7_SMSM_D
-                L5: R7_SMSM_T
         L3: R7_BBSR
             L4: R7_BBSS
-                L5: R7_BBSS_D
-                L5: R7_BBSS_T
             L4: R7_BBSM
-                L5: R7_BBSM_D
-                L5: R7_BBSM_T
         L3: R7_RSBB
             L4: R7_SSBB
-                L5: R7_SSBB_D
-                L5: R7_SSBB_T
             L4: R7_DSBB
-                L5: R7_DSBB_D
-                L5: R7_DSBB_T
             L4: R7_TSBB
-                L5: R7_TSBB_D
-                L5: R7_TSBB_T
             L4: R7_BSBB
-                L5: R7_BSBB_D
-                L5: R7_BSBB_T
         L3: R7_SBBS
-            L4: R7_SBBS_D
-            L4: R7_SBBS_T
 L1: multiplebond_intra
     L2: doublebond_intra
         L3: doublebond_intra_2H

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*1', '1'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "Rn",

--- a/input/kinetics/families/Intra_R_Add_ExoTetCyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_ExoTetCyclic/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['GAIN_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "R1_rad_R2_R3",

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['GAIN_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "Rn",

--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -16,6 +16,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*1', '1'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "RnH",

--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -122,8 +122,8 @@ entry(
     label = "R2H_D",
     group = 
 """
-1 *1 Cd u1 {2,D}
-2 *2 Cd u0 {1,D} {3,S}
+1 *1 R!H u1 {2,D}
+2 *2 R!H u0 {1,D} {3,S}
 3 *3 H  u0 {2,S}
 """,
     kinetics = None,
@@ -134,8 +134,8 @@ entry(
     label = "R2H_B",
     group = 
 """
-1 *1 Cb u1 {2,B}
-2 *2 Cb u0 {1,B} {3,S}
+1 *1 R!H u1 {2,B}
+2 *2 R!H u0 {1,B} {3,S}
 3 *3 H  u0 {2,S}
 """,
     kinetics = None,
@@ -221,12 +221,12 @@ entry(
 
 entry(
     index = 18,
-    label = "R3H_SS_OOCs",
+    label = "R3H_SS_O",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
-3 *2 Cs u0 {2,S} {4,S}
+3 *2 R!H u0 {2,S} {4,S}
 4 *3 H  u0 {3,S}
 """,
     kinetics = None,
@@ -295,7 +295,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,S}
 3 *2 R!H u0 {2,S} {4,S} {5,[S,D,B]}
 4 *3 H   u0 {3,S}
-5    R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+5 *5 R!H u0 {1,[S,D,B]} {3,[S,D,B]}
 """,
     kinetics = None,
 )
@@ -384,7 +384,7 @@ entry(
 """
 1 *1 R!H u1 {2,S}
 2 *4 Cd  u0 {1,S} {3,D}
-3 *2 Cd  u0 {2,D} {4,S}
+3 *2 R!H  u0 {2,D} {4,S}
 4 *3 H   u0 {3,S}
 """,
     kinetics = None,
@@ -397,7 +397,7 @@ entry(
 """
 1 *1 R!H u1 {2,S}
 2 *4 Ct  u0 {1,S} {3,T}
-3 *2 Ct  u0 {2,T} {4,S}
+3 *2 R!H  u0 {2,T} {4,S}
 4 *3 H   u0 {3,S}
 """,
     kinetics = None,
@@ -410,7 +410,7 @@ entry(
 """
 1 *1 R!H u1 {2,S}
 2 *4 Cb  u0 {1,S} {3,B}
-3 *2 Cb  u0 {2,B} {4,S}
+3 *2 R!H  u0 {2,B} {4,S}
 4 *3 H   u0 {3,S}
 """,
     kinetics = None,
@@ -429,12 +429,13 @@ entry(
     kinetics = None,
 )
 
+
 entry(
     index = 32,
     label = "R3H_DS",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *2 R!H u0 {2,S} {4,S}
 4 *3 H   u0 {3,S}
@@ -447,7 +448,7 @@ entry(
     label = "R3H_TS",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *2 R!H u0 {2,S} {4,S}
 4 *3 H   u0 {3,S}
@@ -460,7 +461,7 @@ entry(
     label = "R3H_BS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *2 R!H u0 {2,S} {4,S}
 4 *3 H   u0 {3,S}
@@ -473,9 +474,9 @@ entry(
     label = "R3H_BB",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
-3 *2 Cb  u0 {2,B} {4,S}
+3 *2 R!H  u0 {2,B} {4,S}
 4 *3 H   u0 {3,S}
 """,
     kinetics = None,
@@ -581,13 +582,13 @@ entry(
 
 entry(
     index = 43,
-    label = "R4H_SSS_CsSCsCs",
+    label = "R4H_SSS_SCs",
     group = 
 """
-1 *1 Cs u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Ss u0 {1,S} {3,S}
 3 *5 Cs u0 {2,S} {4,S}
-4 *2 Cs u0 {3,S} {5,S}
+4 *2 R!H u0 {3,S} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -595,13 +596,13 @@ entry(
 
 entry(
     index = 44,
-    label = "R4H_SSS_CsCsSCs",
+    label = "R4H_SSS_CsS",
     group = 
 """
-1 *1 Cs u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Cs u0 {1,S} {3,S}
 3 *5 Ss u0 {2,S} {4,S}
-4 *2 Cs u0 {3,S} {5,S}
+4 *2 R!H u0 {3,S} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -609,13 +610,13 @@ entry(
 
 entry(
     index = 45,
-    label = "R4H_SSS_OOCsCs",
+    label = "R4H_SSS_OCs",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *5 Cs u0 {2,S} {4,S}
-4 *2 Cs u0 {3,S} {5,S}
+4 *2 R!H u0 {3,S} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -623,13 +624,13 @@ entry(
 
 entry(
     index = 46,
-    label = "R4H_SSS_OO(Cs/Cs)Cs",
+    label = "R4H_SSS_O(Cs)Cs",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *5 Cs u0 {2,S} {4,S} {6,S}
-4 *2 Cs u0 {3,S} {5,S}
+4 *2 R!H u0 {3,S} {5,S}
 5 *3 H  u0 {4,S}
 6    Cs u0 {3,S}
 """,
@@ -638,30 +639,16 @@ entry(
 
 entry(
     index = 47,
-    label = "R4H_SSS_OO(Cs/Cs/Cs)Cs",
+    label = "R4H_SSS_O(Cs)CsCs",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *5 Cs u0 {2,S} {4,S} {6,S} {7,S}
-4 *2 Cs u0 {3,S} {5,S}
+4 *2 R!H u0 {3,S} {5,S}
 5 *3 H  u0 {4,S}
 6    Cs u0 {3,S}
 7    Cs u0 {3,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 48,
-    label = "R4H_SSS_OOCsCd",
-    group = 
-"""
-1 *1 Os u1 {2,S}
-2 *4 Os u0 {1,S} {3,S}
-3 *5 Cs u0 {2,S} {4,S}
-4 *2 Cd u0 {3,S} {5,S}
-5 *3 H  u0 {4,S}
 """,
     kinetics = None,
 )
@@ -671,7 +658,7 @@ entry(
     label = "R4H_DSS",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *5 R!H u0 {2,S} {4,S}
 4 *2 R!H u0 {3,S} {5,S}
@@ -685,7 +672,7 @@ entry(
     label = "R4H_TSS",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *5 R!H u0 {2,S} {4,S}
 4 *2 R!H u0 {3,S} {5,S}
@@ -699,7 +686,7 @@ entry(
     label = "R4H_BSS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *5 R!H u0 {2,S} {4,S}
 4 *2 R!H u0 {3,S} {5,S}
@@ -716,7 +703,7 @@ entry(
 1 *1 R!H u1 {2,[S,D,T,B]}
 2 *4 R!H u0 {1,[S,D,T,B]} {3,S}
 3 *5 Cd  u0 {2,S} {4,D}
-4 *2 Cd  u0 {3,D} {5,S}
+4 *2 R!H  u0 {3,D} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -730,7 +717,7 @@ entry(
 1 *1 R!H u1 {2,S}
 2 *4 R!H u0 {1,S} {3,S}
 3 *5 Cd  u0 {2,S} {4,D}
-4 *2 Cd  u0 {3,D} {5,S}
+4 *2 R!H  u0 {3,D} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -741,10 +728,10 @@ entry(
     label = "R4H_DSD",
     group = 
 """
-1 *1 Cd u1 {2,D}
+1 *1 R!H u1 {2,D}
 2 *4 Cd u0 {1,D} {3,S}
 3 *5 Cd u0 {2,S} {4,D}
-4 *2 Cd u0 {3,D} {5,S}
+4 *2 R!H u0 {3,D} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -755,10 +742,10 @@ entry(
     label = "R4H_TSD",
     group = 
 """
-1 *1 Ct u1 {2,T}
+1 *1 R!H u1 {2,T}
 2 *4 Ct u0 {1,T} {3,S}
 3 *5 Cd u0 {2,S} {4,D}
-4 *2 Cd u0 {3,D} {5,S}
+4 *2 R!H u0 {3,D} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -769,10 +756,10 @@ entry(
     label = "R4H_BSD",
     group = 
 """
-1 *1 Cb u1 {2,B}
+1 *1 R!H u1 {2,B}
 2 *4 Cb u0 {1,B} {3,S}
 3 *5 Cd u0 {2,S} {4,D}
-4 *2 Cd u0 {3,D} {5,S}
+4 *2 R!H u0 {3,D} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -786,7 +773,7 @@ entry(
 1 *1 R!H u1 {2,[S,D,T,B]}
 2 *4 R!H u0 {1,[S,D,T,B]} {3,S}
 3 *5 Ct  u0 {2,S} {4,T}
-4 *2 Ct  u0 {3,T} {5,S}
+4 *2 R!H  u0 {3,T} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -800,7 +787,7 @@ entry(
 1 *1 R!H u1 {2,S}
 2 *4 R!H u0 {1,S} {3,S}
 3 *5 Ct  u0 {2,S} {4,T}
-4 *2 Ct  u0 {3,T} {5,S}
+4 *2 R!H  u0 {3,T} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -811,10 +798,10 @@ entry(
     label = "R4H_DST",
     group = 
 """
-1 *1 Cd u1 {2,D}
+1 *1 R!H u1 {2,D}
 2 *4 Cd u0 {1,D} {3,S}
 3 *5 Ct u0 {2,S} {4,T}
-4 *2 Ct u0 {3,T} {5,S}
+4 *2 R!H u0 {3,T} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -825,10 +812,10 @@ entry(
     label = "R4H_TST",
     group = 
 """
-1 *1 Ct u1 {2,T}
+1 *1 R!H u1 {2,T}
 2 *4 Ct u0 {1,T} {3,S}
 3 *5 Ct u0 {2,S} {4,T}
-4 *2 Ct u0 {3,T} {5,S}
+4 *2 R!H u0 {3,T} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -839,10 +826,10 @@ entry(
     label = "R4H_BST",
     group = 
 """
-1 *1 Cb u1 {2,B}
+1 *1 R!H u1 {2,B}
 2 *4 Cb u0 {1,B} {3,S}
 3 *5 Ct u0 {2,S} {4,T}
-4 *2 Ct u0 {3,T} {5,S}
+4 *2 R!H u0 {3,T} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -856,7 +843,7 @@ entry(
 1 *1 R!H u1 {2,[S,D,T,B]}
 2 *4 R!H u0 {1,[S,D,T,B]} {3,S}
 3 *5 Cb  u0 {2,S} {4,B}
-4 *2 Cb  u0 {3,B} {5,S}
+4 *2 R!H  u0 {3,B} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -870,7 +857,7 @@ entry(
 1 *1 R!H u1 {2,S}
 2 *4 R!H u0 {1,S} {3,S}
 3 *5 Cb  u0 {2,S} {4,B}
-4 *2 Cb  u0 {3,B} {5,S}
+4 *2 R!H  u0 {3,B} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -881,10 +868,10 @@ entry(
     label = "R4H_DSB",
     group = 
 """
-1 *1 Cd u1 {2,D}
+1 *1 R!H u1 {2,D}
 2 *4 Cd u0 {1,D} {3,S}
 3 *5 Cb u0 {2,S} {4,B}
-4 *2 Cb u0 {3,B} {5,S}
+4 *2 R!H u0 {3,B} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -895,10 +882,10 @@ entry(
     label = "R4H_TSB",
     group = 
 """
-1 *1 Ct u1 {2,T}
+1 *1 R!H u1 {2,T}
 2 *4 Ct u0 {1,T} {3,S}
 3 *5 Cb u0 {2,S} {4,B}
-4 *2 Cb u0 {3,B} {5,S}
+4 *2 R!H u0 {3,B} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -909,10 +896,10 @@ entry(
     label = "R4H_BSB",
     group = 
 """
-1 *1 Cb u1 {2,B}
+1 *1 R!H u1 {2,B}
 2 *4 Cb u0 {1,B} {3,S}
 3 *5 Cb u0 {2,S} {4,B}
-4 *2 Cb u0 {3,B} {5,S}
+4 *2 R!H u0 {3,B} {5,S}
 5 *3 H  u0 {4,S}
 """,
     kinetics = None,
@@ -982,7 +969,7 @@ entry(
 1 *1 R!H       u1 {2,S}
 2 *4 [Cb,Cd]   u0 {1,S} {3,[D,B]}
 3 *5 [Cbf,Cdd] u0 {2,[D,B]} {4,[D,B]}
-4 *2 [Cb,Cd]   u0 {3,[D,B]} {5,S}
+4 *2 R!H   u0 {3,[D,B]} {5,S}
 5 *3 H         u0 {4,S}
 """,
     kinetics = None,
@@ -996,7 +983,7 @@ entry(
 1 *1 R!H u1 {2,S}
 2 *4 Cb  u0 {1,S} {3,B}
 3 *5 Cbf u0 {2,B} {4,B}
-4 *2 Cb  u0 {3,B} {5,S}
+4 *2 R!H u0 {3,B} {5,S}
 5 *3 H   u0 {4,S}
 """,
     kinetics = None,
@@ -1007,7 +994,7 @@ entry(
     label = "R4H_MMS",
     group = 
 """
-1 *1 [Cb,Cd]   u1 {2,[D,B]}
+1 *1 R!H       u1 {2,[D,B]}
 2 *4 [Cbf,Cdd] u0 {1,[D,B]} {3,[D,B]}
 3 *5 [Cb,Cd]   u0 {2,[D,B]} {4,S}
 4 *2 R!H       u0 {3,S} {5,S}
@@ -1021,7 +1008,7 @@ entry(
     label = "R4H_BBS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *5 Cb  u0 {2,B} {4,S}
 4 *2 R!H u0 {3,S} {5,S}
@@ -1035,10 +1022,10 @@ entry(
     label = "R4H_BBB",
     group = 
 """
-1  *1 Cb       u1 {2,B} {15,B}
+1  *1 R!H       u1 {2,B} {15,B}
 2  *4 Cbf      u0 {1,B} {3,B} {12,B}
 3  *5 Cbf      u0 {2,B} {4,B} {9,B}
-4  *2 Cb       u0 {3,B} {5,S} {6,B}
+4  *2 R!H       u0 {3,B} {5,S} {6,B}
 5  *3 H        u0 {4,S}
 6     [Cb,Cbf] u0 {4,B} {7,B}
 7     [Cb,Cbf] u0 {6,B} {8,B}
@@ -1176,14 +1163,14 @@ entry(
 
 entry(
     index = 82,
-    label = "R5H_CCCC_O",
+    label = "R5H_CCC",
     group = 
 """
-1 *1 O u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 C u0 {1,S} {3,S}
 3 *6 C u0 {2,S} {4,S}
 4 *5 C u0 {3,S} {5,S}
-5 *2 C u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H u0 {5,S}
 """,
     kinetics = None,
@@ -1191,14 +1178,14 @@ entry(
 
 entry(
     index = 266,
-    label = "R5H_C(Od)CCC_O",
+    label = "R5H_CCC_O",
     group = 
 """
-1 *1 O  u1 {2,S}
+1 *1 R!H  u1 {2,S}
 2 *4 C  u0 {1,S} {3,S}
 3 *6 C  u0 {2,S} {4,S}
 4 *5 C  u0 {3,S} {5,S}
-5 *2 CO u0 {4,S} {6,S} {7,D}
+5 *2 R!H u0 {4,S} {6,S} {7,D}
 6 *3 H  u0 {5,S}
 7    Od u0 {5,D}
 """,
@@ -1207,14 +1194,14 @@ entry(
 
 entry(
     index = 267,
-    label = "R5H_CC(Od)CC_O",
+    label = "R5H_CC(Od)CC",
     group = 
 """
-1 *1 O  u1 {2,S}
+1 *1 R!H  u1 {2,S}
 2 *4 C  u0 {1,S} {3,S}
 3 *6 C  u0 {2,S} {4,S}
 4 *5 CO u0 {3,S} {5,S} {7,D}
-5 *2 C  u0 {4,S} {6,S}
+5 *2 R!H  u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Od u0 {4,D}
 """,
@@ -1223,14 +1210,14 @@ entry(
 
 entry(
     index = 268,
-    label = "R5H_CCC(Od)C_O",
+    label = "R5H_CCC(Od)C",
     group = 
 """
-1 *1 O  u1 {2,S}
+1 *1 R!H  u1 {2,S}
 2 *4 C  u0 {1,S} {3,S}
 3 *6 CO u0 {2,S} {4,S} {7,D}
 4 *5 C  u0 {3,S} {5,S}
-5 *2 C  u0 {4,S} {6,S}
+5 *2 R!H  u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Od u0 {3,D}
 """,
@@ -1239,14 +1226,14 @@ entry(
 
 entry(
     index = 269,
-    label = "R5H_CCCC(Od)_O",
+    label = "R5H_CCCC(Od)",
     group = 
 """
-1 *1 O  u1 {2,S}
+1 *1 R!H  u1 {2,S}
 2 *4 CO u0 {1,S} {3,S} {7,D}
 3 *6 C  u0 {2,S} {4,S}
 4 *5 C  u0 {3,S} {5,S}
-5 *2 C  u0 {4,S} {6,S}
+5 *2 R!H  u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Od u0 {2,D}
 """,
@@ -1255,14 +1242,14 @@ entry(
 
 entry(
     index = 83,
-    label = "R5H_SSSS_CsCsCsSCs",
+    label = "R5H_SSSS_CsCsS",
     group = 
 """
-1 *1 Cs u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Cs u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S}
 4 *5 Ss u0 {3,S} {5,S}
-5 *2 Cs u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 """,
     kinetics = None,
@@ -1270,14 +1257,14 @@ entry(
 
 entry(
     index = 84,
-    label = "R5H_SSSS_OOCCC",
+    label = "R5H_SSSS_OCC",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S}
 4 *5 Cs u0 {3,S} {5,S}
-5 *2 Cs u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 """,
     kinetics = None,
@@ -1285,14 +1272,14 @@ entry(
 
 entry(
     index = 85,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs",
+    label = "R5H_SSSS_OCC_C",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S} {7,S}
 4 *5 Cs u0 {3,S} {5,S}
-5 *2 Cs u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Cs u0 {3,S}
 """,
@@ -1301,14 +1288,14 @@ entry(
 
 entry(
     index = 86,
-    label = "R5H_SSSS_OO(Cs/Cs/Cs)Cs",
+    label = "R5H_SSSS_OCC_CC",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S} {7,S} {8,S}
 4 *5 Cs u0 {3,S} {5,S}
-5 *2 Cs u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Cs u0 {3,S}
 8    Cs u0 {3,S}
@@ -1318,14 +1305,14 @@ entry(
 
 entry(
     index = 87,
-    label = "R5H_SSSS_OOCs(Cs/Cs)",
+    label = "R5H_SSSS_OCs(Cs/Cs)",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S}
 4 *5 Cs u0 {3,S} {5,S} {7,S}
-5 *2 Cs u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Cs u0 {4,S}
 """,
@@ -1334,14 +1321,14 @@ entry(
 
 entry(
     index = 88,
-    label = "R5H_SSSS_OOCs(Cs/Cs/Cs)",
+    label = "R5H_SSSS_OCs(Cs/Cs/Cs)",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S}
 4 *5 Cs u0 {3,S} {5,S} {7,S} {8,S}
-5 *2 Cs u0 {4,S} {6,S}
+5 *2 R!H u0 {4,S} {6,S}
 6 *3 H  u0 {5,S}
 7    Cs u0 {4,S}
 8    Cs u0 {4,S}
@@ -1358,7 +1345,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cd  u0 {3,S} {5,D}
-5 *2 Cd  u0 {4,D} {6,S}
+5 *2 R!H  u0 {4,D} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1373,7 +1360,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Ct  u0 {3,S} {5,T}
-5 *2 Ct  u0 {4,T} {6,S}
+5 *2 R!H  u0 {4,T} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1388,7 +1375,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cb  u0 {3,S} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1399,7 +1386,7 @@ entry(
     label = "R5H_DSSR",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 R!H u0 {3,S} {5,[S,D,T,B]}
@@ -1414,7 +1401,7 @@ entry(
     label = "R5H_DSSS",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 R!H u0 {3,S} {5,S}
@@ -1429,11 +1416,11 @@ entry(
     label = "R5H_DSSD",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cd  u0 {3,S} {5,D}
-5 *2 Cd  u0 {4,D} {6,S}
+5 *2 R!H  u0 {4,D} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1444,11 +1431,11 @@ entry(
     label = "R5H_DSST",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Ct  u0 {3,S} {5,T}
-5 *2 Ct  u0 {4,T} {6,S}
+5 *2 R!H  u0 {4,T} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1459,11 +1446,11 @@ entry(
     label = "R5H_DSSB",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cb  u0 {3,S} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1474,7 +1461,7 @@ entry(
     label = "R5H_TSSR",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 R!H u0 {3,S} {5,[S,D,T,B]}
@@ -1489,7 +1476,7 @@ entry(
     label = "R5H_TSSS",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 R!H u0 {3,S} {5,S}
@@ -1504,11 +1491,11 @@ entry(
     label = "R5H_TSSD",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cd  u0 {3,S} {5,D}
-5 *2 Cd  u0 {4,D} {6,S}
+5 *2 R!H  u0 {4,D} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1519,11 +1506,11 @@ entry(
     label = "R5H_TSST",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Ct  u0 {3,S} {5,T}
-5 *2 Ct  u0 {4,T} {6,S}
+5 *2 R!H  u0 {4,T} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1534,11 +1521,11 @@ entry(
     label = "R5H_TSSB",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cb  u0 {3,S} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1549,7 +1536,7 @@ entry(
     label = "R5H_BSSR",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 R!H u0 {3,S} {5,[S,D,T,B]}
@@ -1564,7 +1551,7 @@ entry(
     label = "R5H_BSSS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 R!H u0 {3,S} {5,S}
@@ -1579,11 +1566,11 @@ entry(
     label = "R5H_BSSD",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cd  u0 {3,S} {5,D}
-5 *2 Cd  u0 {4,D} {6,S}
+5 *2 R!H  u0 {4,D} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1594,11 +1581,11 @@ entry(
     label = "R5H_BSST",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Ct  u0 {3,S} {5,T}
-5 *2 Ct  u0 {4,T} {6,S}
+5 *2 R!H  u0 {4,T} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1609,11 +1596,11 @@ entry(
     label = "R5H_BSSB",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 R!H u0 {2,S} {4,S}
 4 *5 Cb  u0 {3,S} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1654,7 +1641,7 @@ entry(
     label = "R5H_DSMS",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 R!H u0 {2,S} {4,[D,T,B]}
 4 *5 R!H u0 {3,[D,T,B]} {5,S}
@@ -1669,7 +1656,7 @@ entry(
     label = "R5H_TSMS",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 R!H u0 {2,S} {4,[D,T,B]}
 4 *5 R!H u0 {3,[D,T,B]} {5,S}
@@ -1684,7 +1671,7 @@ entry(
     label = "R5H_BSMS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 R!H u0 {2,S} {4,[D,T,B]}
 4 *5 R!H u0 {3,[D,T,B]} {5,S}
@@ -1733,7 +1720,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,[D,T,B]}
 3 *6 R!H u0 {2,[D,T,B]} {4,S}
 4 *5 Cd  u0 {3,S} {5,D}
-5 *2 Cd  u0 {4,D} {6,S}
+5 *2 R!H  u0 {4,D} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1748,7 +1735,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,[D,T,B]}
 3 *6 R!H u0 {2,[D,T,B]} {4,S}
 4 *5 Ct  u0 {3,S} {5,T}
-5 *2 Ct  u0 {4,T} {6,S}
+5 *2 R!H  u0 {4,T} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1763,7 +1750,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,[D,T,B]}
 3 *6 R!H u0 {2,[D,T,B]} {4,S}
 4 *5 Cb  u0 {3,S} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1774,7 +1761,7 @@ entry(
     label = "R5H_BBSR",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *5 R!H u0 {3,S} {5,[S,D,T,B]}
@@ -1789,7 +1776,7 @@ entry(
     label = "R5H_BBSS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *5 R!H u0 {3,S} {5,S}
@@ -1804,11 +1791,11 @@ entry(
     label = "R5H_BBSD",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *5 Cd  u0 {3,S} {5,D}
-5 *2 Cd  u0 {4,D} {6,S}
+5 *2 R!H  u0 {4,D} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1819,11 +1806,11 @@ entry(
     label = "R5H_BBST",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *5 Ct  u0 {3,S} {5,T}
-5 *2 Ct  u0 {4,T} {6,S}
+5 *2 R!H  u0 {4,T} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1834,11 +1821,11 @@ entry(
     label = "R5H_BBSB",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *5 Cb  u0 {3,S} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1853,7 +1840,7 @@ entry(
 2 *4 R!H u0 {1,[S,D,T,B]} {3,S}
 3 *6 Cb  u0 {2,S} {4,B}
 4 *5 Cbf u0 {3,B} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1868,7 +1855,7 @@ entry(
 2 *4 R!H u0 {1,S} {3,S}
 3 *6 Cb  u0 {2,S} {4,B}
 4 *5 Cbf u0 {3,B} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1879,11 +1866,11 @@ entry(
     label = "R5H_DSBB",
     group = 
 """
-1 *1 Cd  u1 {2,D}
+1 *1 R!H  u1 {2,D}
 2 *4 Cd  u0 {1,D} {3,S}
 3 *6 Cb  u0 {2,S} {4,B}
 4 *5 Cbf u0 {3,B} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1894,11 +1881,11 @@ entry(
     label = "R5H_TSBB",
     group = 
 """
-1 *1 Ct  u1 {2,T}
+1 *1 R!H  u1 {2,T}
 2 *4 Ct  u0 {1,T} {3,S}
 3 *6 Cb  u0 {2,S} {4,B}
 4 *5 Cbf u0 {3,B} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1909,11 +1896,11 @@ entry(
     label = "R5H_BSBB",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cb  u0 {1,B} {3,S}
 3 *6 Cb  u0 {2,S} {4,B}
 4 *5 Cbf u0 {3,B} {5,B}
-5 *2 Cb  u0 {4,B} {6,S}
+5 *2 R!H  u0 {4,B} {6,S}
 6 *3 H   u0 {5,S}
 """,
     kinetics = None,
@@ -1943,7 +1930,7 @@ entry(
 2  *4 Cb       u0 {1,S} {3,B} {16,B}
 3  *6 Cbf      u0 {2,B} {4,B} {13,B}
 4  *5 Cbf      u0 {3,B} {5,B} {10,B}
-5  *2 Cb       u0 {4,B} {6,S} {7,B}
+5  *2 R!H       u0 {4,B} {6,S} {7,B}
 6  *3 H        u0 {5,S}
 7     [Cb,Cbf] u0 {5,B} {8,B}
 8     [Cb,Cbf] u0 {7,B} {9,B}
@@ -1964,7 +1951,7 @@ entry(
     label = "R5H_BBBS",
     group = 
 """
-1  *1 Cb       u1 {2,B} {16,B}
+1  *1 R!H       u1 {2,B} {16,B}
 2  *4 Cbf      u0 {1,B} {3,B} {13,B}
 3  *6 Cbf      u0 {2,B} {4,B} {10,B}
 4  *5 Cb       u0 {3,B} {5,S} {7,B}
@@ -1989,11 +1976,11 @@ entry(
     label = "R5H_BBBB",
     group = 
 """
-1  *1 Cb       u1 {2,B} {19,B}
+1  *1 R!H       u1 {2,B} {19,B}
 2  *4 Cbf      u0 {1,B} {3,B} {16,B}
 3  *6 Cbf      u0 {2,B} {4,B} {13,B}
 4  *5 Cbf      u0 {3,B} {5,B} {10,B}
-5  *2 Cb       u0 {4,B} {6,S} {7,B}
+5  *2 R!H       u0 {4,B} {6,S} {7,B}
 6  *3 H        u0 {5,S}
 7     [Cb,Cbf] u0 {5,B} {8,B}
 8     [Cb,Cbf] u0 {7,B} {9,B}
@@ -2161,12 +2148,12 @@ entry(
     label = "R6H_SSSSS_OO",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S}
 4 *7 Cs u0 {3,S} {5,S}
 5 *5 Cs u0 {4,S} {6,S}
-6 *2 Cs u0 {5,S} {7,S}
+6 *2 R!H u0 {5,S} {7,S}
 7 *3 H  u0 {6,S}
 """,
     kinetics = None,
@@ -2177,12 +2164,12 @@ entry(
     label = "R6H_SSSSS_OO(Cs/Cs)Cs",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S} {8,S}
 4 *7 Cs u0 {3,S} {5,S}
 5 *5 Cs u0 {4,S} {6,S}
-6 *2 Cs u0 {5,S} {7,S}
+6 *2 R!H u0 {5,S} {7,S}
 7 *3 H  u0 {6,S}
 8    Cs u0 {3,S}
 """,
@@ -2194,12 +2181,12 @@ entry(
     label = "R6H_SSSSS_OO(Cs/Cs)C(Cs/Cs)",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S} {8,S}
 4 *7 Cs u0 {3,S} {5,S}
 5 *5 Cs u0 {4,S} {6,S}
-6 *2 Cs u0 {5,S} {7,S} {9,S}
+6 *2 R!H u0 {5,S} {7,S} {9,S}
 7 *3 H  u0 {6,S}
 8    Cs u0 {3,S}
 9    Cs u0 {6,S}
@@ -2212,12 +2199,12 @@ entry(
     label = "R6H_SSSSS_OOCCC(Cs/Cs)",
     group = 
 """
-1 *1 Os u1 {2,S}
+1 *1 R!H u1 {2,S}
 2 *4 Os u0 {1,S} {3,S}
 3 *6 Cs u0 {2,S} {4,S}
 4 *7 Cs u0 {3,S} {5,S}
 5 *5 Cs u0 {4,S} {6,S}
-6 *2 Cs u0 {5,S} {7,S} {8,S}
+6 *2 R!H u0 {5,S} {7,S} {8,S}
 7 *3 H  u0 {6,S}
 8    Cs u0 {6,S}
 """,
@@ -2601,7 +2588,7 @@ entry(
     label = "R6H_BBSRS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *7 R!H u0 {3,S} {5,[S,D,T,B]}
@@ -2617,7 +2604,7 @@ entry(
     label = "R6H_BBSSM",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *7 R!H u0 {3,S} {5,S}
@@ -2633,12 +2620,12 @@ entry(
     label = "R6H_BBSBB",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cb  u0 {2,B} {4,S}
 4 *7 Cb  u0 {3,S} {5,B}
 5 *5 Cbf u0 {4,B} {6,B}
-6 *2 Cb  u0 {5,B} {7,S}
+6 *2 R!H  u0 {5,B} {7,S}
 7 *3 H   u0 {6,S}
 """,
     kinetics = None,
@@ -2681,7 +2668,7 @@ entry(
     label = "R6H_BBBSR",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cbf u0 {2,B} {4,B}
 4 *7 Cb  u0 {3,B} {5,S}
@@ -2718,7 +2705,7 @@ entry(
 3 *6 Cb  u0 {2,S} {4,B}
 4 *7 Cbf u0 {3,B} {5,B}
 5 *5 Cbf u0 {4,B} {6,B}
-6 *2 Cb  u0 {5,B} {7,S}
+6 *2 R!H  u0 {5,B} {7,S}
 7 *3 H   u0 {6,S}
 """,
     kinetics = None,
@@ -2734,7 +2721,7 @@ entry(
 3 *6 Cbf u0 {2,B} {4,B}
 4 *7 Cbf u0 {3,B} {5,B}
 5 *5 Cbf u0 {4,B} {6,B}
-6 *2 Cb  u0 {5,B} {7,S}
+6 *2 R!H  u0 {5,B} {7,S}
 7 *3 H   u0 {6,S}
 """,
     kinetics = None,
@@ -2745,7 +2732,7 @@ entry(
     label = "R6H_BBBBS",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cbf u0 {2,B} {4,B}
 4 *7 Cbf u0 {3,B} {5,B}
@@ -2761,12 +2748,12 @@ entry(
     label = "R6H_BBBBB",
     group = 
 """
-1 *1 Cb  u1 {2,B}
+1 *1 R!H  u1 {2,B}
 2 *4 Cbf u0 {1,B} {3,B}
 3 *6 Cbf u0 {2,B} {4,B}
 4 *7 Cbf u0 {3,B} {5,B}
 5 *5 Cbf u0 {4,B} {6,B}
-6 *2 Cb  u0 {5,B} {7,S}
+6 *2 R!H  u0 {5,B} {7,S}
 7 *3 H   u0 {6,S}
 """,
     kinetics = None,
@@ -2896,7 +2883,7 @@ entry(
     label = "R7H_OOCs4",
     group = 
 """
-1 *1 Os  u1 {2,S}
+1 *1 R!H  u1 {2,S}
 2 *4 Os  u0 {1,S} {3,S}
 3 *6 R!H u0 {2,S} {4,[S,D,T,B]}
 4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
@@ -2913,7 +2900,7 @@ entry(
     label = "R7H_OOCCCC(Cs/Cs)",
     group = 
 """
-1 *1 Os  u1 {2,S}
+1 *1 R!H  u1 {2,S}
 2 *4 Os  u0 {1,S} {3,S}
 3 *6 R!H u0 {2,S} {4,[S,D,T,B]}
 4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
@@ -3017,7 +3004,7 @@ entry(
     group = 
 """
 1 *1 Ct u1 {2,T}
-2 *4 Ct u0 {1,T}
+2    Ct u0 {1,T}
 """,
     kinetics = None,
 )
@@ -3028,7 +3015,7 @@ entry(
     group = 
 """
 1 *1 Cb       u1 {2,B}
-2 *4 [Cb,Cbf] u0 {1,B}
+2    [Cb,Cbf] u0 {1,B}
 """,
     kinetics = None,
 )
@@ -3925,7 +3912,7 @@ L1: RnH
             L4: R3H_SR
                 L5: R3H_SS
                     L6: R3H_SS_2Cd
-                    L6: R3H_SS_OOCs
+                    L6: R3H_SS_O
                     L6: R3H_SS_Cs
                     L6: R3H_SS_S
                     L6: R3H_SS_12cy3
@@ -3951,12 +3938,11 @@ L1: RnH
             L4: R4H_RSR
                 L5: R4H_RSS
                     L6: R4H_SSS
-                        L7: R4H_SSS_CsSCsCs
-                        L7: R4H_SSS_CsCsSCs
-                        L7: R4H_SSS_OOCsCs
-                            L8: R4H_SSS_OO(Cs/Cs)Cs
-                                L9: R4H_SSS_OO(Cs/Cs/Cs)Cs
-                        L7: R4H_SSS_OOCsCd
+                        L7: R4H_SSS_SCs
+                        L7: R4H_SSS_CsS
+                        L7: R4H_SSS_OCs
+                            L8: R4H_SSS_O(Cs)Cs
+                                L9: R4H_SSS_O(Cs)CsCs
                     L6: R4H_DSS
                     L6: R4H_TSS
                     L6: R4H_BSS
@@ -3992,17 +3978,17 @@ L1: RnH
             L4: R5H_RSSR
                 L5: R5H_SSSR
                     L6: R5H_SSSS
-                        L7: R5H_CCCC_O
-                            L8: R5H_C(Od)CCC_O
-                            L8: R5H_CC(Od)CC_O
-                            L8: R5H_CCC(Od)C_O
-                            L8: R5H_CCCC(Od)_O
-                        L7: R5H_SSSS_CsCsCsSCs
-                        L7: R5H_SSSS_OOCCC
-                            L8: R5H_SSSS_OO(Cs/Cs)Cs
-                                L9: R5H_SSSS_OO(Cs/Cs/Cs)Cs
-                            L8: R5H_SSSS_OOCs(Cs/Cs)
-                                L9: R5H_SSSS_OOCs(Cs/Cs/Cs)
+                        L7: R5H_CCC
+                            L8: R5H_CCC_O
+                            L8: R5H_CC(Od)CC
+                            L8: R5H_CCC(Od)C
+                            L8: R5H_CCCC(Od)
+                        L7: R5H_SSSS_CsCsS
+                        L7: R5H_SSSS_OCC
+                            L8: R5H_SSSS_OCC_C
+                                L9: R5H_SSSS_OCC_CC
+                            L8: R5H_SSSS_OCs(Cs/Cs)
+                                L9: R5H_SSSS_OCs(Cs/Cs/Cs)
                     L6: R5H_SSSD
                     L6: R5H_SSST
                     L6: R5H_SSSB

--- a/input/kinetics/families/intra_H_migration/groupsTest.py
+++ b/input/kinetics/families/intra_H_migration/groupsTest.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "intra_H_migration/groups"
+shortDesc = u""
+longDesc = u"""
+
+"""
+
+template(reactants=["RnH"], products=["RnH"], ownReverse=True)
+
+recipe(actions=[
+    ['BREAK_BOND', '*2', 1, '*3'],
+    ['FORM_BOND', '*1', 1, '*3'],
+    ['GAIN_RADICAL', '*2', '1'],
+    ['LOSE_RADICAL', '*1', '1'],
+])
+
+entry(
+    index = 1,
+    label = "RnH",
+    group = "OR{R2Hall, R3Hall, R4Hall, R5Hall, R6Hall, R7Hall}",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "Y_rad_out",
+    group = 
+"""
+1 *1 R!H u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
+    label = "XH_out",
+    group = 
+"""
+1 *2 R!H u0 {2,S}
+2 *3 H   u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 74,
+    label = "R5Hall",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 75,
+    label = "R5HJ_1",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u1 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 76,
+    label = "R5HJ_2",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u1 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 77,
+    label = "R5HJ_3",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u1 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 78,
+    label = "R5H",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *5 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *2 R!H u0 {4,[S,D,T,B]} {6,S}
+6 *3 H   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 131,
+    label = "R6Hall",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H ux {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 132,
+    label = "R6HJ_1",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u1 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 133,
+    label = "R6HJ_2",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u1 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 134,
+    label = "R6HJ_3",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u1 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 135,
+    label = "R6HJ_4",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u1 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 136,
+    label = "R6H",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3 *6 R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+4 *7 R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]}
+5 *5 R!H u0 {4,[S,D,T,B]} {6,[S,D,T,B]}
+6 *2 R!H u0 {5,[S,D,T,B]} {7,S}
+7 *3 H   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 188,
+    label = "O_rad_out",
+    group = 
+"""
+1 *1 O u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 190,
+    label = "Cd_rad_out",
+    group = 
+"""
+1 *1 Cd u1
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 199,
+    label = "C_rad_out_single",
+    group = 
+"""
+1 *1 C u1 {2,S} {3,S}
+2    R u0 {1,S}
+3    R u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 219,
+    label = "O_H_out",
+    group = 
+"""
+1 *2 O u0 {2,S}
+2 *3 H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 223,
+    label = "Cd_H_out_double",
+    group = 
+"""
+1 *2 Cd         u0 {2,S} {3,D}
+2 *3 H          u0 {1,S}
+3    [Cd,Cdd,O] u0 {1,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 226,
+    label = "Cd_H_out_single",
+    group = 
+"""
+1 *2 Cd u0 {2,S} {3,S}
+2 *3 H  u0 {1,S}
+3    R  u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 230,
+    label = "Cs_H_out",
+    group = 
+"""
+1 *2 Cs u0 {2,S} {3,S} {4,S}
+2 *3 H  u0 {1,S}
+3    R  u0 {1,S}
+4    R  u0 {1,S}
+""",
+    kinetics = None,
+)
+
+tree(
+"""
+L1: RnH
+    L2: R5Hall
+        L3: R5HJ_1
+        L3: R5HJ_2
+        L3: R5HJ_3
+        L3: R5H
+    L2: R6Hall
+        L3: R6HJ_1
+        L3: R6HJ_2
+        L3: R6HJ_3
+        L3: R6HJ_4
+        L3: R6H
+L1: Y_rad_out
+    L2: O_rad_out
+    L2: Cd_rad_out
+    L2: C_rad_out_single
+L1: XH_out
+    L2: O_H_out
+    L2: Cd_H_out_double
+    L2: Cd_H_out_single
+    L2: Cs_H_out
+"""
+)
+
+forbidden(
+    label = "[CH2]C1=CC(C)CC=C1_1",
+    group = 
+"""
+1 *5 C u0 {2,S} {3,S} {8,S}
+2 *2 C u0 {1,S} {9,S}
+3    C u0 {1,S} {4,S}
+4    C u0 {3,S} {5,D}
+5    C u0 {4,D} {6,S}
+6 *4 C u0 {5,S} {7,S} {8,D}
+7 *1 C u1 {6,S}
+8 *6 C u0 {1,S} {6,D}
+9 *3 H u0 {2,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "[CH2]C1=CC(C)CC=C1_2",
+    group = 
+"""
+1 *5 C u0 {2,S} {3,S} {8,S}
+2    C u0 {1,S}
+3 *2 C u0 {1,S} {4,S} {9,S}
+4    C u0 {3,S} {5,D}
+5    C u0 {4,D} {6,S}
+6 *4 C u0 {5,S} {7,S} {8,D}
+7 *1 C u1 {6,S}
+8 *6 C u0 {1,S} {6,D}
+9 *3 H u0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "[CH2]C1=CC(C)CC=C1_3",
+    group = 
+"""
+1    C u0 {2,S} {3,S} {8,S}
+2    C u0 {1,S}
+3 *2 C u0 {1,S} {4,S} {9,S}
+4 *5 C u0 {3,S} {5,D}
+5 *6 C u0 {4,D} {6,S}
+6 *4 C u0 {5,S} {7,S} {8,D}
+7 *1 C u1 {6,S}
+8    C u0 {1,S} {6,D}
+9 *3 H u0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "bridged56_1243",
+    group = 
+"""
+1 *1 C u1 {2,S} {6,S}
+2 *4 C u0 {1,S} {3,S} {7,S}
+3 *2 C u0 {2,S} {4,S} {8,S}
+4 *5 C u0 {3,S} {5,S}
+5    C u0 {4,S} {6,S} {7,S}
+6    C u0 {1,S} {5,S}
+7    C u0 {2,S} {5,S}
+8 *3 H u0 {3,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+forbidden(
+    label = "bridged56_1254",
+    group = 
+"""
+1 *1 C u1 {2,S} {6,S}
+2 *4 C u0 {1,S} {3,S} {7,S}
+3    C u0 {2,S} {4,S}
+4 *2 C u0 {3,S} {5,S} {8,S}
+5 *5 C u0 {4,S} {6,S} {7,S}
+6    C u0 {1,S} {5,S}
+7    C u0 {2,S} {5,S}
+8 *3 H u0 {4,S}
+""",
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+
+""",
+)
+
+

--- a/input/kinetics/families/intra_H_migration/rules.py
+++ b/input/kinetics/families/intra_H_migration/rules.py
@@ -3516,7 +3516,7 @@ Sumathy B3LYP/CCPVDZ calculations (hindered rotor potential barrier calculations
 
 entry(
     index = 798,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_2H",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (4.71e+08, 's^-1'),
         n = 1.45,
@@ -3535,7 +3535,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 799,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (6.66e+08, 's^-1'),
         n = 1.28,
@@ -3554,7 +3554,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 800,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_H/(NonDeC/Cs)",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_H/(NonDeC/Cs)",
     kinetics = ArrheniusEP(
         A = (2.43e+09, 's^-1'),
         n = 1.17,
@@ -3573,7 +3573,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 801,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_H/(NonDeC/Cs/Cs)",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_H/(NonDeC/Cs/Cs)",
     kinetics = ArrheniusEP(
         A = (1.07e+10, 's^-1'),
         n = 0.98,
@@ -3592,7 +3592,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 802,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_H/(NonDeC/Cs/Cs/Cs)",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_H/(NonDeC/Cs/Cs/Cs)",
     kinetics = ArrheniusEP(
         A = (6.62e+09, 's^-1'),
         n = 1.04,
@@ -3611,7 +3611,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 803,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_Cs2",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_Cs2",
     kinetics = ArrheniusEP(
         A = (4.97e+09, 's^-1'),
         n = 1.01,
@@ -3630,7 +3630,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 804,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_2H",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (1.99e+11, 's^-1'),
         n = 0.15,
@@ -3649,7 +3649,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 805,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_2H",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (6.38e+08, 's^-1'),
         n = 1.06,
@@ -3668,7 +3668,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 806,
-    label = "R4H_SSS_OO(Cs/Cs/Cs)Cs;O_rad_out;Cs_H_out_2H",
+    label = "R4H_SSS_O(Cs)CsCs;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (5.06e+08, 's^-1'),
         n = 1.2,
@@ -3687,7 +3687,7 @@ Sumathy CBS-Q calculations
 
 entry(
     index = 807,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (2e+08, 's^-1'),
         n = 1.1,
@@ -3701,7 +3701,7 @@ entry(
 
 entry(
     index = 808,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (9.81e+08, 's^-1'),
         n = 0.88,
@@ -3715,7 +3715,7 @@ entry(
 
 entry(
     index = 809,
-    label = "R4H_SSS_OO(Cs/Cs/Cs)Cs;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R4H_SSS_O(Cs)CsCs;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (3.53e+09, 's^-1'),
         n = 0.69,
@@ -3729,7 +3729,7 @@ entry(
 
 entry(
     index = 810,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_Cs2",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_Cs2",
     kinetics = ArrheniusEP(
         A = (2.64e+09, 's^-1'),
         n = 0.78,
@@ -3743,7 +3743,7 @@ entry(
 
 entry(
     index = 811,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_Cs2",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_Cs2",
     kinetics = ArrheniusEP(
         A = (9.25e+09, 's^-1'),
         n = 0.57,
@@ -3757,7 +3757,7 @@ entry(
 
 entry(
     index = 812,
-    label = "R4H_SSS_OO(Cs/Cs/Cs)Cs;O_rad_out;Cs_H_out_Cs2",
+    label = "R4H_SSS_O(Cs)CsCs;O_rad_out;Cs_H_out_Cs2",
     kinetics = ArrheniusEP(
         A = (4.87e+10, 's^-1'),
         n = 0.35,
@@ -3771,7 +3771,7 @@ entry(
 
 entry(
     index = 813,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_2H",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (1.69e+06, 's^-1'),
         n = 1.55,
@@ -3790,7 +3790,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 814,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_2H",
+    label = "R5H_SSSS_OCC_C;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (6.78e+06, 's^-1'),
         n = 1.35,
@@ -3809,7 +3809,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 815,
-    label = "R5H_SSSS_OO(Cs/Cs/Cs)Cs;O_rad_out;Cs_H_out_2H",
+    label = "R5H_SSSS_OCC_CC;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (4.35e+07, 's^-1'),
         n = 1.12,
@@ -3828,7 +3828,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 816,
-    label = "R5H_SSSS_OOCs(Cs/Cs);O_rad_out;Cs_H_out_2H",
+    label = "R5H_SSSS_OCs(Cs/Cs);O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (1.41e+07, 's^-1'),
         n = 1.32,
@@ -3847,7 +3847,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 817,
-    label = "R5H_SSSS_OOCs(Cs/Cs/Cs);O_rad_out;Cs_H_out_2H",
+    label = "R5H_SSSS_OCs(Cs/Cs/Cs);O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (1.09e+08, 's^-1'),
         n = 1.23,
@@ -3866,7 +3866,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 818,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (8.94e+06, 's^-1'),
         n = 1.26,
@@ -3885,7 +3885,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 819,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R5H_SSSS_OCC_C;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (3.38e+10, 's^-1'),
         n = 0.21,
@@ -3904,7 +3904,7 @@ CBS-QB3 and BH&HLYP calculations (Catherina Wijaya & Sumathy Raman). Including t
 
 entry(
     index = 820,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_Cs2",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_Cs2",
     kinetics = ArrheniusEP(
         A = (3.174e+08, 's^-1'),
         n = 1.15,
@@ -4036,7 +4036,7 @@ entry(
 
 entry(
     index = 850,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_H/NonDeO",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_H/NonDeO",
     kinetics = ArrheniusEP(
         A = (3e+08, 's^-1'),
         n = 1.23,
@@ -4055,7 +4055,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 851,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_NDMustO",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_NDMustO",
     kinetics = ArrheniusEP(
         A = (3e+08, 's^-1'),
         n = 1.23,
@@ -4074,7 +4074,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 852,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_H/NonDeO",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_H/NonDeO",
     kinetics = ArrheniusEP(
         A = (1.61e+08, 's^-1'),
         n = 1.09,
@@ -4093,7 +4093,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 855,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_NDMustO",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_NDMustO",
     kinetics = ArrheniusEP(
         A = (5.29e+09, 's^-1'),
         n = 0.75,
@@ -4112,7 +4112,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 855,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_H/NonDeO",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_H/NonDeO",
     kinetics = ArrheniusEP(
         A = (9.2e+08, 's^-1'),
         n = 0.82,
@@ -4127,7 +4127,7 @@ entry(
 
 entry(
     index = 856,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_NDMustO",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_NDMustO",
     kinetics = ArrheniusEP(
         A = (1.18e+11, 's^-1'),
         n = 0.51,
@@ -4146,7 +4146,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 858,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_H/NonDeO",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_H/NonDeO",
     kinetics = ArrheniusEP(
         A = (11500, 's^-1'),
         n = 2.11,
@@ -4165,7 +4165,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 863,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_NDMustO",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_NDMustO",
     kinetics = ArrheniusEP(
         A = (1.9e+07, 's^-1'),
         n = 1.1,
@@ -4184,7 +4184,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 864,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_H/NonDeO",
+    label = "R5H_SSSS_OCC_C;O_rad_out;Cs_H_out_H/NonDeO",
     kinetics = ArrheniusEP(
         A = (2.29e+08, 's^-1'),
         n = 1.12,
@@ -4203,7 +4203,7 @@ Sandeep and Sumathy paper (submitted to JPCA 2009), intra_H_migration of ROO & H
 
 entry(
     index = 865,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_NDMustO",
+    label = "R5H_SSSS_OCC_C;O_rad_out;Cs_H_out_NDMustO",
     kinetics = ArrheniusEP(
         A = (1.17e+11, 's^-1'),
         n = 0.43,
@@ -4467,7 +4467,7 @@ The number appearing in the database has been divided by two to account for the 
 
 entry(
     index = 878,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_OOH/H",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_OOH/H",
     kinetics = ArrheniusEP(
         A = (2.47e+12, 's^-1'),
         n = -0.24,
@@ -4482,7 +4482,7 @@ entry(
 
 entry(
     index = 879,
-    label = "R4H_SSS_OOCsCs;O_rad_out;Cs_H_out_OOH/Cs",
+    label = "R4H_SSS_OCs;O_rad_out;Cs_H_out_OOH/Cs",
     kinetics = ArrheniusEP(
         A = (2.76e+08, 's^-1'),
         n = 1.2,
@@ -4497,7 +4497,7 @@ entry(
 
 entry(
     index = 880,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_OOH/H",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_OOH/H",
     kinetics = ArrheniusEP(
         A = (1.22e+07, 's^-1'),
         n = 1.6,
@@ -4512,7 +4512,7 @@ entry(
 
 entry(
     index = 881,
-    label = "R4H_SSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_OOH/Cs",
+    label = "R4H_SSS_O(Cs)Cs;O_rad_out;Cs_H_out_OOH/Cs",
     kinetics = ArrheniusEP(
         A = (1.75e+08, 's^-1'),
         n = 1.7,
@@ -4527,7 +4527,7 @@ entry(
 
 entry(
     index = 882,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_OOH/H",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_OOH/H",
     kinetics = ArrheniusEP(
         A = (25900, 's^-1'),
         n = 1.9,
@@ -4542,7 +4542,7 @@ entry(
 
 entry(
     index = 883,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_OOH/H",
+    label = "R5H_SSSS_OCC_C;O_rad_out;Cs_H_out_OOH/H",
     kinetics = ArrheniusEP(
         A = (5490, 's^-1'),
         n = 2.4,
@@ -4557,7 +4557,7 @@ entry(
 
 entry(
     index = 884,
-    label = "R5H_SSSS_OOCs(Cs/Cs/Cs);O_rad_out;Cs_H_out_OOH/H",
+    label = "R5H_SSSS_OCs(Cs/Cs/Cs);O_rad_out;Cs_H_out_OOH/H",
     kinetics = ArrheniusEP(
         A = (6.5, 's^-1'),
         n = 3.6,
@@ -4572,7 +4572,7 @@ entry(
 
 entry(
     index = 885,
-    label = "R5H_SSSS_OOCCC;O_rad_out;Cs_H_out_OOH/Cs",
+    label = "R5H_SSSS_OCC;O_rad_out;Cs_H_out_OOH/Cs",
     kinetics = ArrheniusEP(
         A = (57.9, 's^-1'),
         n = 2.9,
@@ -4587,7 +4587,7 @@ entry(
 
 entry(
     index = 886,
-    label = "R5H_SSSS_OO(Cs/Cs)Cs;O_rad_out;Cs_H_out_OOH/Cs",
+    label = "R5H_SSSS_OCC_C;O_rad_out;Cs_H_out_OOH/Cs",
     kinetics = ArrheniusEP(
         A = (175, 's^-1'),
         n = 3.1,
@@ -4692,7 +4692,7 @@ entry(
 
 entry(
     index = 893,
-    label = "R5H_CCCC_O;O_rad_out;Cs_H_out_2H",
+    label = "R5H_CCC;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (4e+10, 's^-1'),
         n = 0,
@@ -4707,7 +4707,7 @@ entry(
 
 entry(
     index = 894,
-    label = "R5H_CCCC_O;O_rad_out;Cs_H_out_H/NonDeC",
+    label = "R5H_CCC;O_rad_out;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (4e+10, 's^-1'),
         n = 0,
@@ -4722,7 +4722,7 @@ entry(
 
 entry(
     index = 895,
-    label = "R5H_CCCC_O;O_rad_out;Cs_H_out",
+    label = "R5H_CCC;O_rad_out;Cs_H_out",
     kinetics = ArrheniusEP(
         A = (4e+10, 's^-1'),
         n = 0,
@@ -4902,7 +4902,7 @@ entry(
 
 entry(
     index = 1001,
-    label = "R4H_SSS_CsCsSCs;C_rad_out_H/NonDeC;Cs_H_out_H/NonDeC",
+    label = "R4H_SSS_CsS;C_rad_out_H/NonDeC;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (0.00114, 's^-1'),
         n = 3.95,
@@ -4917,7 +4917,7 @@ entry(
 
 entry(
     index = 1002,
-    label = "R5H_SSSS_CsCsCsSCs;C_rad_out_H/NonDeC;Cs_H_out_H/NonDeC",
+    label = "R5H_SSSS_CsCsS;C_rad_out_H/NonDeC;Cs_H_out_H/NonDeC",
     kinetics = ArrheniusEP(
         A = (0.0282, 's^-1'),
         n = 3.28,
@@ -5082,7 +5082,7 @@ entry(
 
 entry(
     index = 1012,
-    label = "R5H_CCCC_O;O_rad_out;Cs_H_out_2H",
+    label = "R5H_CCC;O_rad_out;Cs_H_out_2H",
     kinetics = ArrheniusEP(
         A = (20700, 's^-1'),
         n = 1.78,
@@ -5427,7 +5427,7 @@ entry(
 
 entry(
     index = 1036,
-    label = "R3H_SS_OOCs;O_rad_out;Cs_H_out_H/Cd",
+    label = "R3H_SS_O;O_rad_out;Cs_H_out_H/Cd",
     kinetics = ArrheniusEP(
         A = (1.66e+07, 's^-1'),
         n = 1.69,
@@ -5442,7 +5442,7 @@ entry(
 
 entry(
     index = 1037,
-    label = "R4H_SSS_OOCsCd;O_rad_out;Cd_H_out_doubleC",
+    label = "R4H_SSS_OCs;O_rad_out;Cd_H_out_doubleC",
     kinetics = ArrheniusEP(
         A = (274, 's^-1'),
         n = 3.09,

--- a/input/kinetics/families/intra_H_migration/rulesTest.py
+++ b/input/kinetics/families/intra_H_migration/rulesTest.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "intra_H_migration/rules"
+shortDesc = u""
+longDesc = u"""
+
+"""
+entry(
+    index = 614,
+    label = "RnH;Y_rad_out;XH_out",
+    kinetics = ArrheniusEP(
+        A = (1e+10, 's^-1'),
+        n = 0,
+        alpha = 0,
+        E0 = (25, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 0,
+    shortDesc = u"""default""",
+)
+
+entry(
+    index = 615,
+    label = "R2H_S;C_rad_out_single;Cs_H_out",
+    kinetics = ArrheniusEP(
+        A = (5.48e+08, 's^-1'),
+        n = 1.62,
+        alpha = 0,
+        E0 = (38.76, 'kcal/mol'),
+        Tmin = (300, 'K'),
+        Tmax = (1500, 'K'),
+    ),
+    rank = 5,
+    shortDesc = u"""Currans's estimation [5] in his reaction type 5.""",
+    longDesc = 
+u"""
+[5] Curran, H.J.; Gaffuri, P.; Pit z, W.J.; Westbrook, C.K. Combust. Flame 1998, 114, 149. 
+Currans's estimation in his reaction type 5. C7H15
+
+Checked by Paul Green.
+""",
+)

--- a/input/kinetics/families/intra_OH_migration/groups.py
+++ b/input/kinetics/families/intra_OH_migration/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*1', '1'],
 ])
 
+boundaryAtoms = ["*1", "*2"]
+
 entry(
     index = 1,
     label = "RnOOH",

--- a/input/kinetics/families/intra_substitutionCS_cyclization/groups.py
+++ b/input/kinetics/families/intra_substitutionCS_cyclization/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*3"]
+
 entry(
     index = 1,
     label = "XSYJ",

--- a/input/kinetics/families/intra_substitutionCS_isomerization/groups.py
+++ b/input/kinetics/families/intra_substitutionCS_isomerization/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*3"]
+
 entry(
     index = 1,
     label = "XSYJ",

--- a/input/kinetics/families/intra_substitutionS_cyclization/groups.py
+++ b/input/kinetics/families/intra_substitutionS_cyclization/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*3', '1'],
 ])
 
+boundaryAtoms = ["*1", "*3"]
+
 entry(
     index = 1,
     label = "XSYJ",

--- a/input/kinetics/families/intra_substitutionS_isomerization/groups.py
+++ b/input/kinetics/families/intra_substitutionS_isomerization/groups.py
@@ -23,6 +23,8 @@ entry(
     kinetics = None,
 )
 
+boundaryAtoms = ["*1", "*3"]
+
 entry(
     index = 2,
     label = "YJ",

--- a/input/kinetics/families/ketoenol/groups.py
+++ b/input/kinetics/families/ketoenol/groups.py
@@ -19,6 +19,36 @@ recipe(actions=[
 ])
 
 entry(
+        index = 19,
+        label = 'R1_doublebond',
+        group = 
+"""
+1 *1 R u0
+""",
+    kinetics = None,
+)
+
+entry(
+        index = 20,
+        label = 'R2_doublebond',
+        group = 
+"""
+1 *2 R u0
+""",
+    kinetics = None,
+)
+
+entry( 
+        index = 21,
+        label = 'R_O',
+        group = 
+"""
+1 *4 R u0 
+""",
+    kinetics = None,
+        )
+
+entry(
     index = 1,
     label = "R_ROR",
     group = 
@@ -32,262 +62,145 @@ entry(
 )
 
 entry(
-    index = 2,
-    label = "C_COH",
+    index = 22,
+    label = "R_O_H",
     group = 
 """
-1 *1 C u0 {2,D}
-2 *2 C u0 {1,D} {3,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 H u0 {3,S}
+1 *4 H u0
 """,
     kinetics = None,
 )
 
 entry(
-    index = 3,
-    label = "Cds/H2_Cds/ROH",
+    index = 23,
+    label = "R_O_R",
     group = 
 """
-1 *1 C u0 {2,D} {5,S} {6,S}
-2 *2 C u0 {1,D} {3,S} {7,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 H u0 {3,S}
-5    H u0 {1,S}
-6    H u0 {1,S}
-7    R u0 {2,S}
+1 *4 R!H u0
 """,
     kinetics = None,
 )
 
 entry(
-    index = 4,
-    label = "Cds/H2_Cds/HOH",
+    index = 34,
+    label = "R_O_C",
     group = 
 """
-1 *1 C u0 {2,D} {5,S} {6,S}
-2 *2 C u0 {1,D} {3,S} {7,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 H u0 {3,S}
-5    H u0 {1,S}
-6    H u0 {1,S}
-7    H u0 {2,S}
+1 *4 C u0
 """,
     kinetics = None,
 )
 
 entry(
-    index = 5,
-    label = "Cds/H2_Cds/CsOH",
+    index = 24,
+    label = "R1_doublebond_CH2",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    H  u0 {1,S}
-6    H  u0 {1,S}
-7    Cs u0 {2,S}
+1 *1 C u0 {2,S} {3,S}
+2    H u0 {1,S}
+3    H u0 {1,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 6,
-    label = "Cds/CsH_Cds/ROH",
+    index = 25,
+    label = "R1_doublebond_CHR",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {1,S}
-6    H  u0 {1,S}
-7    R  u0 {2,S}
+1 *1 C u0 {2,S} {3,S}
+2    R!H u0 {1,S}
+3    H u0 {1,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 7,
-    label = "Cds/CsH_Cds/HOH",
+    index = 26,
+    label = "R1_doublebond_S",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {1,S}
-6    H  u0 {1,S}
-7    H  u0 {2,S}
+1 *1 S u0 
 """,
     kinetics = None,
 )
 
 entry(
-    index = 8,
-    label = "Cds/CsH_Cds/CsOH",
+    index = 27,
+    label = "R1_doublebond_CHCH3",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {1,S}
-6    H  u0 {1,S}
-7    Cs u0 {2,S}
+1 *1 C u0 {2,S} {3,S}
+2    C u0 {1,S} {4,S} {5,S} {6,S}
+3    H u0 {1,S}
+4    H u0 {2,S}
+5    H u0 {2,S}
+6    H u0 {2,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 9,
-    label = "Cds/CsCs_Cds/ROH",
+    index = 28,
+    label = "R2_doublebond_Cs",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {1,S}
-6    Cs u0 {1,S}
-7    R  u0 {2,S}
+1 *2 C u0 {2,S}
+2    Cs u0 {1,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 10,
-    label = "Cds/CsCs_Cds/HOH",
+    index = 29,
+    label = "R2_doublebond_H",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {1,S}
-6    Cs u0 {1,S}
-7    H  u0 {2,S}
+1 *2 C u0 {2,S}
+2    H u0 {1,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 11,
-    label = "Cds/CsCs_Cds/CsOH",
+    index = 31,
+    label = "R2_doublebond_CH3",
     group = 
 """
-1 *1 C  u0 {2,D} {5,S} {6,S}
-2 *2 C  u0 {1,D} {3,S} {7,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {1,S}
-6    Cs u0 {1,S}
-7    Cs u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 12,
-    label = "C_COC",
-    group = 
-"""
-1 *1 C u0 {2,D}
-2 *2 C u0 {1,D} {3,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 C u0 {3,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 13,
-    label = "S_COH",
-    group = 
-"""
-1 *1 S u0 {2,D}
-2 *2 C u0 {1,D} {3,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 H u0 {3,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 14,
-    label = "S_Cds/HOH",
-    group = 
-"""
-1 *1 S u0 {2,D}
-2 *2 C u0 {1,D} {3,S} {5,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 H u0 {3,S}
+1 *2 C u0 {2,S} 
+2    Cs u0 {1,S} {3,S} {4,S} {5,S}
+3    H u0 {2,S}
+4    H u0 {2,S}
 5    H u0 {2,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 15,
-    label = "S_Cds/CsOH",
+    index = 32,
+    label = "R2_doublebond_CsC",
     group = 
 """
-1 *1 S  u0 {2,D}
-2 *2 C  u0 {1,D} {3,S} {5,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {2,S}
+1 *2 C u0 {2,S}
+2    Cs u0 {1,S} {3,S}
+3    C u0 {2,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 16,
-    label = "S_Cds/CH3OH",
+    index = 33,
+    label = "R2_doublebond_CH2CH3",
     group = 
 """
-1 *1 S  u0 {2,D}
-2 *2 C  u0 {1,D} {3,S} {5,S}
-3 *3 O  u0 {2,S} {4,S}
-4 *4 H  u0 {3,S}
-5    Cs u0 {2,S} {6,S} {7,S} {8,S}
-6    H  u0 {5,S}
-7    H  u0 {5,S}
-8    H  u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 17,
-    label = "S_Cds/CH2CH3OH",
-    group = 
-"""
-1  *1 S  u0 {2,D}
-2  *2 C  u0 {1,D} {3,S} {5,S}
-3  *3 O  u0 {2,S} {4,S}
-4  *4 H  u0 {3,S}
-5     Cs u0 {2,S} {6,S} {7,S} {8,S}
-6     Cs u0 {5,S} {9,S} {10,S} {11,S}
-7     H  u0 {5,S}
-8     H  u0 {5,S}
-9     H  u0 {6,S}
-10    H  u0 {6,S}
-11    H  u0 {6,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 18,
-    label = "S_COC",
-    group = 
-"""
-1 *1 S u0 {2,D}
-2 *2 C u0 {1,D} {3,S}
-3 *3 O u0 {2,S} {4,S}
-4 *4 C u0 {3,S}
+1 *2 C u0 {2,S}
+2    Cs u0 {1,S} {3,S} {4,S} {5,S}
+3    Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    H u0 {2,S}
+5    H u0 {2,S}
+6    H u0 {3,S}
+7    H u0 {3,S}
+8    H u0 {3,S}
 """,
     kinetics = None,
 )
@@ -295,23 +208,21 @@ entry(
 tree(
 """
 L1: R_ROR
-    L2: C_COH
-        L3: Cds/H2_Cds/ROH
-            L4: Cds/H2_Cds/HOH
-            L4: Cds/H2_Cds/CsOH
-        L3: Cds/CsH_Cds/ROH
-            L4: Cds/CsH_Cds/HOH
-            L4: Cds/CsH_Cds/CsOH
-        L3: Cds/CsCs_Cds/ROH
-            L4: Cds/CsCs_Cds/HOH
-            L4: Cds/CsCs_Cds/CsOH
-    L2: C_COC
-    L2: S_COH
-        L3: S_Cds/HOH
-        L3: S_Cds/CsOH
-            L4: S_Cds/CH3OH
-            L4: S_Cds/CH2CH3OH
-    L2: S_COC
+L1: R1_doublebond
+    L2: R1_doublebond_CH2
+    L2: R1_doublebond_CHR
+        L3: R1_doublebond_CHCH3
+    L2: R1_doublebond_S
+L1: R2_doublebond
+    L2: R2_doublebond_H
+    L2: R2_doublebond_Cs
+        L3: R2_doublebond_CH3
+        L3: R2_doublebond_CsC
+            L4: R2_doublebond_CH2CH3
+L1: R_O
+    L2: R_O_H
+    L2: R_O_R
+        L3: R_O_C
 """
 )
 

--- a/input/kinetics/families/ketoenol/groups.py
+++ b/input/kinetics/families/ketoenol/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['FORM_BOND', '*4', 1, '*1'],
 ])
 
+boundaryAtoms = ["*2", "*3"]
+
 entry(
         index = 19,
         label = 'R1_doublebond',

--- a/input/kinetics/families/ketoenol/rules.py
+++ b/input/kinetics/families/ketoenol/rules.py
@@ -8,7 +8,7 @@ longDesc = u"""
 """
 entry(
     index = 1,
-    label = "R_ROR",
+    label = "R_ROR;R1_doublebond;R2_doublebond;R_O",
     kinetics = ArrheniusEP(
         A = (100000, 's^-1'),
         n = 2,
@@ -23,7 +23,7 @@ entry(
 
 entry(
     index = 2,
-    label = "Cds/H2_Cds/CsOH",
+    label = "R_ROR;R1_doublebond_CH2;R2_doublebond_CsC;R_O_H",
     kinetics = ArrheniusEP(
         A = (205000, 's^-1'),
         n = 2.37,
@@ -38,7 +38,7 @@ entry(
 
 entry(
     index = 3,
-    label = "Cds/H2_Cds/HOH",
+    label = "R_ROR;R1_doublebond_CH2;R2_doublebond_H;R_O_H",
     kinetics = ArrheniusEP(
         A = (7040, 's^-1'),
         n = 2.66,
@@ -53,7 +53,7 @@ entry(
 
 entry(
     index = 4,
-    label = "S_Cds/HOH",
+    label = "R_ROR;R1_doublebond_S;R2_doublebond_H;R_O_H",
     kinetics = ArrheniusEP(
         A = (52, 's^-1'),
         n = 3.26,
@@ -68,7 +68,7 @@ entry(
 
 entry(
     index = 5,
-    label = "S_Cds/CH3OH",
+    label = "R_ROR;R1_doublebond_S;R2_doublebond_CH3;R_O_H",
     kinetics = ArrheniusEP(
         A = (104, 's^-1'),
         n = 3.21,
@@ -83,7 +83,7 @@ entry(
 
 entry(
     index = 6,
-    label = "S_Cds/CH2CH3OH",
+    label = "R_ROR;R1_doublebond_S;R2_doublebond_CH2CH3;R_O_H",
     kinetics = ArrheniusEP(
         A = (87.5, 's^-1'),
         n = 3.23,


### PR DESCRIPTION
Unimolecular Group formatting changes and testing.

A new test requires that end group labels are consistent throughout each end group tree, that the backbone has all labels present in the end groups and labels indicating the shortest path between end groups, and that each end group subgraph in each entry in the backbone tree is the top level of the corresponding end group tree.

Specifically exempts Diels_alder_addition family from these requirements because of its strange structure (to be fixed later)

Groups were adapted to meet these requirements and pass all database tests. Part2 includes the problematic families that need more thorough review of the RMG-tests.