### PR TITLE
Allow ozone by modifying the Ods globally forbidden group

### DIFF
--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -8,16 +8,17 @@ longDesc = u"""
 """
 entry(
     label = "Ods",
-    group = 
+    group =
 """
-1 O ux {2,D} {3,S}
+1 O ux c0 {2,D} {3,S}
 2 R ux {1,D}
 3 R ux {1,S}
 """,
     shortDesc = u"""""",
-    longDesc = 
+    longDesc =
 u"""
-
+This forbids O with both single and double bonds WHILE keeping a zero partial charge.
+This does not forbid ozone, [O-][O+]=O
 """,
 )
 

--- a/input/thermo/groups/ring.py
+++ b/input/thermo/groups/ring.py
@@ -120,9 +120,9 @@ entry(
     label = "Cyclopropene",
     group = 
 """
-1 * [Cs,N]    u0 {2,S} {3,S}
-2   [C,N,O,S] u0 {1,S} {3,D}
-3   [C,N,O,S] u0 {1,S} {2,D}
+1 * [Cs,N]  u0 {2,S} {3,S}
+2   [C,N,S] u0 {1,S} {3,D}
+3   [C,N,S] u0 {1,S} {2,D}
 """,
     thermo = ThermoData(
         Tdata = ([300,400,500,600,800,1000,1500],'K'),
@@ -4416,7 +4416,7 @@ L1: Ring
         L3: Cyclopropadiene
         L3: Cyclopropadiene2
         L3: Cyclopropyne
-		L3: oxirene
+        L3: oxirene
         L3: Cyclopropatriene
         L3: Ethylene_oxide
         L3: dioxirane

--- a/input/thermo/libraries/primaryThermoLibrary.py
+++ b/input/thermo/libraries/primaryThermoLibrary.py
@@ -865,3 +865,29 @@ u"""
 
 """,
 )
+
+entry(
+    index = 36,
+    label = "O3",
+    molecule =
+"""
+1 O u0 p3 c-1 {2,S}
+2 O u0 p1 c+1 {1,S} {3,D}
+3 O u0 p2 c0 {2,D}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[2.46261,0.00958278,-7.08736e-06,1.36337e-09,2.96965e-13,16061.5,12.1419], Tmin=(200,'K'), Tmax=(1000,'K')),
+            NASAPolynomial(coeffs=[5.42937,0.00182038,-7.70561e-07,1.49929e-10,-1.07556e-14,15235.3,-3.26639], Tmin=(1000,'K'), Tmax=(5000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (5000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc =
+u"""
+Ozone
+Taken from the GlarborgH2S thermo library,
+in agreement with the data by Burcat et al. (H298 = 34.10 kcal/mol in GlarborgH2S vs. 33.89 kcal/mol in BurcatNS)
+""",
+)


### PR DESCRIPTION
The `Ods` globally forbidden group forbids oxygen with both double and single bonds.
Now that atomTypes were updated (`O4dc` describes `-[O+]=`), we can correctly (and should) represent such structures, e.g., ozone `[O-][O+]=O` (we also have both thermo and kinetics for ozone from several new libraries).

Since currently GAV is doing a terrible job for ozone's thermo (`group(O2s-CsCs) + group(O2s-CsCs)`, missing the `-[O+]=` of course, but also the double bond on the terminal O isn't captured), and ozone now might pop in different jobs, a respective entry was also added to the PrimaryThermoLibrary.

We should check that nothing else significantly changes following this PR (-tests).

In this PR the `Ods` group was modified so that O cannot have both double and single bonds **while** keeping a partial charge of `0` (we also don't have an atomType for this situation)

(A point to consider: if we want, we could still forbid `R[O+]=R` structures where R != O)