### PR TITLE
add GAIN_CHARGE and REMOVE_CHARGE to recipes

### DIFF
--- a/input/kinetics/families/1,2_Insertion_CO/groups.py
+++ b/input/kinetics/families/1,2_Insertion_CO/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['FORM_BOND', '*1', 1, '*2'],
     ['FORM_BOND', '*1', 1, '*3'],
     ['LOSE_PAIR', '*1', '1'],
+    ['GAIN_CHARGE', '*1', '1'],
+    ['LOSE_CHARGE', '*4', '1'],
 ])
 
 entry(

--- a/input/kinetics/families/CO_Disproportionation/groups.py
+++ b/input/kinetics/families/CO_Disproportionation/groups.py
@@ -26,6 +26,8 @@ recipe(actions=[
     ['CHANGE_BOND', '*2', 1, '*3'],
     ['LOSE_RADICAL', '*1', '1'],
     ['LOSE_RADICAL', '*3', '1'],
+    ['GAIN_CHARGE', '*2', '1'],
+    ['LOSE_CHARGE', '*3', '1'],
 ])
 
 entry(

--- a/input/kinetics/families/R_Addition_COm/groups.py
+++ b/input/kinetics/families/R_Addition_COm/groups.py
@@ -13,11 +13,13 @@ reverse = "COM_Elimination_From_Carbonyl"
 
 recipe(actions=[
     ['LOSE_PAIR', '*1', '1'],
-    ['GAIN_PAIR', '*3', '1'],
     ['CHANGE_BOND', '*1', -1, '*3'],
+    ['GAIN_PAIR', '*3', '1'],
     ['GAIN_RADICAL', '*1', '1'],
     ['FORM_BOND', '*1', 1, '*2'],
     ['LOSE_RADICAL', '*2', '1'],
+    ['GAIN_CHARGE', '*1', '1'],
+    ['LOSE_CHARGE', '*3', '1'],
 ])
 
 entry(


### PR DESCRIPTION
This pull request related to the rmg-py pull request with similar name which added GAIN_CHARGE and LOSE_CHARGE action for generating templates so that rmg can generate reactions whose products contain CO.