### PR TITLE
Aromatics updates 2 (out of 4): Thermo Groups

### DIFF
--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -595,3 +595,25 @@ Certain unsaturated versions of this strained tricyclic cause RMG
 to crash.
 """,
 )
+
+entry(
+    label = "strained_tricyclic_3",
+    group =
+"""
+1  R!H ux {3,[S,D,T,B]} {7,[S,D,T,B]}
+3  R!H ux {1,[S,D,T,B]} {4,[S,D,T,B]} {10,[S,D,T,B]}
+4  R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5  R!H ux {4,[S,D,T,B]} {6,[S,D,T,B]} {10,[S,D,T,B]}
+6  R!H ux {5,[S,D,T,B]} {7,[S,D,T,B]}
+7  R!H ux {1,[S,D,T,B]} {6,[S,D,T,B]} {8,[S,D,T,B]}
+8  R!H ux {7,[S,D,T,B]} {9,[S,D,T,B]}
+9  R!H ux {8,[S,D,T,B]} {10,[S,D,T,B]}
+10 R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]} {9,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Certain unsaturated versions of this strained tricyclic cause RMG
+to crash.
+""",
+)

--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -527,3 +527,48 @@ entry(
 u"""
 """,
 )
+
+entry(
+    label = "strained_tetracyclic_1",
+    group =
+"""
+1  R!H ux {2,[S,D,T,B]} {9,[S,D,T,B]}
+2  R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3  R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]} {10,[S,D,T,B]}
+4  R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]} {9,[S,D,T,B]}
+5  R!H ux {4,[S,D,T,B]} {6,[S,D,T,B]}
+6  R!H ux {5,[S,D,T,B]} {7,[S,D,T,B]}
+7  R!H ux {6,[S,D,T,B]} {8,[S,D,T,B]} {10,[S,D,T,B]}
+8  R!H ux {7,[S,D,T,B]} {9,[S,D,T,B]} {10,[S,D,T,B]}
+9  R!H ux {1,[S,D,T,B]} {4,[S,D,T,B]} {8,[S,D,T,B]}
+10 R!H ux {3,[S,D,T,B]} {7,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+For certain unsaturated versions of this strained tetracyclic, RMG finds multiple reverse H-abstraction reactions, causing RMG
+to crash.
+""",
+)
+
+entry(
+    label = "strained_tricyclic_1",
+    group =
+"""
+2  R!H ux {3,[S,D,T,B]} {10,[S,D,T,B]}
+3  R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]}
+4  R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5  R!H ux {4,[S,D,T,B]} {6,[S,D,T,B]} {9,[S,D,T,B]}
+6  R!H ux {5,[S,D,T,B]} {7,[S,D,T,B]} {10,[S,D,T,B]}
+7  R!H ux {6,[S,D,T,B]} {8,[S,D,T,B]}
+8  R!H ux {7,[S,D,T,B]} {9,[S,D,T,B]}
+9  R!H ux {5,[S,D,T,B]} {8,[S,D,T,B]} {10,[S,D,T,B]}
+10 R!H ux {2,[S,D,T,B]} {6,[S,D,T,B]} {9,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+For certain unsaturated versions of this strained tricyclic, RMG's Clar optimization fails, causing RMG
+to crash.
+""",
+)

--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -443,3 +443,87 @@ Invalid k(E) values computed for path reaction "C(=[CH])[O-][N+]#N(6454) <=> c1c
 """,
 )
 
+entry(
+    label = "cyclobutyne",
+    group =
+"""
+1   R!H ux {2,T} {4,[S,D,T]}
+2   R!H ux {1,T} {3,[S,D,T]}
+3   R!H ux {2,[S,D,T]} {4,[S,D,T]}
+4   R!H ux {1,[S,D,T]} {3,[S,D,T]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+""",
+)
+
+entry(
+    label = "s2_3_4_yne_1",
+    group =
+"""
+1   R!H ux {2,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]}
+2   R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+3   R!H ux {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H ux {1,[S,D,T,B]} {5,T}
+5   R!H ux {2,[S,D,T,B]} {4,T}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+""",
+)
+
+entry(
+    label = "s2_4_4_yne_1",
+    group =
+"""
+1   R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H ux {2,[S,D,T,B]} {4,T}
+4   R!H ux {1,[S,D,T,B]} {3,T}
+5   R!H ux {1,[S,D,T,B]} {6,[S,D,T,B]}
+6   R!H ux {2,[S,D,T,B]} {5,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+""",
+)
+
+entry(
+    label = "s2_4_5_yne_5",
+    group =
+"""
+1   R!H ux {2,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H ux {1,[S,D,T,B]} {4,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H ux {1,[S,D,T,B]} {4,T}
+4   R!H ux {2,[S,D,T,B]} {3,T}
+5   R!H ux {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H ux {2,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H ux {5,[S,D,T,B]} {6,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+""",
+)
+
+entry(
+    label = "s2_4_6_yne_6",
+    group =
+"""
+1   R!H ux {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2   R!H ux {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3   R!H ux {1,[S,D,T,B]} {4,T}
+4   R!H ux {2,[S,D,T,B]} {3,T}
+5   R!H ux {2,[S,D,T,B]} {8,[S,D,T,B]}
+6   R!H ux {1,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H ux {6,[S,D,T,B]} {8,[S,D,T,B]}
+8   R!H ux {5,[S,D,T,B]} {7,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+""",
+)

--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -319,22 +319,22 @@ u"""
 """,
 )
 
-entry(
-    label = "cyclopropyne",
-    group = 
-"""
-1 C u0 {2,T} {3,S}
-2 C u0 {1,T} {3,S}
-3 C u0 {1,S} {2,S} {4,S} {5,S}
-4 H u0 {3,S}
-5 H u0 {3,S}
-""",
-    shortDesc = u"""""",
-    longDesc = 
-u"""
-
-""",
-)
+# entry(
+#     label = "cyclopropyne",
+#     group =
+# """
+# 1 C u0 {2,T} {3,S}
+# 2 C u0 {1,T} {3,S}
+# 3 C u0 {1,S} {2,S} {4,S} {5,S}
+# 4 H u0 {3,S}
+# 5 H u0 {3,S}
+# """,
+#     shortDesc = u"""""",
+#     longDesc =
+# u"""
+#
+# """,
+# )
 
 entry(
     label = "3H-Pyrazol",

--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -572,3 +572,26 @@ For certain unsaturated versions of this strained tricyclic, RMG's Clar optimiza
 to crash.
 """,
 )
+
+entry(
+    label = "strained_tricyclic_2",
+    group =
+"""
+1  R!H ux {2,[S,D,T,B]} {10,[S,D,T,B]}
+2  R!H ux {1,[S,D,T,B]} {3,[S,D,T,B]}
+3  R!H ux {2,[S,D,T,B]} {4,[S,D,T,B]} {8,[S,D,T,B]}
+4  R!H ux {3,[S,D,T,B]} {5,[S,D,T,B]}
+5  R!H ux {4,[S,D,T,B]} {6,[S,D,T,B]} {10,[S,D,T,B]}
+6  R!H ux {5,[S,D,T,B]} {7,[S,D,T,B]}
+7  R!H ux {6,[S,D,T,B]} {8,[S,D,T,B]}
+8  R!H ux {3,[S,D,T,B]} {7,[S,D,T,B]} {9,[S,D,T,B]}
+9  R!H ux {8,[S,D,T,B]} {10,[S,D,T,B]}
+10 R!H ux {1,[S,D,T,B]} {5,[S,D,T,B]} {9,[S,D,T,B]}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Certain unsaturated versions of this strained tricyclic cause RMG
+to crash.
+""",
+)

--- a/input/thermo/groups/group.py
+++ b/input/thermo/groups/group.py
@@ -44845,6 +44845,30 @@ entry(
     """,
 )
 
+entry(
+    index = 1932,
+    label = "Cds-(Cds-Os)CbH",
+    group =
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D} {5,S}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   Os u0 {2,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([5.28, 6.83, 7.245, 7.264, 8.226, 9.901, 10.176],'cal/(mol*K)'),
+        H298 = (10.329,'kcal/mol'),
+        S298 = (2.958,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations for OC=Cc1ccccc1
+""",
+)
+
 tree(
 """
 L1: R
@@ -45053,6 +45077,7 @@ L1: R
                 L5: Cds-CdsCtH
                     L6: Cds-CdsH(CtN3t)
                 L5: Cds-CdsCbH
+                    L6: Cds-(Cds-Os)CbH
                 L5: Cds-CddCsH
                     L6: Cds-(Cdd-Od)CsH
                     L6: Cds-(Cdd-Sd)CsH

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -2581,7 +2581,7 @@ Fitted from molecule s2_3_6_ane from Bicyclics_QM_190_isomorphic library.
 entry(
     index = 0,
     label = "s2_3_6_ene",
-    group = "OR{s2_3_6_ene_1, s2_3_6_ene_2}",
+    group = "OR{s2_3_6_ene_1, s2_3_6_ene_2, s2_3_6_ene_5}",
     thermo = None,
     shortDesc = u"""""",
     longDesc = 
@@ -2645,7 +2645,7 @@ Fitted from molecule s2_3_6_ene_2 from Bicyclics_QM_190_isomorphic library.
 entry(
     index = 0,
     label = "s2_3_6_diene",
-    group = "OR{s2_3_6_diene_0_2, s2_3_6_diene_0_3, s2_3_6_diene_1_3}",
+    group = "OR{s2_3_6_diene_0_2, s2_3_6_diene_0_3, s2_3_6_diene_1_3, s2_3_6_diene_2_5}",
     thermo = None,
     shortDesc = u"""""",
     longDesc = 
@@ -8554,6 +8554,166 @@ Fitted to M06 calculations
 """,
 )
 
+entry(
+    index = 76,
+    label = "s2_3_6_ene_5",
+    group =
+"""
+1   R!H u0 {2,S} {3,D} {4,S}
+2   R!H u0 {1,S} {3,S} {5,S}
+3   R!H u0 {1,D} {2,S}
+4   R!H u0 {1,S} {7,S}
+5   R!H u0 {2,S} {6,S}
+6 * R!H u0 {5,S} {7,S}
+7   R!H u0 {4,S} {6,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-33.0644, -30.4388, -27.9344, -25.2475, -19.6467, -15.2896, -10.1737], 'J/(mol*K)'),
+        H298=(262.495, 'kJ/mol'),
+        S298=(238.794, 'J/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to M06 calculations
+""",
+)
+
+entry(
+    index = 77,
+    label = "s2_3_6_diene_2_5",
+    group =
+"""
+1   R!H u0 {2,S} {3,D} {4,S}
+2   R!H u0 {1,S} {3,S} {5,S}
+3   R!H u0 {1,D} {2,S}
+4   R!H u0 {1,S} {7,S}
+5   R!H u0 {2,S} {6,S}
+6 * R!H u0 {5,S} {7,D}
+7   R!H u0 {4,S} {6,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-25.6671, -24.8396, -23.399, -21.6937, -17.9095, -14.865, -11.0665], 'J/(mol*K)'),
+        H298=(259.334, 'kJ/mol'),
+        S298=(242.952, 'J/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to M06 calculations
+""",
+)
+
+entry(
+    index = 78,
+    label = "s3_5_6_ben_ane_res1",
+    group =
+"""
+1   R!H u0 {3,B} {5,S} {6,B}
+2   R!H u0 {3,B} {4,S} {7,B}
+3   R!H u0 {1,B} {2,B}
+4   R!H u0 {2,S} {5,S}
+5   R!H u0 {1,S} {4,S}
+6   R!H u0 {1,B} {8,B}
+7   R!H u0 {2,B} {8,B}
+8 * R!H u0 {6,B} {7,B}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.469, -0.262, -0.442, -0.825, -0.747, 0.339, 0.354], 'cal/(mol*K)'),
+        H298=(166.291, 'kcal/mol'),
+        S298=(30.103, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 78,
+    label = "s3_5_6_ben_ane_res2",
+    group =
+"""
+1   R!H u0 {3,S} {5,S} {6,D}
+2   R!H u0 {3,D} {4,S} {7,S}
+3   R!H u0 {1,S} {2,D}
+4   R!H u0 {2,S} {5,S}
+5   R!H u0 {1,S} {4,S}
+6   R!H u0 {1,D} {8,S}
+7   R!H u0 {2,S} {8,D}
+8 * R!H u0 {6,S} {7,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.469, -0.262, -0.442, -0.825, -0.747, 0.339, 0.354], 'cal/(mol*K)'),
+        H298=(166.291, 'kcal/mol'),
+        S298=(30.103, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Copy of res 1 correction. Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 79,
+    label = "s3_5_6_ben_ene_res1",
+    group =
+"""
+1   R!H u0 {3,B} {5,S} {6,B}
+2   R!H u0 {3,B} {4,S} {7,B}
+3   R!H u0 {1,B} {2,B}
+4   R!H u0 {2,S} {5,D}
+5   R!H u0 {1,S} {4,D}
+6   R!H u0 {1,B} {8,B}
+7   R!H u0 {2,B} {8,B}
+8 * R!H u0 {6,B} {7,B}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-7.96404, -8.74552, -8.7074, -8.03332, -5.94428, -4.49956, -4.93892], 'J/(mol*K)'),
+        H298=(708.321, 'kJ/mol'),
+        S298=(145.354, 'J/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to M06 calculations
+""",
+)
+
+entry(
+    index = 80,
+    label = "s3_5_6_ben_ene_res2",
+    group =
+"""
+1   R!H u0 {3,S} {5,S} {6,D}
+2   R!H u0 {3,D} {4,S} {7,S}
+3   R!H u0 {1,S} {2,D}
+4   R!H u0 {2,S} {5,D}
+5   R!H u0 {1,S} {4,D}
+6   R!H u0 {1,D} {8,S}
+7   R!H u0 {2,S} {8,D}
+8 * R!H u0 {6,S} {7,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-14.24, -20.6281, -22.933, -23.0957, -21.9272, -19.2272, -22.6791], 'J/(mol*K)'),
+        H298=(600.625, 'kJ/mol'),
+        S298=(297.401, 'J/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to M06 calculations
+""",
+)
+
 tree(
 """
 L1: PolycyclicRing
@@ -8682,10 +8842,12 @@ L1: PolycyclicRing
         L3: s2_3_6_ene
             L4: s2_3_6_ene_1
             L4: s2_3_6_ene_2
+            L4: s2_3_6_ene_5
         L3: s2_3_6_diene
             L4: s2_3_6_diene_0_2
             L4: s2_3_6_diene_0_3
             L4: s2_3_6_diene_1_3
+            L4: s2_3_6_diene_2_5
         L3: s2_3_6_ben
     L2: s2_3_7
         L3: s2_3_7_ane
@@ -8875,6 +9037,10 @@ L1: PolycyclicRing
             L4: s3_5_6_ene_5
         L3: s3_5_6_diene
             L4: s3_5_6_diene_1_5
+        L3: s3_5_6_ben_ane_res1
+        L3: s3_5_6_ben_ane_res2
+        L3: s3_5_6_ben_ene_res1
+        L3: s3_5_6_ben_ene_res2
     L2: s3_6_6
         L3: s3_6_6_ane
         L3: s3_6_6_ene

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -7164,7 +7164,7 @@ Fitted from species product29 from vinylCPD_H library.
 entry(
     index = 0,
     label = "s3_5_5_diene",
-    group = "OR{s3_5_5_diene_1_4}",
+    group = "OR{s3_5_5_diene_1_4, s3_5_5_diene_0_4}",
     thermo = None,
     shortDesc = u"""""",
     longDesc = 
@@ -8035,7 +8035,7 @@ entry(
     group = "OR{s4_6_8_ene_7}",
     thermo = None,
     shortDesc = u"""""",
-    longDesc = 
+    longDesc =
 u"""
 
 """,
@@ -8772,6 +8772,181 @@ u"""
 """,
 )
 
+entry(
+    index = 118,
+    label = "s2_5_6_ben_yne_1_res2",
+    group =
+"""
+1 * R!H u0 {2,D} {3,S} {4,S}
+2   R!H u0 {1,D} {5,S} {6,S}
+3   R!H u0 {1,S} {7,S}
+4   R!H u0 {1,S} {8,D}
+5   R!H u0 {2,S} {7,T}
+6   R!H u0 {2,S} {9,D}
+7   R!H u0 {3,S} {5,T}
+8   R!H u0 {4,D} {9,S}
+9   R!H u0 {6,D} {8,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-1.5365, -2.13592, -2.3522, -2.02817, -1.28741, -1.73936, -3.47344], 'cal/(mol*K)'),
+        H298=(68.097, 'kcal/mol'),
+        S298=(34.0579, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Copy of res 1 correction. Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 118,
+    label = "s2_5_6_ben_yne_1_res3",
+    group =
+"""
+1 * R!H u0 {2,S} {3,S} {4,D}
+2   R!H u0 {1,S} {5,S} {6,D}
+3   R!H u0 {1,S} {7,S}
+4   R!H u0 {1,D} {8,S}
+5   R!H u0 {2,S} {7,T}
+6   R!H u0 {2,D} {9,S}
+7   R!H u0 {3,S} {5,T}
+8   R!H u0 {4,S} {9,D}
+9   R!H u0 {6,S} {8,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-1.5365, -2.13592, -2.3522, -2.02817, -1.28741, -1.73936, -3.47344], 'cal/(mol*K)'),
+        H298=(68.097, 'kcal/mol'),
+        S298=(34.0579, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Copy of res 1 correction. Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 119,
+    label = "s3_5_5_diene_0_4",
+    group =
+"""
+1   R!H u0 {3,S} {6,S} {7,S}
+2   R!H u0 {3,S} {4,D} {5,S}
+3   R!H u0 {1,S} {2,S}
+4 * R!H u0 {2,D} {6,S}
+5   R!H u0 {2,S} {7,D}
+6   R!H u0 {1,S} {4,S}
+7   R!H u0 {1,S} {5,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.117, -6.624, -6.352, -6.401, -5.37, -3.457, -3.059],'cal/(mol*K)'),
+        H298 = (86.425,'kcal/mol'),
+        S298 = (57.025,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted to CBS-QB3 calculation""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation.
+""",
+)
+
+entry(
+    index = 0,
+    label = "s4_6_6_ben_ben",
+    group = "OR{s4_6_6_ben_ben_res1, s4_6_6_ben_ben_res2, s4_6_6_ben_ben_res3}",
+    thermo = None,
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
+    index = 180,
+    label = "s4_6_6_ben_ben_res1",
+    group =
+"""
+1 * R!H u0 {3,B} {6,B} {8,B}
+2   R!H u0 {4,B} {5,B} {7,B}
+3   R!H u0 {1,B} {4,B}
+4   R!H u0 {2,B} {3,B}
+5   R!H u0 {2,B} {6,B}
+6   R!H u0 {1,B} {5,B}
+7   R!H u0 {2,B} {8,B}
+8   R!H u0 {1,B} {7,B}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0.711, 2.163, 2.154, 1.273, 0.527, 0.897, -1.267],'cal/(mol*K)'),
+        H298 = (165.718,'kcal/mol'),
+        S298 = (12.735,'cal/(mol*K)'),
+    ),
+    shortDesc=u"""Fitted to CBS-QB3 calculation""",
+    longDesc=
+    u"""
+    Fitted to CBS-QB3 calculation.
+    """,
+)
+
+entry(
+    index = 181,
+    label = "s4_6_6_ben_ben_res2",
+    group =
+"""
+1 * R!H u0 {3,S} {6,B} {8,B}
+2   R!H u0 {4,S} {5,B} {7,B}
+3   R!H u0 {1,S} {4,D}
+4   R!H u0 {2,S} {3,D}
+5   R!H u0 {2,B} {6,B}
+6   R!H u0 {1,B} {5,B}
+7   R!H u0 {2,B} {8,B}
+8   R!H u0 {1,B} {7,B}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-2.829, -1.234, -0.797, -1.155, -1.114, -0.25, -0.824],'cal/(mol*K)'),
+        H298 = (156.978,'kcal/mol'),
+        S298 = (28.635,'cal/(mol*K)'),
+    ),
+    shortDesc=u"""Fitted to CBS-QB3 calculation""",
+    longDesc=
+    u"""
+    Fitted to CBS-QB3 calculation.
+    """,
+)
+
+entry(
+    index = 182,
+    label = "s4_6_6_ben_ben_res3",
+    group =
+"""
+1 * R!H u0 {3,S} {6,D} {8,S}
+2   R!H u0 {4,S} {5,D} {7,S}
+3   R!H u0 {1,S} {4,D}
+4   R!H u0 {2,S} {3,D}
+5   R!H u0 {2,D} {6,S}
+6   R!H u0 {1,D} {5,S}
+7   R!H u0 {2,S} {8,D}
+8   R!H u0 {1,S} {7,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.711, 2.163, 2.154, 1.273, 0.527, 0.897, -1.267], 'cal/(mol*K)'),
+        H298=(165.718, 'kcal/mol'),
+        S298=(12.735, 'cal/(mol*K)'),
+    ),
+    shortDesc=u"""""",
+    longDesc=
+    u"""
+    Copy of res 1 correction.
+    """,
+)
+
 tree(
 """
 L1: PolycyclicRing
@@ -9090,6 +9265,7 @@ L1: PolycyclicRing
         L3: s3_5_5_ane
         L3: s3_5_5_diene
             L4: s3_5_5_diene_1_4
+            L4: s3_5_5_diene_0_4
     L2: s3_5_6
         L3: s3_5_6_ane
         L3: s3_5_6_ene
@@ -9126,6 +9302,10 @@ L1: PolycyclicRing
             L4: s3_6_7_diene_6_9-0
     L2: s4_6_6
         L3: s4_6_6_ane
+        L3: s4_6_6_ben_ben
+            L4: s4_6_6_ben_ben_res1
+            L4: s4_6_6_ben_ben_res2
+            L4: s4_6_6_ben_ben_res3
     L2: s4_6_8
         L3: s4_6_8_ane
         L3: s4_6_8_ene

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -9116,9 +9116,6 @@ L1: PolycyclicRing
             L4: s2_3_6_diene_1_3
             L4: s2_3_6_diene_2_5
         L3: s2_3_6_ben
-        L3: s2_3_6_yne
-            L4: s2_3_6_yne_1
-            L4: s2_3_6_yne_2
     L2: s2_3_7
         L3: s2_3_7_ane
     L2: s2_3_8
@@ -9151,9 +9148,6 @@ L1: PolycyclicRing
             L4: s2_4_6_diene_2_6
             L4: s2_4_6_diene_5_7
         L3: s2_4_6_ben
-        L3: s2_4_6_yne
-            L4: s2_4_6_yne_1
-            L4: s2_4_6_yne_2
     L2: s2_5_5
         L3: s2_5_5_ane
         L3: s2_5_5_ene
@@ -9265,9 +9259,6 @@ L1: PolycyclicRing
             L4: s2_6_6_ben_ene_1
             L4: s2_6_6_ben_ene_2
         L3: s2_6_6_naphthalene
-        L3: s2_6_6_yne
-            L4: s2_6_6_yne_1
-            L4: s2_6_6_yne_2
     L2: s3_4_4
         L3: s3_4_4_ane
         L3: s3_4_4_ene

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -8915,6 +8915,70 @@ entry(
     """,
 )
 
+entry(
+    index = 0,
+    label = "s3_4_6_ben_ane",
+    group = "OR{s3_4_6_ben_ane_res1, s3_4_6_ben_ane_res2}",
+    thermo = None,
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
+    index = 213,
+    label = "s3_4_6_ben_ane_res1",
+    group =
+"""
+1   R!H u0 {3,B} {4,S} {6,B}
+2   R!H u0 {3,B} {4,S} {7,B}
+3   R!H u0 {1,B} {2,B}
+4 * R!H u0 {2,S} {1,S}
+6   R!H u0 {1,B} {8,B}
+7   R!H u0 {2,B} {8,B}
+8   R!H u0 {6,B} {7,B}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.971, 1.615, 1.051, -0.042, -1.098, -0.849, -2.199], 'cal/(mol*K)'),
+        H298=(150.622, 'kcal/mol'),
+        S298=(34.822, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 214,
+    label = "s3_4_6_ben_ane_res2",
+    group =
+"""
+1   R!H u0 {3,S} {4,S} {6,D}
+2   R!H u0 {3,D} {4,S} {7,S}
+3   R!H u0 {1,S} {2,D}
+4 * R!H u0 {2,S} {1,S}
+6   R!H u0 {1,D} {8,S}
+7   R!H u0 {2,S} {8,D}
+8   R!H u0 {6,S} {7,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-6.57, -6.954, -7.598, -8.045, -6.641, -4.264, -4.149], 'cal/(mol*K)'),
+        H298=(129.962, 'kcal/mol'),
+        S298=(67.112, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations
+""",
+)
+
 tree(
 """
 L1: PolycyclicRing
@@ -9233,6 +9297,9 @@ L1: PolycyclicRing
             L4: s3_4_6_diene_0_4
             L4: s3_4_6_diene_1_4
             L4: s3_4_6_diene_1_5
+        L3: s3_4_6_ben_ane
+            L4: s3_4_6_ben_ane_res1
+            L4: s3_4_6_ben_ane_res2
     L2: s3_5_5
         L3: s3_5_5_ene
             L4: s3_5_5_ene_0

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -8714,6 +8714,64 @@ Fitted to M06 calculations
 """,
 )
 
+entry(
+    index = 86,
+    label = "s1-2_5d1d3_3_5d1_triene",
+    group =
+"""
+1 * R!H u0 {2,S} {3,S} {4,S} {5,S}
+2 R!H u0 {1,S} {3,S} {6,S}
+3 R!H u0 {1,S} {2,S} {7,S}
+4 R!H u0 {1,S} {9,D}
+5 R!H u0 {1,S} {10,D}
+6 R!H u0 {2,S} {8,D}
+7 R!H u0 {3,S} {8,S}
+8 R!H u0 {6,D} {7,S}
+9 R!H u0 {4,D} {10,S}
+10 R!H u0 {5,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-7.108, -7.764, -7.893, -7.784, -7.495, -7.132, -5.2],'cal/(mol*K)'),
+        H298 = (38.553,'kcal/mol'),
+        S298 = (95.09,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
+    index = 87,
+    label = "s2-2_5d1_3_6d1d3_triene",
+    group =
+"""
+1 * R!H u0 {2,S} {3,S} {4,S} {5,S}
+2 R!H u0 {1,S} {3,S} {7,S}
+3 R!H u0 {1,S} {2,S} {6,S}
+4 R!H u0 {1,S} {8,S}
+5 R!H u0 {1,S} {10,D}
+6 R!H u0 {3,S} {8,D}
+7 R!H u0 {2,S} {9,D}
+8 R!H u0 {4,S} {6,D}
+9 R!H u0 {7,D} {10,S}
+10 R!H u0 {5,D} {9,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-6.846, -7.913, -8.399, -8.495, -8.078, -7.325, -5.437],'cal/(mol*K)'),
+        H298 = (32.243,'kcal/mol'),
+        S298 = (93.33,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
 tree(
 """
 L1: PolycyclicRing
@@ -8731,6 +8789,8 @@ L1: PolycyclicRing
     L2: s2-4f1_5_5_7_ane
     L2: s4-3f1_6_6_6_ane
     L2: s3-3f1_6_5_6_ane
+    L2: s1-2_5d1d3_3_5d1_triene
+    L2: s2-2_5d1_3_6d1d3_triene
     L2: s1_3_3
         L3: s1_3_3_ane
         L3: s1_3_3_ene

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -4976,7 +4976,7 @@ Fitted from molecule s2_5_6_ben from Bicyclics_QM_190_isomorphic library.
 entry(
     index = 117,
     label = "s2_5_6_indene",
-    group = 
+    group =
 """
 1 * R!H u0 {2,B} {3,S} {4,B}
 2   R!H u0 {1,B} {5,S} {6,B}
@@ -4995,7 +4995,7 @@ entry(
         S298 = (33.08,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
-    longDesc = 
+    longDesc =
 u"""
 Verevkin (2011), experimental, S and cp from PM7
 """,

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -2572,10 +2572,10 @@ entry(
         S298 = (236.447,'J/(mol*K)'),
     ),
     shortDesc = u"""Fitted from thermo library values""",
-    longDesc = 
-u"""
-Fitted from molecule s2_3_6_ane from Bicyclics_QM_190_isomorphic library.
-""",
+    longDesc=
+    u"""
+    Fitted from molecule s2_3_6_ane from Bicyclics_QM_190_isomorphic library.
+    """,
 )
 
 entry(
@@ -9052,6 +9052,9 @@ L1: PolycyclicRing
             L4: s2_3_6_diene_1_3
             L4: s2_3_6_diene_2_5
         L3: s2_3_6_ben
+        L3: s2_3_6_yne
+            L4: s2_3_6_yne_1
+            L4: s2_3_6_yne_2
     L2: s2_3_7
         L3: s2_3_7_ane
     L2: s2_3_8
@@ -9084,6 +9087,9 @@ L1: PolycyclicRing
             L4: s2_4_6_diene_2_6
             L4: s2_4_6_diene_5_7
         L3: s2_4_6_ben
+        L3: s2_4_6_yne
+            L4: s2_4_6_yne_1
+            L4: s2_4_6_yne_2
     L2: s2_5_5
         L3: s2_5_5_ane
         L3: s2_5_5_ene
@@ -9195,6 +9201,9 @@ L1: PolycyclicRing
             L4: s2_6_6_ben_ene_1
             L4: s2_6_6_ben_ene_2
         L3: s2_6_6_naphthalene
+        L3: s2_6_6_yne
+            L4: s2_6_6_yne_1
+            L4: s2_6_6_yne_2
     L2: s3_4_4
         L3: s3_4_4_ane
         L3: s3_4_4_ene

--- a/input/thermo/groups/polycyclic.py
+++ b/input/thermo/groups/polycyclic.py
@@ -8607,6 +8607,18 @@ Fitted to M06 calculations
 )
 
 entry(
+    index = 0,
+    label = "s3_5_6_ben_ane",
+    group = "OR{s3_5_6_ben_ane_res1, s3_5_6_ben_ane_res2}",
+    thermo = None,
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
     index = 78,
     label = "s3_5_6_ben_ane_res1",
     group =
@@ -8649,14 +8661,26 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.469, -0.262, -0.442, -0.825, -0.747, 0.339, 0.354], 'cal/(mol*K)'),
-        H298=(166.291, 'kcal/mol'),
-        S298=(30.103, 'cal/(mol*K)'),
+        Cpdata=([-7.466, -8.33, -8.73, -8.665, -6.596, -3.859, -3.506], 'cal/(mol*K)'),
+        H298=(145.431, 'kcal/mol'),
+        S298=(63.603, 'cal/(mol*K)'),
     ),
+    shortDesc=u"""""",
+    longDesc=
+    u"""
+    Fitted to CBS-QB3 calculations
+    """,
+)
+
+entry(
+    index = 0,
+    label = "s3_5_6_ben_ene",
+    group = "OR{s3_5_6_ben_ene_res1, s3_5_6_ben_ene_res2}",
+    thermo = None,
     shortDesc = u"""""",
     longDesc =
 u"""
-Copy of res 1 correction. Fitted to CBS-QB3 calculations
+
 """,
 )
 
@@ -8769,62 +8793,6 @@ entry(
     longDesc =
 u"""
 
-""",
-)
-
-entry(
-    index = 118,
-    label = "s2_5_6_ben_yne_1_res2",
-    group =
-"""
-1 * R!H u0 {2,D} {3,S} {4,S}
-2   R!H u0 {1,D} {5,S} {6,S}
-3   R!H u0 {1,S} {7,S}
-4   R!H u0 {1,S} {8,D}
-5   R!H u0 {2,S} {7,T}
-6   R!H u0 {2,S} {9,D}
-7   R!H u0 {3,S} {5,T}
-8   R!H u0 {4,D} {9,S}
-9   R!H u0 {6,D} {8,S}
-""",
-    thermo=ThermoData(
-        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-1.5365, -2.13592, -2.3522, -2.02817, -1.28741, -1.73936, -3.47344], 'cal/(mol*K)'),
-        H298=(68.097, 'kcal/mol'),
-        S298=(34.0579, 'cal/(mol*K)'),
-    ),
-    shortDesc = u"""""",
-    longDesc =
-u"""
-Copy of res 1 correction. Fitted to CBS-QB3 calculations
-""",
-)
-
-entry(
-    index = 118,
-    label = "s2_5_6_ben_yne_1_res3",
-    group =
-"""
-1 * R!H u0 {2,S} {3,S} {4,D}
-2   R!H u0 {1,S} {5,S} {6,D}
-3   R!H u0 {1,S} {7,S}
-4   R!H u0 {1,D} {8,S}
-5   R!H u0 {2,S} {7,T}
-6   R!H u0 {2,D} {9,S}
-7   R!H u0 {3,S} {5,T}
-8   R!H u0 {4,S} {9,D}
-9   R!H u0 {6,S} {8,D}
-""",
-    thermo=ThermoData(
-        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-1.5365, -2.13592, -2.3522, -2.02817, -1.28741, -1.73936, -3.47344], 'cal/(mol*K)'),
-        H298=(68.097, 'kcal/mol'),
-        S298=(34.0579, 'cal/(mol*K)'),
-    ),
-    shortDesc = u"""""",
-    longDesc =
-u"""
-Copy of res 1 correction. Fitted to CBS-QB3 calculations
 """,
 )
 
@@ -9273,10 +9241,12 @@ L1: PolycyclicRing
             L4: s3_5_6_ene_5
         L3: s3_5_6_diene
             L4: s3_5_6_diene_1_5
-        L3: s3_5_6_ben_ane_res1
-        L3: s3_5_6_ben_ane_res2
-        L3: s3_5_6_ben_ene_res1
-        L3: s3_5_6_ben_ene_res2
+        L3: s3_5_6_ben_ane
+            L4: s3_5_6_ben_ane_res1
+            L4: s3_5_6_ben_ane_res2
+        L3: s3_5_6_ben_ene
+            L4: s3_5_6_ben_ene_res1
+            L4: s3_5_6_ben_ene_res2
     L2: s3_6_6
         L3: s3_6_6_ane
         L3: s3_6_6_ene

--- a/input/thermo/groups/radical.py
+++ b/input/thermo/groups/radical.py
@@ -8352,6 +8352,29 @@ u"""
 """,
 )
 
+entry(
+    index = 137,
+    label = "OC=CJCb",
+    group =
+"""
+1 * Cd u1 {2,D} {3,S}
+2   C  u0 {1,D} {4,S}
+3   Cb u0 {1,S}
+4   Os u0 {2,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([0.047, 0.607, 0.374, -0.3, -1.28, -1.972, -3.196],'cal/(mol*K)'),
+        H298 = (123.797,'kcal/mol'),
+        S298 = (2.661,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fit to CCSD(T)-F12/cc-pVDZ-F12//M06/vtz calculations""",
+    longDesc =
+u"""
+Fit to CCSD(T)-F12/cc-pVDZ-F12//M06/vtz calculations for OC=[C]c1ccccc1
+""",
+)
+
 tree(
 """
 L1: Radical
@@ -8613,6 +8636,7 @@ L1: Radical
                     L6: CCCJ=C=O
                         L7: CC(C)CJ=C=O
                         L7: C=C(C)CJ=C=O
+                    L6: OC=CJCb
                 L5: CdsJ-Ss
                 L5: C=CJO
             L4: CtJ

--- a/input/thermo/groups/radical.py
+++ b/input/thermo/groups/radical.py
@@ -2676,7 +2676,7 @@ u"""
 entry(
     index = 182,
     label = "1,3-cyclopentadiene-allyl",
-    group = 
+    group =
 """
 1 * Cs u1 {2,S} {3,S} {6,S}
 2   Cd u0 {1,S} {4,D}
@@ -2687,14 +2687,15 @@ entry(
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-1.54,-1.82,-2.08,-2.32,-2.75,-3.14,-3.85],'cal/(mol*K)'),
-        H298 = (82.6,'kcal/mol'),
-        S298 = (-3.81,'cal/(mol*K)'),
+        Cpdata = ([2.157, 0.892, -0.937, -2.776, -4.931, -3.793, -4.855],'cal/(mol*K)'),
+        H298 = (84.912,'kcal/mol'),
+        S298 = (-2.047,'cal/(mol*K)'),
     ),
-    shortDesc = u"""Homolytic C-H and N-H bond dissociation energies of strained organic compounds Feng et al. 2004S, Cp copied from Cds_S""",
-    longDesc = 
+    shortDesc = u"""Combined experimental and theoretical results of Tranter for 1,2-CPD'yl""",
+    longDesc =
 u"""
-
+Absolute Enthalpy of formation at 298 K from experiment (1998 Kern and Tranter).
+All other  values from theory (2001 Kiefer and Tranter).
 """,
 )
 

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -1115,8 +1115,8 @@ entry(
     label = "FiveMember",
     group = 
 """
-1 * R!H u0 {2,[S,D]} {5,[S,D]}
-2   R!H u0 {1,[S,D]} {3,[S,D]}
+1 * R!H u0 {2,[S,D,T]} {5,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
 3   R!H u0 {2,[S,D]} {4,[S,D]}
 4   R!H u0 {3,[S,D]} {5,[S,D]}
 5   R!H u0 {1,[S,D]} {4,[S,D]}
@@ -3843,6 +3843,49 @@ u"""
 """,
 )
 
+entry(
+    index = 93,
+    label = "Cyclopentyne",
+    group =
+"""
+1 * Ct u0 {2,T} {5,S}
+2   Ct u0 {1,T} {3,S}
+3   Cs u0 {2,S} {4,S}
+4   Cs u0 {3,S} {5,S}
+5   Cs u0 {1,S} {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-1.441, -1.573, -1.731, -1.812, -1.511, -1.194, -3.151],'cal/(mol*K)'),
+        H298 = (72.047,'kcal/mol'),
+        S298 = (28.96,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted to CBS-QB3 calculation""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
+    index = 94,
+    label = "five-inringonetriple",
+    group =
+"""
+1 * R!H u0 {2,T} {5,[S,D]}
+2   R!H u0 {1,T} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H u0 {1,[S,D]} {4,[S,D]}
+""",
+    thermo = u'Cyclopentyne',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclopentyne ring correction for any five-membered ring containing a triple bond.
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -3902,6 +3945,8 @@ L1: Ring
         L3: Cyclopentadiene
         L3: 1,2-Cyclopentadiene
         L3: Cyclopentatriene
+        L3: five-inringonetriple
+            L4: Cyclopentyne
         L3: Tetrahydrofuran
         L3: 2,3-Dihydrofuran
         L3: 1,3-Dioxolane

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -2734,23 +2734,19 @@ entry(
     label = "six-inringthreedouble",
     group = 
 """
-1   Cd      u0 {2,D} {6,S}
+1   R!H     u0 {2,D} {6,[S,D]}
 2 * Cdd     u0 {1,D} {3,D}
-3   Cd      u0 {2,D} {4,S}
-4   [Cs,Os] u0 {3,S} {5,S}
-5   Cd      u0 {4,S} {6,D}
-6   Cd      u0 {1,S} {5,D}
+3   R!H      u0 {2,D} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H      u0 {4,[S,D]} {6,D}
+6   R!H      u0 {1,[S,D]} {5,D}
 """,
-    thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-4.21,-4.32,-3.9,-3.46,-2.71,-2.25,-1.38],'cal/(mol*K)'),
-        H298 = (36.04,'kcal/mol'),
-        S298 = (26.47,'cal/(mol*K)'),
-    ),
-    shortDesc = u"""CBS-QB3 isodesmic reaction approach C1=CC=CCC=1 + 3 ethane + ethene = allene + 2 2-butene + propane""",
+    thermo = u'124cyclohexatriene',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-
+Use 124cyclohexatriene correction for any 6-membered ring that contains at least 3 double bonds in the 1,2 and 4 p
+positions.
 """,
 )
 
@@ -4085,6 +4081,31 @@ Fitted to CBS-QB3 calculation for 1_3_cyclohexadiyne
 """,
 )
 
+entry(
+    index = 157,
+    label = "124cyclohexatriene",
+    group =
+"""
+1   Cd      u0 {2,D} {6,S}
+2 * Cdd     u0 {1,D} {3,D}
+3   Cd      u0 {2,D} {4,S}
+4   [Cs,Os] u0 {3,S} {5,S}
+5   Cd      u0 {4,S} {6,D}
+6   Cd      u0 {1,S} {5,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.21,-4.32,-3.9,-3.46,-2.71,-2.25,-1.38],'cal/(mol*K)'),
+        H298 = (36.04,'kcal/mol'),
+        S298 = (26.47,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3 isodesmic reaction approach C1=CC=CCC=1 + 3 ethane + ethene = allene + 2 2-butene + propane""",
+    longDesc =
+u"""
+
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -4212,6 +4233,7 @@ L1: Ring
             L4: 1,4-Cyclohexadiene
             L4: 14dioxin
         L3: six-inringthreedouble
+            L4: 124cyclohexatriene
         L3: six-inringtwodouble-12
         L3: six-oneside-twoindoubles-25
             L4: 25cyclohexadienone

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -3155,7 +3155,7 @@ entry(
         S298 = (15.9,'cal/(mol*K)'),
     ),
     shortDesc = u"""Cycloheptane ring BENSON""",
-    longDesc = 
+    longDesc =
 u"""
 
 """,
@@ -4229,6 +4229,31 @@ Use cyclobutadiene_13 correction for 1,2_CBD
 """,
 )
 
+entry(
+    index = 164,
+    label = "o_benzyne",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {1,S} {5,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.003, -4.523, -5.242, -5.892, -5.423, -3.742, -3.198],'cal/(mol*K)'),
+        H298 = (26.527,'kcal/mol'),
+        S298 = (29.264,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for o_benzyne
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -4385,6 +4410,7 @@ L1: Ring
         L3: six-inringonetripleonedouble
             L4: cyclohex_1_yne_4_ene
             L4: cyclohex_1_yne_3_ene
+            L4: o_benzyne
         L3: six-inringtwotriple-13
             L4: 1_3_cyclohexadiyne
     L2: SevenMember

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -1206,11 +1206,11 @@ entry(
     label = "five-inringthreedouble-124",
     group = 
 """
-1 * [Cd,N3d]  u0 {2,D} {5,S}
+1 * R!H  u0 {2,D} {5,[S,D]}
 2   Cdd u0 {1,D} {3,D}
-3   [Cd,N3d]  u0 {2,D} {4,S}
-4   [Cd,N3d]  u0 {3,S} {5,D}
-5   [Cd,N3d]  u0 {1,S} {4,D}
+3   R!H  u0 {2,D} {4,[S,D]}
+4   R!H  u0 {3,[S,D]} {5,D}
+5   R!H  u0 {1,[S,D]} {4,D}
 """,
     thermo = u'Cyclopentatriene',
     shortDesc = u"""""",
@@ -3819,11 +3819,11 @@ entry(
     label = "five-inringtwodouble-12",
     group =
 """
-1 * C u0 {2,[S,D]} {5,S}
-2   Cd u0 {1,[S,D]} {3,D}
+1 * R!H u0 {2,[S,D]} {5,S}
+2   R!H u0 {1,[S,D]} {3,D}
 3   Cdd u0 {2,D} {4,D}
-4   Cd u0 {3,D} {5,[S,D]}
-5   C u0 {1,S} {4,[S,D]}
+4   R!H u0 {3,D} {5,[S,D]}
+5   R!H u0 {1,S} {4,[S,D]}
 """,
     thermo = u'1,2-Cyclopentadiene',
     shortDesc = u"""""",
@@ -3862,11 +3862,11 @@ entry(
     label = "five-inringonetriple",
     group =
 """
-1 * R!H u0 {2,T} {5,[S,D]}
-2   R!H u0 {1,T} {3,[S,D]}
-3   R!H u0 {2,[S,D]} {4,[S,D]}
+1 * R!H u0 {2,T} {5,S}
+2   R!H u0 {1,T} {3,S}
+3   R!H u0 {2,S} {4,[S,D]}
 4   R!H u0 {3,[S,D]} {5,[S,D,T]}
-5   R!H u0 {1,[S,D]} {4,[S,D,T]}
+5   R!H u0 {1,S} {4,[S,D,T]}
 """,
     thermo = u'Cyclopentyne',
     shortDesc = u"""""",
@@ -3904,8 +3904,8 @@ entry(
 1 * Ct u0 {2,T} {6,S}
 2   Ct u0 {1,T} {3,S}
 3   R!H u0 {2,S} {4,[S,D]}
-4   R!H u0 {3,[S,D]} {5,D}
-5   R!H u0 {4,D} {6,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H u0 {4,[S,D]} {6,[S,D]}
 6   R!H u0 {1,S} {5,[S,D]}
 """,
     thermo = u'cyclohex_1_yne_4_ene',
@@ -3951,8 +3951,8 @@ entry(
 2   Ct u0 {1,T} {3,S}
 3   Ct u0 {2,S} {4,T}
 4   Ct u0 {3,T} {5,S}
-5   R!H u0 {4,S} {6,[D,T]}
-6   R!H u0 {1,S} {5,[D,T]}
+5   R!H u0 {4,S} {6,[S,D,T]}
+6   R!H u0 {1,S} {5,[S,D,T]}
 """,
     thermo = u'1_3_cyclohexadiyne',
     shortDesc = u"""CBS-QB3""",

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -601,10 +601,10 @@ entry(
     label = "FourMember",
     group = 
 """
-1 * R!H u0 {2,[S,D]} {4,[S,D]}
-2   R!H u0 {1,[S,D]} {3,[S,D,T]}
-3   R!H u0 {2,[S,D,T]} {4,[S,D]}
-4   R!H u0 {1,[S,D]} {3,[S,D]}
+1 * R!H u0 {2,[S,D,T]} {4,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D,T]}
+4   R!H u0 {1,[S,D]} {3,[S,D,T]}
 """,
     thermo = u'Cyclobutane',
     shortDesc = u"""""",
@@ -4180,9 +4180,9 @@ entry(
     label = "four-inringoneunsaturated",
     group =
 """
-1 * R!H u0 {2,S} {4,S}
-2   R!H u0 {1,S} {3,[D,T]}
-3   R!H u0 {2,[D,T]} {4,S}
+1 * R!H u0 {2,[D,T]} {4,S}
+2   R!H u0 {1,[D,T]} {3,S}
+3   R!H u0 {2,S} {4,S}
 4   R!H u0 {1,S} {3,S}
 """,
     thermo = u'Cyclobutene',
@@ -4195,19 +4195,19 @@ Use cyclobutene correction for any four membered ring with one double or triple 
 
 entry(
     index = 162,
-    label = "four-inringtwodouble",
+    label = "four-inringtwounsaturated",
     group =
 """
-1   R!H u0 {2,D} {4,[S,D]}
-2 * R!H u0 {1,D} {3,[S,D]}
-3   R!H u0 {2,[S,D]} {4,D}
-4   R!H u0 {1,[S,D]} {3,D}
+1   R!H u0 {2,[D,T]} {4,[S,D]}
+2 * R!H u0 {1,[D,T]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[D,T]}
+4   R!H u0 {1,[S,D]} {3,[D,T]}
 """,
     thermo = u'cyclobutadiene_13',
     shortDesc = u"""""",
     longDesc =
 u"""
-Use cyclobutadiene_13 correction for any four membered ring with at least two double bonds
+Use cyclobutadiene_13 correction for any four membered ring with at least two double or triple bonds
 """,
 )
 
@@ -4275,7 +4275,7 @@ L1: Ring
         L3: Cyclobutanone
         L3: 12dioxetane
         L3: dioxerene
-        L3: four-inringtwodouble
+        L3: four-inringtwounsaturated
             L4: cyclobutadiene_13
         L3: cyclobutadiene_12
         L3: thietane

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -602,8 +602,8 @@ entry(
     group = 
 """
 1 * R!H u0 {2,[S,D]} {4,[S,D]}
-2   R!H u0 {1,[S,D]} {3,[S,D]}
-3   R!H u0 {2,[S,D]} {4,[S,D]}
+2   R!H u0 {1,[S,D]} {3,[S,D,T]}
+3   R!H u0 {2,[S,D,T]} {4,[S,D]}
 4   R!H u0 {1,[S,D]} {3,[S,D]}
 """,
     thermo = u'Cyclobutane',
@@ -854,7 +854,7 @@ u"""
 
 entry(
     index = 19,
-    label = "cyclobutadiene",
+    label = "cyclobutadiene_13",
     group = 
 """
 1   [Cd,N3d] u0 {2,D} {4,S}
@@ -4124,7 +4124,7 @@ entry(
     shortDesc = u"""""",
     longDesc =
 u"""
-
+Fitted to M06 calculations
 """,
 )
 
@@ -4171,7 +4171,61 @@ entry(
     shortDesc = u"""""",
     longDesc =
 u"""
+Fitted to M06 calculations
+""",
+)
 
+entry(
+    index = 161,
+    label = "four-inringoneunsaturated",
+    group =
+"""
+1 * R!H u0 {2,S} {4,S}
+2   R!H u0 {1,S} {3,[D,T]}
+3   R!H u0 {2,[D,T]} {4,S}
+4   R!H u0 {1,S} {3,S}
+""",
+    thermo = u'Cyclobutene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclobutene correction for any four membered ring with one double or triple bond
+""",
+)
+
+entry(
+    index = 162,
+    label = "four-inringtwodouble",
+    group =
+"""
+1   R!H u0 {2,D} {4,[S,D]}
+2 * R!H u0 {1,D} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,D}
+4   R!H u0 {1,[S,D]} {3,D}
+""",
+    thermo = u'cyclobutadiene_13',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclobutadiene_13 correction for any four membered ring with at least two double bonds
+""",
+)
+
+entry(
+    index = 163,
+    label = "cyclobutadiene_12",
+    group =
+"""
+1   R!H u0 {2,D} {4,S}
+2 * R!H u0 {1,D} {3,D}
+3   R!H u0 {2,D} {4,S}
+4   R!H u0 {1,S} {3,S}
+""",
+    thermo = u'cyclobutadiene_13',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclobutadiene_13 correction for 1,2_CBD
 """,
 )
 
@@ -4213,12 +4267,17 @@ L1: Ring
         L3: Cyclobutadiene2
         L3: Cyclobutadiene3
         L3: 34methylenecyclobutene
+        L3: four-inringoneunsaturated
+            L4: Cyclobutene
         L3: Oxetane
 		L3: Oxetene
         L3: Beta-Propiolactone
         L3: Cyclobutanone
         L3: 12dioxetane
         L3: dioxerene
+        L3: four-inringtwodouble
+            L4: cyclobutadiene_13
+        L3: cyclobutadiene_12
         L3: thietane
         L3: 1,2-dithietane
         L3: 1,3-dithietane

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -3119,8 +3119,8 @@ entry(
     label = "SevenMember",
     group = 
 """
-1 * R!H u0 {2,[S,D]} {7,[S,D]}
-2   R!H u0 {1,[S,D]} {3,[S,D]}
+1 * R!H u0 {2,[S,D,T]} {7,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
 3   R!H u0 {2,[S,D]} {4,[S,D]}
 4   R!H u0 {3,[S,D]} {5,[S,D]}
 5   R!H u0 {4,[S,D]} {6,[S,D]}
@@ -4254,6 +4254,147 @@ Fitted to CBS-QB3 calculation for o_benzyne
 """,
 )
 
+entry(
+    index = 165,
+    label = "seven-inringtwodouble-12",
+    group =
+"""
+1  * Cd u0 {2,D} {7,S}
+2    Cdd u0 {1,D} {3,D}
+3    Cd u0 {4,S} {2,D}
+4    R!H u0 {3,S} {5,[S,D]}
+5    R!H u0 {6,[S,D]} {4,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {1,S} {6,[S,D]}
+""",
+    thermo = u'1_2_cycloheptadiene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use 1_2_cycloheptadiene correction for any seven membered ring with at least two double bonds in the 1,2-positions
+""",
+)
+
+entry(
+    index = 166,
+    label = "1_2_cycloheptadiene",
+    group =
+"""
+1  * Cd u0 {2,D} {7,S}
+2    Cdd u0 {1,D} {3,D}
+3    Cd u0 {4,S} {2,D}
+4    C u0 {3,S} {5,S}
+5    C u0 {6,S} {4,S}
+6    C u0 {5,S} {7,S}
+7    C u0 {1,S} {6,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-5.058, -4.616, -4.065, -3.549, -2.425, -1.185, -0.012], 'cal/(mol*K)'),
+        H298=(19.726, 'kcal/mol'),
+        S298=(17.979, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 167,
+    label = "seven-inringthreedouble-123",
+    group =
+"""
+1  * R!H u0 {2,D} {7,[S,D]}
+2    Cdd u0 {1,D} {3,D}
+3    Cdd u0 {4,D} {2,D}
+4    R!H u0 {3,D} {5,[S,D]}
+5    R!H u0 {6,[S,D]} {4,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {1,[S,D]} {6,[S,D]}
+""",
+    thermo = u'1_2_3_cycloheptatriene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use 1_2_3_cycloheptatriene correction for any seven membered ring with at least three double bonds in the 1,2 and 3-positions
+""",
+)
+
+entry(
+    index = 168,
+    label = "1_2_3_cycloheptatriene",
+    group =
+"""
+1  * Cd u0 {2,D} {7,S}
+2    Cdd u0 {1,D} {3,D}
+3    Cdd u0 {4,D} {2,D}
+4    Cd u0 {3,D} {5,S}
+5    C u0 {6,S} {4,S}
+6    C u0 {5,S} {7,S}
+7    C u0 {1,S} {6,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-4.854, -4.544, -4.148, -3.726, -2.801, -1.852, -0.8], 'cal/(mol*K)'),
+        H298=(25.76, 'kcal/mol'),
+        S298=(22.122, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations
+""",
+)
+
+entry(
+    index = 169,
+    label = "seven-inringonetriple",
+    group =
+"""
+1  * Ct u0 {2,T} {7,S}
+2    Ct u0 {1,T} {3,S}
+3    R!H u0 {4,[S,D]} {2,S}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {6,[S,D]} {4,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {1,S} {6,[S,D]}
+""",
+    thermo = u'cycloheptyne',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cycloheptyne correction for any seven membered ring with at least one triple bond
+""",
+)
+
+entry(
+    index = 170,
+    label = "cycloheptyne",
+    group =
+"""
+1  * Ct u0 {2,T} {7,S}
+2    Ct u0 {1,T} {3,S}
+3    C u0 {4,S} {2,S}
+4    C u0 {3,S} {5,S}
+5    C u0 {6,S} {4,S}
+6    C u0 {5,S} {7,S}
+7    C u0 {1,S} {6,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-4, -3.568, -3.106, -2.646, -1.582, -0.695, -1.916], 'cal/(mol*K)'),
+        H298=(24.448, 'kcal/mol'),
+        S298=(17.688, 'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculations
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -4420,7 +4561,13 @@ L1: Ring
         L3: 1,3,5-Cycloheptatriene
         L3: Cycloheptanone
         L3: 1,4-Cycloheptadiene
-        L3: 1,2,4,6-Cycloheptatetraene
+        L3: seven-inringtwodouble-12
+            L4: 1_2_cycloheptadiene
+            L4: 1,2,4,6-Cycloheptatetraene
+        L3: seven-inringthreedouble-123
+            L4: 1_2_3_cycloheptatriene
+        L3: seven-inringonetriple
+            L4: cycloheptyne
         L3: heptasulfur
 	L3: oxepane
     L2: EightMember

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -1118,8 +1118,8 @@ entry(
 1 * R!H u0 {2,[S,D,T]} {5,[S,D]}
 2   R!H u0 {1,[S,D,T]} {3,[S,D]}
 3   R!H u0 {2,[S,D]} {4,[S,D]}
-4   R!H u0 {3,[S,D]} {5,[S,D]}
-5   R!H u0 {1,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D,T]}
+5   R!H u0 {1,[S,D]} {4,[S,D,T]}
 """,
     thermo = u'Cyclopentane',
     shortDesc = u"""""",
@@ -1203,7 +1203,7 @@ u"""
 
 entry(
     index = 152,
-    label = "Cyclopentatriene",
+    label = "five-inringthreedouble-124",
     group = 
 """
 1 * [Cd,N3d]  u0 {2,D} {5,S}
@@ -1212,16 +1212,11 @@ entry(
 4   [Cd,N3d]  u0 {3,S} {5,D}
 5   [Cd,N3d]  u0 {1,S} {4,D}
 """,
-    thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-4.08,-4.69,-4.58,-4.25,-3.54,-3.08,-2.47],'cal/(mol*K)'),
-        H298 = (70.16,'kcal/mol'),
-        S298 = (36.76,'cal/(mol*K)'),
-    ),
-    shortDesc = u"""CBS-QB3 isodesmic reaction approach allene + 2-butene = cyclopentatriene + 2 CH4, DHr = 220.8 kJ mol-1, exp data from NIST""",
+    thermo = u'Cyclopentatriene',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-
+For now, any 5-membered ring that has at least 3 double-bonds in the 1,2,4 positions will use this general correction.
 """,
 )
 
@@ -1936,8 +1931,8 @@ entry(
 2   R!H u0 {1,[S,D,T]} {3,[S,D]}
 3   R!H u0 {2,[S,D]} {4,[S,D,T]}
 4   R!H u0 {3,[S,D,T]} {5,[S,D]}
-5   R!H u0 {4,[S,D]} {6,[S,D]}
-6   R!H u0 {1,[S,D]} {5,[S,D]}
+5   R!H u0 {4,[S,D]} {6,[S,D,T]}
+6   R!H u0 {1,[S,D]} {5,[S,D,T]}
 """,
     thermo = u'Cyclohexane',
     shortDesc = u"""""",
@@ -3821,25 +3816,20 @@ u"""
 
 entry(
     index = 92,
-    label = "1,2-Cyclopentadiene",
+    label = "five-inringtwodouble-12",
     group =
 """
-1 * C u0 {2,S} {5,S}
-2   Cd u0 {1,S} {3,D}
+1 * C u0 {2,[S,D]} {5,S}
+2   Cd u0 {1,[S,D]} {3,D}
 3   Cdd u0 {2,D} {4,D}
-4   Cd u0 {3,D} {5,S}
-5   C u0 {1,S} {4,S}
+4   Cd u0 {3,D} {5,[S,D]}
+5   C u0 {1,S} {4,[S,D]}
 """,
-    thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-3.610227533, -3.220365201, -2.9183174, -2.860732314, -2.503231358, -1.669783939, -1.310015296],'cal/(mol*K)'),
-        H298 = (65.85343212,'kcal/mol'),
-        S298 = (26.75230402,'cal/(mol*K)'),
-    ),
-    shortDesc = u"""Fitted to M06 calculation""",
+    thermo = u'1,2-Cyclopentadiene',
+    shortDesc = u"""""",
     longDesc =
 u"""
-
+For now, any 5-membered ring that has at least 2 double-bonds in the 1,2 positions will use this general correction.
 """,
 )
 
@@ -3875,8 +3865,8 @@ entry(
 1 * R!H u0 {2,T} {5,[S,D]}
 2   R!H u0 {1,T} {3,[S,D]}
 3   R!H u0 {2,[S,D]} {4,[S,D]}
-4   R!H u0 {3,[S,D]} {5,[S,D]}
-5   R!H u0 {1,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D,T]}
+5   R!H u0 {1,[S,D]} {4,[S,D,T]}
 """,
     thermo = u'Cyclopentyne',
     shortDesc = u"""""",
@@ -3893,52 +3883,43 @@ entry(
 """
 1 * Ct u0 {2,T} {6,S}
 2   Ct u0 {1,T} {3,S}
-3   [C,Os] u0 {2,S} {4,S}
-4   [C,Os] u0 {3,S} {5,S}
-5   [C,Os] u0 {4,S} {6,S}
-6   [C,Os] u0 {1,S} {5,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,S}
+5   R!H u0 {4,S} {6,S}
+6   R!H u0 {1,S} {5,S}
 """,
-    thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-3.306, -2.849, -2.452, -2.229, -1.543, -0.932, -2.535],'cal/(mol*K)'),
-        H298 = (39.857,'kcal/mol'),
-        S298 = (21.862,'cal/(mol*K)'),
-    ),
-    shortDesc = u"""CBS-QB3""",
+    thermo = u'cyclohexyne',
+    shortDesc = u"""""",
     longDesc =
 u"""
-Fitted to CBS-QB3 calculation for cyclohexyne
+Use cyclohexyne correction for any 6-membered ring containing 1 triple bond
 """,
 )
 
 entry(
     index = 96,
-    label = "six-inringonetripleonedouble-14",
+    label = "six-inringonetripleonedouble",
     group =
 """
 1 * Ct u0 {2,T} {6,S}
 2   Ct u0 {1,T} {3,S}
-3   [C,Os] u0 {2,S} {4,S}
-4   Cd u0 {3,S} {5,D}
-5   Cd u0 {4,D} {6,S}
-6   [C,Os] u0 {1,S} {5,S}
+3   R!H u0 {2,S} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,D}
+5   R!H u0 {4,D} {6,[S,D]}
+6   R!H u0 {1,S} {5,[S,D]}
 """,
-    thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([-1.431, -0.775, -1.308, -1.515, -1.294, -0.369, -1.036],'cal/(mol*K)'),
-        H298 = (38.484,'kcal/mol'),
-        S298 = (25.2137,'cal/(mol*K)'),
-    ),
-    shortDesc = u"""CBS-QB3""",
+    thermo = u'cyclohex_1_yne_4_ene',
+    shortDesc = u"""""",
     longDesc =
 u"""
-Fitted to CBS-QB3 calculation for cyclohex_1_yne_4_ene
+Use cyclohex_1_yne_4_ene correction for any 6-membered ring containing at least one triple bond
+and one double bond.
 """,
 )
 
 entry(
     index = 97,
-    label = "six-inringonetripleonedouble-13",
+    label = "cyclohex_1_yne_3_ene",
     group =
 """
 1 * Ct u0 {2,T} {6,S}
@@ -3964,6 +3945,124 @@ Fitted to CBS-QB3 calculation for cyclohex_1_yne_3_ene
 entry(
     index = 98,
     label = "six-inringtwotriple-13",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   Ct u0 {2,S} {4,T}
+4   Ct u0 {3,T} {5,S}
+5   R!H u0 {4,S} {6,[D,T]}
+6   R!H u0 {1,S} {5,[D,T]}
+""",
+    thermo = u'1_3_cyclohexadiyne',
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Use 1_3_cyclohexadiyne correction for any six-membered  ring with at least two triple bonds
+""",
+)
+
+entry(
+    index = 99,
+    label = "1,2-Cyclopentadiene",
+    group =
+"""
+1 * C u0 {2,S} {5,S}
+2   Cd u0 {1,S} {3,D}
+3   Cdd u0 {2,D} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   C u0 {1,S} {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-3.610227533, -3.220365201, -2.9183174, -2.860732314, -2.503231358, -1.669783939, -1.310015296],'cal/(mol*K)'),
+        H298 = (65.85343212,'kcal/mol'),
+        S298 = (26.75230402,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted to M06 calculation""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
+    index = 153,
+    label = "Cyclopentatriene",
+    group =
+"""
+1 * Cd  u0 {2,D} {5,S}
+2   Cdd u0 {1,D} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   Cd  u0 {1,S} {4,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.08,-4.69,-4.58,-4.25,-3.54,-3.08,-2.47],'cal/(mol*K)'),
+        H298 = (70.16,'kcal/mol'),
+        S298 = (36.76,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3 isodesmic reaction approach allene + 2-butene = cyclopentatriene + 2 CH4, DHr = 220.8 kJ mol-1, exp data from NIST""",
+    longDesc =
+u"""
+
+""",
+)
+
+entry(
+    index = 154,
+    label = "cyclohexyne",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   [C,Os] u0 {2,S} {4,S}
+4   [C,Os] u0 {3,S} {5,S}
+5   [C,Os] u0 {4,S} {6,S}
+6   [C,Os] u0 {1,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-3.306, -2.849, -2.452, -2.229, -1.543, -0.932, -2.535],'cal/(mol*K)'),
+        H298 = (39.857,'kcal/mol'),
+        S298 = (21.862,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for cyclohexyne
+""",
+)
+
+entry(
+    index = 155,
+    label = "cyclohex_1_yne_4_ene",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   [C,Os] u0 {2,S} {4,S}
+4   Cd u0 {3,S} {5,D}
+5   Cd u0 {4,D} {6,S}
+6   [C,Os] u0 {1,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-1.431, -0.775, -1.308, -1.515, -1.294, -0.369, -1.036],'cal/(mol*K)'),
+        H298 = (38.484,'kcal/mol'),
+        S298 = (25.2137,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for cyclohex_1_yne_4_ene
+""",
+)
+
+entry(
+    index = 156,
+    label = "1_3_cyclohexadiyne",
     group =
 """
 1 * Ct u0 {2,T} {6,S}
@@ -4043,8 +4142,10 @@ L1: Ring
         L3: Cyclopentane
         L3: Cyclopentene
         L3: Cyclopentadiene
-        L3: 1,2-Cyclopentadiene
-        L3: Cyclopentatriene
+        L3: five-inringtwodouble-12
+            L4: 1,2-Cyclopentadiene
+        L3: five-inringthreedouble-124
+            L4: Cyclopentatriene
         L3: five-inringonetriple
             L4: Cyclopentyne
         L3: Tetrahydrofuran
@@ -4127,9 +4228,12 @@ L1: Ring
             L4: pxylene
         L3: 3,4-dimethylenecyclohexene
         L3: six-inringonetriple
-        L3: six-inringonetripleonedouble-14
-        L3: six-inringonetripleonedouble-13
+            L4: cyclohexyne
+        L3: six-inringonetripleonedouble
+            L4: cyclohex_1_yne_4_ene
+            L4: cyclohex_1_yne_3_ene
         L3: six-inringtwotriple-13
+            L4: 1_3_cyclohexadiyne
     L2: SevenMember
         L3: Cycloheptane
         L3: Cycloheptene

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -81,8 +81,8 @@ entry(
     label = "ThreeMember",
     group = 
 """
-1 * R!H u0 {2,[S,D]} {3,[S,D]}
-2   R!H u0 {1,[S,D]} {3,[S,D]}
+1 * R!H u0 {2,[S,D,T]} {3,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
 3   R!H u0 {1,[S,D]} {2,[S,D]}
 """,
     thermo = u'Cyclopropane',
@@ -2731,15 +2731,15 @@ u"""
 
 entry(
     index = 153,
-    label = "six-inringthreedouble",
+    label = "six-inringthreedouble_124",
     group = 
 """
-1   R!H     u0 {2,D} {6,[S,D]}
+1   R!H     u0 {2,D} {6,S}
 2 * Cdd     u0 {1,D} {3,D}
-3   R!H      u0 {2,D} {4,[S,D]}
-4   R!H u0 {3,[S,D]} {5,[S,D]}
+3   R!H      u0 {2,D} {4,S}
+4   R!H u0 {3,S} {5,[S,D]}
 5   R!H      u0 {4,[S,D]} {6,D}
-6   R!H      u0 {1,[S,D]} {5,D}
+6   R!H      u0 {1,S} {5,D}
 """,
     thermo = u'124cyclohexatriene',
     shortDesc = u"""""",
@@ -4106,6 +4106,75 @@ u"""
 """,
 )
 
+entry(
+    index = 158,
+    label = "Cyclopropyne",
+    group =
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T} {3,S}
+3   R!H u0 {1,S} {2,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([2.22, 1.515, 0.554, -0.319, -1.215, -1.31, -2.439],'cal/(mol*K)'),
+        H298 = (111.641,'kcal/mol'),
+        S298 = (37.345,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
+
+entry(
+    index = 159,
+    label = "six-inringthreedouble_123",
+    group =
+"""
+1   Cdd     u0 {2,D} {6,D}
+2 * Cdd     u0 {1,D} {3,D}
+3   R!H      u0 {2,D} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H      u0 {4,[S,D]} {6,[S,D]}
+6   R!H      u0 {1,D} {5,[S,D]}
+""",
+    thermo = u'123cyclohexatriene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use 123cyclohexatriene correction for any 6-membered ring that contains at least 3 double bonds in the 1,2 and 3
+positions.
+""",
+)
+
+entry(
+    index = 160,
+    label = "123cyclohexatriene",
+    group =
+"""
+1   Cdd      u0 {2,D} {6,D}
+2 * Cdd     u0 {1,D} {3,D}
+3   Cd      u0 {2,D} {4,S}
+4   Cs u0 {3,S} {5,S}
+5   Cs      u0 {4,S} {6,S}
+6   Cd      u0 {1,D} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-4.033, -4.022, -3.919, -3.755, -3.149 ,-2.312, -1.645],'cal/(mol*K)'),
+        H298 = (50.291,'kcal/mol'),
+        S298 = (27.334,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -4117,6 +4186,7 @@ L1: Ring
         L3: Cyclopropene2
         L3: Cyclopropadiene
         L3: Cyclopropadiene2
+        L3: Cyclopropyne
 		L3: oxirene
         L3: Cyclopropatriene
         L3: Ethylene_oxide
@@ -4232,8 +4302,10 @@ L1: Ring
         L3: six-inringtwodouble-14
             L4: 1,4-Cyclohexadiene
             L4: 14dioxin
-        L3: six-inringthreedouble
+        L3: six-inringthreedouble_124
             L4: 124cyclohexatriene
+        L3: six-inringthreedouble_123
+            L4: 123cyclohexatriene
         L3: six-inringtwodouble-12
         L3: six-oneside-twoindoubles-25
             L4: 25cyclohexadienone

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -661,60 +661,6 @@ u"""
 )
 
 entry(
-    index = 14,
-    label = "Cyclobutene2",
-    group = 
-"""
-1   [Cs,N3s] u0 {2,S} {4,S}
-2 * [Cd,N3d] u0 {1,S} {3,D}
-3   [Cd,N3d] u0 {2,D} {4,S}
-4   [Cs,N3s] u0 {1,S} {3,S}
-""",
-    thermo = u'Cyclobutene',
-    shortDesc = u"""""",
-    longDesc = 
-u"""
-
-""",
-)
-
-entry(
-    index = 14,
-    label = "Cyclobutadiene2",
-    group = 
-"""
-1   [Cs,N3s] u0 {2,S} {4,S}
-2 * [Cd,N3d] u0 {1,S} {3,D}
-3   Cdd      u0 {2,D} {4,D}
-4   [Cd,N3d] u0 {1,S} {3,D}
-""",
-    thermo = u'Cyclobutene',
-    shortDesc = u"""""",
-    longDesc = 
-u"""
-
-""",
-)
-
-entry(
-    index = 14,
-    label = "Cyclobutadiene3",
-    group = 
-"""
-1 * [Cs,N3s] u0 {2,S} {4,S}
-2   [Cd,N3d] u0 {1,S} {3,D}
-3   Cdd      u0 {2,D} {4,D}
-4   [Cd,N3d] u0 {1,S} {3,D}
-""",
-    thermo = u'Cyclobutene',
-    shortDesc = u"""""",
-    longDesc = 
-u"""
-
-""",
-)
-
-entry(
     index = 70,
     label = "Oxetane",
     group = 
@@ -3894,14 +3840,14 @@ Use cyclohexyne correction for any 6-membered ring containing 1 triple bond
 
 entry(
     index = 96,
-    label = "six-inringonetripleonedouble",
+    label = "six-inringonetripleonedouble-13",
     group =
 """
 1 * Ct u0 {2,T} {6,S}
 2   Ct u0 {1,T} {3,S}
-3   R!H u0 {2,S} {4,[S,D]}
-4   R!H u0 {3,[S,D]} {5,[S,D]}
-5   R!H u0 {4,[S,D]} {6,[S,D]}
+3   R!H u0 {2,S} {4,D}
+4   R!H u0 {3,D} {5,S}
+5   R!H u0 {4,S} {6,[S,D]}
 6   R!H u0 {1,S} {5,[S,D]}
 """,
     thermo = u'cyclohex_1_yne_3_ene',
@@ -3909,7 +3855,70 @@ entry(
     longDesc =
 u"""
 Use cyclohex_1_yne_3_ene correction for any 6-membered ring containing at least one triple bond
-and one double bond.
+and one double bond in the 1,3-positions.
+""",
+)
+
+entry(
+    index = 171,
+    label = "six-inringonetripleonedouble-14",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,D}
+5   R!H u0 {4,D} {6,S}
+6   R!H u0 {1,S} {5,S}
+""",
+    thermo = u'cyclohex_1_yne_4_ene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclohex_1_yne_4_ene correction for any 6-membered ring containing at least one triple bond
+and one double bond in the 1,4-positions.
+""",
+)
+
+entry(
+    index = 172,
+    label = "six-inringonetripletwodouble-134",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   R!H u0 {2,S} {4,D}
+4   R!H u0 {3,D} {5,D}
+5   R!H u0 {4,D} {6,S}
+6   R!H u0 {1,S} {5,S}
+""",
+    thermo = u'cyclohex_1_yne_3_ene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclohex_1_yne_3_ene correction for any 6-membered ring containing at least one triple bond
+and two double bonds in the 1,3,4-positions.
+""",
+)
+
+entry(
+    index = 173,
+    label = "six-inringonetriplethreedouble-1345",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   R!H u0 {2,S} {4,D}
+4   R!H u0 {3,D} {5,D}
+5   R!H u0 {4,D} {6,D}
+6   R!H u0 {1,S} {5,D}
+""",
+    thermo = u'cyclohex_1_yne_3_ene',
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Use cyclohex_1_yne_3_ene correction for any 6-membered ring containing at least one triple bond
+and three double bonds in the 1,3,4,5-positions.
 """,
 )
 
@@ -4180,9 +4189,9 @@ entry(
     label = "four-inringonedouble",
     group =
 """
-1 * R!H u0 {2,D} {4,S}
+1   R!H u0 {2,D} {4,S}
 2   R!H u0 {1,D} {3,S}
-3   R!H u0 {2,S} {4,S}
+3 * R!H u0 {2,S} {4,S}
 4   R!H u0 {1,S} {3,S}
 """,
     thermo = u'Cyclobutene',
@@ -4427,20 +4436,15 @@ L1: Ring
         L3: 12Methylenecyclopropane
     L2: FourMember
         L3: Cyclobutane
-        L3: Cyclobutene
-        L3: Cyclobutene2
-        L3: cyclobutadiene
-        L3: Cyclobutadiene2
-        L3: Cyclobutadiene3
         L3: 34methylenecyclobutene
+        L3: dioxerene
+        L3: Oxetene
         L3: four-inringonedouble
             L4: Cyclobutene
         L3: Oxetane
-		L3: Oxetene
         L3: Beta-Propiolactone
         L3: Cyclobutanone
         L3: 12dioxetane
-        L3: dioxerene
         L3: four-inringtwodouble
             L4: cyclobutadiene_13
         L3: cyclobutadiene_12
@@ -4548,10 +4552,13 @@ L1: Ring
         L3: 3,4-dimethylenecyclohexene
         L3: six-inringonetriple
             L4: cyclohexyne
-        L3: six-inringonetripleonedouble
-            L4: cyclohex_1_yne_4_ene
+        L3: six-inringonetripleonedouble-13
             L4: cyclohex_1_yne_3_ene
             L4: o_benzyne
+        L3: six-inringonetripleonedouble-14
+            L4: cyclohex_1_yne_4_ene
+        L3: six-inringonetripletwodouble-134
+        L3: six-inringonetriplethreedouble-1345
         L3: six-inringtwotriple-13
             L4: 1_3_cyclohexadiyne
     L2: SevenMember

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -3824,11 +3824,11 @@ entry(
     label = "1,2-Cyclopentadiene",
     group =
 """
-1 * Cs u0 {2,S} {5,S}
+1 * C u0 {2,S} {5,S}
 2   Cd u0 {1,S} {3,D}
 3   Cdd u0 {2,D} {4,D}
 4   Cd u0 {3,D} {5,S}
-5   Cs u0 {1,S} {4,S}
+5   C u0 {1,S} {4,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -3850,9 +3850,9 @@ entry(
 """
 1 * Ct u0 {2,T} {5,S}
 2   Ct u0 {1,T} {3,S}
-3   Cs u0 {2,S} {4,S}
-4   Cs u0 {3,S} {5,S}
-5   Cs u0 {1,S} {4,S}
+3   C u0 {2,S} {4,S}
+4   C u0 {3,S} {5,S}
+5   C u0 {1,S} {4,S}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -601,10 +601,10 @@ entry(
     label = "FourMember",
     group = 
 """
-1 * R!H u0 {2,[S,D,T]} {4,[S,D]}
-2   R!H u0 {1,[S,D,T]} {3,[S,D]}
-3   R!H u0 {2,[S,D]} {4,[S,D,T]}
-4   R!H u0 {1,[S,D]} {3,[S,D,T]}
+1 * R!H u0 {2,[S,D]} {4,[S,D]}
+2   R!H u0 {1,[S,D]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {1,[S,D]} {3,[S,D]}
 """,
     thermo = u'Cyclobutane',
     shortDesc = u"""""",
@@ -4177,11 +4177,11 @@ Fitted to M06 calculations
 
 entry(
     index = 161,
-    label = "four-inringoneunsaturated",
+    label = "four-inringonedouble",
     group =
 """
-1 * R!H u0 {2,[D,T]} {4,S}
-2   R!H u0 {1,[D,T]} {3,S}
+1 * R!H u0 {2,D} {4,S}
+2   R!H u0 {1,D} {3,S}
 3   R!H u0 {2,S} {4,S}
 4   R!H u0 {1,S} {3,S}
 """,
@@ -4189,25 +4189,25 @@ entry(
     shortDesc = u"""""",
     longDesc =
 u"""
-Use cyclobutene correction for any four membered ring with one double or triple bond
+Use cyclobutene correction for any four membered ring with one double bond
 """,
 )
 
 entry(
     index = 162,
-    label = "four-inringtwounsaturated",
+    label = "four-inringtwodouble",
     group =
 """
-1   R!H u0 {2,[D,T]} {4,[S,D]}
-2 * R!H u0 {1,[D,T]} {3,[S,D]}
-3   R!H u0 {2,[S,D]} {4,[D,T]}
-4   R!H u0 {1,[S,D]} {3,[D,T]}
+1   R!H u0 {2,D} {4,[S,D]}
+2 * R!H u0 {1,D} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,D}
+4   R!H u0 {1,[S,D]} {3,D}
 """,
     thermo = u'cyclobutadiene_13',
     shortDesc = u"""""",
     longDesc =
 u"""
-Use cyclobutadiene_13 correction for any four membered ring with at least two double or triple bonds
+Use cyclobutadiene_13 correction for any four membered ring with at least two double bonds in the 1,3-positions
 """,
 )
 
@@ -4267,7 +4267,7 @@ L1: Ring
         L3: Cyclobutadiene2
         L3: Cyclobutadiene3
         L3: 34methylenecyclobutene
-        L3: four-inringoneunsaturated
+        L3: four-inringonedouble
             L4: Cyclobutene
         L3: Oxetane
 		L3: Oxetene
@@ -4275,7 +4275,7 @@ L1: Ring
         L3: Cyclobutanone
         L3: 12dioxetane
         L3: dioxerene
-        L3: four-inringtwounsaturated
+        L3: four-inringtwodouble
             L4: cyclobutadiene_13
         L3: cyclobutadiene_12
         L3: thietane

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -3904,11 +3904,11 @@ entry(
 5   R!H u0 {4,[S,D]} {6,[S,D]}
 6   R!H u0 {1,S} {5,[S,D]}
 """,
-    thermo = u'cyclohex_1_yne_4_ene',
+    thermo = u'cyclohex_1_yne_3_ene',
     shortDesc = u"""""",
     longDesc =
 u"""
-Use cyclohex_1_yne_4_ene correction for any 6-membered ring containing at least one triple bond
+Use cyclohex_1_yne_3_ene correction for any 6-membered ring containing at least one triple bond
 and one double bond.
 """,
 )

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -3819,6 +3819,30 @@ u"""
 """,
 )
 
+entry(
+    index = 92,
+    label = "1,2-Cyclopentadiene",
+    group =
+"""
+1 * Cs u0 {2,S} {5,S}
+2   Cd u0 {1,S} {3,D}
+3   Cdd u0 {2,D} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   Cs u0 {1,S} {4,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-3.610227533, -3.220365201, -2.9183174, -2.860732314, -2.503231358, -1.669783939, -1.310015296],'cal/(mol*K)'),
+        H298 = (65.85343212,'kcal/mol'),
+        S298 = (26.75230402,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""Fitted to M06 calculation""",
+    longDesc =
+u"""
+
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -3876,6 +3900,8 @@ L1: Ring
         L3: Cyclopentane
         L3: Cyclopentene
         L3: Cyclopentadiene
+        L3: 1,2-Cyclopentadiene
+        L3: Cyclopentatriene
         L3: Tetrahydrofuran
         L3: 2,3-Dihydrofuran
         L3: 1,3-Dioxolane
@@ -3905,7 +3931,6 @@ L1: Ring
         L3: 3-Methylenecyclopentene
         L3: 4-Methylenecyclopentene
         L3: 12methylenecyclopentane
-        L3: Cyclopentatriene
     L2: SixMember
         L3: sixnosidedouble
             L4: Cyclohexane

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -1932,10 +1932,10 @@ entry(
     label = "SixMember",
     group = 
 """
-1 * R!H u0 {2,[S,D]} {6,[S,D]}
-2   R!H u0 {1,[S,D]} {3,[S,D]}
-3   R!H u0 {2,[S,D]} {4,[S,D]}
-4   R!H u0 {3,[S,D]} {5,[S,D]}
+1 * R!H u0 {2,[S,D,T]} {6,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D,T]}
+4   R!H u0 {3,[S,D,T]} {5,[S,D]}
 5   R!H u0 {4,[S,D]} {6,[S,D]}
 6   R!H u0 {1,[S,D]} {5,[S,D]}
 """,
@@ -3886,6 +3886,106 @@ Use cyclopentyne ring correction for any five-membered ring containing a triple 
 """,
 )
 
+entry(
+    index = 95,
+    label = "six-inringonetriple",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   [C,Os] u0 {2,S} {4,S}
+4   [C,Os] u0 {3,S} {5,S}
+5   [C,Os] u0 {4,S} {6,S}
+6   [C,Os] u0 {1,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-3.306, -2.849, -2.452, -2.229, -1.543, -0.932, -2.535],'cal/(mol*K)'),
+        H298 = (39.857,'kcal/mol'),
+        S298 = (21.862,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for cyclohexyne
+""",
+)
+
+entry(
+    index = 96,
+    label = "six-inringonetripleonedouble-14",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   [C,Os] u0 {2,S} {4,S}
+4   Cd u0 {3,S} {5,D}
+5   Cd u0 {4,D} {6,S}
+6   [C,Os] u0 {1,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-1.431, -0.775, -1.308, -1.515, -1.294, -0.369, -1.036],'cal/(mol*K)'),
+        H298 = (38.484,'kcal/mol'),
+        S298 = (25.2137,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for cyclohex_1_yne_4_ene
+""",
+)
+
+entry(
+    index = 97,
+    label = "six-inringonetripleonedouble-13",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   [C,Os] u0 {4,S} {6,S}
+6   [C,Os] u0 {1,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-2.292 ,-2.038, -2.856, -3.187, -2.814, -1.639,-2.564],'cal/(mol*K)'),
+        H298 = (48.034,'kcal/mol'),
+        S298 = (25.6327,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for cyclohex_1_yne_3_ene
+""",
+)
+
+entry(
+    index = 98,
+    label = "six-inringtwotriple-13",
+    group =
+"""
+1 * Ct u0 {2,T} {6,S}
+2   Ct u0 {1,T} {3,S}
+3   Ct u0 {2,S} {4,T}
+4   Ct u0 {3,T} {5,S}
+5   [C,Os] u0 {4,S} {6,S}
+6   [C,Os] u0 {1,S} {5,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([-1.086,-1.458,-1.692,-1.747,-1.465,-1.403,-3.712],'cal/(mol*K)'),
+        H298 = (103.484,'kcal/mol'),
+        S298 = (31.221,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""CBS-QB3""",
+    longDesc =
+u"""
+Fitted to CBS-QB3 calculation for 1_3_cyclohexadiyne
+""",
+)
+
 tree(
 """
 L1: Ring
@@ -4026,6 +4126,10 @@ L1: Ring
             L4: pbenzoquinone
             L4: pxylene
         L3: 3,4-dimethylenecyclohexene
+        L3: six-inringonetriple
+        L3: six-inringonetripleonedouble-14
+        L3: six-inringonetripleonedouble-13
+        L3: six-inringtwotriple-13
     L2: SevenMember
         L3: Cycloheptane
         L3: Cycloheptene


### PR DESCRIPTION
New thermo groups, mostly ring() and polycyclic() corrections, for species that were found to be important in modeling 1,3-CPD and Natural Gas pyrolysis to form aromatics. New groups mostly based on either M06 or CBS-QB3 calculations. Also added a few globally forbidden species that were problematic due to resonance and unlikely to form anyway.

For the ring() corrections, tree was re-organized slightly, so that even if a strained cyclic species doesn't have an exact match (four consecutive double bonds in a 6-membered ring, for example), it will at least use a cyclic correction that provides a reasonable lower bound on the strain (three consecutive double bonds instead, for example), rather than simply falling up to the most general node.

@KEHANG might be the best reviewer for this PR.

Builds off of #205 