### PR TITLE
Corrected the adjList for C2H3O in FFCM1(-) thermo library

### DIFF
--- a/input/kinetics/libraries/FFCM1(-)/dictionary.txt
+++ b/input/kinetics/libraries/FFCM1(-)/dictionary.txt
@@ -216,9 +216,8 @@ multiplicity 2
 6 O u0 p2 c0 {2,D}
 
 H2CC
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 

--- a/input/thermo/libraries/FFCM1(-).py
+++ b/input/thermo/libraries/FFCM1(-).py
@@ -1398,14 +1398,13 @@ entry(
     index = 48,
     label = "C2H3O",
     molecule = 
-"""
-multiplicity 2
-1 C u0 p0 c0 {2,D} {4,S} {5,S}
-2 C u0 p0 c0 {1,D} {3,S} {6,S}
-3 O u1 p2 c0 {2,S}
-4 H u0 p0 c0 {1,S}
+"""multiplicity 2
+1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 O u0 p2 c0 {1,S} {2,S}
 5 H u0 p0 c0 {1,S}
-6 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
 """,
     thermo = NASA(
         polynomials = [

--- a/input/thermo/libraries/FFCM1(-).py
+++ b/input/thermo/libraries/FFCM1(-).py
@@ -1018,9 +1018,8 @@ entry(
     label = "H2CC",
     molecule = 
 """
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 """,


### PR DESCRIPTION
C2H3O is `Oxirane (ethylene oxide) radical' [CH]1CO1, and not C=C[O]
(It appears in FFCM thermo, but does not participate in any of FFCM's reactions)

`H2CC` was also updated