### PR TITLE
Fix adjlist for C6H5 in JetSurf2.0

### DIFF
--- a/input/kinetics/libraries/JetSurF2.0/dictionary.txt
+++ b/input/kinetics/libraries/JetSurF2.0/dictionary.txt
@@ -1783,11 +1783,11 @@ C6H6
 C6H5
 multiplicity 2
 1  C u0 p0 c0 {2,S} {3,D} {8,S}
-2  C u1 p0 c0 {1,S} {4,S} {7,S}
-3  C u0 p0 c0 {1,D} {5,S} {9,S}
-4  C u0 p0 c0 {2,S} {6,D} {10,S}
-5  C u0 p0 c0 {3,S} {6,D} {11,S}
-6  C u0 p0 c0 {4,D} {5,D}
+2  C u0 p0 c0 {1,S} {5,D} {7,S}
+3  C u0 p0 c0 {1,D} {4,S} {9,S}
+4  C u0 p0 c0 {3,S} {6,D} {10,S}
+5  C u0 p0 c0 {2,D} {6,S} {11,S}
+6  C u1 p0 c0 {4,D} {5,S}
 7  H u0 p0 c0 {2,S}
 8  H u0 p0 c0 {1,S}
 9  H u0 p0 c0 {3,S}

--- a/input/thermo/libraries/JetSurF2.0.py
+++ b/input/thermo/libraries/JetSurF2.0.py
@@ -2924,11 +2924,11 @@ entry(
 """
 multiplicity 2
 1  C u0 p0 c0 {2,S} {3,D} {8,S}
-2  C u1 p0 c0 {1,S} {4,S} {7,S}
-3  C u0 p0 c0 {1,D} {5,S} {9,S}
-4  C u0 p0 c0 {2,S} {6,D} {10,S}
-5  C u0 p0 c0 {3,S} {6,D} {11,S}
-6  C u0 p0 c0 {4,D} {5,D}
+2  C u0 p0 c0 {1,S} {5,D} {7,S}
+3  C u0 p0 c0 {1,D} {4,S} {9,S}
+4  C u0 p0 c0 {3,S} {6,D} {10,S}
+5  C u0 p0 c0 {2,D} {6,S} {11,S}
+6  C u1 p0 c0 {4,D} {5,S}
 7  H u0 p0 c0 {2,S}
 8  H u0 p0 c0 {1,S}
 9  H u0 p0 c0 {3,S}

--- a/input/thermo/libraries/USC-Mech-ii.py
+++ b/input/thermo/libraries/USC-Mech-ii.py
@@ -3103,17 +3103,17 @@ entry(
     molecule = 
 """
 multiplicity 2
-1  C u0 p0 c0 {2,D} {6,D}
-2  C u0 p0 c0 {1,D} {3,S} {7,S}
-3  C u1 p0 c0 {2,S} {4,S} {8,S}
-4  C u0 p0 c0 {3,S} {5,D} {9,S}
-5  C u0 p0 c0 {4,D} {6,S} {10,S}
-6  C u0 p0 c0 {1,D} {5,S} {11,S}
+1  C u0 p0 c0 {2,S} {3,D} {8,S}
+2  C u0 p0 c0 {1,S} {5,D} {7,S}
+3  C u0 p0 c0 {1,D} {4,S} {9,S}
+4  C u0 p0 c0 {3,S} {6,D} {10,S}
+5  C u0 p0 c0 {2,D} {6,S} {11,S}
+6  C u1 p0 c0 {4,D} {5,S}
 7  H u0 p0 c0 {2,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {4,S}
-10 H u0 p0 c0 {5,S}
-11 H u0 p0 c0 {6,S}
+8  H u0 p0 c0 {1,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
 """,
     thermo = NASA(
         polynomials = [


### PR DESCRIPTION
Old adjlist was for an invalid resonance structure.

I discovered this randomly while testing RMG-website because it was actually causing unexpected issues. For example, [searching for benzene + H gives the odd resonance structure as the third result](http://rmg.mit.edu/database/kinetics/results/reactant1=1%20%20C%20u0%20p0%20c0%20%7B2,D%7D%20%7B6,S%7D%20%7B7,S%7D%0D%0A2%20%20C%20u0%20p0%20c0%20%7B1,D%7D%20%7B3,S%7D%20%7B8,S%7D%0D%0A3%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B4,D%7D%20%7B9,S%7D%0D%0A4%20%20C%20u0%20p0%20c0%20%7B3,D%7D%20%7B5,S%7D%20%7B10,S%7D%0D%0A5%20%20C%20u0%20p0%20c0%20%7B4,S%7D%20%7B6,D%7D%20%7B11,S%7D%0D%0A6%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B5,D%7D%20%7B12,S%7D%0D%0A7%20%20H%20u0%20p0%20c0%20%7B1,S%7D%0D%0A8%20%20H%20u0%20p0%20c0%20%7B2,S%7D%0D%0A9%20%20H%20u0%20p0%20c0%20%7B3,S%7D%0D%0A10%20H%20u0%20p0%20c0%20%7B4,S%7D%0D%0A11%20H%20u0%20p0%20c0%20%7B5,S%7D%0D%0A12%20H%20u0%20p0%20c0%20%7B6,S%7D%0D%0A__reactant2=multiplicity%202%0D%0A1%20H%20u1%20p0%20c0%0D%0A) because the first reaction match is from JetSurf.