### PR TITLE
Fix training degeneracy

### DIFF
--- a/input/kinetics/families/6_membered_central_C-C_shift/training/reactions.py
+++ b/input/kinetics/families/6_membered_central_C-C_shift/training/reactions.py
@@ -41,7 +41,7 @@ Taken from entry: II <=> I
 entry(
     index = 3,
     label = "C10H10 <=> C10H10-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     duplicate = True,
     kinetics = Arrhenius(A=(2.214e+09, 's^-1'), n=0.749, Ea=(47.859, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
@@ -69,7 +69,7 @@ Taken from entry: W4 <=> W1
 entry(
     index = 5,
     label = "C10H10-3 <=> C10H10-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     duplicate = True,
     kinetics = Arrhenius(A=(4.484e+11, 's^-1'), n=0.032, Ea=(50.631, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,

--- a/input/kinetics/families/Birad_R_Recombination/training/reactions.py
+++ b/input/kinetics/families/Birad_R_Recombination/training/reactions.py
@@ -11,7 +11,7 @@ group additivity values in this file.
 entry(
     index = 1,
     label = "NH + NO2_r <=> HNNO2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.42e+16, 'cm^3/(mol*s)'), n=-0.75, Ea=(1226, 'cal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: primaryNitrogenLibrary""",

--- a/input/kinetics/families/Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Disproportionation/training/reactions.py
@@ -10,7 +10,7 @@ group additivity values in this file.
 entry(
     index = 1,
     label = "C2H + CH3O <=> C2H2 + CH2O",
-    degeneracy = 3,
+    degeneracy = 1,
     kinetics = Arrhenius(
         A = (3.61e+13, 'cm^3/(mol*s)', '*|/', 5),
         n = 0,

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -2390,7 +2390,7 @@ TST
 entry(
     index = 1043,
     label = "HSS_r12 + HSS_r3 <=> HSSH_p23 + S2_p1",
-    degeneracy = 2,
+    degeneracy = 1,
     kinetics = Arrhenius(A=(9.56e+00, 'cm^3/(mol*s)'), n=3.370, Ea=(-1672, 'cal/mol'), T0=(1, 'K'), Tmin = (873, 'K'), Tmax = (1423, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: primarySulfurLibrary""",

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -3743,7 +3743,7 @@ A-factor multiplied by 1/3 to account for different degeneracy of isopropylbenze
 entry(
     index=1276,
     label = "C3H6-3 + C6H5 <=> C6H6 + C3H5-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00551, 'cm^3/(mol*s)'),
         n = 4.401,
@@ -3797,7 +3797,7 @@ Taken from entry: C6H5 + C3H6 <=> C6H6 + CH2CHCH2
 entry(
     index = 1279,
     label = "C4H6-3 + C2H3 <=> C2H4 + C4H5",
-    degeneracy = 1.0,
+    degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0003437, 'cm^3/(mol*s)'),
         n = 4.732,

--- a/input/kinetics/families/Intra_5_membered_conjugated_C=C_C=C_addition/training/reactions.py
+++ b/input/kinetics/families/Intra_5_membered_conjugated_C=C_C=C_addition/training/reactions.py
@@ -13,7 +13,7 @@ group additivity values in this file.
 entry(
     index = 1,
     label = "C6H6 <=> C6H6-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.16177e+12, 's^-1'), n=-0.0456701, Ea=(160.977, 'kJ/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2003_Miller_Propargyl_Recomb_High_P""",

--- a/input/kinetics/families/Intra_Diels_alder_monocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_Diels_alder_monocyclic/training/reactions.py
@@ -25,7 +25,7 @@ Taken from entry: VIII <=> X
 entry(
     index = 2,
     label = "C6H6-3 <=> C6H6-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.012e+13, 's^-1'), n=0.1, Ea=(41.203, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2003_Miller_Propargyl_Recomb_High_P""",

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -53,7 +53,7 @@ Taken from entry: product22 <=> product25
 entry(
     index = 4,
     label = "C6H9 <=> C6H9-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.12e+09, 's^-1'), n=0.63, Ea=(27.4, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C3""",
@@ -66,7 +66,7 @@ Taken from entry: prod_1 <=> prod_2
 entry(
     index = 5,
     label = "C7H11 <=> C7H11-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.71e+11, 's^-1'), n=0.2, Ea=(27.5, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C3""",

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
@@ -53,7 +53,7 @@ Taken from entry: pdt18 <=> pdt19
 entry(
     index = 4,
     label = "C10H11-3 <=> C10H11-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.19e+11, 's^-1'), n=0.08, Ea=(16.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",

--- a/input/kinetics/families/Intra_ene_reaction/training/reactions.py
+++ b/input/kinetics/families/Intra_ene_reaction/training/reactions.py
@@ -12,7 +12,7 @@ group additivity values in this file.
 entry(
     index = 1,
     label = "C7H9 <=> C7H9-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(4.39e+07, 's^-1'), n=1.58, Ea=(21.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -25,7 +25,7 @@ Taken from entry: addB <=> product21
 entry(
     index = 2,
     label = "C7H9-3 <=> C7H9-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(5.06e+07, 's^-1'), n=1.74, Ea=(24.3, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -55,7 +55,7 @@ Taken from entry: pdt22 <=> INDENE
 entry(
     index = 4,
     label = "C6H6 <=> C6H6-2",
-    degeneracy = 1,
+    degeneracy = 4,
     kinetics = Arrhenius(A=(2.08398e+09, 's^-1'), n=0.809263, Ea=(163.807, 'kJ/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2003_Miller_Propargyl_Recomb_High_P""",

--- a/input/kinetics/families/Intra_ene_reaction/training/reactions.py
+++ b/input/kinetics/families/Intra_ene_reaction/training/reactions.py
@@ -85,7 +85,7 @@ Taken from entry: VIII <=> II
 entry(
     index = 6,
     label = "C6H8 <=> C6H8-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(7.0333e+08, 's^-1'), n=1.2, Ea=(24.8, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
@@ -98,7 +98,7 @@ Taken from entry: C5H5CH3-5 <=> C5H5CH3-1
 entry(
     index = 7,
     label = "C6H8-3 <=> C6H8-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.6539e+07, 's^-1'), n=2.1, Ea=(25.1, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
@@ -113,7 +113,7 @@ Taken from entry: C5H5CH3-1 <=> C5H5CH3-2
 entry(
     index = 8,
     label = "C6H7 <=> C6H7-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(2.23e+07, 's^-1'), n=1.54, Ea=(13.4, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
@@ -128,7 +128,7 @@ Taken from entry: C5H5CH2-1 <=> C5H5CH2-2
 entry(
     index = 9,
     label = "C10H9 <=> C10H9-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(2.46e+08, 's^-1'), n=1.46, Ea=(16.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
@@ -141,7 +141,7 @@ Taken from entry: adducta <=> adductb
 entry(
     index = 10,
     label = "C10H9-3 <=> C10H9-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(5.46e+06, 's^-1'), n=2.01, Ea=(27.5, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: naphthalene_H""",
@@ -156,7 +156,7 @@ Taken from entry: adductb <=> adductc
 entry(
     index = 11,
     label = "C10H11 <=> C10H11-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.12e+08, 's^-1'), n=1.64, Ea=(22.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -169,7 +169,7 @@ Taken from entry: adductd <=> pdt15
 entry(
     index = 12,
     label = "C10H11-3 <=> C10H11-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.28e+08, 's^-1'), n=1.55, Ea=(18.4, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -182,7 +182,7 @@ Taken from entry: pdt14 <=> pdt16
 entry(
     index = 13,
     label = "C10H11-5 <=> C10H11-6",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.18e+08, 's^-1'), n=1.8, Ea=(21.8, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -210,7 +210,7 @@ Taken from entry: W8 <=> W102
 entry(
     index = 15,
     label = "C10H9-7 <=> C10H9-8",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.548e+09, 's^-1'), n=0.934, Ea=(9.114, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -79,7 +79,7 @@ DOI: 10.1021/jp403792t
 entry(
     index = 5,
     label = "NO2 + NO2 <=> N2O4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(
         A = (2.63e+08, 'm^3/(mol*s)', '+|-', 3.16e+07),
         n = -1.1,
@@ -226,7 +226,7 @@ and in the Nitrogen_Glarborg_Gimenez_et_al library (index 953)
 entry(
     index = 20,
     label = "CH3 + CH3 <=> C2H6",
-    degeneracy = 1,
+    degeneracy = 0.5,
     kinetics = Arrhenius(A=(9.45e+14, 'cm^3/(mol*s)'), n=-0.538, Ea=(135.1, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
     rank = 2,
     shortDesc = u"""CASPT2/cc-pvdz""",
@@ -258,7 +258,7 @@ doi: 10.1039/B515914H
 entry(
     index = 22,
     label = "C2H5 + C2H5 <=> C4H10",
-    degeneracy = 1,
+    degeneracy = 0.5,
     kinetics = Arrhenius(A=(8.73e+14, 'cm^3/(mol*s)'), n=-0.699, Ea=(-3.2, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
     rank = 2,
     shortDesc = u"""CASPT2/cc-pvdz""",

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -310,7 +310,7 @@ Taken from entry: R2 + H <=> C5H5CH3-5
 entry(
     index = 25,
     label = "C6H7-2 + H <=> C6H8-3",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (6.7982e-11, 'cm^3/(molecule*s)'),
         n = 0.3,
@@ -346,7 +346,7 @@ Taken from entry: R1 + H <=> C5H5CH3-1
 entry(
     index = 27,
     label = "C6H7-4 + H <=> C6H8-5",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.50356e-10, 'cm^3/(molecule*s)'),
         n = 0.1,

--- a/input/kinetics/families/Singlet_Carbene_Intra_Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Singlet_Carbene_Intra_Disproportionation/training/reactions.py
@@ -13,7 +13,7 @@ group additivity values in this file.
 entry(
     index = 1,
     label = "C6H6 <=> C6H6-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(8.067e+10, 's^-1'), n=0.649, Ea=(8.03, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2003_Miller_Propargyl_Recomb_High_P""",
@@ -26,7 +26,7 @@ Taken from entry: A <=> IV
 entry(
     index = 2,
     label = "C6H6-3 <=> C6H6-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.454e+12, 's^-1'), n=0.178, Ea=(0.205, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2003_Miller_Propargyl_Recomb_High_P""",

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -39,7 +39,7 @@ DOI: 10.1039/C1CP22765C
 entry(
     index = 2,
     label = "S1C4 <=> S1C4b",
-    degeneracy = 3,
+    degeneracy = 6,
     kinetics = Arrhenius(
         A = (1.775e+09, 's^-1', '*|/', 3.0),
         n = 0.686,
@@ -116,7 +116,7 @@ Quantum chemistry calculations at the M08SO/MG3S* level using Qchem. High-pressu
 entry(
     index = 5,
     label = "C7H9 <=> C7H9-2",
-    degeneracy = 1,
+    degeneracy = 3,
     kinetics = Arrhenius(A=(5.97e+06, 's^-1'), n=1.8, Ea=(37.9, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -129,7 +129,7 @@ Taken from entry: addA <=> addB
 entry(
     index = 6,
     label = "C7H9-3 <=> C7H9-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(2.81e+07, 's^-1'), n=1.72, Ea=(44.3, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -181,7 +181,7 @@ Taken from entry: addD <=> product10
 entry(
     index = 10,
     label = "C7H9-11 <=> C7H9-12",
-    degeneracy = 1,
+    degeneracy = 4,
     kinetics = Arrhenius(A=(5.11e+09, 's^-1'), n=1.34, Ea=(47.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -194,7 +194,7 @@ Taken from entry: product4 <=> product9
 entry(
     index = 11,
     label = "C7H9-13 <=> C7H9-14",
-    degeneracy = 1,
+    degeneracy = 6,
     kinetics = Arrhenius(A=(2.03e+06, 's^-1'), n=1.96, Ea=(50.8, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -207,7 +207,7 @@ Taken from entry: product2 <=> product5
 entry(
     index = 12,
     label = "C7H9-15 <=> C7H9-16",
-    degeneracy = 1,
+    degeneracy = 4,
     kinetics = Arrhenius(A=(367000, 's^-1'), n=2.24, Ea=(34.5, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -220,7 +220,7 @@ Taken from entry: product17 <=> product6
 entry(
     index = 13,
     label = "C7H9-17 <=> C7H9-18",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.9e+10, 's^-1'), n=0.87, Ea=(34.5, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -233,7 +233,7 @@ Taken from entry: product29 <=> product23
 entry(
     index = 14,
     label = "C7H9-19 <=> C7H9-20",
-    degeneracy = 1,
+    degeneracy = 3,
     kinetics = Arrhenius(A=(285000, 's^-1'), n=2.15, Ea=(43.9, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -246,7 +246,7 @@ Taken from entry: product31 <=> product35
 entry(
     index = 15,
     label = "C7H9-21 <=> C7H9-22",
-    degeneracy = 1,
+    degeneracy = 3,
     kinetics = Arrhenius(A=(671000, 's^-1'), n=2.07, Ea=(48.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -259,7 +259,7 @@ Taken from entry: product32 <=> product38
 entry(
     index = 16,
     label = "C7H7 <=> C7H7-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.41e+08, 's^-1'), n=1.52, Ea=(38.6, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
@@ -313,7 +313,7 @@ Taken from entry: vinylCPDyl <=> product41
 entry(
     index = 20,
     label = "C5H5 <=> C5H5-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.15e+10, 's^-1'), n=0.98, Ea=(26.9, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C3""",
@@ -326,7 +326,7 @@ Taken from entry: prod_24 <=> CPDyl
 entry(
     index = 21,
     label = "C6H7 <=> C6H7-2",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.71e+10, 's^-1'), n=1.01, Ea=(27.8, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C3""",
@@ -339,7 +339,7 @@ Taken from entry: prod_26 <=> meCPDyl
 entry(
     index = 22,
     label = "C6H7-3 <=> C6H7-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.8e+10, 's^-1'), n=1.01, Ea=(28.2, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C3""",
@@ -352,7 +352,7 @@ Taken from entry: prod_28 <=> meCPDyl
 entry(
     index = 23,
     label = "C6H7-5 <=> C6H7-6",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(3.24e+09, 's^-1'), n=1.12, Ea=(39.4, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C3""",
@@ -380,7 +380,7 @@ Taken from entry: pdt14 <=> pdt20
 entry(
     index = 25,
     label = "C10H11-3 <=> C10H11-4",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(250000, 's^-1'), n=1.95, Ea=(24, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -393,7 +393,7 @@ Taken from entry: pdt18 <=> pdt25
 entry(
     index = 26,
     label = "C10H11-5 <=> C10H11-6",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(2.59e+08, 's^-1'), n=1.01, Ea=(26.4, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -419,7 +419,7 @@ Taken from entry: pdt28 <=> pdt29
 entry(
     index = 28,
     label = "C10H11-9 <=> C10H11-10",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.46e+07, 's^-1'), n=1.66, Ea=(31.6, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -458,7 +458,7 @@ Taken from entry: adductd <=> pdt55
 entry(
     index = 31,
     label = "C10H11-15 <=> C10H11-16",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.78e+06, 's^-1'), n=1.75, Ea=(25.3, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -471,7 +471,7 @@ Taken from entry: pdt15 <=> pdt55
 entry(
     index = 32,
     label = "C10H11-17 <=> C10H11-18",
-    degeneracy = 1,
+    degeneracy = 2,
     kinetics = Arrhenius(A=(1.04e+07, 's^-1'), n=1.61, Ea=(27.1, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -486,7 +486,7 @@ Taken from entry: pdt58 <=> pdt20
 entry(
     index = 33,
     label = "C6H7-7 <=> C6H7-8",
-    degeneracy = 1,
+    degeneracy = 3,
     kinetics = Arrhenius(A=(0.00218, 's^-1'), n=4.91, Ea=(40.4, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -501,7 +501,7 @@ Taken from entry: C5H4CH3 <=> C5H5CH2-1
 entry(
     index = 34,
     label = "C9H11 <=> C9H11-2",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(1.68e-11, 's^-1'), n=6.833, Ea=(28.023, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Buras_C6H5_C3H6_highP""",
@@ -514,7 +514,7 @@ Taken from entry: i1 <=> i4
 entry(
     index = 35,
     label = "C9H11-3 <=> C9H11-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.842e-10, 's^-1'), n=6.38, Ea=(25.872, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Buras_C6H5_C3H6_highP""",
@@ -540,7 +540,7 @@ Taken from entry: i2 <=> i9
 entry(
     index = 37,
     label = "C9H11-7 <=> C9H11-8",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.478, 's^-1'), n=3.436, Ea=(23.671, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Buras_C6H5_C3H6_highP""",
@@ -553,7 +553,7 @@ Taken from entry: i1 <=> inew
 entry(
     index = 38,
     label = "C9H11-9 <=> C9H11-10",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(721.5, 's^-1'), n=2.46, Ea=(3.681, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Buras_C6H5_C3H6_highP""",
@@ -581,7 +581,7 @@ Taken from entry: c5-C6H9 <=> c5-C6H9-3
 entry(
     index = 40,
     label = "C6H9-3 <=> C6H9-4",
-    degeneracy = 1.0,
+    degeneracy = 4.0,
     kinetics = Arrhenius(A=(3.537e-16, 's^-1'), n=8.138, Ea=(14.583, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2015_Buras_C2H3_C4H6_highP""",
@@ -594,7 +594,7 @@ Taken from entry: c5-C6H9 <=> c5-C6H9-2
 entry(
     index = 41,
     label = "C6H9-5 <=> C6H9-6",
-    degeneracy = 1.0,
+    degeneracy = 4.0,
     kinetics = Arrhenius(A=(3.239e-08, 's^-1'), n=6.224, Ea=(24.481, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: 2015_Buras_C2H3_C4H6_highP""",
@@ -609,7 +609,7 @@ Taken from entry: c5-C6H9-3 <=> c5-C6H9-2
 entry(
     index = 42,
     label = "C10H9 <=> C10H9-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(264300, 's^-1'), n=1.839, Ea=(33.509, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C4H4_highP""",
@@ -622,7 +622,7 @@ Taken from entry: W1 <=> W4
 entry(
     index = 43,
     label = "C10H9-3 <=> C10H9-4",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(120000, 's^-1'), n=2.099, Ea=(35.296, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C4H4_highP""",
@@ -635,7 +635,7 @@ Taken from entry: W1 <=> W16
 entry(
     index = 44,
     label = "C10H9-5 <=> C10H9-6",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.62e+09, 's^-1'), n=1.05, Ea=(31.179, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C4H4_highP""",
@@ -661,7 +661,7 @@ Taken from entry: W3 <=> W20
 entry(
     index = 46,
     label = "C10H9-9 <=> C10H9-10",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(9.346e+08, 's^-1'), n=1.296, Ea=(39.967, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C4H4_highP""",
@@ -674,7 +674,7 @@ Taken from entry: W5 <=> W6
 entry(
     index = 47,
     label = "C10H9-11 <=> C10H9-12",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(65110, 's^-1'), n=2.209, Ea=(29.053, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C4H4_highP""",
@@ -687,7 +687,7 @@ Taken from entry: W9 <=> W7
 entry(
     index = 48,
     label = "C10H9-13 <=> C10H9-14",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.048e+09, 's^-1'), n=0.924, Ea=(30.972, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C4H4_highP""",
@@ -728,7 +728,7 @@ Taken from entry: W7 <=> W20
 entry(
     index = 51,
     label = "C6H7-9 <=> C6H7-10",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(9220, 's^-1'), n=2.81, Ea=(30.2, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
@@ -756,7 +756,7 @@ Taken from entry: pdt21 <=> pdt27
 entry(
     index = 53,
     label = "C10H11-21 <=> C10H11-22",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.18e+07, 's^-1'), n=1.8, Ea=(15.8, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -769,7 +769,7 @@ Taken from entry: pdt16 <=> pdt33
 entry(
     index = 54,
     label = "C10H11-23 <=> C10H11-24",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(2.27e+06, 's^-1'), n=1.5, Ea=(33.7, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: C10H11""",
@@ -797,7 +797,7 @@ Taken from entry: W1_2 <=> W5
 entry(
     index = 56,
     label = "C9H9-3 <=> C9H9-4",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(401300, 's^-1'), n=2.064, Ea=(37.093, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -810,7 +810,7 @@ Taken from entry: W1_2 <=> W8_9
 entry(
     index = 57,
     label = "C9H9-5 <=> C9H9-6",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(2.915e+06, 's^-1'), n=1.697, Ea=(19.915, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -823,7 +823,7 @@ Taken from entry: W3_4 <=> W13
 entry(
     index = 58,
     label = "C9H9-7 <=> C9H9-8",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(240, 's^-1'), n=2.932, Ea=(30.907, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -836,7 +836,7 @@ Taken from entry: W3_4 <=> W6
 entry(
     index = 59,
     label = "C9H9-9 <=> C9H9-10",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(53440, 's^-1'), n=2.305, Ea=(38.286, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -849,7 +849,7 @@ Taken from entry: W5 <=> W8_9
 entry(
     index = 60,
     label = "C9H9-11 <=> C9H9-12",
-    degeneracy = 1.0,
+    degeneracy = 4.0,
     kinetics = Arrhenius(A=(2.166e+07, 's^-1'), n=1.625, Ea=(37.367, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -862,7 +862,7 @@ Taken from entry: W6 <=> W13
 entry(
     index = 61,
     label = "C9H9-13 <=> C9H9-14",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(420000, 's^-1'), n=2.094, Ea=(61.014, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -888,7 +888,7 @@ Taken from entry: W8_9 <=> W11
 entry(
     index = 63,
     label = "C9H9-17 <=> C9H9-18",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(3.45e+06, 's^-1'), n=1.572, Ea=(60.563, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -901,7 +901,7 @@ Taken from entry: W8_9 <=> W21
 entry(
     index = 64,
     label = "C9H9-19 <=> C9H9-20",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.286e+08, 's^-1'), n=1.323, Ea=(24.182, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -914,7 +914,7 @@ Taken from entry: W11 <=> W21
 entry(
     index = 65,
     label = "C9H9-21 <=> C9H9-22",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.37e+08, 's^-1'), n=1.713, Ea=(43.474, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -927,7 +927,7 @@ Taken from entry: W11 <=> W20
 entry(
     index = 66,
     label = "C9H9-23 <=> C9H9-24",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(59980, 's^-1'), n=1.941, Ea=(8.652, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C9H9_highP""",
@@ -942,7 +942,7 @@ Taken from entry: W21 <=> W20
 entry(
     index = 67,
     label = "C10H9-19 <=> C10H9-20",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(8.964e+07, 's^-1'), n=1.633, Ea=(47.984, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -968,7 +968,7 @@ Taken from entry: W5 <=> W103
 entry(
     index = 69,
     label = "C10H9-23 <=> C10H9-24",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.09e+11, 's^-1'), n=0.703, Ea=(23.53, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -981,7 +981,7 @@ Taken from entry: W104 <=> W6
 entry(
     index = 70,
     label = "C10H9-25 <=> C10H9-26",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(7.423e+08, 's^-1'), n=1.522, Ea=(63.602, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -994,7 +994,7 @@ Taken from entry: W106 <=> W107
 entry(
     index = 71,
     label = "C10H9-27 <=> C10H9-28",
-    degeneracy = 1.0,
+    degeneracy = 6.0,
     kinetics = Arrhenius(A=(68.8, 's^-1'), n=3.351, Ea=(60.931, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -1020,7 +1020,7 @@ Taken from entry: W112 <=> W118
 entry(
     index = 73,
     label = "C10H9-29 <=> C10H9-30",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(3.93e+07, 's^-1'), n=1.684, Ea=(33.806, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -1033,7 +1033,7 @@ Taken from entry: W6 <=> W118
 entry(
     index = 74,
     label = "C10H9-31 <=> C10H9-32",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(2.401e+08, 's^-1'), n=1.453, Ea=(42.614, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -1046,7 +1046,7 @@ Taken from entry: W115 <=> W117
 entry(
     index = 75,
     label = "C10H9-33 <=> C10H9-34",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(1.181e+10, 's^-1'), n=0.964, Ea=(32.063, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2016_Mebel_C10H9_highP""",
@@ -1102,7 +1102,7 @@ Taken from entry: W3_6 <=> W7
 entry(
     index = 79,
     label = "C8H7 <=> C8H7-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(3.445e+06, 's^-1'), n=1.735, Ea=(23.162, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: First_to_Second_Aromatic_Ring\2017_Mebel_C6H5_C2H2_highP""",
@@ -1117,7 +1117,7 @@ Taken from entry: W1 <=> W3
 entry(
     index = 80,
     label = "C7H7-9 <=> C7H7-10",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(A=(4.712e+10, 's^-1'), n=0.722, Ea=(41.878, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: kislovB""",
@@ -1130,7 +1130,7 @@ Taken from entry: C7H7_11 <=> C7H7_10
 entry(
     index = 81,
     label = "C9H9-25 <=> C9H9-26",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(9.527e+10, 's^-1'), n=0.853, Ea=(47.848, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: kislovB""",
@@ -1143,7 +1143,7 @@ Taken from entry: C9H9_3 <=> C9H9_24
 entry(
     index = 82,
     label = "C9H9-27 <=> C9H9-28",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(A=(4.438e+10, 's^-1'), n=0.625, Ea=(38.324, 'kcal/mol'), T0=(1, 'K')),
     rank = 3,
     shortDesc = u"""Training reaction from kinetics library: kislovB""",
@@ -1545,9 +1545,9 @@ Reported A factor from article is multiplied by degeneracy because article A-fac
 entry(
     index = 97,
     label = "C:C([CH2])C:CC <=> C:C(C)C:C[CH2]",
-    degeneracy = 4,
+    degeneracy = 6,
     kinetics = Arrhenius(
-        A = (4.44E+06, 's^-1'),
+        A = (6.66E+06, 's^-1'),
         n = 1.64,
         Ea = (24.0, 'kcal/mol'),
         T0 = (1, 'K'),
@@ -1785,9 +1785,9 @@ Reported A factor from article is multiplied by degeneracy because article A-fac
 entry(
     index = 105,
     label = "C:C([CH2])CC:CC <=> C:C(C)CC:C[CH2]",
-    degeneracy = 3,
+    degeneracy = 6,
     kinetics = Arrhenius(
-        A = (6.33E+04, 's^-1'),
+        A = (12.66E+04, 's^-1'),
         n = 1.92,
         Ea = (21.3, 'kcal/mol'),
         T0 = (1, 'K'),

--- a/scripts/fixTrainingReactionDegeneracies.ipynb
+++ b/scripts/fixTrainingReactionDegeneracies.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": "true"
+   },
+   "source": [
+    "# Table of Contents\n",
+    " <p><div class=\"lev1 toc-item\"><a href=\"#fix-training-reaction-degeneracies\" data-toc-modified-id=\"fix-training-reaction-degeneracies-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>fix training reaction degeneracies</a></div><div class=\"lev2 toc-item\"><a href=\"#load-lib_rxn\" data-toc-modified-id=\"load-lib_rxn-11\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>load lib_rxn</a></div><div class=\"lev2 toc-item\"><a href=\"#identify-wrong-degeneracy-of-training-reactions\" data-toc-modified-id=\"identify-wrong-degeneracy-of-training-reactions-12\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>identify wrong degeneracy of training reactions</a></div><div class=\"lev2 toc-item\"><a href=\"#fix-training-degeneracy-of-families\" data-toc-modified-id=\"fix-training-degeneracy-of-families-13\"><span class=\"toc-item-num\">1.3&nbsp;&nbsp;</span>fix training degeneracy of families</a></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# fix training reaction degeneracies\n",
+    "\n",
+    "This script loads training reactions from all families, finds their degeneracy and outputs the correct degeneracy in its place. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rmgpy.data.rmg import RMGDatabase\n",
+    "from rmgpy.chemkin import saveChemkinFile, saveSpeciesDictionary\n",
+    "from rmgpy.rmg.model import Species\n",
+    "from rmgpy.molecule import Molecule\n",
+    "from rmgpy import settings\n",
+    "from IPython.display import display, HTML, Image\n",
+    "import numpy as np\n",
+    "import os\n",
+    "from rmgpy.data.kinetics.family import TemplateReaction\n",
+    "from rmgpy.exceptions import KineticsError, UndeterminableKineticsError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## load lib_rxn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "database = RMGDatabase()\n",
+    "database.load(\n",
+    "    path = settings['database.directory'], \n",
+    "    thermoLibraries = [],\n",
+    "    kineticsFamilies = 'all', \n",
+    "    kineticsDepositories = ['training']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## identify wrong degeneracy of training reactions\n",
+    "\n",
+    "This section goes through all training reactions and reports when the degeneracy is incorrect.\n",
+    "\n",
+    "If the 'rewrite' option is selected, the updated rates are automatically written to the database, which is useful after PR #186 is fully implemented"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "rewrite=False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for family in database.kinetics.families.values():\n",
+    "    print(\"analyzing family {}\".format(family.name))\n",
+    "    rxn_depository = family.depositories[0]\n",
+    "    training_reaction_entries = rxn_depository.entries.values()\n",
+    "    for entry in training_reaction_entries:\n",
+    "        rxn = entry.item\n",
+    "        old_degeneracy = rxn.degeneracy\n",
+    "        rxn = TemplateReaction(index = rxn.index,\n",
+    "                              reactants = rxn.reactants,\n",
+    "                              products = rxn.products,\n",
+    "                              kinetics = rxn.kinetics,\n",
+    "                              reversible = rxn.reversible,\n",
+    "                              duplicate = rxn.duplicate,\n",
+    "                              degeneracy = rxn.degeneracy,\n",
+    "                              pairs = rxn.pairs)\n",
+    "        try:\n",
+    "            # check if the reaction is written in forward or reverse direction\n",
+    "            rxn.template = family.getReactionTemplateLabels(rxn)\n",
+    "        except UndeterminableKineticsError:\n",
+    "                # This rxn in written in reverse direction.\n",
+    "                # Currently, we don't have to deal with degeneracy of reverse templates\n",
+    "                continue\n",
+    "        try:\n",
+    "            rxn.degeneracy = family.calculateDegeneracy(rxn)\n",
+    "        except KineticsError as e:\n",
+    "            print(e)\n",
+    "            print('entry index is {}'.format(entry.index))\n",
+    "            display(rxn)\n",
+    "        assert id(rxn.degeneracy) != id(old_degeneracy)\n",
+    "        if rxn.degeneracy != old_degeneracy:\n",
+    "            display(rxn)\n",
+    "            print('Degeneracy should be {1} instead of {0} for reaction {2} with index {3}'.format(old_degeneracy,rxn.degeneracy,rxn,entry.index))\n",
+    "    if rewrite:\n",
+    "        family.saveDepository(depository=rxn_depository, path=os.path.join(kinetics_families_path,rxn_depository.label))\n",
+    "        print('finished updating degeneracy for family {}'.format(family.label))"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  },
+  "toc": {
+   "nav_menu": {
+    "height": "172px",
+    "width": "253px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": true,
+   "toc_section_display": "block",
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This PR:

1. creates a script to find 'incorrect' degeneracy values among training reactions.
2. fixes the 'incorrect' degeneracy values among all training reactions. 

In this case 'incorrect' degeneracy means the value in the database is different from what RMG would predict (leading to an incorrect rate rule). 

Currently, the script makes some incorrect assessments without the bugfix in calculateDegeneracy [RMG PR 1276](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1276).

For someone to review this PR, I think running the script and reading through the script code to see if it makes sense should suffice (along with other recommendations).

If you think the script should be turned also a databaseTest, that can also be done. 