### PR TITLE
Added and edited thermo groups entries based on CBS-QB3 Calculations

### DIFF
--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -4208,14 +4208,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-38.1067,-39.288,-37.6375,-33.3805,-24.832,-17.3106,-9.09196],'J/(mol*K)'),
-        H298 = (65.0161,'kJ/mol'),
-        S298 = (206.507,'J/(mol*K)'),
+        Cpdata = ([-8.745000,-9.020000,-8.632000,-7.604000,-5.545000,-3.763000,-1.896000],'cal/(mol*K)'),
+        H298 = (10.102000,'kcal/mol','+|-',2.4),
+        S298 = (50.304000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
     longDesc = 
 u"""
-Fitted from molecule s2_5_6_diene_0_2 from Bicyclics_QM_190_isomorphic library.
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species was C1=CCC2CCCC2=C1
 """,
 )
 
@@ -4236,14 +4241,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-37.6961,-35.2802,-32.024,-27.9105,-19.5952,-13.4391,-6.14448],'J/(mol*K)'),
-        H298 = (55.6806,'kJ/mol'),
-        S298 = (204.632,'J/(mol*K)'),
+        Cpdata = ([-8.664000,-8.012000,-7.206000,-6.217000,-4.239000,-2.796000,-1.157000],'cal/(mol*K)'),
+        H298 = (6.554000,'kcal/mol','+|-',2.4),
+        S298 = (49.142000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
-    longDesc = 
-u"""
-Fitted from molecule s2_5_6_diene_0_3 from Bicyclics_QM_190_isomorphic library.
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species was C=1CC=C2CCCC2C1
 """,
 )
 
@@ -4376,14 +4386,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-37.026,-38.605,-37.5762,-33.1727,-24.9369,-17.2835,-9.61384],'J/(mol*K)'),
-        H298 = (70.9548,'kJ/mol'),
-        S298 = (222.284,'J/(mol*K)'),
+        Cpdata = ([-8.453000,-8.770000,-8.511000,-7.463000,-5.515000,-3.726000,-2.021000],'cal/(mol*K)'),
+        H298 = (10.068000,'kcal/mol','+|-',2.4),
+        S298 = (52.912000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
     longDesc = 
 u"""
-Fitted from molecule s2_5_6_diene_1_3 from Bicyclics_QM_190_isomorphic library.
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species was C1=CC2CCCC2C=C1
 """,
 )
 
@@ -4948,7 +4963,7 @@ Fitted from species 2HINDENE from C10H11 library.
 entry(
     index = 184,
     label = "s2_5_6_ben",
-    group = 
+    group =
 """
 1 * R!H u0 {2,B} {3,S} {5,B}
 2   R!H u0 {1,B} {4,S} {6,B}
@@ -4962,14 +4977,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-18.9363,-17.9366,-16.3584,-14.6161,-10.2889,-6.03196,0.7134],'J/(mol*K)'),
-        H298 = (37.0186,'kJ/mol'),
-        S298 = (96.7074,'J/(mol*K)'),
+        Cpdata = ([-4.265000,-3.932000,-3.518000,-3.105000,-2.096000,-1.115000,0.398000],'cal/(mol*K)'),
+        H298 = (3.655000,'kcal/mol','+|-',2.4),
+        S298 = (23.226000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
-    longDesc = 
-u"""
-Fitted from molecule s2_5_6_ben from Bicyclics_QM_190_isomorphic library.
+    shortDesc = u"""Fitted From Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species used is Indane
 """,
 )
 
@@ -5583,14 +5603,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-41.1697,-42.9508,-41.3835,-35.9799,-25.3008,-16.5271,-7.06396],'J/(mol*K)'),
-        H298 = (63.4493,'kJ/mol'),
-        S298 = (189.537,'J/(mol*K)'),
+        Cpdata = ([-9.598000,-9.932000,-9.489000,-8.152000,-5.559000,-3.471000,-1.324000],'cal/(mol*K)'),
+        H298 = (4.953000,'kcal/mol','+|-',2.4),
+        S298 = (45.449000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
     longDesc = 
 u"""
-Fitted from molecule s2_6_6_diene_0_2 from Bicyclics_QM_190_isomorphic library.
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species was C1=CCC2CCCCC2=C1
 """,
 )
 
@@ -5612,14 +5637,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-42.7321,-39.342,-35.424,-30.3159,-20.1131,-12.6136,-3.65148],'J/(mol*K)'),
-        H298 = (28.0356,'kJ/mol'),
-        S298 = (178.832,'J/(mol*K)'),
+        Cpdata = ([-9.809000,-9.094000,-8.115000,-6.791000,-4.282000,-2.533000,-0.609000],'cal/(mol*K)'),
+        H298 = (-0.243000,'kcal/mol','+|-',2.4),
+        S298 = (42.856000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
-    longDesc = 
-u"""
-Fitted from molecule s2_6_6_diene_0_3 from Bicyclics_QM_190_isomorphic library.
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species was C=1CC=C2CCCCC2C1
 """,
 )
 
@@ -5786,14 +5816,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-40.963,-41.2288,-39.5802,-34.4991,-24.6798,-15.8711,-6.70784],'J/(mol*K)'),
-        H298 = (49.5297,'kJ/mol'),
-        S298 = (182.032,'J/(mol*K)'),
+        Cpdata = ([-9.374000,-9.374000,-8.971000,-7.762000,-5.435000,-3.367000,-1.291000],'cal/(mol*K)'),
+        H298 = (4.291000,'kcal/mol','+|-',2.4),
+        S298 = (45.288000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
     longDesc = 
 u"""
-Fitted from molecule s2_6_6_diene_1_3 from Bicyclics_QM_190_isomorphic library.
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species was C=1C=CC2CCCCC2C1
 """,
 )
 
@@ -6233,7 +6268,7 @@ Fitted from species prod4 from naphthalene_H library.
 entry(
     index = 185,
     label = "s2_6_6_ben",
-    group = 
+    group =
 """
 1    R!H u0 {2,B} {3,B} {5,S}
 2    R!H u0 {1,B} {4,B} {6,S}
@@ -6248,14 +6283,19 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-22.6673,-21.2954,-19.5434,-17.0615,-10.7908,-5.16852,3.2034],'J/(mol*K)'),
-        H298 = (24.5885,'kJ/mol'),
-        S298 = (78.9822,'J/(mol*K)'),
+        Cpdata = ([-3.873000,-4.106000,-3.778000,-3.131000,-2.168000,-1.114000,0.805000],'cal/(mol*K)'),
+        H298 = (-0.183000,'kcal/mol','+|-',2.4),
+        S298 = (15.044000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Fitted from thermo library values""",
-    longDesc = 
-u"""
-Fitted from molecule s2_6_6_ben from Bicyclics_QM_190_isomorphic library.
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model species used is Ethyltetralin
 """,
 )
 

--- a/input/thermo/groups/radical.py
+++ b/input/thermo/groups/radical.py
@@ -637,7 +637,7 @@ DOI: 10.1002/chem.201301381
 entry(
     index = 12,
     label = "Benzyl_P",
-    group = 
+    group =
 """
 1 * Cs u1 {2,S} {3,S} {4,S}
 2   Cb u0 {1,S}
@@ -646,14 +646,20 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([0.75,0.6,0.13,-0.42,-1.41,-2.18,-2.18],'cal/(mol*K)'),
-        H298 = (88.5,'kcal/mol','+|-',0.1),
-        S298 = (-4.74,'cal/(mol*K)'),
+        Cpdata = ([0.492000,0.642000,0.109000,-0.656000,-1.606000,-2.293000,-4.101000],'cal/(mol*K)'),
+        H298 = (90.788000,'kcal/mol','+|-',2.4),
+        S298 = (-5.163000,'cal/(mol*K)'),
     ),
-    shortDesc = u"""LAY et al.""",
-    longDesc = 
-u"""
+    shortDesc = u"""Fitted From  Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
 
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model Compounds Include
+[CH2]C1C=CC=CC=1
 """,
 )
 
@@ -2455,7 +2461,7 @@ u"""
 entry(
     index = 24,
     label = "Benzyl_S",
-    group = 
+    group =
 """
 1 * Cs u1 {2,S} {3,S} {4,S}
 2   Cb u0 {1,S}
@@ -2464,14 +2470,24 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([0.87,0.09,-0.63,-1.21,-2.07,-2.69,-2.69],'cal/(mol*K)'),
-        H298 = (85.9,'kcal/mol'),
-        S298 = (-5.04,'cal/(mol*K)'),
+        Cpdata = ([-0.044800,-1.300200,-2.199000,-2.554600,-2.587200,-2.807400,-5.633600],'cal/(mol*K)'),
+        H298 = (88.064000,'kcal/mol','+|-',2.4),
+        S298 = (-4.855400,'cal/(mol*K)'),
     ),
-    shortDesc = u"""LAY et al.""",
-    longDesc = 
-u"""
+    shortDesc = u"""Fitted From Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 7/2017, Lawrence Lai
 
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model Compounds Include
+C[CH]C1C=CC=CC=1
+CC[CH]C1C=CC=CC=1
+CCC[CH]C1C=CC=CC=1
+CCCC[CH]C1C=CC=CC=1
+CCCCC[CH]C1C=CC=CC=1
 """,
 )
 
@@ -2497,6 +2513,76 @@ entry(
     longDesc = 
 u"""
 
+""",
+)
+
+entry(
+    index = 2001,
+    label = "C=CCJC=C-cyclohexadiene",
+    group =
+"""
+1 * Cs u1 {2,S} {6,S} {7,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   Cs u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {5,D} {1,S}
+7   H u0 {1,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0.140737,-0.726316,-1.615579,-2.344000,-27.807158,-3.672526,-4.955158],'cal/(mol*K)'),
+        H298 = (73.850211,'kcal/mol','+|-',2.4),
+        S298 = (-3.772368,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
+Based on CBS-QB3 calculations and group values for radical groups already present in the database, 01/2018, Lawrence Lai
+
+Uncertainty of CBS-QB3 is 2.4kcal/mol, by Somers, K, and Simmie, J, "Benchmarking Compound Methods (CBS-QB3, CBS-APNO, G3, G4, W1BD") against the Active Thermochemical  Tables: Formation Enthalpies of Radicals. 2015.
+http://pubs.acs.org/doi/abs/10.1021/acs.jpca.5b05448
+
+Model Species used include:
+CC1=C[CH]C=CC1
+CC1[CH]C=CCC=1
+C[C]1C=CCC=C1
+CC1C=C[CH]C=C1
+CCCCCCC1=C[CH]C=CC1
+CCCCCCC1[CH]C=CCC=1
+CCCCCC[C]1C=CCC=C1
+CCCCCCC1C=C[CH]C=C1
+CC1[CH]C(C)C=CC=1
+CC1C(C)[CH]C=CC=1
+CC1C=CC(C)[CH]C=1
+CC1(C)[CH]C=CC=C1
+C1=CC=C2CCCC2[CH]1
+C1=CC=C2CCC(C)C2[CH]1
+C1=CC=C2CCC(CC)C2[CH]1
+C1=CC=C2CCC(CCC)C2[CH]1
+C1CCCC2=CC=C[CH]C21
+CC1CCCC2=CC=C[CH]C21
+CCC1CCCC2=CC=C[CH]C21
+""",
+)
+
+entry(
+    index = 2002,
+    label = "CJC=CC=C-cyclohexadiene",
+    group =
+"""
+1 * Cs u1 {2,S} {6,S} {7,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   Cd u0 {3,S} {5,D}
+5   Cd u0 {4,D} {6,S}
+6   Cs u0 {5,S} {1,S}
+7   H u0 {1,S}
+""",
+    thermo = u'C=CCJC=C-cyclohexadiene',
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
 """,
 )
 
@@ -2951,6 +3037,26 @@ entry(
     longDesc = 
 u"""
 
+""",
+)
+
+entry(
+    index = 2003,
+    label = "C=CCJ(C)C=C-cyclohexadiene",
+    group =
+"""
+1 * Cs u1 {2,S} {6,S} {7,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   Cs u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {5,D} {1,S}
+7   C u0 {1,S}
+""",
+    thermo = u'C=CCJC=C-cyclohexadiene',
+    shortDesc = u"""Calculations from Hexylbenzene Library, Lawrence Lai""",
+    longDesc =
+u""""
 """,
 )
 
@@ -8621,6 +8727,8 @@ L1: Radical
                             L8: cyclohexane
                     L6: Benzyl_S
                         L7: Indenyl
+                    L6: C=CCJC=C-cyclohexadiene
+                    L6: CJC=CC=C-cyclohexadiene
                     L6: Allyl_S
                         L7: cyclobutene-allyl
                         L7: cyclopentene-allyl
@@ -8636,6 +8744,7 @@ L1: Radical
                 L5: Cs_T
                     L6: CCJ(C)CO
                         L7: C2CJCOOH
+                    L6: C=CCJ(C)C=C-cyclohexadiene
                     L6: Tertalkyl
                         L7: bicyclo[1.1.0]butane-tertiary
                         L7: bicyclo[2.1.0]pentane-tertiary


### PR DESCRIPTION
Groups added/editted are:
radical(Benzyl_S)
radical(Benzyl_P)
radical(C=CCJC=C-cyclohexadiene)
radical(CJC=CC=C-cyclohexadiene)
radical(C=CCJ(C)C=C-cyclohexadiene)
polycyclic(s2_5_6_ben)
polycyclic(s2_6_6_ben)
polycyclic(s2_5_6_diene_0_3)
polycyclic(s2_6_6_diene_0_3)

Calculations done by Lawrence Lai, 2017, can be found in
pharos/laitcl/Gaussian