### PR TITLE
Corrections to the strange lone_electron_pair_bond family

### DIFF
--- a/input/kinetics/families/lone_electron_pair_bond/groups.py
+++ b/input/kinetics/families/lone_electron_pair_bond/groups.py
@@ -34,7 +34,7 @@ entry(
     label = "N3sRRR",
     group = 
 """
-1 *1 N3s u0 {2,S} {3,S} {4,S}
+1 *1 N3s u0 p1 {2,S} {3,S} {4,S}
 2    R   u0 {1,S}
 3    R   u0 {1,S}
 4    R   u0 {1,S}
@@ -47,7 +47,7 @@ entry(
     label = "O_atom_singlet",
     group = 
 """
-1 *2 O u0 p3
+1 *2 O u0 p3 c0
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/lone_electron_pair_bond/groups.py
+++ b/input/kinetics/families/lone_electron_pair_bond/groups.py
@@ -25,8 +25,8 @@ template(reactants=["N3sRRR", "O_atom_singlet"], products=["N3sRRRO"], ownRevers
 reverse = "Bond_Dissociation"
 
 recipe(actions=[
-    ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_PAIR', '*1', '1'],
+    ['FORM_BOND', '*1', 1, '*2'],
 ])
 
 entry(

--- a/input/kinetics/families/lone_electron_pair_bond/rules.py
+++ b/input/kinetics/families/lone_electron_pair_bond/rules.py
@@ -4,23 +4,9 @@
 name = "lone_electron_pair_bond/rules"
 shortDesc = u""
 longDesc = u"""
-General comments go at the top of the file,
 
-or in a section(s) titled 'General'
-
-.. the ID must match those in the rateLibrary AS A STRING (ie. '2' is different from '02')
-
-
-.. [MRHCBSQB3RRHO] M.R. Harper (mrharper_at_mit_dot_edu or michael.harper.jr_at_gmail_dot_com)
-The geometries of all reactants, products, and the transition state were optimized using the CBS-QB3 calculations.  The zero-point
-energy is that computed by the CBS-QB3 calculations.  The frequencies were computed with B3LYP/CBSB7.
-In computing k(T), an asymmetric tunneling correction was employed, the calculated frequencies were scaled by 0.99, and the 
-temperatures used were: 300, 331, 370, 419, 482, 568, 692, 885, 1227, 2000 (evenly spaced on inverse temperature scale).
-
-.. [Tsang1990] W. Tsang; "Chemical kinetic database for combustion chemistry. Part IV. Isobutane" J. Phys. Chem. Ref. Data 19 (1990) 1-68
-
-.. [Tsang1991] W. Tsang; "Chemical kinetic database for combustion chemistry. Part V. Propene" J. Phys. Chem. Ref. Data 20 (1991) 221-273
 """
+
 entry(
     index = 0,
     label = "N3sRRR;O_atom_singlet",
@@ -35,4 +21,3 @@ entry(
     rank = 0,
     shortDesc = u"""Default""",
 )
-

--- a/input/kinetics/families/recommended.py
+++ b/input/kinetics/families/recommended.py
@@ -49,7 +49,7 @@ recommendedFamilies = {
 'intra_substitutionS_cyclization':True,
 'intra_substitutionS_isomerization':True,
 'ketoenol':True,
-'lone_electron_pair_bond':True,
+'lone_electron_pair_bond':False,
 'Singlet_Carbene_Intra_Disproportionation':True,
 'Intra_5_membered_conjugated_C=C_C=C_addition':True,
 'Intra_Diels_alder_monocyclic':True,


### PR DESCRIPTION
The lone_electron_pair_bond family seems very strange.
@nyee and I looked at it at some point and didn't exactly understand its role in RMG (4520b47c3f7b32f230b733f988a4748f1684aa06).

Principally, it should do something like `O(S) + NH3 = [NH3+][O-]`, which is equivalent to `O(S) + NH3 = [NH3]=O` (the products should be resonance structures of each other). I'm emphasizing that the reactant O(S) is in a singlet form, i.e., a closed shell atomic O with 3 lone pairs. Since we shouldn't have atomic `O u0 p3` floating around during RMG jobs in the first place, this family indeed seems harmless.

However, in its current state, other structures do react through it, such as `[R+][O-]`, where O also has 3 lone pairs. An example I just came across is `CH2NH2 + N#[N+][O-] = C([NH2+][O-2][NH2+])C`. This doesn't seem like the original intention of this family.

This PR suggests the following corrections to the lone_electron_pair_bond family:
- Better specifying the O atom as `O u0 p3 c0` (explicit charge), so `[R+][O-]` structures won't accidentally react here.
- Remove this family from recommended.py since its purpose isn't clear
- Remove the shady description from rules.py which seems copy-pasted from some template and is definately irrelevant to the data of the only rule given here.
- Correct the recipe: the convention for transitioning between atomTypes with different number of lonePairs is via increment/decrement lonePair actions, and not via increment/decrement/form/break bond actions (we probably won't use this library, but at least let's write it correctly...).

One final comment:
The old O group adjList used to be `1 *2 O 2S 2`, and was changed in 49adac0becdbbbd73a167e9d031d8889bb2212fe to `1 *2 O u0 p3`. The old adjList reads 2 unpaired electrons in a singlet form (practically a lonePair) and 2 lonePairs = 3 lonePairs in the new adjList notations.