### PR TITLE
Added training reactions to R_Recombination

### DIFF
--- a/input/kinetics/families/R_Recombination/training/dictionary.txt
+++ b/input/kinetics/families/R_Recombination/training/dictionary.txt
@@ -206,4 +206,42 @@ CH3NO2
 6 H u0 p0 c0 {1,S}
 7 H u0 p0 c0 {1,S}
 
+C2H6
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+
+C3H8
+1  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+3  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  H u0 p0 c0 {1,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+
+C4H10
+1  C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2  C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+3  C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  C u0 p0 c0 {3,S} {12,S} {13,S} {14,S}
+5  H u0 p0 c0 {1,S}
+6  H u0 p0 c0 {1,S}
+7  H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {4,S}
 

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -293,3 +293,51 @@ The high-pressure limit kinetics was taken. Troe coefficients are:
 """,
 )
 
+entry(
+    index = 20,
+    label = "CH3 + CH3 <=> C2H6",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(9.45e+14, 'cm^3/(mol*s)'), n=-0.538, Ea=(135.1, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
+    rank = 2,
+    shortDesc = u"""CASPT2/cc-pvdz""",
+    longDesc = 
+u"""
+S.J. Klippenstein, Y. Georgievskiia, L.B. Hardingb
+Predictive theory for the combination kinetics of two alkyl radicals
+Phys. Chem. Chem. Phys., 2006, 8, 1133-1147
+doi: 10.1039/B515914H
+""",
+)
+
+entry(
+    index = 21,
+    label = "CH3 + C2H5 <=> C3H8",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.23e+15, 'cm^3/(mol*s)'), n=-0.562, Ea=(20.5, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
+    rank = 2,
+    shortDesc = u"""CASPT2/cc-pvdz""",
+    longDesc = 
+u"""
+S.J. Klippenstein, Y. Georgievskiia, L.B. Hardingb
+Predictive theory for the combination kinetics of two alkyl radicals
+Phys. Chem. Chem. Phys., 2006, 8, 1133-1147
+doi: 10.1039/B515914H
+""",
+)
+
+entry(
+    index = 22,
+    label = "C2H5 + C2H5 <=> C4H10",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(8.73e+14, 'cm^3/(mol*s)'), n=-0.699, Ea=(-3.2, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
+    rank = 2,
+    shortDesc = u"""CASPT2/cc-pvdz""",
+    longDesc = 
+u"""
+S.J. Klippenstein, Y. Georgievskiia, L.B. Hardingb
+Predictive theory for the combination kinetics of two alkyl radicals
+Phys. Chem. Chem. Phys., 2006, 8, 1133-1147
+doi: 10.1039/B515914H
+""",
+)
+


### PR DESCRIPTION
Added
CH3 + CH3 <=> C2H6,
CH3 + C2H5 <=> C3H8, and
C2H5 + C2H5 <=> C4H10
training reactions from Klippenstein 2006 (doi: 10.1039/B515914H)