### PR TITLE
Updated AdjLists for [C] and [CH]

### DIFF
--- a/input/kinetics/libraries/Dooley/C1/dictionary.txt
+++ b/input/kinetics/libraries/Dooley/C1/dictionary.txt
@@ -12,8 +12,8 @@ CH3OH
 6 H u0 p0 c0 {2,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CH2OH
@@ -136,8 +136,8 @@ multiplicity 2
 6 H u0 p0 c0 {2,S}
 
 C
-multiplicity 5
-1 C u4 p0 c0
+multiplicity 3
+1 C u2 p1 c0
 
 CH3O2H
 1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}

--- a/input/kinetics/libraries/Dooley/methylformate/dictionary.txt
+++ b/input/kinetics/libraries/Dooley/methylformate/dictionary.txt
@@ -472,8 +472,8 @@ multiplicity 2
 4 H u0 p0 c0 {1,S}
 
 C
-multiplicity 5
-1 C u4 p0 c0
+multiplicity 3
+1 C u2 p1 c0
 
 C2H4O2H
 multiplicity 2
@@ -804,8 +804,8 @@ multiplicity 2
 9 H u0 p0 c0 {3,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 HOCH2O2

--- a/input/kinetics/libraries/Dooley/methylformate_all_ARHEbathgas/dictionary.txt
+++ b/input/kinetics/libraries/Dooley/methylformate_all_ARHEbathgas/dictionary.txt
@@ -1186,8 +1186,8 @@ C2H5CHCO
 11 O u0 p2 c0 {4,D}
 
 C
-multiplicity 5
-1 C u4 p0 c0
+multiplicity 3
+1 C u2 p1 c0
 
 C2H4O2H
 multiplicity 2
@@ -1972,8 +1972,8 @@ ME
 11 O u0 p2 c0 {3,D}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 HOCH2O2

--- a/input/kinetics/libraries/Dooley/methylformate_all_N2bathgas/dictionary.txt
+++ b/input/kinetics/libraries/Dooley/methylformate_all_N2bathgas/dictionary.txt
@@ -1186,8 +1186,8 @@ C2H5CHCO
 11 O u0 p2 c0 {4,D}
 
 C
-multiplicity 5
-1 C u4 p0 c0
+multiplicity 3
+1 C u2 p1 c0
 
 C2H4O2H
 multiplicity 2
@@ -1972,8 +1972,8 @@ ME
 11 O u0 p2 c0 {3,D}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 HOCH2O2

--- a/input/kinetics/libraries/ERC-FoundationFuelv0.9/dictionary.txt
+++ b/input/kinetics/libraries/ERC-FoundationFuelv0.9/dictionary.txt
@@ -103,8 +103,8 @@ multiplicity 2
 4 H u0 p0 c0 {1,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CO

--- a/input/kinetics/libraries/ERC-FoundationFuelv0.9/reactions.py
+++ b/input/kinetics/libraries/ERC-FoundationFuelv0.9/reactions.py
@@ -4,7 +4,8 @@
 name = "ERC-FoundationFuelv0.9"
 shortDesc = u"Small molecule combustion kinetics by ERC"
 longDesc = u"""
-Small molecule combustion kinetics created by Engine Research Center at University of Wisconsin.  
+Small molecule combustion kinetics created by Engine Research Center at University of Wisconsin.
+https://www.erc.wisc.edu/
 """
 entry(
     index = 1,

--- a/input/kinetics/libraries/GRI-Mech3.0-N/dictionary.txt
+++ b/input/kinetics/libraries/GRI-Mech3.0-N/dictionary.txt
@@ -173,8 +173,8 @@ NH
 2 H u0 p0 c0 {1,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CO

--- a/input/kinetics/libraries/GRI-Mech3.0/dictionary.txt
+++ b/input/kinetics/libraries/GRI-Mech3.0/dictionary.txt
@@ -123,8 +123,8 @@ multiplicity 3
 1 C u2 p1 c0
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CO

--- a/input/kinetics/libraries/GRI-Mech3.0/reactions.py
+++ b/input/kinetics/libraries/GRI-Mech3.0/reactions.py
@@ -15,9 +15,8 @@ and carried out at The University of California at Berkeley, Stanford
 University, The University of Texas at Austin, and SRI International.
 
 http://combustion.berkeley.edu/gri-mech/
-
-
 """
+
 entry(
     index = 1,
     label = "O + H2 <=> H + OH",

--- a/input/kinetics/libraries/Nitrogen_Dean_and_Bozzelli/dictionary.txt
+++ b/input/kinetics/libraries/Nitrogen_Dean_and_Bozzelli/dictionary.txt
@@ -226,8 +226,8 @@ CH3NH2
 7 H u0 p0 c0 {2,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 N2O

--- a/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/dictionary.txt
+++ b/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/dictionary.txt
@@ -712,8 +712,8 @@ HOCN
 4 N u0 p1 c0 {2,T}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CH2OH

--- a/input/kinetics/libraries/Nitrogen_Glarborg_Zhang_et_al/dictionary.txt
+++ b/input/kinetics/libraries/Nitrogen_Glarborg_Zhang_et_al/dictionary.txt
@@ -510,8 +510,8 @@ CH2O
 4 O u0 p2 c0 {1,D}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CH3ONO2

--- a/input/kinetics/libraries/combustion_core/version2/dictionary.txt
+++ b/input/kinetics/libraries/combustion_core/version2/dictionary.txt
@@ -118,8 +118,8 @@ multiplicity 2
 6 H u0 p0 c0 {2,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CO

--- a/input/kinetics/libraries/combustion_core/version2/reactions.py
+++ b/input/kinetics/libraries/combustion_core/version2/reactions.py
@@ -4,7 +4,8 @@
 name = "combustion_core/version2"
 shortDesc = u""
 longDesc = u"""
-2nd version of core combustion mechanisms developed at Leeds University 
+2nd version of core combustion mechanisms developed at Leeds University
+http://mcm.leeds.ac.uk/MCM/
 """
 entry(
     index = 1,

--- a/input/kinetics/libraries/combustion_core/version3/dictionary.txt
+++ b/input/kinetics/libraries/combustion_core/version3/dictionary.txt
@@ -219,8 +219,8 @@ multiplicity 2
 13 H u0 p0 c0 {4,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CO

--- a/input/kinetics/libraries/combustion_core/version3/reactions.py
+++ b/input/kinetics/libraries/combustion_core/version3/reactions.py
@@ -5,6 +5,7 @@ name = "combustion_core/version3"
 shortDesc = u""
 longDesc = u"""
 3rd version of core combustion mechanisms developed at Leeds University
+http://mcm.leeds.ac.uk/MCM/
 """
 entry(
     index = 1,

--- a/input/kinetics/libraries/combustion_core/version4/dictionary.txt
+++ b/input/kinetics/libraries/combustion_core/version4/dictionary.txt
@@ -134,8 +134,8 @@ multiplicity 2
 6 H u0 p0 c0 {2,S}
 
 CH
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CO

--- a/input/kinetics/libraries/combustion_core/version4/reactions.py
+++ b/input/kinetics/libraries/combustion_core/version4/reactions.py
@@ -5,6 +5,7 @@ name = "combustion_core/version4"
 shortDesc = u""
 longDesc = u"""
 4th version of core combustion mechanisms developed at Leeds University
+http://mcm.leeds.ac.uk/MCM/
 """
 entry(
     index = 1,

--- a/input/kinetics/libraries/combustion_core/version5/reactions.py
+++ b/input/kinetics/libraries/combustion_core/version5/reactions.py
@@ -5,6 +5,7 @@ name = "combustion_core/version5"
 shortDesc = u""
 longDesc = u"""
 5th version of core combustion mechanisms developed at Leeds University
+http://mcm.leeds.ac.uk/MCM/
 """
 entry(
     index = 1,

--- a/input/thermo/libraries/Chernov.py
+++ b/input/thermo/libraries/Chernov.py
@@ -558,8 +558,8 @@ entry(
     label = "CH",
     molecule = 
 """
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = NASA(

--- a/input/thermo/libraries/DFT_QCI_thermo.py
+++ b/input/thermo/libraries/DFT_QCI_thermo.py
@@ -36,8 +36,8 @@ entry(
     label = "CH",
     molecule = 
 """
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = ThermoData(

--- a/input/thermo/libraries/GRI-Mech3.0-N.py
+++ b/input/thermo/libraries/GRI-Mech3.0-N.py
@@ -346,8 +346,8 @@ entry(
     label = "CH",
     molecule = 
 """
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = ThermoData(

--- a/input/thermo/libraries/GRI-Mech3.0.py
+++ b/input/thermo/libraries/GRI-Mech3.0.py
@@ -251,8 +251,8 @@ entry(
     label = "CH",
     molecule = 
 """
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = NASA(

--- a/input/thermo/libraries/USC-Mech-ii.py
+++ b/input/thermo/libraries/USC-Mech-ii.py
@@ -322,8 +322,8 @@ entry(
     label = "CH",
     molecule = 
 """
-multiplicity 4
-1 C u3 p0 c0 {2,S}
+multiplicity 2
+1 C u1 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = NASA(


### PR DESCRIPTION
The AdjLists for [C] and [CH] for many kinetic and thermo libraries throughout our database were updated.

According to FFCM-1, H298 of [CH] is 142.40 kcal/mol, while H298 of [CH*] is 209.41 kcal/mol

- In GRI-Mech3.0 (and GRI-Mech3.0-N), Chernov, Naraswamy, USC-Mech-ii H298 of [CH] is 142.77, 142.49, 142.77, 142.77 kcal/mol, respectively.
  Therefore, in all the above libraries the AdjList of [CH] was changed to the ground state (having 1 lone pair)
- Dooley is based on GRI-Mech for small radicals, and was changed accordingly.
- Nitrogen_Dean_Bozzelli: [CH] changed to ground state as well, see p. 221 for example
- In Nitrogen_Glarborg_Gimenez_et_al and Nitrogen_Glarborg_Zhang_et_al [CH] was changed to the ground state as well.
  The lead was the reaction CH+N2=NCN+H cited from M.C. Lin 2000, where [CH] attaks N2 with its lone pair
- in DFT_QCI_thermo, the paper by Golsdmith et al. explicitly says CH(doublet) - see p. 9037. Changed to the ground state.

**Libraries still unchanged:**
- Combustion_core
- ERC-FoundationFuelv0.9

The ERC library isn't well documented.
The website of the combustion core ("The Master Chemical Mechanism" from LEEDS university, http://mcm.leeds.ac.uk/MCM/) isn't user-friendly. I couldn't find [CH] there.
I recommend assuming ground states for [CH] in these libraries as well (all documented changes above always ended up in the ground state as well)