### PR TITLE
New Training Reactions and Groups intra_H_migration 

### DIFF
--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -3870,6 +3870,289 @@ entry(
     kinetics = None,
 )
 
+entry(
+    index = 266,
+    label = "R6H_RS(M)SMS",
+    group = 
+"""
+1 *1 R!H u1 {2,[S,D,T,B]}
+2 *4 R!H u0 {1,[S,D,T,B]} {3,S} {8,[D,T,B]}
+3 *6 R!H u0 {2,S} {4,S}
+4 *7 R!H u0 {3,S} {5,[D,T,B]}
+5 *5 R!H u0 {4,[D,T,B]} {6,S}
+6 *2 R!H u0 {5,S} {7,S}
+7 *3 H   u0 {6,S}
+8    R!H u0 {2,[D,T,B]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 267,
+    label = "R4H_SDS_SM",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 Cd  u0 {1,S} {3,D}
+3 *5 Cd  u0 {2,D} {4,S}
+4 *2 R!H u0 {3,S} {5,S} {6,S}
+5 *3 H   u0 {4,S}
+6    C   u0 {4,S} {7,[D,T,B]}
+7    C   u0 {6,[D,T,B]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 268,
+    label = "R5H_CCC_CdCd",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 C u0 {1,S} {3,S}
+3 *6 C u0 {2,S} {4,S}
+4 *5 C u0 {3,S} {5,S}
+5 *2 R!H u0 {4,S} {6,S} {7,[S,D,T,B]}
+6 *3 H u0 {5,S}
+7    Cd u0 {5,[S,D,T,B]} {8,D}
+8    Cd u0 {7,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 269,
+    label = "R5H_CCCd(Cd)",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 Cd u0 {1,S} {3,S}
+3 *6 C u0 {2,S} {4,S}
+4 *5 C u0 {3,S} {5,S} {7,D}
+5 *2 R!H u0 {4,S} {6,S}
+6 *3 H u0 {5,S}
+7    Cd u0 {4,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 270,
+    label = "R6H_SSSS(M)S",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S}
+3 *6 R!H u0 {2,S} {4,S}
+4 *7 R!H u0 {3,S} {5,S}
+5 *5 R!H u0 {4,S} {6,S} {8,[D,T,B]}
+6 *2 R!H u0 {5,S} {7,S}
+7 *3 H   u0 {6,S}
+8    Cd  u0 {5,[D,T,B]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 271,
+    label = "R4H_SS(D)S",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S}
+3 *5 R!H u0 {2,S} {4,S} {6,D}
+4 *2 R!H u0 {3,S} {5,S}
+5 *3 H   u0 {4,S}
+6    R!H u0 {3,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 272,
+    label = "R5H_S(D)SMS",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S} {7,D}
+3 *6 R!H u0 {2,S} {4,[D,T,B]}
+4 *5 R!H u0 {3,[D,T,B]} {5,S}
+5 *2 R!H u0 {4,S} {6,S}
+6 *3 H   u0 {5,S}
+7    R!H u0 {2,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 273,
+    label = "R4H_SSS_SM",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S}
+3 *5 R!H u0 {2,S} {4,S}
+4 *2 R!H u0 {3,S} {5,S} {6,S}
+5 *3 H   u0 {4,S}
+6    R!H u0 {4,S} {7,[D,T,B]}
+7    R!H u0 {6,[D,T,B]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 274,
+    label = "R4H_S(D)SS_SM",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S} {8,D}
+3 *5 R!H u0 {2,S} {4,S}
+4 *2 R!H u0 {3,S} {5,S} {6,S}
+5 *3 H   u0 {4,S}
+6    R!H u0 {4,S} {7,[D,T,B]}
+7    R!H u0 {6,[D,T,B]}
+8    R!H u0 {2,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 275,
+    label = "R3H_SS_12cy5_RingSSDSS",
+    group = 
+"""
+1 *1 R!H u1 {2,S} {7,S}
+2 *4 R!H u0 {1,S} {3,S} {5,S}
+3 *2 R!H u0 {2,S} {4,S}
+4 *3 H   u0 {3,S}
+5    R!H u0 {2,S} {6,D}
+6    R!H u0 {5,D} {7,S}
+7    R!H u0 {1,S} {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 276,
+    label = "R3H_SS_12cy5_RingSSSDS",
+    group = 
+"""
+1 *1 R!H u1 {2,S} {7,S}
+2 *4 R!H u0 {1,S} {3,S} {5,S}
+3 *2 R!H u0 {2,S} {4,S}
+4 *3 H   u0 {3,S}
+5    R!H u0 {2,S} {6,S}
+6    R!H u0 {5,S} {7,D}
+7    R!H u0 {1,S} {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 277,
+    label = "R6H_SSSSS_SM",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S}
+3 *6 R!H u0 {2,S} {4,S}
+4 *7 R!H u0 {3,S} {5,S}
+5 *5 R!H u0 {4,S} {6,S}
+6 *2 R!H u0 {5,S} {7,S} {8,S}
+7 *3 H   u0 {6,S}
+8    R!H u0 {6,S} {9,[D,T,B]}
+9    R!H u0 {8,[D,T,B]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 278,
+    label = "R6H_S(M)SSSS_SD",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 R!H u0 {1,S} {3,S} {10,D}
+3 *6 R!H u0 {2,S} {4,S}
+4 *7 R!H u0 {3,S} {5,S}
+5 *5 R!H u0 {4,S} {6,S}
+6 *2 R!H u0 {5,S} {7,S} {8,S}
+7 *3 H   u0 {6,S}
+8    R!H u0 {6,S} {9,[D,T,B]}
+9    R!H u0 {8,[D,T,B]}
+10   R!H u0 {2,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 279,
+    label = "R2H_S_RingSSDSD",
+    group = 
+"""
+1 *1 R!H u1 {2,S} {6,D}
+2 *2 R!H u0 {1,S} {3,S} {4,S}
+3 *3 H   u0 {2,S}
+4    R!H u0 {2,S} {5,D}
+5    R!H u0 {4,D} {6,S}
+6    R!H u0 {1,D} {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 280,
+    label = "R2H_S_RingSSD(S)SD",
+    group = 
+"""
+1 *1 R!H u1 {2,S} {6,D}
+2 *2 R!H u0 {1,S} {3,S} {4,S}
+3 *3 H   u0 {2,S}
+4    R!H u0 {2,S} {5,D}
+5    R!H u0 {4,D} {6,S} {7,S}
+6    R!H u0 {1,D} {5,S}
+7    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 281,
+    label = "R2H_S_RingS(S)SDSD",
+    group = 
+"""
+1 *1 R!H u1 {2,S} {6,D}
+2 *2 R!H u0 {1,S} {3,S} {4,S}
+3 *3 H   u0 {2,S}
+4    R!H u0 {2,S} {5,D} {7,S}
+5    R!H u0 {4,D} {6,S}
+6    R!H u0 {1,D} {5,S}
+7    R!H u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 282,
+    label = "R4H_SDS_SMCy5",
+    group = 
+"""
+1 *1 R!H u1 {2,S}
+2 *4 Cd  u0 {1,S} {3,D}
+3 *5 Cd  u0 {2,D} {4,S}
+4 *2 R!H u0 {3,S} {5,S} {6,S}
+5 *3 H   u0 {4,S}
+6    C   u0 {4,S} {7,[D,T,B]}
+7    C   u0 {6,[D,T,B]} {8,S} {11,S}
+8    C   u0 {7,S} {9,D}
+9    C   u0 {8,D} {10,S}
+10   C   u0 {9,S} {11,D}
+11   C   u0 {7,S} {10,D}
+""",
+    kinetics = None,
+)
+
 tree(
 """
 L1: RnH
@@ -3879,6 +4162,9 @@ L1: RnH
                 L5: R2H_S_cy3
                 L5: R2H_S_cy4
                 L5: R2H_S_cy5
+                    L6: R2H_S_RingSSDSD
+                        L7: R2H_S_RingSSD(S)SD
+                        L7: R2H_S_RingS(S)SDSD
             L4: R2H_D
             L4: R2H_B
     L2: R3Hall
@@ -3893,6 +4179,8 @@ L1: RnH
                     L6: R3H_SS_23cy4
                     L6: R3H_SS_13cy5
                     L6: R3H_SS_12cy5
+                        L7: R3H_SS_12cy5_RingSSDSS
+                        L7: R3H_SS_12cy5_RingSSSDS
                     L6: R3H_SS_23cy5
                     L6: R3H_SS_2Cd
                     L6: R3H_SS_O
@@ -3918,6 +4206,9 @@ L1: RnH
                         L7: R4H_SSS_OCs
                             L8: R4H_SSS_O(Cs)Cs
                                 L9: R4H_SSS_O(Cs)CsCs
+                        L7: R4H_SSS_SM
+                            L8: R4H_S(D)SS_SM
+                        L7: R4H_SS(D)S
                     L6: R4H_DSS
                     L6: R4H_TSS
                     L6: R4H_BSS
@@ -3938,6 +4229,8 @@ L1: RnH
                     L6: R4H_BSB
             L4: R4H_SMS
                 L5: R4H_SDS
+                    L6: R4H_SDS_SM
+                        L7: R4H_SDS_SMCy5
                 L5: R4H_STS
                 L5: R4H_SBS
             L4: R4H_SMM
@@ -3958,6 +4251,11 @@ L1: RnH
                             L8: R5H_CC(O2d)CC
                             L8: R5H_CCC(O2d)C
                             L8: R5H_CCCC(O2d)
+                            L8: R5H_CC(Od)CC
+                            L8: R5H_CCC(Od)C
+                            L8: R5H_CCCC(Od)
+                            L8: R5H_CCC_CdCd
+                            L8: R5H_CCCd(Cd)
                         L7: R5H_SSSS_CsCsS
                         L7: R5H_SSSS_OCC
                             L8: R5H_SSSS_OCC_C
@@ -3984,6 +4282,7 @@ L1: RnH
                     L6: R5H_BSSB
             L4: R5H_RSMS
                 L5: R5H_SSMS
+                    L6: R5H_S(D)SMS
                 L5: R5H_DSMS
                 L5: R5H_TSMS
                 L5: R5H_BSMS
@@ -4020,6 +4319,9 @@ L1: RnH
                                 L9: R6H_SSSSS_OO(Cs/Cs)C(Cs/Cs)
                             L8: R6H_SSSSS_OOCCC(Cs/Cs)
                         L7: R6H_SSSSS_bicyclopentane
+                        L7: R6H_SSSS(M)S
+                        L7: R6H_SSSSS_SM
+                            L8: R6H_S(M)SSSS_SD
                     L6: R6H_SSSSD
                     L6: R6H_SSSST
                     L6: R6H_SSSSB
@@ -4039,6 +4341,7 @@ L1: RnH
                     L6: R6H_BSSST
                     L6: R6H_BSSSB
             L4: R6H_RSSMS
+                L5: R6H_RS(M)SMS
             L4: R6H_RSMSR
             L4: R6H_SMSSR
             L4: R6H_SMSMS

--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -4248,12 +4248,6 @@ L1: RnH
                     L6: R5H_SSSS
                         L7: R5H_CCC
                             L8: R5H_CCC_O
-                            L8: R5H_CC(O2d)CC
-                            L8: R5H_CCC(O2d)C
-                            L8: R5H_CCCC(O2d)
-                            L8: R5H_CC(Od)CC
-                            L8: R5H_CCC(Od)C
-                            L8: R5H_CCCC(Od)
                             L8: R5H_CCC_CdCd
                             L8: R5H_CCCd(Cd)
                         L7: R5H_SSSS_CsCsS

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -1256,3 +1256,1324 @@ multiplicity 2
 15    H u0 p0 c0 {6,S}
 16    H u0 p0 c0 {7,S}
 
+C:CC[CH2]
+multiplicity 2
+1      C u0 p0 c0 {2,D} {7,S} {8,S}
+2      C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *2  C u0 p0 c0 {2,S} {4,S} {10,S} {11,S}
+4  *1  C u1 p0 c0 {3,S} {5,S} {6,S}
+5      H u0 p0 c0 {4,S}
+6      H u0 p0 c0 {4,S}
+7      H u0 p0 c0 {1,S}
+8      H u0 p0 c0 {1,S}
+9      H u0 p0 c0 {2,S}
+10 *3  H u0 p0 c0 {3,S}
+11     H u0 p0 c0 {3,S}
+
+C:C[CH]C
+multiplicity 2
+1      C u0 p0 c0 {2,D} {6,S} {7,S}
+2      C u0 p0 c0 {1,D} {3,S} {8,S}
+3   *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4      H u0 p0 c0 {3,S}
+5   *1 C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+6      H u0 p0 c0 {1,S}
+7      H u0 p0 c0 {1,S}
+8      H u0 p0 c0 {2,S}
+9   *3 H u0 p0 c0 {5,S}
+10     H u0 p0 c0 {5,S}
+11     H u0 p0 c0 {5,S}
+
+C:CCC[CH2]
+multiplicity 2
+1    C u0 p0 c0 {2,D} {8,S} {9,S}
+2    C u0 p0 c0 {1,D} {3,S} {10,S}
+3 *2 C u0 p0 c0 {2,S} {4,S} {11,S} {12,S}
+4 *4 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5 *1 C u1 p0 c0 {4,S} {6,S} {7,S}
+6    H u0 p0 c0 {5,S}
+7    H u0 p0 c0 {5,S}
+8    H u0 p0 c0 {1,S}
+9    H u0 p0 c0 {1,S}
+10   H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+
+C:C[CH]CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {7,S} {8,S}
+2     C u0 p0 c0 {1,D} {3,S} {9,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *4 C u0 p0 c0 {3,S} {6,S} {10,S} {11,S}
+6  *1 C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *3 H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+
+C:CCCC[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2     C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C:C[CH]CCC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *5 C u0 p0 c0 {3,S} {6,S} {11,S} {12,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {13,S} {14,S}
+7  *1 C u0 p0 c0 {6,S} {15,S} {16,S} {17,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15 *3 H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {7,S}
+
+C:CCCCC[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2     C u0 p0 c0 {1,D} {3,S} {12,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13 *3 H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {6,S}
+
+C:C[CH]CCCC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2     C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *6 C u0 p0 c0 {3,S} {6,S} {12,S} {13,S}
+6  *5 C u0 p0 c0 {5,S} {7,S} {14,S} {15,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {16,S} {17,S}
+8  *1 C u0 p0 c0 {7,S} {18,S} {19,S} {20,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {7,S}
+18 *3 H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {8,S}
+
+C:CCCCCC[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {11,S} {12,S}
+2     C u0 p0 c0 {1,D} {3,S} {13,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {14,S} {15,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {16,S} {17,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {18,S} {19,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {20,S} {21,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {22,S} {23,S}
+8  *1 C u1 p0 c0 {7,S} {9,S} {10,S}
+9     H u0 p0 c0 {8,S}
+10    H u0 p0 c0 {8,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {6,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {7,S}
+
+C:C[CH]CCCCC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2     C u0 p0 c0 {1,D} {3,S} {12,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *5 C u0 p0 c0 {3,S} {6,S} {13,S} {14,S}
+6  *7 C u0 p0 c0 {5,S} {7,S} {15,S} {16,S}
+7  *6 C u0 p0 c0 {6,S} {8,S} {17,S} {18,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {19,S} {20,S}
+9  *1 C u0 p0 c0 {8,S} {21,S} {22,S} {23,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {8,S}
+21 *3 H u0 p0 c0 {9,S}
+22    H u0 p0 c0 {9,S}
+23    H u0 p0 c0 {9,S}
+
+C:C(C)C[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *2 C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4  *4 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     H u0 p0 c0 {5,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+
+C:C([CH2])CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *4 C u0 p0 c0 {2,S} {7,S} {10,S} {11,S}
+7  *1 C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12 *3 H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C:C(C)CC[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *5 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *2 C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11 *3 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C:C([CH2])CCC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *5 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *6 C u0 p0 c0 {2,S} {7,S} {11,S} {12,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {13,S} {14,S}
+8  *1 C u0 p0 c0 {7,S} {15,S} {16,S} {17,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15 *3 H u0 p0 c0 {8,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {8,S}
+
+C:C(C)CCC[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *5 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *2 C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+4  *7 C u0 p0 c0 {2,S} {5,S} {15,S} {16,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {19,S} {20,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {6,S}
+
+C:C([CH2])CCCC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *5 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *7 C u0 p0 c0 {2,S} {7,S} {12,S} {13,S}
+7  *6 C u0 p0 c0 {6,S} {8,S} {14,S} {15,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {16,S} {17,S}
+9  *1 C u0 p0 c0 {8,S} {18,S} {19,S} {20,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {9,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {9,S}
+
+CC:CC[CH2]
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *5 C u0 p0 c0 {1,S} {3,D} {11,S}
+3  *6 C u0 p0 c0 {2,D} {4,S} {12,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {13,S} {14,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     H u0 p0 c0 {5,S}
+7     H u0 p0 c0 {5,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+
+[CH2]C:CCC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,D} {8,S}
+5  *6 C u0 p0 c0 {4,D} {6,S} {9,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {10,S} {11,S}
+7  *1 C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+CC:CCC[CH2]
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+2  *5 C u0 p0 c0 {1,S} {3,D} {12,S}
+3  *7 C u0 p0 c0 {2,D} {4,S} {13,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9  *3 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+[CH2]C:CCCC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,D} {9,S}
+5  *7 C u0 p0 c0 {4,D} {6,S} {10,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {11,S} {12,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {13,S} {14,S}
+8  *1 C u0 p0 c0 {7,S} {15,S} {16,S} {17,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15 *3 H u0 p0 c0 {8,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {8,S}
+
+C:C([CH2])CC:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *2 C u0 p0 c0 {2,S} {7,S} {11,S} {12,S}
+7     C u0 p0 c0 {6,S} {8,D} {13,S}
+8     C u0 p0 c0 {7,D} {14,S} {15,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11 *3 H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {8,S}
+15    H u0 p0 c0 {8,S}
+
+C:C(C)[CH]C:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *1 C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4  *2 C u1 p0 c0 {2,S} {5,S} {6,S}
+5     H u0 p0 c0 {4,S}
+6     C u0 p0 c0 {4,S} {7,D} {13,S}
+7     C u0 p0 c0 {6,D} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10 *3 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C:CCC:C[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2     C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *5 C u0 p0 c0 {3,S} {5,D} {14,S}
+5  *4 C u0 p0 c0 {4,D} {6,S} {15,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+
+C:C[CH]C:CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {8,S} {9,S}
+2     C u0 p0 c0 {1,D} {3,S} {10,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *5 C u0 p0 c0 {3,S} {6,D} {11,S}
+6  *4 C u0 p0 c0 {5,D} {7,S} {12,S}
+7  *1 C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13 *3 H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C:C([CH2])C:CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *6 C u0 p0 c0 {2,S} {7,D} {11,S}
+7  *5 C u0 p0 c0 {6,D} {8,S} {12,S}
+8  *2 C u0 p0 c0 {7,S} {13,S} {14,S} {15,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {7,S}
+13 *3 H u0 p0 c0 {8,S}
+14    H u0 p0 c0 {8,S}
+15    H u0 p0 c0 {8,S}
+
+C:C(C)C:C[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *1 C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+4  *6 C u0 p0 c0 {2,S} {5,D} {14,S}
+5  *5 C u0 p0 c0 {4,D} {6,S} {15,S}
+6  *2 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11 *3 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+
+C:C(C)[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *2 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  *1 C u1 p0 c0 {2,S} {5,S} {6,S}
+5     H u0 p0 c0 {4,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+
+C:C([CH2])C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+
+C:C([CH2])CCC:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *5 C u0 p0 c0 {2,S} {7,S} {12,S} {13,S}
+7  *2 C u0 p0 c0 {6,S} {8,S} {14,S} {15,S}
+8     C u0 p0 c0 {7,S} {9,D} {16,S}
+9     C u0 p0 c0 {8,D} {17,S} {18,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14 *3 H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {9,S}
+18    H u0 p0 c0 {9,S}
+
+C:C(C)C[CH]C:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *1 C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *2 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     H u0 p0 c0 {5,S}
+7     C u0 p0 c0 {5,S} {8,D} {16,S}
+8     C u0 p0 c0 {7,D} {17,S} {18,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11 *3 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {8,S}
+
+C:C([CH2])CCCC:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {11,S} {12,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *6 C u0 p0 c0 {2,S} {7,S} {13,S} {14,S}
+7  *5 C u0 p0 c0 {6,S} {8,S} {15,S} {16,S}
+8  *2 C u0 p0 c0 {7,S} {9,S} {17,S} {18,S}
+9     C u0 p0 c0 {8,S} {10,D} {19,S}
+10    C u0 p0 c0 {9,D} {20,S} {21,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+17 *3 H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {10,S}
+
+C:C(C)CC[CH]C:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *1 C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+4  *6 C u0 p0 c0 {2,S} {5,S} {15,S} {16,S}
+5  *5 C u0 p0 c0 {4,S} {6,S} {17,S} {18,S}
+6  *2 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     C u0 p0 c0 {6,S} {9,D} {19,S}
+9     C u0 p0 c0 {8,D} {20,S} {21,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {8,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {9,S}
+
+C:C([CH2])CCCCC:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {12,S} {13,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *6 C u0 p0 c0 {2,S} {7,S} {14,S} {15,S}
+7  *7 C u0 p0 c0 {6,S} {8,S} {16,S} {17,S}
+8  *5 C u0 p0 c0 {7,S} {9,S} {18,S} {19,S}
+9  *2 C u0 p0 c0 {8,S} {10,S} {20,S} {21,S}
+10    C u0 p0 c0 {9,S} {11,D} {22,S}
+11    C u0 p0 c0 {10,D} {23,S} {24,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {8,S}
+20 *3 H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {9,S}
+22    H u0 p0 c0 {10,S}
+23    H u0 p0 c0 {11,S}
+24    H u0 p0 c0 {11,S}
+
+C:C(C)CCC[CH]C:C
+multiplicity 2
+1     C u0 p0 c0 {2,D} {11,S} {12,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *1 C u0 p0 c0 {2,S} {13,S} {14,S} {15,S}
+4  *6 C u0 p0 c0 {2,S} {5,S} {16,S} {17,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {18,S} {19,S}
+6  *5 C u0 p0 c0 {5,S} {7,S} {20,S} {21,S}
+7  *2 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     C u0 p0 c0 {7,S} {10,D} {22,S}
+10    C u0 p0 c0 {9,D} {23,S} {24,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13 *3 H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {6,S}
+22    H u0 p0 c0 {9,S}
+23    H u0 p0 c0 {10,S}
+24    H u0 p0 c0 {10,S}
+
+CC:C[CH2]
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,S} {3,D} {10,S}
+3  *4 C u0 p0 c0 {2,D} {4,S} {11,S}
+4  *1 C u1 p0 c0 {3,S} {5,S} {6,S}
+5     H u0 p0 c0 {4,S}
+6     H u0 p0 c0 {4,S}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+
+[CH2]C:CC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,D} {7,S}
+5  *4 C u0 p0 c0 {4,D} {6,S} {8,S}
+6  *1 C u0 p0 c0 {5,S} {9,S} {10,S} {11,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {5,S}
+9  *3 H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+
+C:CCCC:C[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2     C u0 p0 c0 {1,D} {3,S} {12,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+5  *6 C u0 p0 c0 {4,S} {6,D} {17,S}
+6  *4 C u0 p0 c0 {5,D} {7,S} {18,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13 *3 H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+
+
+C:C[CH]CC:CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {9,S} {10,S}
+2     C u0 p0 c0 {1,D} {3,S} {11,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *5 C u0 p0 c0 {3,S} {6,S} {12,S} {13,S}
+6  *6 C u0 p0 c0 {5,S} {7,D} {14,S}
+7  *4 C u0 p0 c0 {6,D} {8,S} {15,S}
+8  *1 C u0 p0 c0 {7,S} {16,S} {17,S} {18,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16 *3 H u0 p0 c0 {8,S}
+17    H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {8,S}
+
+C:CCCCC:C[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {11,S} {12,S}
+2     C u0 p0 c0 {1,D} {3,S} {13,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {14,S} {15,S}
+4  *5 C u0 p0 c0 {3,S} {5,S} {16,S} {17,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {18,S} {19,S}
+6  *6 C u0 p0 c0 {5,S} {7,D} {20,S}
+7  *4 C u0 p0 c0 {6,D} {8,S} {21,S}
+8  *1 C u1 p0 c0 {7,S} {9,S} {10,S}
+9     H u0 p0 c0 {8,S}
+10    H u0 p0 c0 {8,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14 *3 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {6,S}
+21    H u0 p0 c0 {7,S}
+
+C:C[CH]CCC:CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2     C u0 p0 c0 {1,D} {3,S} {12,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *5 C u0 p0 c0 {3,S} {6,S} {13,S} {14,S}
+6  *7 C u0 p0 c0 {5,S} {7,S} {15,S} {16,S}
+7  *6 C u0 p0 c0 {6,S} {8,D} {17,S}
+8  *4 C u0 p0 c0 {7,D} {9,S} {18,S}
+9  *1 C u0 p0 c0 {8,S} {19,S} {20,S} {21,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19 *3 H u0 p0 c0 {9,S}
+20    H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {9,S}
+
+C:C([CH2])CC:CC
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {6,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *6 C u0 p0 c0 {2,S} {7,S} {12,S} {13,S}
+7  *7 C u0 p0 c0 {6,S} {8,D} {14,S}
+8  *5 C u0 p0 c0 {7,D} {9,S} {15,S}
+9  *2 C u0 p0 c0 {8,S} {16,S} {17,S} {18,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {8,S}
+16 *3 H u0 p0 c0 {9,S}
+17    H u0 p0 c0 {9,S}
+18    H u0 p0 c0 {9,S}
+
+C:C(C)CC:C[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,D} {10,S} {11,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+3  *1 C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+4  *6 C u0 p0 c0 {2,S} {5,S} {15,S} {16,S}
+5  *7 C u0 p0 c0 {4,S} {6,D} {17,S}
+6  *5 C u0 p0 c0 {5,D} {7,S} {18,S}
+7  *2 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+
+C[CH2]
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2 *1 C u1 p0 c0 {1,S} {3,S} {4,S}
+3    H u0 p0 c0 {2,S}
+4    H u0 p0 c0 {2,S}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {1,S}
+
+[CH2]C
+multiplicity 2
+1 *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4 *1 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5 *3 H u0 p0 c0 {4,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+
+CCC[CH2]-1
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *1 C u1 p0 c0 {3,S} {5,S} {6,S}
+5     H u0 p0 c0 {4,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12 *3 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+
+CC[CH]C
+multiplicity 2
+1     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2     C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *1 C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11 *3 H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+
+CC[CH2]
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *1 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5     H u0 p0 c0 {3,S}
+6  *3 H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+
+[CH2]CC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *4 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  *1 C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8  *3 H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+
+CCCC[CH2]
+multiplicity 2
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2     C u0 p0 c0 {1,S} {3,S} {11,S} {12,S}
+3  *2 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     H u0 p0 c0 {5,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13 *3 H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+
+CC[CH]CC
+multiplicity 2
+1     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+3  *2 C u1 p0 c0 {2,S} {4,S} {5,S}
+4     H u0 p0 c0 {3,S}
+5  *4 C u0 p0 c0 {3,S} {6,S} {12,S} {13,S}
+6  *1 C u0 p0 c0 {5,S} {14,S} {15,S} {16,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14 *3 H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+
+CCC[CH2]-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,S} {3,S} {10,S} {11,S}
+3  *4 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+4  *1 C u1 p0 c0 {3,S} {5,S} {6,S}
+5     H u0 p0 c0 {4,S}
+6     H u0 p0 c0 {4,S}
+7  *3 H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+
+[CH2]CCC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {9,S} {10,S}
+6  *1 C u0 p0 c0 {5,S} {11,S} {12,S} {13,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11 *3 H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+
+CCCCCCC[CH2]-1
+multiplicity 2
+1     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+2     C u0 p0 c0 {1,S} {3,S} {14,S} {15,S}
+3     C u0 p0 c0 {2,S} {4,S} {16,S} {17,S}
+4     C u0 p0 c0 {3,S} {5,S} {18,S} {19,S}
+5  *2 C u0 p0 c0 {4,S} {6,S} {20,S} {21,S}
+6  *5 C u0 p0 c0 {5,S} {7,S} {22,S} {23,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {24,S} {25,S}
+8  *1 C u1 p0 c0 {7,S} {9,S} {10,S}
+9     H u0 p0 c0 {8,S}
+10    H u0 p0 c0 {8,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {2,S}
+16    H u0 p0 c0 {3,S}
+17    H u0 p0 c0 {3,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {4,S}
+20 *3 H u0 p0 c0 {5,S}
+21    H u0 p0 c0 {5,S}
+22    H u0 p0 c0 {6,S}
+23    H u0 p0 c0 {6,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {7,S}
+
+CCCC[CH]CCC
+multiplicity 2
+1     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+2     C u0 p0 c0 {1,S} {3,S} {13,S} {14,S}
+3     C u0 p0 c0 {2,S} {4,S} {15,S} {16,S}
+4     C u0 p0 c0 {3,S} {5,S} {17,S} {18,S}
+5  *2 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     H u0 p0 c0 {5,S}
+7  *5 C u0 p0 c0 {5,S} {8,S} {19,S} {20,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {21,S} {22,S}
+9  *1 C u0 p0 c0 {8,S} {23,S} {24,S} {25,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {3,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23 *3 H u0 p0 c0 {9,S}
+24    H u0 p0 c0 {9,S}
+25    H u0 p0 c0 {9,S}
+
+CCCC[CH2]-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *5 C u0 p0 c0 {1,S} {3,S} {11,S} {12,S}
+3  *6 C u0 p0 c0 {2,S} {4,S} {13,S} {14,S}
+4  *4 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+5  *1 C u1 p0 c0 {4,S} {6,S} {7,S}
+6     H u0 p0 c0 {5,S}
+7     H u0 p0 c0 {5,S}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+
+
+[CH2]CCCC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {10,S} {11,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {12,S} {13,S}
+7  *1 C u0 p0 c0 {6,S} {14,S} {15,S} {16,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14 *3 H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+
+CCCCC[CH2]-1
+multiplicity 2
+1     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {12,S} {13,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {14,S} {15,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {16,S} {17,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {18,S} {19,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13 *3 H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+
+C[CH]CCCC
+multiplicity 2
+1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     H u0 p0 c0 {2,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {11,S} {12,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {13,S} {14,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {15,S} {16,S}
+7  *1 C u0 p0 c0 {6,S} {17,S} {18,S} {19,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17 *3 H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+
+CCCCC[CH2]-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+2  *5 C u0 p0 c0 {1,S} {3,S} {12,S} {13,S}
+3  *7 C u0 p0 c0 {2,S} {4,S} {14,S} {15,S}
+4  *6 C u0 p0 c0 {3,S} {5,S} {16,S} {17,S}
+5  *4 C u0 p0 c0 {4,S} {6,S} {18,S} {19,S}
+6  *1 C u1 p0 c0 {5,S} {7,S} {8,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {6,S}
+9  *3 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+
+[CH2]CCCCC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {11,S} {12,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {13,S} {14,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {15,S} {16,S}
+8  *1 C u0 p0 c0 {7,S} {17,S} {18,S} {19,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16    H u0 p0 c0 {7,S}
+17 *3 H u0 p0 c0 {8,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {8,S}
+
+CCCCCC[CH2]-1
+multiplicity 2
+1     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {13,S} {14,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {15,S} {16,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {17,S} {18,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {21,S} {22,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {7,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13 *3 H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {3,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {5,S}
+21    H u0 p0 c0 {6,S}
+22    H u0 p0 c0 {6,S}
+
+C[CH]CCCCC
+multiplicity 2
+1     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     H u0 p0 c0 {2,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {12,S} {13,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {14,S} {15,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {16,S} {17,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {18,S} {19,S}
+8  *1 C u0 p0 c0 {7,S} {20,S} {21,S} {22,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {7,S}
+19    H u0 p0 c0 {7,S}
+20 *3 H u0 p0 c0 {8,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+
+CCCCCC[CH2]-2
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+2  *5 C u0 p0 c0 {1,S} {3,S} {13,S} {14,S}
+3  *8 C u0 p0 c0 {2,S} {4,S} {15,S} {16,S}
+4  *7 C u0 p0 c0 {3,S} {5,S} {17,S} {18,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {19,S} {20,S}
+6  *4 C u0 p0 c0 {5,S} {7,S} {21,S} {22,S}
+7  *1 C u1 p0 c0 {6,S} {8,S} {9,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {7,S}
+10 *3 H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {3,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {5,S}
+21    H u0 p0 c0 {6,S}
+22    H u0 p0 c0 {6,S}
+
+[CH2]CCCCCC
+multiplicity 2
+1  *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2     H u0 p0 c0 {1,S}
+3     H u0 p0 c0 {1,S}
+4  *5 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+5  *8 C u0 p0 c0 {4,S} {6,S} {12,S} {13,S}
+6  *7 C u0 p0 c0 {5,S} {7,S} {14,S} {15,S}
+7  *6 C u0 p0 c0 {6,S} {8,S} {16,S} {17,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {18,S} {19,S}
+9  *1 C u0 p0 c0 {8,S} {20,S} {21,S} {22,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+19    H u0 p0 c0 {8,S}
+20 *3 H u0 p0 c0 {9,S}
+21    H u0 p0 c0 {9,S}
+22    H u0 p0 c0 {9,S}
+
+CCCCCCC[CH2]-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {14,S} {15,S}
+3  *5 C u0 p0 c0 {2,S} {4,S} {16,S} {17,S}
+4  *8 C u0 p0 c0 {3,S} {5,S} {18,S} {19,S}
+5  *7 C u0 p0 c0 {4,S} {6,S} {20,S} {21,S}
+6  *6 C u0 p0 c0 {5,S} {7,S} {22,S} {23,S}
+7  *4 C u0 p0 c0 {6,S} {8,S} {24,S} {25,S}
+8  *1 C u1 p0 c0 {7,S} {9,S} {10,S}
+9     H u0 p0 c0 {8,S}
+10    H u0 p0 c0 {8,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {1,S}
+14 *3 H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {2,S}
+16    H u0 p0 c0 {3,S}
+17    H u0 p0 c0 {3,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {4,S}
+20    H u0 p0 c0 {5,S}
+21    H u0 p0 c0 {5,S}
+22    H u0 p0 c0 {6,S}
+23    H u0 p0 c0 {6,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {7,S}
+
+C[CH]CCCCCC
+multiplicity 2
+1     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+2  *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3     H u0 p0 c0 {2,S}
+4  *5 C u0 p0 c0 {2,S} {5,S} {13,S} {14,S}
+5  *8 C u0 p0 c0 {4,S} {6,S} {15,S} {16,S}
+6  *7 C u0 p0 c0 {5,S} {7,S} {17,S} {18,S}
+7  *6 C u0 p0 c0 {6,S} {8,S} {19,S} {20,S}
+8  *4 C u0 p0 c0 {7,S} {9,S} {21,S} {22,S}
+9  *1 C u0 p0 c0 {8,S} {23,S} {24,S} {25,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {8,S}
+22    H u0 p0 c0 {8,S}
+23 *3 H u0 p0 c0 {9,S}
+24    H u0 p0 c0 {9,S}
+25    H u0 p0 c0 {9,S}

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -481,8 +481,6 @@ Taken from entry: pdt58 <=> pdt20
 """,
 )
 
-
-
 entry(
     index = 33,
     label = "C6H7-7 <=> C6H7-8",
@@ -496,3 +494,995 @@ Taken from entry: C5H4CH3 <=> C5H5CH2-1
 """,
 )
 
+entry(
+    index = 34,
+    label = "C:CC[CH2] <=> C:C[CH]C",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.72E+06, 's^-1'),
+        n = 1.99,
+        Ea = (27.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 1.1 - 1,2 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+
+entry(
+    index = 35,
+    label = "C:CCC[CH2] <=> C:C[CH]CC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (2.5E+04, 's^-1'),
+        n = 2.28,
+        Ea = (28.5, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 1.2 - 1,3 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 36,
+    label = "C:CCCC[CH2] <=> C:C[CH]CCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (4.22E+04, 's^-1'),
+        n = 1.93,
+        Ea = (13.5, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 1.3 - 1,4 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 37,
+    label = "C:CCCCC[CH2] <=> C:C[CH]CCCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.54E+04, 's^-1'),
+        n = 1.87,
+        Ea = (7.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 1.4 - 1,5 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 38,
+    label = "C:CCCCCC[CH2] <=> C:C[CH]CCCCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.16E+03, 's^-1'),
+        n = 1.94,
+        Ea = (6.6, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 1.5 - 1,6 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 39,
+    label = "C:C(C)C[CH2] <=> C:C([CH2])CC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (3.24E+04, 's^-1'),
+        n = 2.04,
+        Ea = (19.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 2.1 - 1,4 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 40,
+    label = "C:C(C)CC[CH2] <=> C:C([CH2])CCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (6.90E+03, 's^-1'),
+        n = 1.98,
+        Ea = (10.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 2.2 - 1,5 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 41,
+    label = "C:C(C)CCC[CH2] <=> C:C([CH2])CCCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (3.12E+02, 's^-1'),
+        n = 2.10,
+        Ea = (10.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 2.3 - 1,6 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 42,
+    label = "CC:CC[CH2] <=> [CH2]C:CCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (1.21E+05, 's^-1'),
+        n = 1.90,
+        Ea = (13.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 3.1 - 1,5 H-shift
+Calculation was made for the trans isomer
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 43,
+    label = "CC:CCC[CH2] <=> [CH2]C:CCCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (8.01E+03, 's^-1'),
+        n = 1.94,
+        Ea = (13.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 3.2 - 1,6 H-shift
+Calculation was made for the trans isomer
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 44,
+    label = "C:C([CH2])CC:C <=> C:C(C)[CH]C:C",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (2.08E+04, 's^-1'),
+        n = 2.49,
+        Ea = (43.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 7.1 - 1,3 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 45,
+    label = "C:CCC:C[CH2] <=> C:C[CH]C:CC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (2.56E+05, 's^-1'),
+        n = 2.00,
+        Ea = (28.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 8.1 - 1,4 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 46,
+    label = "C:C([CH2])C:CC <=> C:C(C)C:C[CH2]",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (4.44E+06, 's^-1'),
+        n = 1.64,
+        Ea = (24.0, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 9.1 - 1,5 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 47,
+    label = "C:C(C)[CH2] <=> C:C([CH2])C",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (2.355E+05, 's^-1'),
+        n = 2.44,
+        Ea = (51.6, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 4.1 - 1,3 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 48,
+    label = "C:C([CH2])CCC:C <=> C:C(C)C[CH]C:C",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (1.032E+05, 's^-1'),
+        n = 2.04,
+        Ea = (25.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 4.2 - 1,4 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 49,
+    label = "C:C([CH2])CCCC:C <=> C:C(C)CC[CH]C:C",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (1.884E+04, 's^-1'),
+        n = 1.93,
+        Ea = (16.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 4.3 - 1,5 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 50,
+    label = "C:C([CH2])CCCCC:C <=> C:C(C)CCC[CH]C:C",
+    degeneracy = 4,
+    kinetics = Arrhenius(
+        A = (1.136E+02, 's^-1'),
+        n = 2.07,
+        Ea = (15.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 4.4 - 1,6 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 51,
+    label = "CC:C[CH2] <=> [CH2]C:CC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (8.00E+05, 's^-1'),
+        n = 1.81,
+        Ea = (35.8, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 5.1 - 1,4 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 52,
+    label = "C:CCCC:C[CH2] <=> C:C[CH]CC:CC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (2.52E+05, 's^-1'),
+        n = 1.85,
+        Ea = (21.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 5.2 - 1,5 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 53,
+    label = "C:CCCCC:C[CH2] <=> C:C[CH]CCC:CC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.094E+04, 's^-1'),
+        n = 1.94,
+        Ea = (20.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 5.3 - 1,6 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 54,
+    label = "C:C([CH2])CC:CC <=> C:C(C)CC:C[CH2]",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (6.33E+04, 's^-1'),
+        n = 1.92,
+        Ea = (21.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+Reaction 6.1 - 1,6 H-shift
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 55,
+    label = "C[CH2] <=> [CH2]C",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (7.05E+06, 's^-1'),
+        n = 1.81,
+        Ea = (37.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,2 H-Shift Primary-Primary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 56,
+    label = "CCC[CH2]-1 <=> CC[CH]C",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (6.48E+07, 's^-1'),
+        n = 1.57,
+        Ea = (35.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,2 H-Shift Primary-Secondary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 57,
+    label = "CC[CH2] <=> [CH2]CC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (8.85E+04, 's^-1'),
+        n = 2.17,
+        Ea = (35.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,3 H-Shift Primary-Primary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 58,
+    label = "CCCC[CH2] <=> CC[CH]CC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (1.064E+06, 's^-1'),
+        n = 1.93,
+        Ea = (33.8, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,3 H-Shift Primary-Secondary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 59,
+    label = "CCC[CH2]-2 <=> [CH2]CCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (1.14E+05, 's^-1'),
+        n = 1.74,
+        Ea = (19.8, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,4 H-Shift Primary-Primary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 60,
+    label = "CCCCCCC[CH2]-1 <=> CCCC[CH]CCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (7.54E+05, 's^-1'),
+        n = 1.63,
+        Ea = (17.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,4 H-Shift Primary-Secondary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 61,
+    label = "CCCC[CH2]-2 <=> [CH2]CCCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (6.885E+04, 's^-1'),
+        n = 1.68,
+        Ea = (12.6, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,5 H-Shift Primary-Primary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 62,
+    label = "CCCCC[CH2]-1 <=> C[CH]CCCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (2.62E+05, 's^-1'),
+        n = 1.62,
+        Ea = (11.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,5 H-Shift Primary-Secondary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 63,
+    label = "CCCCC[CH2]-2 <=> [CH2]CCCCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (3.69E+03, 's^-1'),
+        n = 1.79,
+        Ea = (11.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,6 H-Shift Primary-Primary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 64,
+    label = "CCCCCC[CH2]-1 <=> C[CH]CCCCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (2.58E+04, 's^-1'),
+        n = 1.67,
+        Ea = (10.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,6 H-Shift Primary-Secondary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 65,
+    label = "CCCCCC[CH2]-2 <=> [CH2]CCCCCC",
+    degeneracy = 3,
+    kinetics = Arrhenius(
+        A = (6.42E+01, 's^-1'),
+        n = 2.10,
+        Ea = (15.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,7 H-Shift Primary-Primary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)
+
+entry(
+    index = 66,
+    label = "CCCCCCC[CH2]-2 <=> C[CH]CCCCCC",
+    degeneracy = 2,
+    kinetics = Arrhenius(
+        A = (10.62E+02, 's^-1'),
+        n = 1.81,
+        Ea = (13.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ["Kun Wang", "Stephanie M. Villano", "Anthony M. Dean"],
+        title = u'The Impact of Resonance Stabilization on the Intramolecular H-atom Shift Reactions of Hydrocarbon Radicals',
+        journal = "Chemphyschem",
+        volume = "16",
+        pages = """2635-2645""",
+        year = "2015",
+    ),
+    referenceType = "theory",
+    shortDesc = u"""TST calculations at CBS-QB3//B3LYP/6-31G(d) level with 1-D hindered rotor corrections""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3//B3LYP/6-31G(d) level
+using Gaussian 03 and Gaussian 09.
+1,7 H-Shift Primary-Secondary
+Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
+""",
+)


### PR DESCRIPTION
Training Reactions Added to intra_H_Migration

Training reactions index 34 through 66 added to intra_H_migration

Data source from
Wang, Villano, and Dean, "The Impact of Resonance Stabilization
on the Intramolecular Hydrogen-Atom Shift Reactions of
Hydrocarbon Radicals", ChemPhysChem, 2015.

Few rules were used while adding training reactions:
1. Article reports A factors on a per hydrogen basis, as well as
the number of possible hydrogen donors. All A-factors are
multiplied by the number of hydrogens and degeneracy properly
reported so that accurate rates are used in the event where
an exact match takes place.

2. Symmetric reactions (with identical reactants and products)
were reported with an A factor that is a factor of two slower in
the source article, because of the symmetrical reaction
coordinate around the transition state. All symmetric reaction
rates have their A factors multiplied by 2.

3. Some reactants have identical resonance isomers. Reactions
containing these reactants had their degeneracy and A factor
multiplied by 2.

Groups were modified in intra_H_migration in order
to circumvent different reactions matched in the same
group.

This change is particularly made for the new training
reactions, but groups reflecting existing training
reactions were also changed.

