### PR TITLE
prevent the use of O2b rules in H_abstraction for abstractions not done by O2b

### DIFF
--- a/input/kinetics/families/H_Abstraction/groups.py
+++ b/input/kinetics/families/H_Abstraction/groups.py
@@ -3940,6 +3940,7 @@ entry(
 2    Ct u1 {1,T}
 """,
     kinetics = None,
+    nodalDistance=15.0,
 )
 
 entry(


### PR DESCRIPTION
This sets the nodalDistance of the O2b group in H_abstraction to 15.  