### PR TITLE
make travis to test all the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
 script:
   - make test-database
-  - make test
+  - make test-all
   - cd $TRAVIS_BUILD_DIR
 
 after_success:


### PR DESCRIPTION
This the recently merged PR in RMG-Py which has `make test` with tests having no requirements of authentication and `make test-all` with all the tests. So this PR is to update the approriate test mode in RMG-database travis build process. 