### PR TITLE
Fixed various sulfur library entries

### DIFF
--- a/input/kinetics/libraries/SOx/dictionary.txt
+++ b/input/kinetics/libraries/SOx/dictionary.txt
@@ -150,6 +150,12 @@ multiplicity 2
 2 H u0 p0 c0 {1,S}
 3 O u0 p2 c0 {1,D}
 
+HOS
+multiplicity 2
+1 S u1 p2 c0 {3,S}
+2 H u0 p0 c0 {3,S}
+3 O u0 p2 c0 {1,S} {2,S}
+
 HOSO
 multiplicity 2
 1 O u0 p2 c0 {2,S} {4,S}

--- a/input/kinetics/libraries/SOx/reactions.py
+++ b/input/kinetics/libraries/SOx/reactions.py
@@ -24,6 +24,7 @@ Reference legend:
 [GlarBozz] (RMG's Sulfur/GlarborgBozzelli library) P. Glarborg, D. Kubel, K. Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28, 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
 [Lin2003a] C-W. Lu, Y-J. Wu, Y-P. Lee, R.S. Zhu, M.C. Lin, J. Phys. Chem. A, 2003, 107(50), 11020-11029, doi: 10.1021/jp036025c
 [Lin2004] C-W. Lu, Y-J. Wu, Y-P. Lee, R.S. Zhu, M.C. Lin, J. Chem. Phys., 2004, 121(17), 8271-8278, doi: 10.1063/1.1792611
+[Marshall1995] A. Goumri, D. Laakso, J‐D.R. Rocha, C.E. Smith, P. Marshall, J. Chem. Phys., 1995, 102, 161-169, doi: 10.1063/1.469387
 [Marshall1999a] A. Goumri, J-D.R. Rocha, D. Laakso, C.E. Smith, P. Marshall, J. Phys. Chem. A, 1999, 103(51), 11328-11335 doi: 10.1021/jp9924070
 [Marshall1999b] J. Peng, X. Hu, P. Marshall, J. Phys. Chem. A, 1999, 103, 5307-5311, doi: 10.1021/jp984242l
 [Marshall2004] A. Goumri, D.D. Shao, P. Marshall, J. Chem. Phys., 2004, 121, 9999, doi: 10.1063/1.1806419
@@ -31,7 +32,8 @@ Reference legend:
 [Marshall2006] A. Yilmaz, L. Hindiyarti, A.D. Jensen, P. Glarbotg, P. Marshall, J. Phys. Chem. A, 2006, 110 (21), 6654-6659, doi: 10.1021/jp0557215
 [Marshall2007a] L. Hindiyarti, P. Glarborg, P. Marshall, J. Phys. Chem. A, 2007, 111(19), 3984-3991, doi: 10.1021/jp067499p
 [Marshall2007b] C.L. Rasmussen, P. Glarborg, P. Marshall, Proceedings of the Combustion Institute, 2007, 31, 339-347, doi: 10.1016/j.proci.2006.07.249
-[Marshall2011] Y. Gao, P. Marshall, J. Chem. Phys., 2011, 135, 144306, doi: 10.1063/1.3644773
+[Marshall2011a] Y. Gao, P. Marshall, J. Chem. Phys., 2011, 135, 144306, doi: 10.1063/1.3644773
+[Marshall2011b] Y. Gao, C.R. Zhou, K. Sendt, B.S. Haynes, P. Marshall, Proc. Comb. Inst., 2011, 33, 459-465, doi: 10.1016/j.proci.2010.05.020
 [Marshall2012] K.M. Thompson, Y. Gao, P. Marshall, Int. J. Chem. Kin., 2012, 44(1), 90-99, doi: 10.1002/kin.20612
 [Marshall2015a] S. Ayling, Y. Gao, P. Marshall, Proceedings of the Combustion Institute, 2015, 35(1), 215-222, doi: 10.1016/j.proci.2014.05.079
 [Marshall2015b] K.E. Kerr, I.M. Alecu, K.M. Thompson, Y. Gao, P. Marshall, J. Phys. CHem. A, 2015, 119, 7352-7360, doi: 10.1021/jp512966a
@@ -42,7 +44,8 @@ Reference legend:
 [Molina1997] J.T. Jayne, U. Poschl, Y-m. Chen, D. Dai, L.T. Molina, D.R. Worsnop, C.E. Kolb, M.J. Molina, J. Phys. Chem. A, 1997, 101(51), 10000-10011, doi: 10.1021/jp972549z
 [Mukarami1979] T. Higashihara, K. Saito, I. Murakami, Bulletin of the Chemical Society of Japan, 1980, 53(1), 15-18, doi: 10.1246/bcsj.53.15
 [Palmer1977] H. Freund, H.B. Palmer, Int. J. Chem. Kin., 1977, 9(6), 887-905, doi: 10.1002/kin.550090605
-[Pilling2002] M.A. Blitz, K.W. McKee, M.J. Pilling, J. Phys. Chem. A, 2002, 106(36), 8406-8410, doi: 10.1021/jp025508y
+[Pilling2002a] M.A. Blitz, K.W. McKee, M.J. Pilling, J. Phys. Chem. A, 2002, 106(36), 8406-8410, doi: 10.1021/jp025508y
+[Pilling2002b] K.J. Hughes, M.A. Blitz, M.J. Pilling, S.H. Robertson, Proc. Comb. Inst., 2002, 29(2), 2431-2437, doi: 10.1016/S1540-7489(02)80296-6
 [Pilling2003] M.A. Blitz, K.J. Hughes, M.J. Pilling, J. Phys. Chem. A, 2003, 107(12), 1971-1978, doi: 10.1021/jp026524y
 [Pilling2006] M.A. Blitz, K.J. Hughes, M.J. Pilling, S.H. Robertson, J. Phys. Chem. A, 2006, 110(9), 2996-3009, doi: 10.1021/jp054722u
 [Roth1993] D. Woiki, P. Roth, in: R. Burn, L.Z. Dumitrescu (Ed.) Shock Waves @ Marseille II (Proceedings Marseille France), 1993, 53-58, doi: 10.1007/978-3-642-78832-1_9
@@ -50,6 +53,8 @@ Reference legend:
 [Roth1996b] D. Woiki, P. Roth, Symposium (International) on Combustion, 1996, 26(1), 583-588, doi: 10.1016/S0082-0784(96)80263-3
 [Sendt2002] K. Sendt, M. Jazbec, B.S. Haynes, Proceedings of the Combustion Institute, 2002, 29, 2439-2446, doi: 10.1016/S1540-7489(02)80297-8
 [Sendt2008] C.R. Zhou, K. Sendt, B.S. Haynes, J. Phys. Chem. A, 2008, 112, 3239-3247, doi: 10.1021/jp710488d
+[Sendt2009] C.R. Zhou, K. Sendt, B.S. Haynes, J. Phys. Chem. A, 2009, 113, 2975-2981, doi: 10.1021/jp810105e
+[Sitha2011] S. Sitha, L.L. Jewell, S.J. Piketh, G. Fourie, Atmospheric Rnvironment, 2011, 45, 745-754, doi: 10.1016/j.atmosenv.2010.09.018
 [Somnitz2004] H. Somnitz, Phys. Chem. Chem. Phys., 2004, 6(14), 3844-3851, doi: 10.1039/B317055A
 [Tezaki2003] N. Isshiki, Y. Murakami, K. Tsuchiya, A. Tezaki, H. Matsui, J. Phys. Chem. A, 2003, 107(14), 2464-2469, doi: 10.1021/jp0200829
 [Troe1984] H.J. Plach, J. Troe, Int. J. Chem. Kin., 1984, 16(12), 1531-1542, doi: 10.1002/kin.550161207
@@ -60,7 +65,7 @@ entry(
     label = "S + S <=> S2",
     degeneracy = 1,
     kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(3.98e+14, 'cm^6/(mol^2*s)'), n=0, Ea=(-22455, 'cal/mol'), T0 = (1, 'K'),
+        arrheniusLow = Arrhenius(A=(3.98e+14, 'cm^6/(mol^2*s)'), n=0, Ea=(-22455, 'cal/mol'), T0=(1, 'K'),
                                  Tmin=(4500, 'K'), Tmax=(6000, 'K'))),
     shortDesc = u"""[Mukarami1979]""",
     longDesc =
@@ -74,24 +79,33 @@ As reported by [Lin2003a] as k26
 
 entry(
     index = 2,
-    label = "SO2 <=> SO + O",
+    label = "SO + O <=> SO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.84e+16, 'cm^3/(mol*s)'), n=0, Ea=(109674, 'cal/mol'), T0=(1, 'K')),
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(A=(1.75e+17, 'cm^6/(mol^2*s)'), n=-2.17, Ea=(0, 'cal/mol'), T0=(298, 'K')),
+        efficiencies = {'O=S=O': 10, 'O': 10, 'N#N': 1.5},
+    ),
     shortDesc = u"""[Lin2003a]""",
     longDesc =
 u"""
 Part of the "SOx" mechanism
-k1a p. 11028
+k10a
 calculations done at the G2M(RCC2)//B3LYP/6-311+(3df) level of theory
 also validated experimentally in the same study
+efficiencies from: Y. Song, H. Hashemi, J.M. Christensen, C. Zou, B.S. Haynes, P. Marshall, P. Glarborg
+International Journal of Chemical Kinetics 49(1), 2017, 37-52
+doi: 10.1002/kin.21055
+Also available from [Lin2003a] in reverse:
+    label = "SO2 <=> SO + O",
+    kinetics = Arrhenius(A=(2.84e+16, 'cm^3/(mol*s)'), n=0, Ea=(109674, 'cal/mol'), T0=(1, 'K')),
 """,
 )
 
 entry(
     index = 3,
-    label = "S + O2 <=> O + SO",
+    label = "S + O2 <=> SO + O",
     degeneracy = 1,
-    kinetics=Arrhenius(A=(5.43e+05, 'cm^3/(mol*s)', '+|-', 1.63E+04), n=2.11, Ea=(1451, 'cal/mol', '+|-', 238),
+    kinetics=Arrhenius(A=(5.43e+05, 'cm^3/(mol*s)', '+|-', 1.63E+04), n=2.11, Ea=(-1451, 'cal/mol', '+|-', 238),
                        T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(3460, 'K')),
     shortDesc = u"""[Lin2004]""",
     longDesc =
@@ -182,16 +196,18 @@ entry(
     label = "SO2 + H <=> HOSO",
     degeneracy = 1,
     kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(2.37e+08, 'cm^3/(mol*s)'), n=1.63, Ea=(7339, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1700, 'K')),
-        arrheniusLow = Arrhenius(A=(1.85e+37, 'cm^6/(mol^2*s)'), n=-6.14, Ea=(11075, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1700, 'K')),
+        arrheniusHigh = Arrhenius(A=(2.59e+12, 'cm^3/(mol*s)'), n=1.63, Ea=(7339, 'cal/mol'), T0=(300, 'K'), Tmin=(300, 'K'), Tmax=(1700, 'K')),
+        arrheniusLow = Arrhenius(A=(1.14e+22, 'cm^6/(mol^2*s)'), n=-6.14, Ea=(11075, 'cal/mol'), T0=(300, 'K'), Tmin=(300, 'K'), Tmax=(1700, 'K')),
         alpha=0.283, T3=(272, 'K'), T1=(3995, 'K'), efficiencies={'O=S=O': 10, 'O': 10, 'O=C=O': 2.5}),
     shortDesc = u"""[Pilling2006]""",
     longDesc =
 u"""
 Part of the "SOx" mechanism
 T range: 300-1700 K
-As reported by Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
+k2, Table 3
+efficiencies taken from Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
 Added as a training reaction to R_Addition_MultipleBond
+Also available from [Pilling2002b]
 """,
 )
 
@@ -200,15 +216,17 @@ entry(
     label = "SO2 + H <=> HSO2",
     degeneracy = 1,
     kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(5.31e+08, 'cm^3/(mol*s)'), n=1.59, Ea=(2472, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(1000, 'K')),
-        arrheniusLow = Arrhenius(A=(1.41e+31, 'cm^6/(mol^2*s)'), n=-5.19, Ea=(4513, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(1000, 'K')),
-        alpha=0.39, T3=(167, 'K'), T1=(2191, 'K'), efficiencies={'O=S=O': 10, 'O': 10, 'O=C=O': 2.5}),
+        arrheniusHigh = Arrhenius(A=(4.61e+12, 'cm^3/(mol*s)'), n=1.59, Ea=(2472, 'cal/mol'), T0=(300, 'K'), Tmin=(200, 'K'), Tmax=(1000, 'K')),
+        arrheniusLow = Arrhenius(A=(1.97e+18, 'cm^6/(mol^2*s)'), n=-5.19, Ea=(4513, 'cal/mol'), T0=(300, 'K'), Tmin=(200, 'K'), Tmax=(1000, 'K')),
+        alpha=0.390, T3=(167, 'K'), T1=(2191, 'K'), efficiencies={'O=S=O': 10, 'O': 10, 'O=C=O': 2.5}),
     shortDesc = u"""[Pilling2006]""",
     longDesc =
 u"""
 Part of the "SOx" mechanism
 T range: 200-1000 K
-As reported by Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
+k1, Table 3
+efficiencies taken from Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
+Also available from [Pilling2002b]
 """,
 )
 
@@ -217,15 +235,17 @@ entry(
     label = "SO2 + H <=> SO + OH",
     degeneracy = 1,
     kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(9.19e+25, 'cm^3/(mol*s)'), n=2.77, Ea=(20850, 'cal/mol'), T0=(1, 'K'), Tmin=(900, 'K'), Tmax=(1800, 'K')),
-        arrheniusLow = Arrhenius(A=(1.35e+22, 'cm^6/(mol^2*s)'), n=-2.30, Ea=(30965, 'cal/mol'), T0=(1, 'K'), Tmin=(900, 'K'), Tmax=(1800, 'K')),
-        alpha=0.283, T3=(272, 'K'), T1=(3995, 'K'), efficiencies={'O=S=O': 10, 'O': 10, 'O=C=O': 2.5}),
+        arrheniusHigh = Arrhenius(A=(6.68e+32, 'cm^3/(mol*s)'), n=2.77, Ea=(20848, 'cal/mol'), T0=(300, 'K'), Tmin=(900, 'K'), Tmax=(1800, 'K')),
+        arrheniusLow = Arrhenius(A=(1.64e+40, 'cm^6/(mol^2*s)'), n=-2.30, Ea=(30965, 'cal/mol'), T0=(300, 'K'), Tmin=(900, 'K'), Tmax=(1800, 'K')),
+        alpha=1, T3=(272, 'K'), T1=(27617, 'K'), efficiencies={'O=S=O': 10, 'O': 10, 'O=C=O': 2.5}),
     shortDesc = u"""[Pilling2006]""",
     longDesc =
 u"""
 Part of the "SOx" mechanism
 T range: 900-1800 K
-As reported by Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
+k3, Table 3
+efficiencies taken from Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
+Also available from [Pilling2002b]
 """,
 )
 
@@ -367,16 +387,53 @@ Added as a training reaction to R_Recombination
 )
 
 entry(
-    index = 19,
-    label = "HOSO <=> OH + SO",
+    index = 68,
+    label = "SH + O2 <=> SO + OH",
     degeneracy = 1,
-    kinetics = Lindemann(
-        arrheniusHigh = Arrhenius(A=(1.65e+16, 's^-1'), n=-0.32, Ea=(67720, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
-        arrheniusLow = Arrhenius(A=(1.25e+32, 'cm^3/(mol*s)'), n=-4.33, Ea=(69115, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K'))),
-    shortDesc = u"""[Marshall1999a]""",
+    kinetics = Arrhenius(A=(7.5e+04, 'cm^3/(mol*s)'), n=2.052, Ea=(16396, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Sendt2009]""",
     longDesc =
 u"""
 Part of the "SOx" subset
+k1b
+Table 7 on p. 11333
+calculations done at the MRCI/aug-cc-pV(Q+d)Z//CASSCF/cc-pVTZ level of theory
+""",
+)
+
+entry(
+    index = 69,
+    label = "SH + O2 <=> HSO + O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.3e+06, 'cm^3/(mol*s)'), n=1.816, Ea=(20005, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Sendt2009]""",
+    longDesc =
+u"""
+Part of the "SOx" subset
+k1c
+calculations done at the MRCI/aug-cc-pV(Q+d)Z//CASSCF/cc-pVTZ level of theory
+""",
+)
+
+entry(
+    index = 19,
+    label = "HOSO <=> SO + OH",
+    degeneracy = 1,
+    kinetics = Troe(
+        arrheniusHigh = Arrhenius(A=(9.94e+21, 's^-1'), n=-2.54, Ea=(75891, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+        arrheniusLow = Arrhenius(A=(1.16e+46, 'cm^3/(mol*s)'), n=-9.02, Ea=(52953, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+        alpha=0.95, T3=(2989, 'K'), T1=(1.1, 'K'), efficiencies={'O=S=O': 10, 'O': 10, 'O=C=O': 2.5}),
+    shortDesc = u"""[Pilling2002b]""",
+    longDesc =
+u"""
+Part of the "SOx" subset
+RRKM
+Also available from [Marshall1999a]:
+    kinetics = Lindemann(
+        arrheniusHigh = Arrhenius(A=(1.65e+16, 's^-1'), n=-0.32, Ea=(67720, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
+        arrheniusLow = Arrhenius(A=(1.25e+32, 'cm^3/(mol*s)'), n=-4.33, Ea=(69115, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K'))),
 T range: 200-2000 K
 Table 7 on p. 11333
 calculations done at the QCISD(T)/6-311+G(3df,2p)//MP2=FULL/6-31G(d) level of theory
@@ -434,7 +491,7 @@ As reported by [GlarBozz] (14)
 
 entry(
     index = 23,
-    label = "S + SO2 <=> SO + SO",
+    label = "SO2 + S <=> SO + SO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.89e+12, 'cm^3/(mol*s)'), n=0, Ea=(9034, 'cal/mol'), T0=(1, 'K'),
                          Tmin=(1120, 'K'), Tmax=(1540, 'K')),
@@ -452,15 +509,54 @@ entry(
     index = 24,
     label = "H2S + O <=> HSO + H",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.0e+13, 'cm^3/(mol*s)','+|-',1.52e+13), n=0, Ea=(7650, 'cal/mol','+|-',482), T0=(1, 'K'),
-                         Tmin=(1520, 'K'), Tmax=(1820, 'K')),
-    shortDesc = u"""[Dupre1993]""",
+    kinetics = Arrhenius(A=(1.4e+09, 'cm^3/(mol*s)'), n=1.10, Ea=(5099, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Marshall1995]""",
     longDesc =
 u"""
 Part of the "SOx" subset
-Sock Tube
-T range: 1520-1820 K
-Uncertainty: A 38%, Ea 6.3%
+RRKM
+QCISD(T)/6-311+G(3df,2p)//MP2=FULL/6-31G(d)
+k1b
+As reported by:
+Y. Song, H. Hashemi, J.M. Christensen, C. Zou, B.S. Haynes, P. Marshall, P. Glarborg
+International Journal of Chemical Kinetics 49(1), 2017, 37-52
+doi: 10.1002/kin.21055
+
+Also available from [Dupre1993]:
+    kinetics = Arrhenius(A=(4.0e+13, 'cm^3/(mol*s)','+|-',1.52e+13), n=0, Ea=(7650, 'cal/mol','+|-',482), T0=(1, 'K'),
+                         Tmin=(1520, 'K'), Tmax=(1820, 'K')),
+Sock Tube, Uncertainty: A 38%, Ea 6.3%
+""",
+)
+
+entry(
+    index = 66,
+    label = "H2S + O <=> SH + OH",
+    degeneracy = 1,
+    duplicate=True,
+    kinetics = Arrhenius(A=(7.47e+07, 'cm^3/(mol*s)','+|-',4.48e+06), n=1.746, Ea=(2895, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(200, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Marshall1995]""",
+    longDesc =
+u"""
+RRKM
+QCISD(T)/6-311+G(3df,2p)//MP2=FULL/6-31G(d)
+k1a
+""",
+)
+
+entry(
+    index = 67,
+    label = "HOS + H <=> SO + H2",
+    degeneracy = 1,
+    duplicate=True,
+    kinetics = Arrhenius(A=(1.79e+07, 'cm^3/(mol*s)'), n=1.94, Ea=(1590, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(298, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Marshall1995]""",
+    longDesc =
+u"""
+RRKM
+QCISD(T)/6-311+G(3df,2p)//MP2=FULL/6-31G(d)
 """,
 )
 
@@ -483,22 +579,31 @@ Measured in 100-760 torr N2
 
 entry(
     index = 26,
-    label = "HOSO2 <=> SO2 + OH",
+    label = "SO2 + OH <=> HOSO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.34e+14, 's^-1'), n=0, Ea=(25832, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(150, 'K'), Tmax=(1500, 'K')),
-    shortDesc = u"""[Somnitz2004]""",
+    kinetics = Arrhenius(A=(1.26e+06, 'cm^3/(mol*s)','*|/',1.12511), n=1.97952, Ea=(153.0, 'cal/mol','+|-',14.4),
+                         T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(1025, 'K')),
+    shortDesc = u"""[Sitha2011]""",
     longDesc =
 u"""
 Part of the "SOx" subset
-T range: 150-1500 K
-k_dec_inf, p. 3847 in Fig. 2
-calculated at the B3LYP/apVTZþ1//UB3LYP/apVTZþ1 level of theory
-Also available in reverse from [Pilling2003], but for a relatively low T range (up to 673):
+Calculated at QCISD/6-31++G(2df,2p)
+Arrhenius parameters generated from discrete values given in the paper
+
+Also available from [Pilling2003], but for a relatively low T range (up to 673):
     kinetics = Lindemann(
         arrheniusHigh = Arrhenius(A=(1.23e+12, 'cm^3/(mol*s)'), n=-0.27, Ea=(0, 'cal/mol'), T0=(300, 'K')),
         arrheniusLow = Arrhenius(A=(1.25e+17, 'cm^6/(mol^2*s)'), n=-4.09, Ea=(0, 'cal/mol'), T0=(300, 'K'))),
     Collider efficiencies taken from: Gimenez-Lopez, M. Martinez, A. Millera, R. Bilbao, M.U. Alzueta, Comb. Flame 2011, 158(1), 48-56, doi: 10.1016/j.combustflame.2010.07.017
+
+Also available (in reverse) from [Somnitz2004]:
+    kinetics = Arrhenius(A=(4.34e+14, 's^-1'), n=0, Ea=(25832, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(150, 'K'), Tmax=(1500, 'K')),
+    k_dec_inf, p. 3847 in Fig. 2
+    calculated at the B3LYP/apVTZþ1//UB3LYP/apVTZþ1 level of theory
+
+Also available from doi: 10.1039/A901596E
+Also available from doi: 10.1039/B317055A
 """,
 )
 
@@ -638,7 +743,7 @@ entry(
     index = 35,
     label = "H2S + S <=> SH + SH",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(3.7e+06, 'cm^3/(mol*s)'), n=2.297, Ea=(9010, 'cal/mol'), T0=(1, 'K'),
+    kinetics = Arrhenius(A=(7.4e+06, 'cm^3/(mol*s)'), n=2.297, Ea=(9011, 'cal/mol'), T0=(1, 'K'),
                          Tmin=(300, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Sendt2008]""",
     longDesc =
@@ -648,6 +753,15 @@ k_abstraction, (R4a)
 T range: 300-3000 K
 calculations done at the MRCI/aug-cc-pV(Q+d)Z//MRCI/aug-cc-pVTZ level of theory
 Added as a training reaction to H_Abstraction
+
+* Note that this special reaction has two paths: a direct H-abstraction path (which rate is reported here),
+as well as a P-Dep rate described by [Marshall2011b], with zero high-P rate.
+The PDep path is found in the Sulfur/H2S+S=2SH_1bar reported for 1 bar.
+These paths are also described by the [Sulfur/GlarborgH2S] library, but they use a fitted high-P rate for the PDep path,
+which theoretically should be zero.
+
+(note that this source has a CORRECTION, doi: 10.1021/jp810800a, and the original rate should is multiplied by a factor
+of x2: i.e., A = 7.4e+06 cm^3/(mol*s), NOT 3.7e+06 cm^3/(mol*s))
 """,
 )
 
@@ -1011,7 +1125,7 @@ entry(
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.87e+13, 'cm^3/(mol*s)'), n=0.00, Ea=(8843, 'cal/mol'), T0=(1, 'K'),
                          Tmin=(690, 'K'), Tmax=(1040, 'K')),
-    shortDesc = u"""[Marshall2011]""",
+    shortDesc = u"""[Marshall2011a]""",
     longDesc =
 u"""
 Part of the "C-S" mechanism
@@ -1024,7 +1138,7 @@ entry(
     label = "NS + NO2 <=> N2 + SO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.55e+13, 'cm^3/(mol*s)'), n=-1.10, Ea=(0, 'cal/mol'), T0=(295, 'K')),
-    shortDesc = u"""[Pilling2002]""",
+    shortDesc = u"""[Pilling2002a]""",
     longDesc =
 u"""
 Part of the "SOx-NOx" direct interactions subset
@@ -1153,23 +1267,7 @@ u"""
 Calculated by Yi-Pei Li
 HO + O2 -> SOSO4 -> TS1 -> SO3-HO2 (VDW complex) -> SO3 + HO2
 Bath gas: N2
-""",
-)
 
-entry(
-    index = 66,
-    label = "SO2(T) <=> SO2",
-    degeneracy = 1,
-    duplicate=True,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(1.82e+16, 'cm^3/(mol*s)'), n=0, Ea=(2800, 'cal/mol'), T0 = (1, 'K'),
-                                 Tmin=(298, 'K'), Tmax=(400, 'K'))),
-    shortDesc = u"""[Calvert1973]""",
-    longDesc =
-u"""
-Experimental measurement
-Value for CO2 as third body collider was taken here
-p. 680, Table V
-T range: 298-400 K
+The energetics of this reaction are available at doi: 10.1063/1.480605 (were not used in the above calculation)
 """,
 )

--- a/input/kinetics/libraries/Sulfur/GlarborgH2S/reactions.py
+++ b/input/kinetics/libraries/Sulfur/GlarborgH2S/reactions.py
@@ -2934,7 +2934,7 @@ entry(
     degeneracy = 1,
     kinetics = Troe(
         arrheniusHigh = Arrhenius(
-            A = (9e+11, 'cm^3/(mol*s)'),
+            A = (3.5e+12, 'cm^3/(mol*s)'),
             n = 0.155,
             Ea = (-1432, 'cal/mol'),
             T0 = (1, 'K'),

--- a/input/kinetics/libraries/Sulfur/H2S+S=2SH_1bar/dictionary.txt
+++ b/input/kinetics/libraries/Sulfur/H2S+S=2SH_1bar/dictionary.txt
@@ -1,0 +1,13 @@
+S
+multiplicity 3
+1 S u2 p2 c0
+
+SH
+multiplicity 2
+1 S u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+H2S
+1 S u0 p2 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}

--- a/input/kinetics/libraries/Sulfur/H2S+S=2SH_1bar/reactions.py
+++ b/input/kinetics/libraries/Sulfur/H2S+S=2SH_1bar/reactions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Sulfur/H2S+S=2SH_1bar"
+shortDesc = u"H2S + S = SH + SH at 1bar"
+longDesc =u"""
+The H2S + S = SH + SH reaction has several pathways.
+The direct H-abstraction on the triplet surface has a barrier of 45 kJ/mol
+H2S + S can also pass through an inter-system crossing (barrier estimated to be only 3 kJ/mol),
+passing through singlet H2SS and HSSH, yielding the same products (SH + SH).
+The direct H-abvstraction is significant above 800 K, and dominates above 1000 K.
+However, below 700-800 K this reaction is significantly dependent on pressure. 
+This reaction should be modeled as two duplicate reactions - Arhennius and PDep.
+However, the PDep path is only givin in literature at 1 bar.
+This reaction behaves as P-Dep at low P, while its high-P limit is zero(!).
+This library should not be used at higher pressures.
+
+[Marshall2011b] Y. Gao, C.(R) Z., K. Sendt, B.S. Haynes, P. Marshall, Proc. Comb. Inst., 2011, 33, 459-465, doi: 10.1016/j.proci.2010.05.020
+[Sendt2008] C.R. Zhou, K. Sendt, B.S. Haynes, J. Phys. Chem. A, 2008, 112, 3239-3247, doi: 10.1021/jp710488d
+"""
+
+entry(
+    index = 1,
+    label = "H2S + S <=> SH + SH",
+    degeneracy = 1,
+    duplicate = True,
+    kinetics = Arrhenius(A=(7.4e+06, 'cm^3/(mol*s)'), n=2.297, Ea=(9011, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc = u"""[Sendt2008]""",
+    longDesc =
+u"""
+k_abstraction, (R4a)
+T range: 300-3000 K
+calculations done at the MRCI/aug-cc-pV(Q+d)Z//MRCI/aug-cc-pVTZ level of theory
+
+(note that this source has a CORRECTION, doi: 10.1021/jp810800a, and the original rate should is multiplied by a factor
+of x2: i.e., A = 7.4e+06 cm^3/(mol*s), NOT 3.7e+06 cm^3/(mol*s))
+""",
+)
+
+entry(
+    index = 2,
+    label = "H2S + S <=> SH + SH",
+    degeneracy = 1,
+    duplicate = True,
+    kinetics = Arrhenius(A=(1.18e+18, 'cm^3/(mol*s)'), n=-1.685, Ea=(5975, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(1040, 'K')),
+    shortDesc = u"""[Marshall2011b]""",
+    longDesc =
+u"""
+DKCCSD(T)/cc-PVQZ_DK
+The H2S+S PES passes through an inter-system crossing with a low barrier, and is infact P-Dep at low T (below 800 K)
+The rate here is computed at 1 bar. Bath gas: Ar.
+""",
+)

--- a/input/thermo/libraries/SOxNOx.py
+++ b/input/thermo/libraries/SOxNOx.py
@@ -9,7 +9,7 @@ longDesc = u"""
 
 entry(
     index = 1,
-    label = "HOSH",
+    label = "HSOH",
     molecule = 
 """
 1 O u0 p2 c0 {2,S} {3,S}
@@ -20,7 +20,7 @@ entry(
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
         Cpdata = ([49.66,56.19,60.09,64.27,68.62,71.38,75.68],'J/(mol*K)'),
-        H298 = (-236.3,'kJ/mol'),
+        H298 = (-118.83,'kJ/mol','+|-',4.2),
         S298 = (270.4,'J/(mol*K)'),
     ),
     shortDesc = u"""""",
@@ -29,7 +29,12 @@ u"""
 UMP2=full/6-31G+
 A. Goumri, J-D.R. Rocha, D. Laakso, C.E. Smith, P. Marshall
 The Journal of Chemical Physics 101, 9405 (1994); doi: http://dx.doi.org/10.1063/1.467971
-As reported by: M.U. Alzueta, R. Bilbao, P. Glarborg, Comb. Flame, 2001, 127(4) 2234-2251, doi: 10.1016/S0010-2180(01)00325-X 
+As reported by: M.U. Alzueta, R. Bilbao, P. Glarborg, Comb. Flame, 2001, 127(4) 2234-2251, doi: 10.1016/S0010-2180(01)00325-X
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
+This is significantly different that the value reported  by Marshall 1994 (-236.3 kJ/mol),
+but in agreement with SulfurGlargotgBozzelli library that took it from a currently untraceable source.
+Also in agreement with Table 8 in P.A. Denis, Molecular Physics 2008, 106(21-23), 2557-2567, doi: 10.1080/00268970802603523
 """,
 )
 
@@ -45,7 +50,7 @@ multiplicity 3
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
         Cpdata = ([7.22,7.55,7.84,8.08,8.43,8.62,8.95],'cal/(mol*K)'),
-        H298 = (1.2,'kcal/mol'),
+        H298 = (1.2,'kcal/mol','+|-',0.3),
         S298 = (53.01,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
@@ -53,6 +58,8 @@ multiplicity 3
 u"""
 R.J. Kee, F.M. Rupley, J.A. Miller, The Chemkin Thermodynamic Data Base, Sandia Report SAND87-8215, Sandia National Laboratories, Livermore, California, 1991
 As reported by: P. Glarborg, D. Kubel, K Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
 """,
 )
 
@@ -68,7 +75,7 @@ entry(
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
         Cpdata = ([9.54,10.41,11.12,11.71,12.55,13.03,13.61],'cal/(mol*K)'),
-        H298 = (-71.0,'kcal/mol'),
+        H298 = (-70.94,'kcal/mol','+|-',0.05),
         S298 = (59.29,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
@@ -76,6 +83,8 @@ entry(
 u"""
 R.J. Kee, F.M. Rupley, J.A. Miller, The Chemkin Thermodynamic Data Base, Sandia Report SAND87-8215, Sandia National Laboratories, Livermore, California, 1991
 As reported by: P. Glarborg, D. Kubel, K Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
 """,
 )
 
@@ -114,16 +123,21 @@ multiplicity 2
 3 O u0 p2 c0 {1,D}
 """,
     thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([9.02,9.93,10.73,11.36,12.22,12.73,13.34],'cal/(mol*K)'),
-        H298 = (-5.4,'kcal/mol'),
-        S298 = (57.80,'cal/(mol*K)'),
+        Tdata = ([300,400,500,700,1000,1300,2000],'K'),
+        Cpdata = ([36.15,38.6,41.4,45.8,50.1,52.7,55.6],'J/(mol*K)'),
+        H298 = (-5.2,'kcal/mol','+|-',0.5),
+        S298 = (57.65,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
     longDesc = 
 u"""
-H.M. Chiang, J.W. Bozzelli, Quantum Rice–Ramsberger–Kassel (QRRK) Analysis on Reaction of HSO + O, H + SO2, and OH + SO; HO2 and HOSO Formation and Dissociation
-As reported by: P. Glarborg, D. Kubel, K Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
+A. Goumri, D. Laakso, J‐D R. Rocha, C.E. Smith, P. Marshall
+The Journal of Chemical Physics 102, 161 (1995)
+doi: 10.1063/1.469387
+Table V.
+Cp(200K) = 33.7; Cp(300K) interpolated
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
 """,
 )
 
@@ -138,16 +152,77 @@ multiplicity 2
 3 H u0 p0 c0 {1,S}
 """,
     thermo = ThermoData(
-        Tdata = ([300,400,500,600,800,1000,1500],'K'),
-        Cpdata = ([8.71,9.42,10.00,10.45,11.08,11.53,12.33],'cal/(mol*K)'),
-        H298 = (0.0,'kcal/mol'),
-        S298 = (57.15,'cal/(mol*K)'),
+        Tdata = ([300,400,500,700,1000,1300,2000],'K'),
+        Cpdata = ([36.85,39.6,42.0,45.3,48.6,50.9,54.2],'J/(mol*K)'),
+        H298 = (-1.6,'kcal/mol','+|-',0.5),
+        S298 = (57.48,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
     longDesc = 
 u"""
-H.M. Chiang, J.W. Bozzelli, Quantum Rice–Ramsberger–Kassel (QRRK) Analysis on Reaction of HSO + O, H + SO2, and OH + SO; HO2 and HOSO Formation and Dissociation
-As reported by: P. Glarborg, D. Kubel, K Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
+A. Goumri, D. Laakso, J‐D R. Rocha, C.E. Smith, P. Marshall
+The Journal of Chemical Physics 102, 161 (1995)
+doi: 10.1063/1.469387
+Table VI.
+Cp(200K) = 34.1; Cp(300K) interpolated
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
+""",
+)
+
+entry(
+    index = 25,
+    label = "HSS",
+    molecule =
+"""
+multiplicity 2
+1 S u1 p1 c0 {2,D} {3,S}
+2 S u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([9.62,10.30,10.80,11.19,11.80,12.26,12.98],'cal/(mol*K)'),
+        H298 = (25.0,'kcal/mol','+|-',0.5),
+        S298 = (60.95,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Taken from the SulfurGlarborgH2S library with comment:
+Zhou - K. Sendt, B.S. Haynes, J. Phys. Chem. A 109 (2005) 8180 to 8186;
+K. Sendt, M. Jazbec, B.S. Haynes, Proc. Combust. Inst. 29 (2003) 2439-2446.
+25.84  60.94
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
+""",
+)
+
+entry(
+    index = 26,
+    label = "HSSH",
+    molecule =
+"""
+1 S u0 p2 c0 {2,S} {3,S}
+2 S u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([11.63,12.90,13.84,14.57,15.73,16.62,18.02],'cal/(mol*K)'),
+        H298 = (3.70,'kcal/mol','+|-',0.5),
+        S298 = (61.62,'cal/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Taken from the SulfurGlarborgH2S library with comment:
+Zhou - K. Sendt, B.S. Haynes, J. Phys. Chem. A 109 (2005) 8180 to 8186;
+K. Sendt, M. Jazbec, B.S. Haynes, Proc. Combust. Inst. 29 (2003) 2439-2446.
+3.70  61.61
+
+H298 (updated uncertainty) is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
 """,
 )
 
@@ -164,7 +239,7 @@ entry(
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
         Cpdata = ([9.53,11.13,12.66,13.95,15.82,17.00,18.44],'cal/(mol*K)'),
-        H298 = (-11.3,'kcal/mol'),
+        H298 = (-12.5,'kcal/mol','+|-',1),
         S298 = (57.26,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
@@ -172,6 +247,8 @@ entry(
 u"""
 H.M. Chiang, J.W. Bozzelli, Quantum Rice–Ramsberger–Kassel (QRRK) Analysis on Reaction of HSO + O, H + SO2, and OH + SO; HO2 and HOSO Formation and Dissociation
 As reported by: P. Glarborg, D. Kubel, K Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
+
+H298 is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
 """,
 )
 
@@ -243,7 +320,7 @@ multiplicity 2
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
         Cpdata = ([16.74,18.76,20.13,21.07,22.22,22.94,24.02],'cal/(mol*K)'),
-        H298 = (-93.5,'kcal/mol'),
+        H298 = (-89.4,'kcal/mol','+|-',0.72),
         S298 = (70.72,'cal/(mol*K)'),
     ),
     shortDesc = u"""""",
@@ -251,40 +328,44 @@ multiplicity 2
 u"""
 H.M. Chiang, J.W. Bozzelli, Quantum Rice–Ramsberger–Kassel (QRRK) Analysis on Reaction of HSO + O, H + SO2, and OH + SO; HO2 and HOSO Formation and Dissociation
 As reported by: P. Glarborg, D. Kubel, K Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
+H298 is calculated at fc-CCSD(T)/cc-pV(T+d)Z and taken from W. Klopper, D.P. Tew, N. Gonzalez-Garcia, M. Olzmann, J. Chem. Phys. 2008, 129, 114308, doi: 10.1063/1.2973637
 """,
 )
 
-entry(
-    index = 11,
-    label = "HSOO",
-    molecule = 
-"""
-multiplicity 2
-1 S u0 p2 c0 {2,S} {4,S}
-2 O u0 p2 c0 {1,S} {3,S}
-3 O u1 p2 c0 {2,S}
-4 H u0 p0 c0 {1,S}
-""",
-    thermo = ThermoData(
-        Tdata = ([300,400,500,700,1000,1300,2500],'K'),
-        Cpdata = ([51.7,56.8,60.5,65.6,70.2,72.9,76.0],'J/(mol*K)'),
-        H298 = (111.5,'kJ/mol'),
-        S298 = (283.0,'J/(mol*K)'),
-    ),
-    shortDesc = u"""""",
-    longDesc = 
-u"""
-Table 5
-MP2=FULL/6-31G(d)
-A. Goumri, J-D.R. Rocha, D. Laakso, C.E. Smith, P. Marshall
-J. Phys. Chem. A, 1999, 103, 11328-11335, doi: 10.1021/jp9924070
-""",
-)
+# entry(
+#     index = 11,
+#     label = "HSOO",
+#     molecule =
+# """
+# multiplicity 2
+# 1 S u0 p2 c0 {2,S} {4,S}
+# 2 O u0 p2 c0 {1,S} {3,S}
+# 3 O u1 p2 c0 {2,S}
+# 4 H u0 p0 c0 {1,S}
+# """,
+#     thermo = ThermoData(
+#         Tdata = ([300,400,500,700,1000,1300,2500],'K'),
+#         Cpdata = ([51.7,56.8,60.5,65.6,70.2,72.9,76.0],'J/(mol*K)'),
+#         H298 = (111.5,'kJ/mol'),
+#         S298 = (283.0,'J/(mol*K)'),
+#     ),
+#     shortDesc = u"""""",
+#     longDesc =
+# u"""
+# Table 5
+# MP2=FULL/6-31G(d)
+# A. Goumri, J-D.R. Rocha, D. Laakso, C.E. Smith, P. Marshall
+# J. Phys. Chem. A, 1999, 103, 11328-11335, doi: 10.1021/jp9924070
+#
+# Also available from the SulfurGlarborgH2S library where H298 is 32.29 kcal/mol (here it is 26.65 kcal/mol).
+# Since this library should describe species with trusted thermo, this entry is commented-out until a definite value is obtained.
+# """,
+# )
 
 entry(
     index = 13,
     label = "HOSO",
-    molecule = 
+    molecule =
 """
 multiplicity 2
 1 O u0 p2 c0 {2,S} {4,S}
@@ -299,7 +380,7 @@ multiplicity 2
         S298 = (282.3,'J/(mol*K)'),
     ),
     shortDesc = u"""""",
-    longDesc = 
+    longDesc =
 u"""
 Table 4
 MP2=FULL/6-31G(d)
@@ -605,3 +686,26 @@ Cp @ 6000 K 0.25%. Calculated from original tables.
 """,
 )
 
+entry(
+    index = 3,
+    label = "NSO",
+    molecule =
+"""
+1 N u1 p1 c0 {2,D}
+2 S u0 p1 c0 {1,D} {3,D}
+3 O u0 p2 c0 {2,D}
+""",
+    thermo = ThermoData(
+        Tdata = ([300,400,500,600,800,1000,1500],'K'),
+        Cpdata = ([42.70,46.11,48.85,50.92,53.56,55.04,56.70],'J/(mol*K)'),
+        H298 = (175.31,'kJ/mol','+|-',2.092),
+        S298 = (262.6,'J/(mol*K)'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Taken from the SulfurGlarborgNS library
+
+H298 is updated from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
+""",
+)

--- a/input/thermo/libraries/SulfurLibrary.py
+++ b/input/thermo/libraries/SulfurLibrary.py
@@ -78,12 +78,13 @@ entry(
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
         Cpdata = ([8.18,8.49,8.89,9.31,10.16,10.93,12.3],'cal/(mol*K)','+|-',[1,1,1,1,1,1,1]),
-        H298 = (-4.9,'kcal/mol','+|-',1),
+        H298 = (-4.9,'kcal/mol','+|-',0.5),
         S298 = (49.18,'cal/(mol*K)','+|-',1),
     ),
     shortDesc = u"""All from [10]""",
     longDesc = 
 u"""
+H298 (updated uncertainty) is taken from Table 7 in P.A. Denis, J. Sulfur Chem. 2008, 29(3-4), 327-352, doi: 10.1080/17415990802047352
 """,
 )
 


### PR DESCRIPTION
- **Fixed SH + SH <=> HSSH in GlarborgH2S kinetic library**
The original study (DOI 10.1002/kin.21055) reported a model in which the
high-P rate of the reaction in the title was deliberately reduced to fit
the experiment (See Fig. 4). This PR assigns the original pre-exponential
factor value back.
- **Added kinetics from Marshall1995 to the SOx library**
- **Added thermo of HSO and HOS from Marhsall1995 to the SOxNOx library**
- **Removed the `SO2(T) <=> SO2` transition from the SOx library**
It should be treated better using the Singlet_Val6_to_triplet library
- **Updated `SO + O <=> SO2` in the SOx library**
- **Updated `HOSO <=> SO + OH` in the SOx library**
- **Added the `Sulfur/H2S+S=2SH_1bar` library**
- **Updated H298 and uncertainties in thermo SOxNOx library**
- **Added the SH + O2 PES from Sendt2009 to the SOx kinetic library**