### PR TITLE
Fixes the longDesc attribute of two nodes that were improperly changed

### DIFF
--- a/input/kinetics/families/H_Abstraction/rules.py
+++ b/input/kinetics/families/H_Abstraction/rules.py
@@ -172,7 +172,7 @@ entry(
     shortDesc = u"""Estimate [W.H. Green]""",
     longDesc = 
 u"""
-Sumathy CBS-Q calculations. Rate expression per H atom.
+
 """,
 )
 
@@ -191,7 +191,7 @@ entry(
     shortDesc = u"""Estimate [W.H. Green]""",
     longDesc = 
 u"""
-Sumathy CBS-Q calculations. Rate expression per H atom.
+
 """,
 )
 


### PR DESCRIPTION
A longDesc contradicting the shortDesc was improperly added to two rules during the commit "Manual merge of RMG-Java 8ce558. H_Abstraction family updated" this pull request removes the improper longDesc from these rules.  