### PR TITLE
The FFCM library was changed with respect to `[CH]*`

### DIFF
--- a/input/kinetics/libraries/FFCM1(-)/dictionary.txt
+++ b/input/kinetics/libraries/FFCM1(-)/dictionary.txt
@@ -60,14 +60,9 @@ C(T)
 multiplicity 3
 1 C u2 p1 c0
 
-CH(D)
+CH
 multiplicity 2
 1 C u1 p1 c0 {2,S}
-2 H u0 p0 c0 {1,S}
-
-CH(Q)
-multiplicity 4
-1 C u3 p0 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CH2(T)

--- a/input/kinetics/libraries/FFCM1(-)/reactions.py
+++ b/input/kinetics/libraries/FFCM1(-)/reactions.py
@@ -14,11 +14,28 @@ Release date: 05/31/3016.
 G. P. Smith, Y. Tao, and H. Wang, Foundational Fuel Chemistry Model Version 1.0 (FFCM-1),
 http://nanoenergy.stanford.edu/ffcm1, 2016.
 
-Reactions that were not included:
-CH(D)+O2<=>CO+OH*                                     1.800E+11    0.000        0.00
-H+O+M<=>OH*+M                                       5.450E+12    0.000        0.00
-2OH+H<=>OH*+H2O                                     1.450E+15    0.000        0.00
-OH*<=>OH                                            1.450E+06    0.000        0.00
+The following reactions involve excited CH and OH species, which currently cannot be represented in RMG.
+In order to compare RMG's predictions with experimental results of excited CH or OH,
+it is advised to append the following reactions to the final Chemkin file.
+Note that the model generation in RMG could have been somewhat different if these reactions were to integrated as a library.
+See https://github.com/ReactionMechanismGenerator/RMG-database/issues/174 for more info.
+
+CH+O2<=>CO+OH*                                     1.800E+11    0.000        0.00
+C2H+O<=>CO+CH*                                     2.500E+12    0.000        0.00
+C2H+O2<=>CO2+CH*                                   3.200E+11    0.000     1600.00
+H+O+M=>OH*+M                                       5.450E+12    0.000        0.00
+2OH+H=>OH*+H2O                                     1.450E+15    0.000        0.00
+CH*=>CH                                            1.850E+06    0.000        0.00
+CH*+N2<=>CH+N2                                     3.030E+02    3.400     -381.00
+CH*+O2<=>CH+O2                                     2.400E+06    2.140    -1720.00
+CH*+H2O<=>CH+H2O                                   5.300E+13    0.000        0.00
+CH*+H2<=>CH+H2                                     1.470E+14    0.000     1361.00
+CH*+CO2<=>CH+CO2                                   2.410E-01    4.300    -1694.00
+CH*+CO<=>CH+CO                                     2.440E+12    0.500        0.00
+CH*+CH4<=>CH+CH4                                   1.730E+13    0.000      167.00
+CH*+Ar<=>CH+Ar                                     1.250E+10    0.500        0.00
+CH*+He<=>CH+He                                     1.950E+09    0.500        0.00
+OH*=>OH                                            1.450E+06    0.000        0.00
 OH*+N2<=>OH+N2                                     1.080E+11    0.500    -1238.00
 OH*+O2<=>OH+O2                                     2.100E+12    0.500     -482.00
 OH*+H2O<=>OH+H2O                                   5.920E+12    0.500     -861.00
@@ -476,28 +493,28 @@ entry(
 
 entry(
     index = 38,
-    label = "CH(D) + H <=> C(T) + H2",
+    label = "CH + H <=> C(T) + H2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.089e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
 
 entry(
     index = 39,
-    label = "CH(D) + O <=> H + CO",
+    label = "CH + O <=> H + CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.7e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
 
 entry(
     index = 40,
-    label = "CH(D) + OH <=> H + HCO",
+    label = "CH + OH <=> H + HCO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
 
 entry(
     index = 41,
-    label = "CH(D) + H2 <=> H + CH2(T)",
+    label = "CH + H2 <=> H + CH2(T)",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (1.612e+14, 'cm^3/(mol*s)'),
@@ -509,7 +526,7 @@ entry(
 
 entry(
     index = 42,
-    label = "CH(D) + H2 <=> CH3",
+    label = "CH + H2 <=> CH3",
     degeneracy = 1,
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(5.13e+13, 'cm^3/(mol*s)'), n=0.15, Ea=(0, 'cal/mol'), T0=(1, 'K')),
@@ -529,14 +546,14 @@ entry(
 
 entry(
     index = 43,
-    label = "CH(D) + H2O <=> H + CH2O",
+    label = "CH + H2O <=> H + CH2O",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3.43e+12, 'cm^3/(mol*s)'), n=0, Ea=(-884, 'cal/mol'), T0=(1, 'K')),
 )
 
 entry(
     index = 44,
-    label = "CH(D) + O2 <=> O + HCO",
+    label = "CH + O2 <=> O + HCO",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (1.84e+08, 'cm^3/(mol*s)'),
@@ -548,7 +565,7 @@ entry(
 
 entry(
     index = 45,
-    label = "CH(D) + O2 <=> CO2 + H",
+    label = "CH + O2 <=> CO2 + H",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (2.781e+08, 'cm^3/(mol*s)'),
@@ -560,7 +577,7 @@ entry(
 
 entry(
     index = 46,
-    label = "CH(D) + O2 <=> CO + OH",
+    label = "CH + O2 <=> CO + OH",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (1.84e+08, 'cm^3/(mol*s)'),
@@ -572,7 +589,7 @@ entry(
 
 entry(
     index = 47,
-    label = "CH(D) + O2 <=> O + H + CO",
+    label = "CH + O2 <=> O + H + CO",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (2.789e+08, 'cm^3/(mol*s)'),
@@ -584,7 +601,7 @@ entry(
 
 entry(
     index = 48,
-    label = "CH(D) + CO <=> HCCO",
+    label = "CH + CO <=> HCCO",
     degeneracy = 1,
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(1.02e+15, 'cm^3/(mol*s)'), n=-0.4, Ea=(0, 'cal/mol'), T0=(1, 'K')),
@@ -604,7 +621,7 @@ entry(
 
 entry(
     index = 49,
-    label = "CH(D) + CO2 <=> HCO + CO",
+    label = "CH + CO2 <=> HCO + CO",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (6.38e+07, 'cm^3/(mol*s)'),
@@ -655,7 +672,7 @@ entry(
 
 entry(
     index = 53,
-    label = "CH2(T) + OH <=> CH(D) + H2O",
+    label = "CH2(T) + OH <=> CH + H2O",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (863000, 'cm^3/(mol*s)'),
@@ -743,7 +760,7 @@ entry(
 
 entry(
     index = 62,
-    label = "CH2(T) + CH(D) <=> H + C2H2",
+    label = "CH2(T) + CH <=> H + C2H2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
@@ -785,7 +802,7 @@ entry(
 
 entry(
     index = 68,
-    label = "CH2(S) + H <=> CH(D) + H2",
+    label = "CH2(S) + H <=> CH + H2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
@@ -997,7 +1014,7 @@ entry(
 
 entry(
     index = 87,
-    label = "CH2O + CH(D) <=> H + CH2CO",
+    label = "CH2O + CH <=> H + CH2CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(9.64e+13, 'cm^3/(mol*s)'), n=0, Ea=(-517, 'cal/mol'), T0=(1, 'K')),
 )
@@ -1172,7 +1189,7 @@ entry(
 
 entry(
     index = 104,
-    label = "CH3 + CH(D) <=> H + C2H3",
+    label = "CH3 + CH <=> H + C2H3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3.062e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
@@ -1504,7 +1521,7 @@ entry(
 
 entry(
     index = 135,
-    label = "CH4 + CH(D) <=> H + C2H4",
+    label = "CH4 + CH <=> H + C2H4",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(-397, 'cal/mol'), T0=(1, 'K')),
 )
@@ -1635,7 +1652,7 @@ entry(
 
 entry(
     index = 148,
-    label = "CH3OH + CH(D) <=> CH3 + CH2O",
+    label = "CH3OH + CH <=> CH3 + CH2O",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (9.04e+18, 'cm^3/(mol*s)'),
@@ -1737,7 +1754,7 @@ entry(
 
 entry(
     index = 160,
-    label = "C2H + O <=> CH(D) + CO",
+    label = "C2H + O <=> CH + CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
@@ -1794,7 +1811,7 @@ entry(
 
 entry(
     index = 166,
-    label = "HCCO + O <=> CH(D) + CO2",
+    label = "HCCO + O <=> CH + CO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.95e+13, 'cm^3/(mol*s)'), n=0, Ea=(1113, 'cal/mol'), T0=(1, 'K')),
 )
@@ -1808,7 +1825,7 @@ entry(
 
 entry(
     index = 168,
-    label = "HCCO + CH(D) <=> CO + C2H2",
+    label = "HCCO + CH <=> CO + C2H2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
@@ -2054,7 +2071,7 @@ entry(
 
 entry(
     index = 191,
-    label = "CH2CO + CH(D) <=> C2H3 + CO",
+    label = "CH2CO + CH <=> C2H3 + CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.45e+14, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 )
@@ -2720,7 +2737,7 @@ entry(
 
 entry(
     index = 255,
-    label = "C2H6 + CH(D) <=> CH3 + C2H4",
+    label = "C2H6 + CH <=> CH3 + C2H4",
     degeneracy = 1,
     kinetics = Arrhenius(
         A = (1.077e+14, 'cm^3/(mol*s)'),
@@ -2766,89 +2783,5 @@ entry(
         Ea = (16850, 'cal/mol'),
         T0 = (1, 'K'),
     ),
-)
-
-entry(
-    index = 260,
-    label = "C2H + O <=> CO + CH(Q)",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(2.50E+12, 'cm^3/(mol*s)'), n = 0, Ea = (0, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 261,
-    label = "C2H + O2 <=> CO2 + CH(Q)",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(3.20E+11, 'cm^3/(mol*s)'), n = 0, Ea = (1600, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 262,
-    label = "CH(Q) <=> CH(D)",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.85E+06, 'cm^3/(mol*s)'), n = 0, Ea = (0, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 263,
-    label = "CH(Q) + N2 <=> CH(D) + N2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(3.03E+02, 'cm^3/(mol*s)'), n = 3.40, Ea = (-381, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 264,
-    label = "CH(Q) + O2 <=> CH(D) + O2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(2.40E+06, 'cm^3/(mol*s)'), n = 2.14, Ea = (-1720, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 265,
-    label = "CH(Q) + H2O <=> CH(D) + H2O",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(5.30E+13, 'cm^3/(mol*s)'), n = 0, Ea = (0, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 266,
-    label = "CH(Q) + H2 <=> CH(D) + H2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.47E+14, 'cm^3/(mol*s)'), n = 0, Ea = (1361, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 267,
-    label = "CH(Q) + CO2 <=> CH(D) + CO2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(2.41E-01, 'cm^3/(mol*s)'), n = 4.30, Ea = (-1694, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 268,
-    label = "CH(Q) + CO <=> CH(D) + CO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(2.44E+12, 'cm^3/(mol*s)'), n = 0.50, Ea = (0, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 269,
-    label = "CH(Q) + CH4 <=> CH(D) + CH4",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.73E+13, 'cm^3/(mol*s)'), n = 0, Ea = (167, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 270,
-    label = "CH(Q) + Ar <=> CH(D) + Ar",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.25E+10, 'cm^3/(mol*s)'), n = 0.50, Ea = (0, 'cal/mol'), T0 = (1, 'K')),
-)
-
-entry(
-    index = 271,
-    label = "CH(Q) + He <=> CH(D) + He",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.95E+09, 'cm^3/(mol*s)'), n = 0.50, Ea = (0, 'cal/mol'), T0 = (1, 'K')),
 )
 

--- a/input/thermo/libraries/FFCM1(-).py
+++ b/input/thermo/libraries/FFCM1(-).py
@@ -19,7 +19,10 @@ OH*               ATcT AO   1H   1    0    0G   200.000  6000.000 1000.        1
  2.75582920E+00 1.39848756E-03-4.19428493E-07 6.33453282E-11-3.56042218E-15    2! OH A 2Sigma+ (excited)
  5.09751756E+04 5.62581429E+00 3.46084428E+00 5.01872172E-04-2.00254474E-06    3! CAS: 3352-57-6 (?)
  3.18901984E-09-1.35451838E-12 5.07349466E+04 1.73976415E+00 5.17770741E+04    4! Uncertainty unknown => -1.0
-
+CH*               EG4/09C   1H   1    0    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
+ 2.78220752E+00 1.47246754E-03-4.63436227E-07 7.32736021E-11-4.19705404E-15    2! CH A2Delta  excited state only
+ 1.04547060E+05 5.17421018E+00 3.47250101E+00 4.26443626E-04-1.95181794E-06    3! CAS: 3315-37-5
+ 3.51755043E-09-1.60436174E-12 1.04334869E+05 1.44799533E+00 1.05378099E+05    4! Uncertainty unknown => -1.0
 CH2*              IU3/03C   1H   2    0    0G   200.000  6000.000 1000.        1! Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
  3.13501686E+00 2.89593926E-03-8.16668090E-07 1.13572697E-10-6.36262835E-15    2! Methylene radical excited 
  5.05040504E+04 4.06030621E+00 4.19331325E+00-2.33105184E-03 8.15676451E-06    3! CAS 2465-56-7
@@ -452,7 +455,7 @@ CAS 7440-44-0
 
 entry(
     index = 15,
-    label = "CH(D)",
+    label = "CH",
     molecule = 
 """
 multiplicity 2
@@ -474,33 +477,6 @@ Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
 Methylidyne
 CAS 3315-37-5
 596.173 +- 0.124 kJ/mol ATcT 31.01.2011
-""",
-)
-
-entry(
-    index = 37,
-    label = "CH(Q)",
-    molecule = 
-"""
-multiplicity 4
-1 C u3 p0 c0 {2,S}
-2 H u0 p0 c0 {1,S}
-""",
-    thermo = NASA(
-        polynomials = [
-			NASAPolynomial(coeffs=[3.4725,0.000426444,-1.95182e-06,3.51755e-09,-1.60436e-12,104335,1.448], Tmin=(200,'K'), Tmax=(1000,'K')),
-			NASAPolynomial(coeffs=[2.78221,0.00147247,-4.63436e-07,7.32736e-11,-4.19705e-15,104547,5.17421], Tmin=(1000,'K'), Tmax=(6000,'K'))
-        ],
-        Tmin = (200,'K'),
-        Tmax = (6000,'K'),
-    ),
-    shortDesc = u"""IU3/03""",
-    longDesc = 
-u"""
-Goos-Burcat-Ruscic-thermodatabase; Y. Tao 25.05.2012
-CH A2Delta  excited state only
-CAS 3315-37-5
-Uncertainty unknown => -1.0
 """,
 )
 


### PR DESCRIPTION
The reactions involving `[CH]*` were removed, since the `CH(Q)` representation was wrong,
and currently we cannot represent `[CH]*` uniquely in RMG.
These reactions were added at the top of the library as a comment.
An explanatory comment was added for users who would like to have `[CH]*` and [OH]* in their models.

The `CH(D)` name was also replaced to simply `CH`,
not to cause a false impression that the excited state is other than a doublet as well.

See issue #174