### PR TITLE
Fixes to units for some training reactions and depositories

### DIFF
--- a/input/kinetics/families/H_Abstraction/NIST/reactions.py
+++ b/input/kinetics/families/H_Abstraction/NIST/reactions.py
@@ -38348,7 +38348,7 @@ entry(
     label = "C6H12 + HO2 <=> H2O2 + C6H11",
     degeneracy = 12,
     kinetics = Arrhenius(
-        A = (0.0103, 'm^3/(mol*s)', '+|-', 0.00047),
+        A = (2.04e+07, 'm^3/(mol*s)', '*|/', 2.95),
         n = 0,
         Ea = (74.3, 'kJ/mol', '+|-', 4.9),
         T0 = (1, 'K'),

--- a/input/kinetics/families/H_Abstraction/NIST/reactions.py
+++ b/input/kinetics/families/H_Abstraction/NIST/reactions.py
@@ -38386,7 +38386,7 @@ entry(
     label = "C6H12 + HO2 <=> H2O2 + C6H11",
     degeneracy = 12,
     kinetics = Arrhenius(
-        A = (0.112, 'm^3/(mol*s)'),
+        A = (1.58e+11, 'm^3/(mol*s)'),
         n = 2.5,
         Ea = (59.199, 'kJ/mol'),
         T0 = (1, 'K'),

--- a/input/kinetics/families/H_Abstraction/rules.py
+++ b/input/kinetics/families/H_Abstraction/rules.py
@@ -6065,20 +6065,20 @@ entry(
     shortDesc = u"""Aaron Vandeputte GAVs BMK/6-311G(2,d,p)""",
 )
 
-entry(
-    index = 2007,
-    label = "C/H3/Cs;InChI=1S/NO3/c2-1(3)4",
-    kinetics = ArrheniusEP(
-        A = (2.03e-12, 'cm^3/(mol*s)'),
-        n = 0,
-        alpha = 0,
-        E0 = (8.31, 'kcal/mol'),
-        Tmin = (300, 'K'),
-        Tmax = (2000, 'K'),
-    ),
-    rank = 1,
-    shortDesc = u"""Added by Beat Buesser from 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli""",
-)
+# entry(
+#     index = 2007,
+#     label = "C/H3/Cs;InChI=1S/NO3/c2-1(3)4",
+#     kinetics = ArrheniusEP(
+#         A = (2.03e-12, 'cm^3/(mol*s)'),
+#         n = 0,
+#         alpha = 0,
+#         E0 = (8.31, 'kcal/mol'),
+#         Tmin = (300, 'K'),
+#         Tmax = (2000, 'K'),
+#     ),
+#     rank = 1,
+#     shortDesc = u"""Added by Beat Buesser from 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli""",
+# )
 
 entry(
     index = 2008,

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -1951,7 +1951,7 @@ entry(
     label = "CH4b + SH <=> CH3_p1 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (7.78e-22, 'cm^3/(mol*s)'),
+        A = (4.69e+02, 'cm^3/(mol*s)'),
         n = 3.02,
         Ea = (66.3, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -1971,7 +1971,7 @@ entry(
     label = "C2H6 + SH <=> C2H5b + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (4.37e-22, 'cm^3/(mol*s)'),
+        A = (2.63e+02, 'cm^3/(mol*s)'),
         n = 3.41,
         Ea = (42.2, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -1991,7 +1991,7 @@ entry(
     label = "C3H8 + SH <=> CH2CH2CH3 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (8.51e-22, 'cm^3/(mol*s)'),
+        A = (5.12e+02, 'cm^3/(mol*s)'),
         n = 3.39,
         Ea = (43.2, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2011,7 +2011,7 @@ entry(
     label = "C3H8 + SH <=> CH3CHCH3 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (5.25e-18, 'cm^3/(mol*s)'),
+        A = (3.16e+06, 'cm^3/(mol*s)'),
         n = 1.79,
         Ea = (34.6, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2031,7 +2031,7 @@ entry(
     label = "C4H10 + SH <=> CH3CHCH2CH3 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (3.26e-20, 'cm^3/(mol*s)'),
+        A = (1.94e+04, 'cm^3/(mol*s)'),
         n = 2.53,
         Ea = (31.3, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2051,7 +2051,7 @@ entry(
     label = "C2H4 + SH <=> CHCH2 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (2.96e-25, 'cm^3/(mol*s)'),
+        A = (1.78e-01, 'cm^3/(mol*s)'),
         n = 3.31,
         Ea = (81.3, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2071,7 +2071,7 @@ entry(
     label = "C3H6 + SH <=> CH2CHCH2 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (2.00e-24, 'cm^3/(mol*s)'),
+        A = (1.20e+00, 'cm^3/(mol*s)'),
         n = 3.79,
         Ea = (9.9, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2091,7 +2091,7 @@ entry(
     label = "C4H8-4 + SH <=> CH2CHCHCH3 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (2.19e-23, 'cm^3/(mol*s)'),
+        A = (1.32e+01, 'cm^3/(mol*s)'),
         n = 3.40,
         Ea = (0.4, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2111,7 +2111,7 @@ entry(
     label = "C4H8-6 + SH <=> CH2CCH2CH3 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (2.69e-22, 'cm^3/(mol*s)'),
+        A = (1.62e+02, 'cm^3/(mol*s)'),
         n = 3.32,
         Ea = (36.5, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2131,7 +2131,7 @@ entry(
     label = "C3H4-1 + SH <=> CH2CCH + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (2.51e-22, 'cm^3/(mol*s)'),
+        A = (1.51e+02, 'cm^3/(mol*s)'),
         n = 3.37,
         Ea = (30.2, 'kJ/mol'),
         T0 = (1, 'K'),
@@ -2151,7 +2151,7 @@ entry(
     label = "C4H6 + SH <=> CHCCHCH3 + H2S",
     degeneracy = 1,
     kinetics = Arrhenius(
-        A = (1.10e-22, 'cm^3/(mol*s)'),
+        A = (6.62e+01, 'cm^3/(mol*s)'),
         n = 3.32,
         Ea = (8.01, 'kJ/mol'),
         T0 = (1, 'K'),


### PR DESCRIPTION
The evaluateKinetics.py testing script was used to discover training reactions/rules that had very bad comparisons with NIST depository or Leave one out cross validation. 

In this PR, the incorrect rates in the H-abstraction family were fixed. Most of them were from incorrect recording of the A-factor. 