### PR TITLE
Forbid CO and CS birads

### DIFF
--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -479,3 +479,39 @@ Certain unsaturated versions of this strained tricyclic cause RMG
 to crash.
 """,
 )
+
+entry(
+    label = "CO_birad",
+    group =
+"""
+multiplicity [3]
+1 C u2 p0 c0 {2,D}
+2 O u0 p2 c0 {1,D}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbidden after discussion with whgreen.
+This species should quickly transform into a closed shell [C-]#[O+].
+We don't need it as a resonance structure of carbon monoxide for reactivity since carbon monoxide has its designated
+reaction families (CO_Disprop, R_Add_COm).
+""",
+)
+
+entry(
+    label = "CS_birad",
+    group =
+"""
+multiplicity [3]
+1 C u2 p0 c0 {2,D}
+2 S u0 p2 c0 {1,D}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Forbidden after discussion with whgreen.
+This species should quickly transform into a closed shell [C-]#[S+] similar to the carbon monoxide case above.
+We don't need it as a resonance structure of carbon monsulfide for reactivity since carbon monsulfide has its designated
+reaction families (CO_Disprop [also deals with CS], R_Add_CSm).
+""",
+)


### PR DESCRIPTION
In past RMG models (probably RMG-Java) we used to have two CO species at times, `[C-]#[O+]` and `[C]=O` (the correct and the birad forms of carbon monoxide, respectively). @mjohnson541 confirmed that the birad CO form gets pulled into RMG-Py models' core as well if they are run long enough to include low flux species.

It is noted that we have designated reaction families in RMG to deal with the special reactivity of CO (CO_Disprop and R_Add_COm), hence we don't need to keep the birad form for reactivity reasons. According to @whgreen, this excited birad is 139 kcal/mol higher in energy than ground state CO.

This PR adds both `[C]=O` and the isoelectronic structure `[C]=S` to the forbidden structure list to avoid generating them altogether in future models.