### PR TITLE
Added training reactions found to be important in rich-methane modeling

### DIFF
--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -3564,3 +3564,60 @@ multiplicity 2
 6    H u0 p0 c0 {1,S}
 7    O u0 p2 c0 {2,D}
 8 *3 O u1 p2 c0 {3,S}
+
+C4H4
+1    C u0 p0 c0 {2,T} {5,S}
+2    C u0 p0 c0 {1,T} {4,S}
+3    C u0 p0 c0 {4,D} {6,S} {7,S}
+4 *1 C u0 p0 c0 {2,S} {3,D} {8,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8 *2 H u0 p0 c0 {4,S}
+
+C4H3
+multiplicity 2
+1    C u0 p0 c0 {2,T} {5,S}
+2    C u0 p0 c0 {1,T} {3,S}
+3 *3 C u1 p0 c0 {2,S} {4,D}
+4    C u0 p0 c0 {3,D} {6,S} {7,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+
+C4H6-5
+1     C u0 p0 c0 {2,D} {3,D}
+2  *1 C u0 p0 c0 {1,D} {5,S} {6,S}
+3     C u0 p0 c0 {1,D} {4,S} {7,S}
+4     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  *2 H u0 p0 c0 {2,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+
+C4H5-4
+multiplicity 2
+1 *3 C u1 p0 c0 {2,D} {5,S}
+2    C u0 p0 c0 {1,D} {3,D}
+3    C u0 p0 c0 {2,D} {4,S} {6,S}
+4    C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-5
+multiplicity 2
+1    C u0 p0 c0 {2,T} {5,S}
+2    C u0 p0 c0 {1,T} {3,S}
+3 *3 C u1 p0 c0 {2,S} {4,S} {6,S}
+4    C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -3626,3 +3626,127 @@ multiplicity 2
 1 *1 O u1 p2 c0 {2,S}
 2 *2 H u0 p0 c0 {1,S}
 
+C12H8
+1     C u0 p0 c0 {3,B} {4,B} {14,S}
+2     C u0 p0 c0 {5,B} {6,B} {17,S}
+3     C u0 p0 c0 {1,B} {10,B} {13,S}
+4     C u0 p0 c0 {1,B} {9,B} {15,S}
+5     C u0 p0 c0 {2,B} {11,B} {16,S}
+6     C u0 p0 c0 {2,B} {10,B} {18,S}
+7  *1 C u0 p0 c0 {8,D} {9,S} {19,S}
+8     C u0 p0 c0 {7,D} {11,S} {20,S}
+9     C u0 p0 c0 {4,B} {7,S} {12,B}
+10    C u0 p0 c0 {3,B} {6,B} {12,B}
+11    C u0 p0 c0 {5,B} {8,S} {12,B}
+12    C u0 p0 c0 {9,B} {10,B} {11,B}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {1,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {2,S}
+18    H u0 p0 c0 {6,S}
+19 *2 H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {8,S}
+
+C12H7
+multiplicity 2
+1  *3 C u1 p0 c0 {2,D} {9,S}
+2     C u0 p0 c0 {1,D} {10,S} {13,S}
+3     C u0 p0 c0 {5,B} {6,B} {15,S}
+4     C u0 p0 c0 {7,B} {8,B} {18,S}
+5     C u0 p0 c0 {3,B} {9,B} {16,S}
+6     C u0 p0 c0 {3,B} {11,B} {14,S}
+7     C u0 p0 c0 {4,B} {10,B} {17,S}
+8     C u0 p0 c0 {4,B} {11,B} {19,S}
+9     C u0 p0 c0 {1,S} {5,B} {12,B}
+10    C u0 p0 c0 {2,S} {7,B} {12,B}
+11    C u0 p0 c0 {6,B} {8,B} {12,B}
+12    C u0 p0 c0 {9,B} {10,B} {11,B}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {8,S}
+
+C10H8
+1     C u0 p0 c0 {2,B} {8,B} {11,S}
+2     C u0 p0 c0 {1,B} {5,B} {12,S}
+3     C u0 p0 c0 {4,B} {6,B} {15,S}
+4     C u0 p0 c0 {3,B} {7,B} {16,S}
+5  *1 C u0 p0 c0 {2,B} {9,B} {13,S}
+6     C u0 p0 c0 {3,B} {9,B} {14,S}
+7     C u0 p0 c0 {4,B} {10,B} {17,S}
+8     C u0 p0 c0 {1,B} {10,B} {18,S}
+9     C u0 p0 c0 {5,B} {6,B} {10,B}
+10    C u0 p0 c0 {7,B} {8,B} {9,B}
+11    H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13 *2 H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+
+C10H7
+multiplicity 2
+1  *3 C u1 p0 c0 {2,B} {9,B}
+2     C u0 p0 c0 {1,B} {3,B} {11,S}
+3     C u0 p0 c0 {2,B} {8,B} {12,S}
+4     C u0 p0 c0 {5,B} {6,B} {14,S}
+5     C u0 p0 c0 {4,B} {7,B} {15,S}
+6     C u0 p0 c0 {4,B} {9,B} {13,S}
+7     C u0 p0 c0 {5,B} {10,B} {16,S}
+8     C u0 p0 c0 {3,B} {10,B} {17,S}
+9     C u0 p0 c0 {1,B} {6,B} {10,B}
+10    C u0 p0 c0 {7,B} {8,B} {9,B}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {7,S}
+17    H u0 p0 c0 {8,S}
+
+C10H8-2
+1  *1 C u0 p0 c0 {2,B} {8,B} {11,S}
+2     C u0 p0 c0 {1,B} {5,B} {12,S}
+3     C u0 p0 c0 {4,B} {6,B} {15,S}
+4     C u0 p0 c0 {3,B} {7,B} {16,S}
+5     C u0 p0 c0 {2,B} {9,B} {13,S}
+6     C u0 p0 c0 {3,B} {9,B} {14,S}
+7     C u0 p0 c0 {4,B} {10,B} {17,S}
+8     C u0 p0 c0 {1,B} {10,B} {18,S}
+9     C u0 p0 c0 {5,B} {6,B} {10,B}
+10    C u0 p0 c0 {7,B} {8,B} {9,B}
+11 *2 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {7,S}
+18    H u0 p0 c0 {8,S}
+
+C10H7-2
+multiplicity 2
+1  *3 C u1 p0 c0 {2,B} {3,B}
+2     C u0 p0 c0 {1,B} {6,B} {11,S}
+3     C u0 p0 c0 {1,B} {9,B} {12,S}
+4     C u0 p0 c0 {5,B} {7,B} {15,S}
+5     C u0 p0 c0 {4,B} {8,B} {16,S}
+6     C u0 p0 c0 {2,B} {10,B} {13,S}
+7     C u0 p0 c0 {4,B} {10,B} {14,S}
+8     C u0 p0 c0 {5,B} {9,B} {17,S}
+9     C u0 p0 c0 {3,B} {8,B} {10,B}
+10    C u0 p0 c0 {6,B} {7,B} {9,B}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {8,S}
+

--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -3621,3 +3621,8 @@ multiplicity 2
 8    H u0 p0 c0 {4,S}
 9    H u0 p0 c0 {4,S}
 
+HO
+multiplicity 2
+1 *1 O u1 p2 c0 {2,S}
+2 *2 H u0 p0 c0 {1,S}
+

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -3877,36 +3877,54 @@ Taken from entry: benzene_1 + methyl_7 <=> phenyl_16 + CH4_26
 entry(
     index = 1284,
     label = "C7H8 + H <=> H2 + C7H7",
-    degeneracy = 1.0,
+    degeneracy = 3.0,
     kinetics = Arrhenius(
-        A = (1.152e+06, 'cm^3/(mol*s)'),
-        n = 1.985,
-        Ea = (6.175, 'kcal/mol'),
+        A = (75372.2, 'cm^3/(mol*s)'),
+        n = 2.57378,
+        Ea = (3145.75, 'cal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: kislovB""",
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C7H8_17 + H_15 <=> C7H7_10 + H2_23
+G4//B3LYP/6-31G(2df,p)
 """,
 )
 
 entry(
     index = 1285,
     label = "C7H8-2 + H <=> H2 + C7H7-2",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(
-        A = (1.738e+07, 'cm^3/(mol*s)'),
-        n = 1.889,
-        Ea = (15.461, 'kcal/mol'),
+        A = (281049, 'cm^3/(mol*s)'),
+        n = 2.41207,
+        Ea = (8837.35, 'cal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: kislovB""",
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C7H8_17 + H_15 <=> C7H7_11 + H2_23
+G4//B3LYP/6-31G(2df,p)
 """,
 )
 
@@ -4813,6 +4831,493 @@ entry(
     longDesc = 
 u"""
 UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 1571,
+    label = "C7H8 + OH <=> H2O + C7H7",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(
+        A = (130169, 'cm^3/(mol*s)'),
+        n = 2.28048,
+        Ea = (-572.972, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1572,
+    label = "C7H8-2 + OH <=> H2O + C7H7-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (277.731, 'cm^3/(mol*s)'),
+        n = 2.99789,
+        Ea = (1245.72, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1573,
+    label = "C7H8-3 + OH <=> H2O + C7H7-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (819.665, 'cm^3/(mol*s)'),
+        n = 3.09594,
+        Ea = (1507.71, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1574,
+    label = "C7H8-4 + OH <=> H2O + C7H7-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (763.895, 'cm^3/(mol*s)'),
+        n = 3.10443,
+        Ea = (1688.65, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+
+entry(
+    index = 1575,
+    label = "C7H8-3 + H <=> H2 + C7H7-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.16e+06, 'cm^3/(mol*s)'),
+        n = 2.44202,
+        Ea = (9052.88, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1576,
+    label = "C7H8-4 + H <=> H2 + C7H7-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.57e+06, 'cm^3/(mol*s)'),
+        n = 2.40693,
+        Ea = (9440.52, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1577,
+    label = "C7H8 + O_rad <=> HO + C7H7",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(
+        A = (0.00788, 'cm^3/(mol*s)'),
+        n = 4.29278,
+        Ea = (11250.7, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1578,
+    label = "C7H8-2 + O_rad <=> HO + C7H7-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.71418, 'cm^3/(mol*s)'),
+        n = 3.64569,
+        Ea = (21743.3, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1579,
+    label = "C7H8-3 + O_rad <=> HO + C7H7-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (3.02029, 'cm^3/(mol*s)'),
+        n = 3.64209,
+        Ea = (22208.2, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1580,
+    label = "C7H8-4 + O_rad <=> HO + C7H7-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.79741, 'cm^3/(mol*s)'),
+        n = 3.6191,
+        Ea = (22697.5, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1581,
+    label = "C7H8 + CH3_p23 <=> CH4b + C7H7",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(
+        A = (1.07e+06, 'cm^3/(mol*s)'),
+        n = 2.26764,
+        Ea = (4392.37, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1582,
+    label = "C7H8-2 + CH3_p23 <=> CH4b + C7H7-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (3.21e+07, 'cm^3/(mol*s)'),
+        n = 1.81483,
+        Ea = (14155.6, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1583,
+    label = "C7H8-3 + CH3_p23 <=> CH4b + C7H7-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.11e+08, 'cm^3/(mol*s)'),
+        n = 1.80464,
+        Ea = (14389, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1584,
+    label = "C7H8-4 + CH3_p23 <=> CH4b + C7H7-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.05e+08, 'cm^3/(mol*s)'),
+        n = 1.81188,
+        Ea = (14672.5, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1585,
+    label = "C7H8 + HO2_r3 <=> H2O2 + C7H7",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(
+        A = (2.55836, 'cm^3/(mol*s)'),
+        n = 3.80712,
+        Ea = (7395.74, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1586,
+    label = "C7H8-2 + HO2_r3 <=> H2O2 + C7H7-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (91.4407, 'cm^3/(mol*s)'),
+        n = 3.28308,
+        Ea = (14233.3, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1587,
+    label = "C7H8-3 + HO2_r3 <=> H2O2 + C7H7-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (197.267, 'cm^3/(mol*s)'),
+        n = 3.28482,
+        Ea = (14542.4, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 1588,
+    label = "C7H8-4 + HO2_r3 <=> H2O2 + C7H7-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (204.902, 'cm^3/(mol*s)'),
+        n = 3.30806,
+        Ea = (14723.9, 'cal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Li, S.-H.', 'Guo, J.-J.', 'Li, R.', 'Wang, F.', 'Li, X.-Y.'],
+        title = u'Theoretical Prediction of Rate Constants for Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '120 (20)',
+        pages = '3424-3432',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G4//B3LYP/6-31G(2df,p)
 """,
 )
 

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -4762,3 +4762,57 @@ Jim Chu's calculation
 """,
 )
 
+entry(
+    index = 1569,
+    label = "C3H4 + OH <=> H2O + C3H3-2",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(
+        A = (12560, 'cm^3/(mol*s)'),
+        n = 2.794,
+        Ea = (0.153, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 1570,
+    label = "C3H4-1 + OH <=> H2O + C3H3",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(
+        A = (33830, 'cm^3/(mol*s)'),
+        n = 2.802,
+        Ea = (0.933, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -4543,3 +4543,113 @@ entry(
     rank=1,
     shortDesc = u"""Taken from Klippenstein_Glarborg2016, Experimental, original source: doi 10.1063/1.1748524""",
 )
+
+entry(
+    index = 1559,
+    label = "C3H3-2 + H2 <=> C3H4 + H",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (3.056, 'cm^3/(mol*s)'),
+        n = 3.503,
+        Ea = (15.039, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Narendrapurapu, B. S.', 'Simmonett, A. C.', 'Schaefer, H. F.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Combustion Chemistry: Important Features of the C3H5 Potential Energy Surface, Including Allyl Radical, Propargyl + H2, Allene + H, and Eight Transition States',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '115 (49)',
+        pages = '14209-14214',
+        year = '2011',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Accurate geometries are obtained using coupled cluster theory with single, double, and perturbative triple excitations [CCSD(T)] combined with Dunning’s correlation consistent quadruple-ζ basis set cc pVQZ. The energies for these stationary points are then refined by a systematic series of computations, within the focal point scheme, using the cc-pVXZ (X = D, T, Q, 5, 6) basis sets and correlation treatments as extensive as coupled cluster with full single, double, and triple excitation and perturbative quadruple excitations [CCSDT(Q)]. TST rates calculated in CanTherm
+""",
+)
+
+
+entry(
+    index = 1560,
+    label = "C3H3 + H2 <=> C3H4-1 + H",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (0.07496, 'cm^3/(mol*s)'),
+        n = 3.944,
+        Ea = (16.255, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Narendrapurapu, B. S.', 'Simmonett, A. C.', 'Schaefer, H. F.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Combustion Chemistry: Important Features of the C3H5 Potential Energy Surface, Including Allyl Radical, Propargyl + H2, Allene + H, and Eight Transition States',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '115 (49)',
+        pages = '14209-14214',
+        year = '2011',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Accurate geometries are obtained using coupled cluster theory with single, double, and perturbative triple excitations [CCSD(T)] combined with Dunning’s correlation consistent quadruple-ζ basis set cc pVQZ. The energies for these stationary points are then refined by a systematic series of computations, within the focal point scheme, using the cc-pVXZ (X = D, T, Q, 5, 6) basis sets and correlation treatments as extensive as coupled cluster with full single, double, and triple excitation and perturbative quadruple excitations [CCSDT(Q)]. TST rates calculated in CanTherm
+""",
+)
+
+entry(
+    index = 1561,
+    label = "C3H4 + H <=> H2 + C3H3-2",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(
+        A = (196.3, 'cm^3/(mol*s)'),
+        n = 3.47,
+        Ea = (3.214, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Narendrapurapu, B. S.', 'Simmonett, A. C.', 'Schaefer, H. F.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Combustion Chemistry: Important Features of the C3H5 Potential Energy Surface, Including Allyl Radical, Propargyl + H2, Allene + H, and Eight Transition States',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '115 (49)',
+        pages = '14209-14214',
+        year = '2011',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Accurate geometries are obtained using coupled cluster theory with single, double, and perturbative triple excitations [CCSD(T)] combined with Dunning’s correlation consistent quadruple-ζ basis set cc pVQZ. The energies for these stationary points are then refined by a systematic series of computations, within the focal point scheme, using the cc-pVXZ (X = D, T, Q, 5, 6) basis sets and correlation treatments as extensive as coupled cluster with full single, double, and triple excitation and perturbative quadruple excitations [CCSDT(Q)]. TST rates calculated in CanTherm
+""",
+)
+
+entry(
+    index = 1562,
+    label = "C3H4-1 + H <=> H2 + C3H3",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(
+        A = (14.13, 'cm^3/(mol*s)'),
+        n = 3.852,
+        Ea = (3.502, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Narendrapurapu, B. S.', 'Simmonett, A. C.', 'Schaefer, H. F.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Combustion Chemistry: Important Features of the C3H5 Potential Energy Surface, Including Allyl Radical, Propargyl + H2, Allene + H, and Eight Transition States',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '115 (49)',
+        pages = '14209-14214',
+        year = '2011',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Accurate geometries are obtained using coupled cluster theory with single, double, and perturbative triple excitations [CCSD(T)] combined with Dunning’s correlation consistent quadruple-ζ basis set cc pVQZ. The energies for these stationary points are then refined by a systematic series of computations, within the focal point scheme, using the cc-pVXZ (X = D, T, Q, 5, 6) basis sets and correlation treatments as extensive as coupled cluster with full single, double, and triple excitation and perturbative quadruple excitations [CCSDT(Q)]. TST rates calculated in CanTherm
+""",
+)
+

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -4653,3 +4653,112 @@ Accurate geometries are obtained using coupled cluster theory with single, doubl
 """,
 )
 
+entry(
+    index = 1563,
+    label = "C4H4 + CH3_p23 <=> CH4b + C4H3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.24, 'cm^3/(mol*s)'), n=3.335, Ea=(7.75, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+TST calculation based on the CBS-QB3 level of theory with 1D hinder rotoer consideration
+Jim Chu's calculation
+""",
+)
+
+entry(
+    index = 1564,
+    label = "C4H4 + H <=> H2 + C4H3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.092e+06, 'cm^3/(mol*s)'),
+        n = 2.211,
+        Ea = (7.181, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+TST calculation based on the CBS-QB3 level of theory with 1D hinder rotoer consideration
+Jim Chu's calculation
+""",
+)
+
+entry(
+    index = 1565,
+    label = "C4H6-5 + CH3_p23 <=> CH4b + C4H5-4",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (14.26, 'cm^3/(mol*s)'),
+        n = 3.317,
+        Ea = (6.61, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+TST calculation based on the CBS-QB3 level of theory with 1D hinder rotoer consideration
+Jim Chu's calculation
+""",
+)
+
+entry(
+    index = 1566,
+    label = "C4H6-5 + H <=> H2 + C4H5-4",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.867e+06, 'cm^3/(mol*s)'),
+        n = 2.242,
+        Ea = (5.318, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+TST calculation based on the CBS-QB3 level of theory with 1D hinder rotoer consideration
+Jim Chu's calculation
+""",
+)
+
+entry(
+    index = 1567,
+    label = "C4H6 + CH3_p23 <=> CH4b + C4H5-5",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (29.41, 'cm^3/(mol*s)'),
+        n = 3.184,
+        Ea = (5.529, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+TST calculation based on the CBS-QB3 level of theory with 1D hinder rotoer consideration
+Jim Chu's calculation
+""",
+)
+
+entry(
+    index = 1568,
+    label = "C4H6 + H <=> H2 + C4H5-5",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (8.501e+06, 'cm^3/(mol*s)'),
+        n = 2.027,
+        Ea = (4.069, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+TST calculation based on the CBS-QB3 level of theory with 1D hinder rotoer consideration
+Jim Chu's calculation
+""",
+)
+

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -5321,3 +5321,273 @@ G4//B3LYP/6-31G(2df,p)
 """,
 )
 
+entry(
+    index = 1589,
+    label = "C6H6 + H <=> H2 + C6H5",
+    degeneracy = 6.0,
+    kinetics = Arrhenius(
+        A = (4.57e+08, 'cm^3/(mol*s)'),
+        n = 1.88,
+        Ea = (14.839, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Semenikhin, A. S.', 'Savchenkova, A. S.', 'Chechet, I. V.', 'Matveev, S. G.', 'Liu, Z.', 'Frenklach, M.', 'Mebel, A. M.'],
+        title = u'Rate constants for H abstraction from benzo(a)pyrene and chrysene: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (37)',
+        pages = '25401-25413',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3(MP2,CC)//B3LYP
+""",
+)
+
+entry(
+    index = 1590,
+    label = "C12H8 + H <=> H2 + C12H7",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (3.27e+08, 'cm^3/(mol*s)'),
+        n = 1.71,
+        Ea = (16.236, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 4,
+    reference = Article(
+        authors = ['Violi, A.', 'Truong, T. N.', 'Sarofim, A. F.'],
+        title = u'Kinetics of Hydrogen Abstraction Reactions from Polycyclic Aromatic Hydrocarbons by H Atoms',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '108 (22)',
+        pages = '4846-4852',
+        year = '2004',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+B3LYP structural and vibrational information with BH&HLYP corrected barrier
+""",
+)
+
+entry(
+    index = 1591,
+    label = "C6H6 + OH <=> H2O + C6H5",
+    degeneracy = 6.0,
+    kinetics = Arrhenius(
+        A = (3.88e-20, 'cm^3/(molecule*s)'),
+        n = 2.683,
+        Ea = (0.7333, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 1,
+    reference = Article(
+        authors = ['Seta, T.', 'Nakajima, M.', 'Miyoshi, A.'],
+        title = u'High-Temperature Reactions of OH Radicals with Benzene and Toluene',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '110 (15)',
+        pages = '5081-5090',
+        year = '2006',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CBS-QB3 + Exp.
+""",
+)
+
+entry(
+    index = 1592,
+    label = "C6H6 + CH3_p23 <=> CH4b + C6H5",
+    degeneracy = 6.0,
+    kinetics = Arrhenius(
+        A = (3.07e-21, 'cm^3/(molecule*s)'),
+        n = 2.88,
+        Ea = (13.332, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Mai, T. V. T.', 'Ratkiewicz, A.', 'Duong, M. v.', 'Huynh, L. K.'],
+        title = u'Direct ab initio study of the C6H6+CH3/C2H5=C6H5+CH4/C2H6 reactions',
+        journal = 'Chemical Physics Letters',
+        volume = '646',
+        pages = '102-109',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)/CBS//BH&HLYP/cc-pVDZ, and canonical variational transition state theory (CVT) with corrections for small curvaturetunneling (SCT) and hindered internal rotation (HIR)
+""",
+)
+
+entry(
+    index = 1593,
+    label = "C6H6 + C2H5 <=> C2H6 + C6H5",
+    degeneracy = 6.0,
+    kinetics = Arrhenius(
+        A = (2.62e-22, 'cm^3/(molecule*s)'),
+        n = 3.11,
+        Ea = (18.66, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Mai, T. V. T.', 'Ratkiewicz, A.', 'Duong, M. v.', 'Huynh, L. K.'],
+        title = u'Direct ab initio study of the C6H6+CH3/C2H5=C6H5+CH4/C2H6 reactions',
+        journal = 'Chemical Physics Letters',
+        volume = '646',
+        pages = '102-109',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)/CBS//BH&HLYP/cc-pVDZ, and canonical variational transition state theory (CVT) with corrections for small curvaturetunneling (SCT) and hindered internal rotation (HIR)
+""",
+)
+
+entry(
+    index = 1594,
+    label = "C10H8 + H <=> H2 + C10H7",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(
+        A = (3.91e+08, 'cm^3/(mol*s)'),
+        n = 1.84,
+        Ea = (14.973, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Semenikhin, A. S.', 'Savchenkova, A. S.', 'Chechet, I. V.', 'Matveev, S. G.', 'Liu, Z.', 'Frenklach, M.', 'Mebel, A. M.'],
+        title = u'Rate constants for H abstraction from benzo(a)pyrene and chrysene: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (37)',
+        pages = '25401-25413',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3(MP2,CC)//B3LYP
+""",
+)
+
+entry(
+    index = 1595,
+    label = "C10H8-2 + H <=> H2 + C10H7-2",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(
+        A = (4.04e+08, 'cm^3/(mol*s)'),
+        n = 1.83,
+        Ea = (14.98, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Semenikhin, A. S.', 'Savchenkova, A. S.', 'Chechet, I. V.', 'Matveev, S. G.', 'Liu, Z.', 'Frenklach, M.', 'Mebel, A. M.'],
+        title = u'Rate constants for H abstraction from benzo(a)pyrene and chrysene: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (37)',
+        pages = '25401-25413',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3(MP2,CC)//B3LYP
+""",
+)
+
+entry(
+    index = 1596,
+    label = "C6H5 + H2 <=> C6H6 + H",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (16900, 'cm^3/(mol*s)'),
+        n = 2.63,
+        Ea = (4.559, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Semenikhin, A. S.', 'Savchenkova, A. S.', 'Chechet, I. V.', 'Matveev, S. G.', 'Liu, Z.', 'Frenklach, M.', 'Mebel, A. M.'],
+        title = u'Rate constants for H abstraction from benzo(a)pyrene and chrysene: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (37)',
+        pages = '25401-25413',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3(MP2,CC)//B3LYP
+""",
+)
+
+entry(
+    index = 1597,
+    label = "C10H7 + H2 <=> C10H8 + H",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (15800, 'cm^3/(mol*s)'),
+        n = 2.63,
+        Ea = (4.107, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Semenikhin, A. S.', 'Savchenkova, A. S.', 'Chechet, I. V.', 'Matveev, S. G.', 'Liu, Z.', 'Frenklach, M.', 'Mebel, A. M.'],
+        title = u'Rate constants for H abstraction from benzo(a)pyrene and chrysene: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (37)',
+        pages = '25401-25413',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3(MP2,CC)//B3LYP
+""",
+)
+
+entry(
+    index = 1598,
+    label = "C10H7-2 + H2 <=> C10H8-2 + H",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (18400, 'cm^3/(mol*s)'),
+        n = 2.61,
+        Ea = (4.446, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Semenikhin, A. S.', 'Savchenkova, A. S.', 'Chechet, I. V.', 'Matveev, S. G.', 'Liu, Z.', 'Frenklach, M.', 'Mebel, A. M.'],
+        title = u'Rate constants for H abstraction from benzo(a)pyrene and chrysene: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (37)',
+        pages = '25401-25413',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3(MP2,CC)//B3LYP
+""",
+)
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
@@ -5373,3 +5373,139 @@ multiplicity 2
 8    H u0 p0 c0 {4,S}
 9    H u0 p0 c0 {4,S}
 
+C7H7-9
+multiplicity 2
+1  *1 C u1 p0 c0 {2,D} {7,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {8,S}
+3  *6 C u0 p0 c0 {2,S} {4,D} {11,S}
+4  *5 C u0 p0 c0 {3,D} {5,S} {10,S}
+5  *2 C u0 p0 c0 {4,S} {6,D} {9,S}
+6  *3 C u0 p0 c0 {5,D} {7,S} {12,S}
+7     C u0 p0 c0 {1,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-10
+multiplicity 2
+1  *6 C u0 p0 c0 {2,D} {3,S} {9,S}
+2  *5 C u0 p0 c0 {1,D} {4,S} {8,S}
+3  *4 C u0 p0 c0 {1,S} {5,D} {10,S}
+4  *2 C u1 p0 c0 {2,S} {7,S} {11,S}
+5  *1 C u0 p0 c0 {3,D} {6,S} {7,S}
+6     C u0 p0 c0 {5,S} {7,S} {12,S} {13,S}
+7  *3 C u0 p0 c0 {4,S} {5,S} {6,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-11
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,D} {9,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,D} {5,S} {10,S}
+4     C u0 p0 c0 {2,D} {7,S} {11,S}
+5  *2 C u1 p0 c0 {3,S} {6,S} {7,S}
+6  *1 C u0 p0 c0 {5,S} {7,S} {12,S} {13,S}
+7  *3 C u0 p0 c0 {4,S} {5,S} {6,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-12
+multiplicity 2
+1  *1 C u1 p0 c0 {7,S} {8,S} {9,S}
+2     C u0 p0 c0 {3,S} {5,D} {11,S}
+3     C u0 p0 c0 {2,S} {4,D} {10,S}
+4     C u0 p0 c0 {3,D} {6,S} {13,S}
+5     C u0 p0 c0 {2,D} {7,S} {12,S}
+6  *3 C u0 p0 c0 {4,S} {7,D} {14,S}
+7  *2 C u0 p0 c0 {1,S} {5,S} {6,D}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+
+C7H7-13
+multiplicity 2
+1     C u0 p0 c0 {7,D} {8,S} {9,S}
+2  *2 C u0 p0 c0 {3,S} {6,D} {11,S}
+3  *5 C u0 p0 c0 {2,S} {4,D} {12,S}
+4  *4 C u0 p0 c0 {3,D} {5,S} {13,S}
+5  *1 C u1 p0 c0 {4,S} {7,S} {14,S}
+6  *3 C u0 p0 c0 {2,D} {7,S} {10,S}
+7     C u0 p0 c0 {1,D} {5,S} {6,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+
+C7H7-14
+multiplicity 2
+1     C u0 p0 c0 {5,D} {8,S} {9,S}
+2  *5 C u0 p0 c0 {3,S} {4,D} {10,S}
+3  *2 C u1 p0 c0 {2,S} {7,S} {11,S}
+4  *4 C u0 p0 c0 {2,D} {6,S} {12,S}
+5     C u0 p0 c0 {1,D} {6,S} {7,S}
+6  *1 C u0 p0 c0 {4,S} {5,S} {7,S} {14,S}
+7  *3 C u0 p0 c0 {3,S} {5,S} {6,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {6,S}
+
+C7H7-15
+multiplicity 2
+1     C u0 p0 c0 {5,D} {8,S} {9,S}
+2  *5 C u0 p0 c0 {3,S} {4,D} {10,S}
+3  *2 C u1 p0 c0 {2,S} {7,S} {12,S}
+4  *6 C u0 p0 c0 {2,D} {6,S} {11,S}
+5  *1 C u0 p0 c0 {1,D} {6,S} {7,S}
+6  *4 C u0 p0 c0 {4,S} {5,S} {7,S} {13,S}
+7  *3 C u0 p0 c0 {3,S} {5,S} {6,S} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-16
+multiplicity 2
+1  *1 C u1 p0 c0 {2,D} {7,S}
+2     C u0 p0 c0 {1,D} {8,S} {9,S}
+3  *5 C u0 p0 c0 {4,S} {5,D} {10,S}
+4  *2 C u0 p0 c0 {3,S} {6,D} {11,S}
+5  *6 C u0 p0 c0 {3,D} {7,S} {12,S}
+6  *3 C u0 p0 c0 {4,D} {7,S} {13,S}
+7  *4 C u0 p0 c0 {1,S} {5,S} {6,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/dictionary.txt
@@ -5277,3 +5277,99 @@ multiplicity 2
 13    H u0 p0 c0 {4,S}
 14    H u0 p0 c0 {6,S}
 
+C4H5
+multiplicity 2
+1 *2 C u0 p0 c0 {2,D} {4,S} {5,S}
+2 *3 C u0 p0 c0 {1,D} {6,S} {7,S}
+3    C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *1 C u1 p0 c0 {1,S} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C4H5-2
+multiplicity 2
+1 *3 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2 *1 C u0 p0 c0 {1,S} {3,S} {4,D}
+3 *2 C u1 p0 c0 {1,S} {2,S} {7,S}
+4    C u0 p0 c0 {2,D} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-3
+multiplicity 2
+1    C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+2 *3 C u0 p0 c0 {4,D} {8,S} {9,S}
+3 *1 C u1 p0 c0 {1,S} {4,D}
+4 *2 C u0 p0 c0 {2,D} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {2,S}
+
+C4H5-4
+multiplicity 2
+1 *3 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+2    C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3 *1 C u0 p0 c0 {1,S} {2,S} {4,D}
+4 *2 C u1 p0 c0 {1,S} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {2,S}
+
+C4H5-5
+multiplicity 2
+1    C u0 p0 c0 {3,D} {5,S} {6,S}
+2 *2 C u1 p0 c0 {3,S} {4,S} {7,S}
+3 *3 C u0 p0 c0 {1,D} {2,S} {4,S}
+4 *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-6
+multiplicity 2
+1 *3 C u0 p0 c0 {2,D} {4,D}
+2    C u0 p0 c0 {1,D} {5,S} {6,S}
+3 *1 C u1 p0 c0 {4,S} {7,S} {8,S}
+4 *2 C u0 p0 c0 {1,D} {3,S} {9,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-7
+multiplicity 2
+1 *2 C u1 p0 c0 {2,D} {4,S}
+2 *3 C u0 p0 c0 {1,D} {3,S} {4,S}
+3    C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+4 *1 C u0 p0 c0 {1,S} {2,S} {8,S} {9,S}
+5    H u0 p0 c0 {3,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-8
+multiplicity 2
+1 *2 C u0 p0 c0 {2,T} {3,S}
+2 *3 C u0 p0 c0 {1,T} {4,S}
+3 *1 C u1 p0 c0 {1,S} {5,S} {6,S}
+4    C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5    H u0 p0 c0 {3,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -1987,49 +1987,45 @@ Taken from entry: W3 <=> W4
 
 entry(
     index = 83,
-    label = "C6H7-7 <=> C6H7-8",
-    degeneracy = 2.0,
-    kinetics = Arrhenius(A=(3.18e+11, 's^-1'), n=0.17, Ea=(4.4, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
+    label = "C6H7-8 <=> C6H7-7",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.018e+12, 's^-1'), n=0.05, Ea=(5.961, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
     reference = Article(
-        authors = ['A. J. Vervust', 'M. R. Djokic', 'S. S. Merchant', 'H.-H. Carstensen', 'A. E. Long', 'G. B. Marin', 'W. H. Green', 'K. M. Van Geem'],
-        title = u'Detailed Experimental and Kinetic Modeling Study of Cyclopentadiene Pyrolysis in the Presence of Ethene',
-        journal = 'Energy & Fuels',
-        volume = '32(3)',
-        pages = '3920-3934',
-        year = '2018',
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
     ),
     referenceType = 'theory',
     shortDesc = u"""""",
     longDesc = 
 u"""
-Calculations done at CBS-QB3 level of theory
-From kinetics library: Fulvene_H
-Taken from entry: C5H5CH2-1 <=> biring1
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
 entry(
     index = 84,
-    label = "C6H7-9 <=> C6H7-10",
+    label = "C6H7-10 <=> C6H7-9",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(8.51e+11, 's^-1'), n=0.41, Ea=(16.7, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
+    kinetics = Arrhenius(A=(1.307e+12, 's^-1'), n=0.256, Ea=(36.797, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
     reference = Article(
-        authors = ['A. J. Vervust', 'M. R. Djokic', 'S. S. Merchant', 'H.-H. Carstensen', 'A. E. Long', 'G. B. Marin', 'W. H. Green', 'K. M. Van Geem'],
-        title = u'Detailed Experimental and Kinetic Modeling Study of Cyclopentadiene Pyrolysis in the Presence of Ethene',
-        journal = 'Energy & Fuels',
-        volume = '32(3)',
-        pages = '3920-3934',
-        year = '2018',
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
     ),
     referenceType = 'theory',
     shortDesc = u"""""",
     longDesc = 
 u"""
-Calculations done at CBS-QB3 level of theory
-From kinetics library: Fulvene_H
-Taken from entry: biring1 <=> cyC6H7
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -3141,23 +3141,21 @@ entry(
     index = 131,
     label = "C7H7-3 <=> C7H7-4",
     degeneracy = 2.0,
-    kinetics = Arrhenius(A=(3.32e+11, 's^-1'), n=0.3, Ea=(8.6, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
+    kinetics = Arrhenius(A=(9.25e+11, 's^-1'), n=0.16, Ea=(9.81, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
     reference = Article(
-        authors = ['A. J. Vervust', 'M. R. Djokic', 'S. S. Merchant', 'H.-H. Carstensen', 'A. E. Long', 'G. B. Marin', 'W. H. Green', 'K. M. Van Geem'],
-        title = u'Detailed Experimental and Kinetic Modeling Study of Cyclopentadiene Pyrolysis in the Presence of Ethene',
-        journal = 'Energy & Fuels',
-        volume = '32(3)',
-        pages = '3920-3934',
-        year = '2018',
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
     ),
     referenceType = 'theory',
     shortDesc = u"""""",
     longDesc = 
 u"""
-Calculations done at CBS-QB3 level of theory
-From kinetics library: vinylCPD_H
-Taken from entry: product44 <=> product45
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 
@@ -3165,23 +3163,21 @@ entry(
     index = 132,
     label = "C7H7-5 <=> C7H7-6",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(3.84e+11, 's^-1'), n=0.66, Ea=(23.8, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
+    kinetics = Arrhenius(A=(4.51e+12, 's^-1'), n=0.26, Ea=(25.25, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
     reference = Article(
-        authors = ['A. J. Vervust', 'M. R. Djokic', 'S. S. Merchant', 'H.-H. Carstensen', 'A. E. Long', 'G. B. Marin', 'W. H. Green', 'K. M. Van Geem'],
-        title = u'Detailed Experimental and Kinetic Modeling Study of Cyclopentadiene Pyrolysis in the Presence of Ethene',
-        journal = 'Energy & Fuels',
-        volume = '32(3)',
-        pages = '3920-3934',
-        year = '2018',
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
     ),
     referenceType = 'theory',
     shortDesc = u"""""",
     longDesc = 
 u"""
-Calculations done at CBS-QB3 level of theory
-From kinetics library: vinylCPD_H
-Taken from entry: product45 <=> product33
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 
@@ -3294,6 +3290,94 @@ entry(
     longDesc = 
 u"""
 CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 138,
+    label = "C7H7-9 <=> C7H7-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.1e+12, 's^-1'), n=0.14, Ea=(0.3, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 139,
+    label = "C7H7-11 <=> C7H7-12",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.24e+12, 's^-1'), n=0.31, Ea=(3.62, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 140,
+    label = "C7H7-13 <=> C7H7-14",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.98e+12, 's^-1'), n=0.5, Ea=(61, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 141,
+    label = "C7H7-15 <=> C7H7-16",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.8e+13, 's^-1'), n=0.15, Ea=(19.35, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -3209,3 +3209,91 @@ Taken from entry: product46 <=> BENZYL
 """,
 )
 
+entry(
+    index = 134,
+    label = "C4H5 <=> C4H5-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.605e+12, 's^-1'), n=0.275, Ea=(32.899, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 135,
+    label = "C4H5-3 <=> C4H5-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.631e+12, 's^-1'), n=0.216, Ea=(46.951, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 136,
+    label = "C4H5-5 <=> C4H5-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.403e+13, 's^-1'), n=0.233, Ea=(17.146, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 137,
+    label = "C4H5-7 <=> C4H5-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.114e+13, 's^-1'), n=0.256, Ea=(8.237, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+

--- a/input/kinetics/families/Intra_ene_reaction/training/dictionary.txt
+++ b/input/kinetics/families/Intra_ene_reaction/training/dictionary.txt
@@ -584,3 +584,105 @@ multiplicity 2
 18    H u0 p0 c0 {10,S}
 19    H u0 p0 c0 {10,S}
 
+C7H7
+multiplicity 2
+1     C u1 p0 c0 {2,D} {8,S}
+2     C u0 p0 c0 {1,D} {7,S} {9,S}
+3  *4 C u0 p0 c0 {4,S} {5,D} {10,S}
+4  *3 C u0 p0 c0 {3,S} {6,D} {11,S}
+5  *5 C u0 p0 c0 {3,D} {7,S} {12,S}
+6  *2 C u0 p0 c0 {4,D} {7,S} {13,S}
+7  *1 C u0 p0 c0 {2,S} {5,S} {6,S} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14 *6 H u0 p0 c0 {7,S}
+
+C7H7-2
+multiplicity 2
+1     C u1 p0 c0 {2,D} {8,S}
+2     C u0 p0 c0 {1,D} {6,S} {9,S}
+3  *4 C u0 p0 c0 {4,S} {5,D} {11,S}
+4  *3 C u0 p0 c0 {3,S} {6,D} {10,S}
+5  *5 C u0 p0 c0 {3,D} {7,S} {12,S}
+6  *2 C u0 p0 c0 {2,S} {4,D} {7,S}
+7  *1 C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13 *6 H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-3
+multiplicity 2
+1     C u1 p0 c0 {2,D} {7,S}
+2     C u0 p0 c0 {1,D} {8,S} {9,S}
+3  *4 C u0 p0 c0 {4,S} {5,D} {10,S}
+4  *3 C u0 p0 c0 {3,S} {6,D} {11,S}
+5  *5 C u0 p0 c0 {3,D} {7,S} {12,S}
+6  *2 C u0 p0 c0 {4,D} {7,S} {13,S}
+7  *1 C u0 p0 c0 {1,S} {5,S} {6,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+14 *6 H u0 p0 c0 {7,S}
+
+C7H7-4
+multiplicity 2
+1     C u1 p0 c0 {2,D} {6,S}
+2     C u0 p0 c0 {1,D} {8,S} {9,S}
+3  *4 C u0 p0 c0 {4,S} {5,D} {11,S}
+4  *3 C u0 p0 c0 {3,S} {6,D} {10,S}
+5  *5 C u0 p0 c0 {3,D} {7,S} {12,S}
+6  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+7  *1 C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13 *6 H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-5
+multiplicity 2
+1     C u1 p0 c0 {2,S} {7,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {3,D} {9,S}
+3  *3 C u0 p0 c0 {2,D} {4,S} {10,S}
+4  *4 C u0 p0 c0 {3,S} {5,D} {11,S}
+5  *5 C u0 p0 c0 {4,D} {6,S} {12,S}
+6  *1 C u0 p0 c0 {5,S} {7,D} {13,S}
+7     C u0 p0 c0 {1,S} {6,D} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13 *6 H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-6
+multiplicity 2
+1  *2 C u0 p0 c0 {2,D} {3,D}
+2  *3 C u0 p0 c0 {1,D} {4,S} {8,S}
+3     C u0 p0 c0 {1,D} {5,S} {9,S}
+4  *4 C u0 p0 c0 {2,S} {6,D} {10,S}
+5     C u1 p0 c0 {3,S} {7,S} {11,S}
+6  *5 C u0 p0 c0 {4,D} {7,S} {12,S}
+7  *1 C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14 *6 H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/Intra_ene_reaction/training/reactions.py
+++ b/input/kinetics/families/Intra_ene_reaction/training/reactions.py
@@ -80,31 +80,47 @@ Taken from entry: VIII <=> II
 """,
 )
 
-
-
 entry(
     index = 6,
     label = "C6H8 <=> C6H8-2",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(7.0333e+08, 's^-1'), n=1.2, Ea=(24.8, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(3.201e+11, 's^-1'), n=0.6, Ea=(23.767, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C5H5CH3-5 <=> C5H5CH3-1
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
 entry(
     index = 7,
     label = "C6H8-3 <=> C6H8-4",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.6539e+07, 's^-1'), n=2.1, Ea=(25.1, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(4.432e+11, 's^-1'), n=0.625, Ea=(26.957, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C5H5CH3-1 <=> C5H5CH3-2
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -290,6 +306,4 @@ u"""
 G3SX//B3LYP/6-31G(2df,p)
 """,
 )
-
-
 

--- a/input/kinetics/families/Intra_ene_reaction/training/reactions.py
+++ b/input/kinetics/families/Intra_ene_reaction/training/reactions.py
@@ -108,22 +108,27 @@ Taken from entry: C5H5CH3-1 <=> C5H5CH3-2
 """,
 )
 
-
-
 entry(
     index = 8,
     label = "C6H7 <=> C6H7-2",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(2.23e+07, 's^-1'), n=1.54, Ea=(13.4, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(2.27e+10, 's^-1'), n=0.581, Ea=(16.586, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C5H5CH2-1 <=> C5H5CH2-2
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
-
-
 
 entry(
     index = 9,
@@ -285,4 +290,6 @@ u"""
 G3SX//B3LYP/6-31G(2df,p)
 """,
 )
+
+
 

--- a/input/kinetics/families/Intra_ene_reaction/training/reactions.py
+++ b/input/kinetics/families/Intra_ene_reaction/training/reactions.py
@@ -220,3 +220,69 @@ Taken from entry: W107 <=> W108
 """,
 )
 
+entry(
+    index = 16,
+    label = "C7H7 <=> C7H7-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(1.01e+10, 's^-1'), n=0.97, Ea=(19.17, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 17,
+    label = "C7H7-3 <=> C7H7-4",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(6.21e+08, 's^-1'), n=1.38, Ea=(15.29, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 18,
+    label = "C7H7-5 <=> C7H7-6",
+    degeneracy = 14.0,
+    kinetics = Arrhenius(A=(5.5e+08, 's^-1'), n=1.56, Ea=(62.12, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+

--- a/input/kinetics/families/R_Addition_COm/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_COm/training/dictionary.txt
@@ -18,3 +18,25 @@ multiplicity 2
 5    H u0 p0 c0 {1,S}
 6 *3 O u0 p2 c0 {2,D}
 
+C3H5O
+multiplicity 2
+1 *3 O u0 p2 c0 {2,D}
+2 *1 C u1 p0 c0 {1,D} {4,S}
+3    C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4 *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5    H u0 p0 c0 {3,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C2H5
+multiplicity 2
+1    C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 *2 C u1 p0 c0 {1,S} {6,S} {7,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+

--- a/input/kinetics/families/R_Addition_COm/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_COm/training/dictionary.txt
@@ -1,0 +1,20 @@
+CH3
+multiplicity 2
+1 *2 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+CO
+1 *1 C u0 p1 c-1 {2,T}
+2 *3 O u0 p1 c+1 {1,T}
+
+C2H3O
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 *1 C u1 p0 c0 {1,S} {6,D}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6 *3 O u0 p2 c0 {2,D}
+

--- a/input/kinetics/families/R_Addition_COm/training/reactions.py
+++ b/input/kinetics/families/R_Addition_COm/training/reactions.py
@@ -7,3 +7,52 @@ longDesc = u"""
 Put kinetic parameters for reactions to use as a training set for fitting
 group additivity values in this file.
 """
+entry(
+    index = 1,
+    label = "CH3 + CO <=> C2H3O",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.634e+07, 'cm^3/(mol*s)'),
+        n = 1.512,
+        Ea = (6.013, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Senosiain, J. P.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'Pathways and Rate Coefficients for the Decomposition of Vinoxy and Acetyl Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '110 (17)',
+        pages = '5772-5781',
+        year = '2006',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
+""",
+)
+
+entry(
+    index = 2,
+    label = "C2H3O <=> CO + CH3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.07e+12, 's^-1'), n=0.63, Ea=(70698, 'J/mol'), T0=(1, 'K')),
+    rank = 3,
+    reference = Article(
+        authors = ['Senosiain, J. P.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'Pathways and Rate Coefficients for the Decomposition of Vinoxy and Acetyl Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '110 (17)',
+        pages = '5772-5781',
+        year = '2006',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
+""",
+)
+

--- a/input/kinetics/families/R_Addition_COm/training/reactions.py
+++ b/input/kinetics/families/R_Addition_COm/training/reactions.py
@@ -56,3 +56,25 @@ RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
 """,
 )
 
+entry(
+    index = 3,
+    label = "C3H5O <=> CO + C2H5",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(8.417e+12, 's^-1'), n=0.428, Ea=(15.009, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -6273,3 +6273,75 @@ multiplicity 2
 8    H u0 p0 c0 {2,S}
 9    H u0 p0 c0 {4,S}
 
+C3H5O-2
+multiplicity 2
+1    O u0 p2 c0 {2,D}
+2 *2 C u1 p0 c0 {1,D} {4,S}
+3 *3 C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4 *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5    H u0 p0 c0 {3,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C3H5O-3
+multiplicity 2
+1    O u0 p2 c0 {3,D}
+2 *2 C u1 p0 c0 {3,S} {5,S} {6,S}
+3 *1 C u0 p0 c0 {1,D} {2,S} {4,S}
+4 *3 C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C3H5O-4
+multiplicity 2
+1 *3 O u0 p2 c0 {3,S} {5,S}
+2 *2 C u1 p0 c0 {3,D} {4,S}
+3 *1 C u0 p0 c0 {1,S} {2,D} {6,S}
+4    C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C3H5O-5
+multiplicity 2
+1 *3 O u0 p2 c0 {3,S} {6,S}
+2 *2 C u1 p0 c0 {3,D} {5,S}
+3 *1 C u0 p0 c0 {1,S} {2,D} {4,S}
+4    C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C3H5O-6
+multiplicity 2
+1 *3 O u0 p2 c0 {4,S} {5,S}
+2 *2 C u1 p0 c0 {3,D} {4,S}
+3    C u0 p0 c0 {2,D} {6,S} {7,S}
+4 *1 C u0 p0 c0 {1,S} {2,S} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C3H5O-7
+multiplicity 2
+1 *3 O u0 p2 c0 {4,S} {5,S}
+2 *2 C u1 p0 c0 {4,S} {6,S} {7,S}
+3    C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *1 C u0 p0 c0 {1,S} {2,S} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -6345,3 +6345,67 @@ multiplicity 2
 8    H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
+C7H7-4
+multiplicity 2
+1  *2 C u1 p0 c0 {2,D} {8,S}
+2  *1 C u0 p0 c0 {1,D} {6,S} {9,S}
+3     C u0 p0 c0 {4,S} {5,D} {11,S}
+4     C u0 p0 c0 {3,S} {6,D} {10,S}
+5     C u0 p0 c0 {3,D} {7,S} {12,S}
+6     C u0 p0 c0 {2,S} {4,D} {7,S}
+7     C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {1,S}
+9  *3 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H6-2
+1  *2 C u0 p0 c0 {2,T} {8,S}
+2  *1 C u0 p0 c0 {1,T} {6,S}
+3     C u0 p0 c0 {4,S} {5,D} {10,S}
+4     C u0 p0 c0 {3,S} {6,D} {9,S}
+5     C u0 p0 c0 {3,D} {7,S} {11,S}
+6     C u0 p0 c0 {2,S} {4,D} {7,S}
+7     C u0 p0 c0 {5,S} {6,S} {12,S} {13,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {7,S}
+13    H u0 p0 c0 {7,S}
+
+C7H7-5
+multiplicity 2
+1     C u0 p0 c0 {2,D} {6,D}
+2     C u0 p0 c0 {1,D} {8,S} {9,S}
+3     C u0 p0 c0 {4,D} {5,S} {11,S}
+4     C u0 p0 c0 {3,D} {6,S} {10,S}
+5  *2 C u1 p0 c0 {3,S} {7,S} {12,S}
+6     C u0 p0 c0 {1,D} {4,S} {7,S}
+7  *1 C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14 *3 H u0 p0 c0 {7,S}
+
+C7H6-3
+1     C u0 p0 c0 {2,D} {7,D}
+2     C u0 p0 c0 {1,D} {8,S} {9,S}
+3  *2 C u0 p0 c0 {4,S} {5,D} {12,S}
+4     C u0 p0 c0 {3,S} {6,D} {13,S}
+5  *1 C u0 p0 c0 {3,D} {7,S} {10,S}
+6     C u0 p0 c0 {4,D} {7,S} {11,S}
+7     C u0 p0 c0 {1,D} {5,S} {6,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -6125,3 +6125,151 @@ multiplicity 2
 6    H u0 p0 c0 {2,S}
 7 *3 H u0 p0 c0 {4,S}
 
+C4H4-5
+1 *2 C u0 p0 c0 {2,S} {3,S} {4,D}
+2    C u0 p0 c0 {1,S} {3,D} {5,S}
+3    C u0 p0 c0 {1,S} {2,D} {6,S}
+4 *1 C u0 p0 c0 {1,D} {7,S} {8,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+
+C4H5-3
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2 *2 C u1 p0 c0 {1,S} {3,S} {4,S}
+3    C u0 p0 c0 {2,S} {4,D} {8,S}
+4    C u0 p0 c0 {2,S} {3,D} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7 *3 H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+
+C4H4-6
+1    C u0 p0 c0 {2,S} {3,S} {4,D}
+2 *1 C u0 p0 c0 {1,S} {3,D} {5,S}
+3 *2 C u0 p0 c0 {1,S} {2,D} {6,S}
+4    C u0 p0 c0 {1,D} {7,S} {8,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+
+C4H5-4
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2    C u0 p0 c0 {1,S} {3,S} {4,D}
+3 *2 C u1 p0 c0 {1,S} {2,S} {7,S}
+4    C u0 p0 c0 {2,D} {8,S} {9,S}
+5    H u0 p0 c0 {1,S}
+6 *3 H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
+
+C4H4-7
+1    C u0 p0 c0 {3,D} {5,S} {6,S}
+2    C u0 p0 c0 {4,D} {7,S} {8,S}
+3 *1 C u0 p0 c0 {1,D} {4,D}
+4 *2 C u0 p0 c0 {2,D} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {2,S}
+
+C4H5-5
+multiplicity 2
+1 *1 C u0 p0 c0 {2,D} {4,S} {5,S}
+2    C u0 p0 c0 {1,D} {6,S} {7,S}
+3    C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *2 C u1 p0 c0 {1,S} {3,D}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C4H5-6
+multiplicity 2
+1    C u0 p0 c0 {2,D} {4,S} {5,S}
+2    C u0 p0 c0 {1,D} {6,S} {7,S}
+3 *1 C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *2 C u1 p0 c0 {1,S} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9 *3 H u0 p0 c0 {3,S}
+
+C4H5-7
+multiplicity 2
+1    C u0 p0 c0 {2,S} {3,D} {5,S}
+2 *1 C u0 p0 c0 {1,S} {4,D} {6,S}
+3    C u0 p0 c0 {1,D} {7,S} {8,S}
+4 *2 C u1 p0 c0 {2,D} {9,S}
+5    H u0 p0 c0 {1,S}
+6 *3 H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-8
+multiplicity 2
+1 *3 C u0 p0 c0 {2,S} {3,D} {5,S}
+2 *1 C u0 p0 c0 {1,S} {4,D} {6,S}
+3    C u0 p0 c0 {1,D} {7,S} {8,S}
+4 *2 C u1 p0 c0 {2,D} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-9
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2 *2 C u1 p0 c0 {1,S} {3,S} {8,S}
+3    C u0 p0 c0 {2,S} {4,T}
+4    C u0 p0 c0 {3,T} {9,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7 *3 H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {4,S}
+
+C4H4-8
+1 *1 C u0 p0 c0 {3,D} {5,S} {6,S}
+2    C u0 p0 c0 {4,D} {7,S} {8,S}
+3 *2 C u0 p0 c0 {1,D} {4,D}
+4    C u0 p0 c0 {2,D} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {2,S}
+
+C4H5-10
+multiplicity 2
+1 *1 C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+2    C u0 p0 c0 {4,D} {8,S} {9,S}
+3 *2 C u1 p0 c0 {1,S} {4,D}
+4    C u0 p0 c0 {2,D} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7 *3 H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {2,S}
+
+C4H5-11
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2 *2 C u1 p0 c0 {1,S} {7,S} {8,S}
+3    C u0 p0 c0 {1,S} {4,T}
+4    C u0 p0 c0 {3,T} {9,S}
+5    H u0 p0 c0 {1,S}
+6 *3 H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -6409,3 +6409,75 @@ C7H6-3
 12    H u0 p0 c0 {3,S}
 13    H u0 p0 c0 {4,S}
 
+C7H8-14
+1  *2 C u0 p0 c0 {2,B} {4,B} {9,S}
+2     C u0 p0 c0 {1,B} {3,B} {10,S}
+3     C u0 p0 c0 {2,B} {5,B} {11,S}
+4  *1 C u0 p0 c0 {1,B} {6,B} {8,S}
+5     C u0 p0 c0 {3,B} {6,B} {12,S}
+6     C u0 p0 c0 {4,B} {5,B} {7,S}
+7     C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H9-28
+multiplicity 2
+1     C u0 p0 c0 {2,D} {3,S} {9,S}
+2     C u0 p0 c0 {1,D} {4,S} {8,S}
+3     C u0 p0 c0 {1,S} {5,D} {10,S}
+4  *2 C u1 p0 c0 {2,S} {7,S} {11,S}
+5     C u0 p0 c0 {3,D} {6,S} {7,S}
+6     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+7  *1 C u0 p0 c0 {4,S} {5,S} {15,S} {16,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16 *3 H u0 p0 c0 {7,S}
+
+C7H8-15
+1  *1 C u0 p0 c0 {2,B} {4,B} {9,S}
+2  *2 C u0 p0 c0 {1,B} {3,B} {10,S}
+3     C u0 p0 c0 {2,B} {5,B} {11,S}
+4     C u0 p0 c0 {1,B} {6,B} {8,S}
+5     C u0 p0 c0 {3,B} {6,B} {12,S}
+6     C u0 p0 c0 {4,B} {5,B} {7,S}
+7     C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H9-29
+multiplicity 2
+1     C u0 p0 c0 {2,D} {3,S} {8,S}
+2     C u0 p0 c0 {1,D} {5,S} {9,S}
+3  *2 C u1 p0 c0 {1,S} {7,S} {11,S}
+4     C u0 p0 c0 {5,D} {7,S} {10,S}
+5     C u0 p0 c0 {2,S} {4,D} {6,S}
+6     C u0 p0 c0 {5,S} {12,S} {13,S} {14,S}
+7  *1 C u0 p0 c0 {3,S} {4,S} {15,S} {16,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {7,S}
+16 *3 H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -6047,3 +6047,45 @@ multiplicity 2
 2 *2 S u1 p1 c0 {1,S} {3,D}
 3    O u0 p2 c0 {2,D}
 4    H u0 p0 c0 {1,S}
+
+C2H2O-2
+1 *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 *2 C u0 p0 c0 {1,D} {5,D}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    O u0 p2 c0 {2,D}
+
+C2H3O
+multiplicity 2
+1 *1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 *2 C u1 p0 c0 {1,S} {6,D}
+3 *3 H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6    O u0 p2 c0 {2,D}
+
+C2H3O-2
+multiplicity 2
+1 *2 C u1 p0 c0 {2,S} {5,S} {6,S}
+2 *1 C u0 p0 c0 {1,S} {3,D} {4,S}
+3    O u0 p2 c0 {2,D}
+4 *3 H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+
+C2H3O-3
+multiplicity 2
+1 *2 O u1 p2 c0 {3,S}
+2    C u0 p0 c0 {3,D} {4,S} {5,S}
+3 *1 C u0 p0 c0 {1,S} {2,D} {6,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6 *3 H u0 p0 c0 {3,S}
+
+C2H2O-3
+1 *2 O u0 p2 c0 {2,D}
+2 *1 C u0 p0 c0 {1,D} {3,D}
+3    C u0 p0 c0 {2,D} {4,S} {5,S}
+4    H u0 p0 c0 {3,S}
+5    H u0 p0 c0 {3,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/dictionary.txt
@@ -6089,3 +6089,39 @@ C2H2O-3
 4    H u0 p0 c0 {3,S}
 5    H u0 p0 c0 {3,S}
 
+C4H2
+1 *1 C u0 p0 c0 {3,T} {5,S}
+2    C u0 p0 c0 {4,T} {6,S}
+3 *2 C u0 p0 c0 {1,T} {4,S}
+4    C u0 p0 c0 {2,T} {3,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+
+C4H3
+multiplicity 2
+1    C u0 p0 c0 {2,T} {5,S}
+2    C u0 p0 c0 {1,T} {3,S}
+3 *2 C u1 p0 c0 {2,S} {4,D}
+4 *1 C u0 p0 c0 {3,D} {6,S} {7,S}
+5    H u0 p0 c0 {1,S}
+6 *3 H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+
+C4H2-2
+1 *2 C u0 p0 c0 {3,T} {5,S}
+2    C u0 p0 c0 {4,T} {6,S}
+3 *1 C u0 p0 c0 {1,T} {4,S}
+4    C u0 p0 c0 {2,T} {3,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+
+C4H3-2
+multiplicity 2
+1    C u0 p0 c0 {3,T} {5,S}
+2 *2 C u1 p0 c0 {4,D} {6,S}
+3    C u0 p0 c0 {1,T} {4,S}
+4 *1 C u0 p0 c0 {2,D} {3,S} {7,S}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7 *3 H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -2986,3 +2986,79 @@ The paper reports a HO-RR rate, and a sum-over-states rate (where vib-rot aren't
 The sum-over-states rate was taken here.
 """,
 )
+entry(
+    index = 186,
+    label = "H + C2H2O-2 <=> C2H3O",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.82e-16, 'cm^3/(molecule*s)'),
+        n = 1.61,
+        Ea = (10992, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Senosiain, J. P.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'Pathways and Rate Coefficients for the Decomposition of Vinoxy and Acetyl Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '110 (17)',
+        pages = '5772-5781',
+        year = '2006',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
+""",
+)
+
+entry(
+    index = 187,
+    label = "H + C2H2O <=> C2H3O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.3e-15, 'cm^3/(molecule*s)'),
+        n = 1.43,
+        Ea = (25318, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Senosiain, J. P.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'Pathways and Rate Coefficients for the Decomposition of Vinoxy and Acetyl Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '110 (17)',
+        pages = '5772-5781',
+        year = '2006',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
+""",
+)
+
+entry(
+    index = 188,
+    label = "C2H3O-3 <=> C2H2O-3 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.43e+15, 's^-1'), n=-0.15, Ea=(190834, 'J/mol'), T0=(1, 'K')),
+    rank = 3,
+    reference = Article(
+        authors = ['Senosiain, J. P.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'Pathways and Rate Coefficients for the Decomposition of Vinoxy and Acetyl Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '110 (17)',
+        pages = '5772-5781',
+        year = '2006',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -3118,3 +3118,443 @@ These QCISD(T) calculations employed the correlation-consistent, polarized-valen
 """,
 )
 
+entry(
+    index = 191,
+    label = "C4H4-5 + H <=> C4H5-3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.802e+09, 'cm^3/(mol*s)'),
+        n = 1.467,
+        Ea = (0.65, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 192,
+    label = "C4H4-6 + H <=> C4H5-4",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.644e+09, 'cm^3/(mol*s)'),
+        n = 1.533,
+        Ea = (1.858, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 193,
+    label = "C4H4-7 + H <=> C4H5-5",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.246e+09, 'cm^3/(mol*s)'),
+        n = 1.429,
+        Ea = (3.987, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 194,
+    label = "C4H4-3 + H <=> C4H5-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.156e+09, 'cm^3/(mol*s)'),
+        n = 1.502,
+        Ea = (2.371, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 195,
+    label = "C4H4-2 + H <=> C4H5-7",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.642e+08, 'cm^3/(mol*s)'),
+        n = 1.548,
+        Ea = (4.546, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 196,
+    label = "C2H2 + C2H3 <=> C4H5-8",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.168e+07, 'cm^3/(mol*s)'),
+        n = 1.997,
+        Ea = (5.452, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 197,
+    label = "C4H4 + H <=> C4H5-9",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.163e+09, 'cm^3/(mol*s)'),
+        n = 1.493,
+        Ea = (1.378, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 198,
+    label = "C4H4-8 + H <=> C4H5-10",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (3.466e+09, 'cm^3/(mol*s)'),
+        n = 1.473,
+        Ea = (1.273, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 199,
+    label = "C4H4-4 + H <=> C4H5-11",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.726e+08, 'cm^3/(mol*s)'),
+        n = 1.617,
+        Ea = (4.056, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 200,
+    label = "C4H5-3 <=> C4H4-5 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.385e+09, 's^-1'), n=1.347, Ea=(37.909, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 201,
+    label = "C4H5-4 <=> C4H4-6 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.905e+11, 's^-1'), n=0.877, Ea=(54.203, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 202,
+    label = "C4H5-5 <=> C4H4-7 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.575e+11, 's^-1'), n=0.753, Ea=(57.151, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 203,
+    label = "C4H5-6 <=> C4H4-3 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.976e+12, 's^-1'), n=0.79, Ea=(47.629, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 204,
+    label = "C4H5-7 <=> C4H4-2 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.502e+09, 's^-1'), n=1.257, Ea=(39.226, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 205,
+    label = "C4H5-8 <=> C2H2 + C2H3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.898e+14, 's^-1'), n=0.366, Ea=(45.569, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 206,
+    label = "C4H5-9 <=> C4H4 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.345e+09, 's^-1'), n=1.312, Ea=(45.774, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+entry(
+    index = 207,
+    label = "C4H5-10 <=> C4H4-8 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.727e+09, 's^-1'), n=1.411, Ea=(56.058, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 208,
+    label = "C4H5-11 <=> C4H4-4 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.246e+09, 's^-1'), n=1.319, Ea=(35.573, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -3836,3 +3836,57 @@ G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 
+entry(
+    index = 217,
+    label = "C7H8-14 + H <=> C7H9-28",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (5.726e+07, 'cm^3/(mol*s)'),
+        n = 1.725,
+        Ea = (2.395, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Bao, J. L.', 'Zheng, J.', 'Truhlar, D. G.'],
+        title = u'Kinetics of Hydrogen Radical Reactions with Toluene Including Chemical Activation Theory Employing System-Specific Quantum RRK Theory Calibrated by Variational Transition State Theory',
+        journal = 'Journal of the American Chemical Society',
+        volume = '138 (8)',
+        pages = '2690-2704',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+System-specific (SS) QRRK approach is adjusted with SS parameters to agree with multistructural canonical variational transition state theory with multidimensional tunneling (MS-CVT/SCT) at the high-pressure limit. The MPW1K/MG3S level of theory
+""",
+)
+
+entry(
+    index = 218,
+    label = "C7H8-15 + H <=> C7H9-29",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.757e+07, 'cm^3/(mol*s)'),
+        n = 1.859,
+        Ea = (2.679, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Bao, J. L.', 'Zheng, J.', 'Truhlar, D. G.'],
+        title = u'Kinetics of Hydrogen Radical Reactions with Toluene Including Chemical Activation Theory Employing System-Specific Quantum RRK Theory Calibrated by Variational Transition State Theory',
+        journal = 'Journal of the American Chemical Society',
+        volume = '138 (8)',
+        pages = '2690-2704',
+        year = '2016',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+System-specific (SS) QRRK approach is adjusted with SS parameters to agree with multistructural canonical variational transition state theory with multidimensional tunneling (MS-CVT/SCT) at the high-pressure limit. The MPW1K/MG3S level of theory
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -1069,16 +1069,25 @@ entry(
     label = "C6H6 + H <=> C6H7-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
-        A = (1.69e+09, 'cm^3/(mol*s)'),
-        n = 1.46,
-        Ea = (-0.7, 'kcal/mol'),
+        A = (1.031e+09, 'cm^3/(mol*s)'),
+        n = 1.339,
+        Ea = (-0.477, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: FULVENE + H <=> C5H4CH3
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -1086,12 +1095,26 @@ entry(
     index = 64,
     label = "C6H6-3 + H <=> C6H7-5",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.31e+08, 'cm^3/(mol*s)'), n=1.76, Ea=(2, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    kinetics = Arrhenius(
+        A = (1.997e+08, 'cm^3/(mol*s)'),
+        n = 1.629,
+        Ea = (3.519, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: FULVENE + H <=> C5H5CH2-1
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -1100,16 +1123,25 @@ entry(
     label = "C6H6-5 + H <=> C6H7-6",
     degeneracy = 2.0,
     kinetics = Arrhenius(
-        A = (7.26e+09, 'cm^3/(mol*s)'),
-        n = 1.48,
-        Ea = (0.4, 'kcal/mol'),
+        A = (8.37e+08, 'cm^3/(mol*s)'),
+        n = 1.488,
+        Ea = (2.039, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: FULVENE + H <=> C5H5CH2-3
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -1118,29 +1150,52 @@ entry(
     label = "C6H6-4 + H <=> C6H7-7",
     degeneracy = 2.0,
     kinetics = Arrhenius(
-        A = (3.52e+09, 'cm^3/(mol*s)'),
-        n = 1.52,
-        Ea = (0.9, 'kcal/mol'),
+        A = (2.022e+09, 'cm^3/(mol*s)'),
+        n = 1.369,
+        Ea = (2.244, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: FULVENE + H <=> C5H5CH2-2
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
 entry(
     index = 67,
-    label = "C6H7-8 <=> C6H6-2 + H",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.84e+09, 's^-1'), n=1.3, Ea=(27.4, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    label = "C6H6-2 + H <=> C6H7-8",
+    degeneracy = 6.0,
+    kinetics = Arrhenius(
+        A = (9.221e+08, 'cm^3/(mol*s)'),
+        n = 1.608,
+        Ea = (4.599, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: cyC6H7 <=> benzene + H
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -511,32 +511,50 @@ Taken from entry: product37 <=> product13 + H
 
 entry(
     index = 27,
-    label = "C2H2 + C5H5 <=> C7H7",
+    label = "C5H5 + C2H2 <=> C7H7",
     degeneracy = 10.0,
-    kinetics = Arrhenius(A=(25500, 'cm^3/(mol*s)'), n=2.27, Ea=(10.2, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    kinetics = Arrhenius(
+        A = (408000, 'cm^3/(mol*s)'),
+        n = 2.24,
+        Ea = (10.8, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: CPDyl + ethyne <=> product44
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 
 entry(
     index = 28,
-    label = "C7H6 + H <=> C7H7-2",
+    label = "C7H7-2 <=> C7H6 + H",
     degeneracy = 1.0,
-    kinetics = Arrhenius(
-        A = (2.1e+09, 'cm^3/(mol*s)'),
-        n = 1.43,
-        Ea = (4.13, 'kcal/mol'),
-        T0 = (1, 'K'),
+    kinetics = Arrhenius(A=(4.16e+10, 's^-1'), n=1.24, Ea=(65.98, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: vinylCPD_H""",
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: FA + H <=> vinylCPDyl
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 
@@ -545,11 +563,20 @@ entry(
     label = "C3H4 + allyl <=> C6H9",
     degeneracy = 2.0,
     kinetics = Arrhenius(A=(42, 'cm^3/(mol*s)'), n=3.27, Ea=(11, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: C3""",
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: aC3H5 + C3H4a <=> prod_1
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 
@@ -3707,6 +3734,50 @@ entry(
     longDesc = 
 u"""
 UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 215,
+    label = "C7H7-4 <=> C7H6-2 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.06e+10, 's^-1'), n=1.16, Ea=(26.18, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 216,
+    label = "C7H7-5 <=> C7H6-3 + H",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.02e+13, 's^-1'), n=0.34, Ea=(46.7, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
 """,
 )
 

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -3062,3 +3062,59 @@ RQCISD(T)/cc-pV∞Z //UQCISD/UB3LYP
 """,
 )
 
+entry(
+    index = 189,
+    label = "H + C4H2 <=> C4H3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (7.16e-14, 'cm^3/(molecule*s)'),
+        n = 1.119,
+        Ea = (1.672, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'The Addition of Hydrogen Atoms to Diacetylene and the Heats of Formation of i-C4H3 and n-C4H3',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '109 (19)',
+        pages = '4285-4295',
+        year = '2005',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+The restricted QCISD(T)/∞ barrier heights//B3LYP/6-311++G(d,p)
+These QCISD(T) calculations employed the correlation-consistent, polarized-valence, triple-ú (cc-pvtz) and quadruple-ú (cc-pvqz) basis sets and were extrapolated to the infinite basis-set limit via the expression
+""",
+)
+
+entry(
+    index = 190,
+    label = "H + C4H2-2 <=> C4H3-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.35e-14, 'cm^3/(molecule*s)'),
+        n = 1.305,
+        Ea = (5.018, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'The Addition of Hydrogen Atoms to Diacetylene and the Heats of Formation of i-C4H3 and n-C4H3',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '109 (19)',
+        pages = '4285-4295',
+        year = '2005',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+The restricted QCISD(T)/∞ barrier heights//B3LYP/6-311++G(d,p)
+These QCISD(T) calculations employed the correlation-consistent, polarized-valence, triple-ú (cc-pvtz) and quadruple-ú (cc-pvqz) basis sets and were extrapolated to the infinite basis-set limit via the expression
+""",
+)
+

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -3558,3 +3558,155 @@ CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
 """,
 )
 
+entry(
+    index = 209,
+    label = "C3H5O-2 <=> C2H2O-2 + CH3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.977e+09, 's^-1'), n=1.37, Ea=(41.408, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 210,
+    label = "C3H5O-3 <=> C2H2O + CH3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.022e+12, 's^-1'), n=0.577, Ea=(41.055, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 211,
+    label = "C3H4-2 + OH <=> C3H5O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.508e+07, 'cm^3/(mol*s)'),
+        n = 1.628,
+        Ea = (-0.462, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 212,
+    label = "C3H4-4 + OH <=> C3H5O-5",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.148e+06, 'cm^3/(mol*s)'),
+        n = 1.876,
+        Ea = (-0.423, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 213,
+    label = "C3H4-3 + OH <=> C3H5O-6",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (1.973e+06, 'cm^3/(mol*s)'),
+        n = 2.037,
+        Ea = (-1.433, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 214,
+    label = "C3H4 + OH <=> C3H5O-7",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (41610, 'cm^3/(mol*s)'),
+        n = 2.487,
+        Ea = (-1.81, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Zádor, J.', 'Miller, J. A.'],
+        title = u'Adventures on the C3H5O potential energy surface: OH + propyne, OH + allene and related reactions',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '35 (1)',
+        pages = '181-188',
+        year = '2015',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
+""",
+)
+

--- a/input/kinetics/families/R_Recombination/training/dictionary.txt
+++ b/input/kinetics/families/R_Recombination/training/dictionary.txt
@@ -1070,3 +1070,63 @@ C6H6-3
 11    H u0 p0 c0 {6,S}
 12    H u0 p0 c0 {6,S}
 
+C4H6
+1     C u0 p0 c0 {2,D} {3,D}
+2     C u0 p0 c0 {1,D} {5,S} {6,S}
+3  *2 C u0 p0 c0 {1,D} {4,S} {7,S}
+4  *1 C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5     H u0 p0 c0 {2,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+
+C4H5
+multiplicity 2
+1 * C u1 p0 c0 {2,D} {4,S}
+2   C u0 p0 c0 {1,D} {5,S} {6,S}
+3   C u0 p0 c0 {4,D} {7,S} {8,S}
+4   C u0 p0 c0 {1,S} {3,D} {9,S}
+5   H u0 p0 c0 {2,S}
+6   H u0 p0 c0 {2,S}
+7   H u0 p0 c0 {3,S}
+8   H u0 p0 c0 {3,S}
+9   H u0 p0 c0 {4,S}
+
+C4H6-2
+1     C u0 p0 c0 {3,D} {5,S} {6,S}
+2     C u0 p0 c0 {4,D} {7,S} {8,S}
+3     C u0 p0 c0 {1,D} {4,S} {9,S}
+4  *1 C u0 p0 c0 {2,D} {3,S} {10,S}
+5     H u0 p0 c0 {1,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10 *2 H u0 p0 c0 {4,S}
+
+C4H5-2
+multiplicity 2
+1   C u0 p0 c0 {2,T} {3,S}
+2   C u0 p0 c0 {1,T} {4,S}
+3 * C u1 p0 c0 {1,S} {5,S} {6,S}
+4   C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5   H u0 p0 c0 {3,S}
+6   H u0 p0 c0 {3,S}
+7   H u0 p0 c0 {4,S}
+8   H u0 p0 c0 {4,S}
+9   H u0 p0 c0 {4,S}
+
+C4H6-3
+1     C u0 p0 c0 {2,T} {3,S}
+2     C u0 p0 c0 {1,T} {4,S}
+3     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4  *1 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+5     H u0 p0 c0 {3,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10 *2 H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/R_Recombination/training/dictionary.txt
+++ b/input/kinetics/families/R_Recombination/training/dictionary.txt
@@ -987,3 +987,26 @@ C9H8-3
 15    H u0 p0 c0 {9,S}
 16    H u0 p0 c0 {7,S}
 17    H u0 p0 c0 {6,S}
+
+C3H3O2
+multiplicity 2
+1    O u1 p2 c0 {2,S}
+2 *2 O u0 p2 c0 {1,S} {5,S}
+3    C u0 p0 c0 {4,T} {6,S}
+4    C u0 p0 c0 {3,T} {5,S}
+5 *1 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {5,S}
+8    H u0 p0 c0 {5,S}
+
+C3H3O2-2
+multiplicity 2
+1    O u1 p2 c0 {2,S}
+2 *2 O u0 p2 c0 {1,S} {5,S}
+3    C u0 p0 c0 {4,D} {5,D}
+4    C u0 p0 c0 {3,D} {6,S} {7,S}
+5 *1 C u0 p0 c0 {2,S} {3,D} {8,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {5,S}
+

--- a/input/kinetics/families/R_Recombination/training/dictionary.txt
+++ b/input/kinetics/families/R_Recombination/training/dictionary.txt
@@ -1130,3 +1130,105 @@ C4H6-3
 9     H u0 p0 c0 {4,S}
 10 *2 H u0 p0 c0 {4,S}
 
+C7H8
+1     C u0 p0 c0 {2,B} {3,B} {9,S}
+2     C u0 p0 c0 {1,B} {5,B} {8,S}
+3     C u0 p0 c0 {1,B} {4,B} {10,S}
+4     C u0 p0 c0 {3,B} {6,B} {11,S}
+5     C u0 p0 c0 {2,B} {6,B} {12,S}
+6  *1 C u0 p0 c0 {4,B} {5,B} {7,S}
+7  *2 C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15    H u0 p0 c0 {7,S}
+
+C7H8-2
+1     C u0 p0 c0 {2,B} {4,B} {9,S}
+2     C u0 p0 c0 {1,B} {3,B} {10,S}
+3     C u0 p0 c0 {2,B} {5,B} {11,S}
+4     C u0 p0 c0 {1,B} {6,B} {8,S}
+5     C u0 p0 c0 {3,B} {6,B} {12,S}
+6     C u0 p0 c0 {4,B} {5,B} {7,S}
+7  *1 C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+15 *2 H u0 p0 c0 {7,S}
+
+C7H7-2
+multiplicity 2
+1    C u0 p0 c0 {7,D} {8,S} {9,S}
+2    C u0 p0 c0 {3,S} {6,D} {11,S}
+3    C u0 p0 c0 {2,S} {4,D} {12,S}
+4    C u0 p0 c0 {3,D} {5,S} {13,S}
+5  * C u1 p0 c0 {4,S} {7,S} {14,S}
+6    C u0 p0 c0 {2,D} {7,S} {10,S}
+7    C u0 p0 c0 {1,D} {5,S} {6,S}
+8    H u0 p0 c0 {1,S}
+9    H u0 p0 c0 {1,S}
+10   H u0 p0 c0 {6,S}
+11   H u0 p0 c0 {2,S}
+12   H u0 p0 c0 {3,S}
+13   H u0 p0 c0 {4,S}
+14   H u0 p0 c0 {5,S}
+
+C7H8-3
+1     C u0 p0 c0 {6,D} {8,S} {9,S}
+2     C u0 p0 c0 {3,S} {4,D} {11,S}
+3     C u0 p0 c0 {2,S} {5,D} {12,S}
+4     C u0 p0 c0 {2,D} {6,S} {10,S}
+5     C u0 p0 c0 {3,D} {7,S} {13,S}
+6     C u0 p0 c0 {1,D} {4,S} {7,S}
+7  *1 C u0 p0 c0 {5,S} {6,S} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15 *2 H u0 p0 c0 {7,S}
+
+C7H7-3
+multiplicity 2
+1    C u0 p0 c0 {7,D} {8,S} {9,S}
+2  * C u1 p0 c0 {3,S} {4,S} {12,S}
+3    C u0 p0 c0 {2,S} {5,D} {11,S}
+4    C u0 p0 c0 {2,S} {6,D} {13,S}
+5    C u0 p0 c0 {3,D} {7,S} {10,S}
+6    C u0 p0 c0 {4,D} {7,S} {14,S}
+7    C u0 p0 c0 {1,D} {5,S} {6,S}
+8    H u0 p0 c0 {1,S}
+9    H u0 p0 c0 {1,S}
+10   H u0 p0 c0 {5,S}
+11   H u0 p0 c0 {3,S}
+12   H u0 p0 c0 {2,S}
+13   H u0 p0 c0 {4,S}
+14   H u0 p0 c0 {6,S}
+
+C7H8-4
+1     C u0 p0 c0 {6,D} {8,S} {9,S}
+2     C u0 p0 c0 {4,D} {6,S} {10,S}
+3     C u0 p0 c0 {5,D} {6,S} {11,S}
+4     C u0 p0 c0 {2,D} {7,S} {12,S}
+5     C u0 p0 c0 {3,D} {7,S} {13,S}
+6     C u0 p0 c0 {1,D} {2,S} {3,S}
+7  *1 C u0 p0 c0 {4,S} {5,S} {14,S} {15,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {7,S}
+15 *2 H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/R_Recombination/training/dictionary.txt
+++ b/input/kinetics/families/R_Recombination/training/dictionary.txt
@@ -1010,3 +1010,63 @@ multiplicity 2
 7    H u0 p0 c0 {4,S}
 8    H u0 p0 c0 {5,S}
 
+C3H4
+1    C u0 p0 c0 {2,T} {4,S}
+2    C u0 p0 c0 {1,T} {3,S}
+3 *1 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {3,S}
+6    H u0 p0 c0 {3,S}
+7 *2 H u0 p0 c0 {3,S}
+
+C3H4-2
+1    C u0 p0 c0 {2,D} {3,D}
+2    C u0 p0 c0 {1,D} {4,S} {5,S}
+3 *1 C u0 p0 c0 {1,D} {6,S} {7,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+7 *2 H u0 p0 c0 {3,S}
+
+C6H6
+1     C u0 p0 c0 {3,D} {5,D}
+2     C u0 p0 c0 {4,D} {6,D}
+3     C u0 p0 c0 {1,D} {7,S} {8,S}
+4     C u0 p0 c0 {2,D} {9,S} {10,S}
+5  *1 C u0 p0 c0 {1,D} {6,S} {11,S}
+6  *2 C u0 p0 c0 {2,D} {5,S} {12,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+
+C6H6-2
+1     C u0 p0 c0 {2,T} {7,S}
+2     C u0 p0 c0 {1,T} {6,S}
+3     C u0 p0 c0 {4,D} {5,D}
+4     C u0 p0 c0 {3,D} {8,S} {9,S}
+5  *2 C u0 p0 c0 {3,D} {6,S} {10,S}
+6  *1 C u0 p0 c0 {2,S} {5,S} {11,S} {12,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+
+C6H6-3
+1     C u0 p0 c0 {3,T} {7,S}
+2     C u0 p0 c0 {4,T} {8,S}
+3     C u0 p0 c0 {1,T} {5,S}
+4     C u0 p0 c0 {2,T} {6,S}
+5  *1 C u0 p0 c0 {3,S} {6,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {4,S} {5,S} {11,S} {12,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -274,18 +274,27 @@ doi: 10.1039/B515914H
 entry(
     index = 23,
     label = "C5H5 + CH3 <=> C6H8",
-    degeneracy = 1.0,
+    degeneracy = 5.0,
     kinetics = Arrhenius(
-        A = (1.38482e-08, 'cm^3/(molecule*s)'),
-        n = -0.7,
-        Ea = (-0.5, 'kcal/mol'),
+        A = (1.623e+17, 'cm^3/(mol*s)'),
+        n = -1.07,
+        Ea = (0.002, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
-    longDesc =
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
 u"""
-Taken from entry: c-C5H5 + CH3 <=> C5H5CH3-5
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -294,34 +303,52 @@ entry(
     label = "C6H7 + H <=> C6H8-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
-        A = (7.582e-10, 'cm^3/(molecule*s)'),
-        n = -0.1,
-        Ea = (0.4, 'kcal/mol'),
+        A = (3.62e+13, 'cm^3/(mol*s)'),
+        n = 0.228,
+        Ea = (-0.022, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
-    longDesc =
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
 u"""
-Taken from entry: R2 + H <=> C5H5CH3-5
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
 entry(
     index = 25,
     label = "C6H7-2 + H <=> C6H8-3",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(
-        A = (6.7982e-11, 'cm^3/(molecule*s)'),
-        n = 0.3,
-        Ea = (0.1, 'kcal/mol'),
+        A = (1.884e+13, 'cm^3/(mol*s)'),
+        n = 0.408,
+        Ea = (0.002, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
-    longDesc =
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
 u"""
-Taken from entry: R2 + H <=> C5H5CH3-1
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -330,34 +357,52 @@ entry(
     label = "C6H7-3 + H <=> C6H8-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
-        A = (1.74338e-12, 'cm^3/(molecule*s)'),
-        n = 0.6,
-        Ea = (-0.2, 'kcal/mol'),
+        A = (3.156e+12, 'cm^3/(mol*s)'),
+        n = 0.461,
+        Ea = (-0.001, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
-    longDesc =
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
 u"""
-Taken from entry: R1 + H <=> C5H5CH3-1
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
 entry(
     index = 27,
     label = "C6H7-4 + H <=> C6H8-5",
-    degeneracy = 1.0,
+    degeneracy = 2.0,
     kinetics = Arrhenius(
-        A = (1.50356e-10, 'cm^3/(molecule*s)'),
-        n = 0.1,
-        Ea = (0, 'kcal/mol'),
+        A = (5.871e+13, 'cm^3/(mol*s)'),
+        n = 0.158,
+        Ea = (-0.004, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
-    longDesc =
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
 u"""
-Taken from entry: R2 + H <=> C5H5CH3-2
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 
@@ -366,16 +411,25 @@ entry(
     label = "C6H7-5 + H <=> C6H8-6",
     degeneracy = 1.0,
     kinetics = Arrhenius(
-        A = (5.6921e-12, 'cm^3/(molecule*s)'),
-        n = 0.5,
-        Ea = (-0.1, 'kcal/mol'),
+        A = (7.09e+12, 'cm^3/(mol*s)'),
+        n = 0.412,
+        Ea = (0.009, 'kcal/mol'),
         T0 = (1, 'K'),
     ),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: 2009_Sharma_C5H5_CH3_highP""",
-    longDesc =
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
 u"""
-Taken from entry: R3 + H <=> C5H5CH3-2
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
 

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -764,3 +764,57 @@ u"""
 Taken from entry: C9H7_19 + H_15 <=> indene_25
 """,
 )
+entry(
+    index = 52,
+    label = "C3H3 + O2 <=> C3H3O2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (47800, 'cm^3/(mol*s)'),
+        n = 2.243,
+        Ea = (-1.064, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Hahn, D. K.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'A theoretical analysis of the reaction between propargyl and molecular oxygen',
+        journal = 'Faraday Discussions',
+        volume = '119 (0)',
+        pages = '79-100',
+        year = '2002',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+approximate QCISD(T,Full)/6-311&&G(3df,2pd)//B3LYP
+""",
+)
+
+entry(
+    index = 53,
+    label = "C3H3-2 + O2 <=> C3H3O2-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (8270, 'cm^3/(mol*s)'),
+        n = 2.525,
+        Ea = (1.989, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Hahn, D. K.', 'Klippenstein, S. J.', 'Miller, J. A.'],
+        title = u'A theoretical analysis of the reaction between propargyl and molecular oxygen',
+        journal = 'Faraday Discussions',
+        volume = '119 (0)',
+        pages = '79-100',
+        year = '2002',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+approximate QCISD(T,Full)/6-311&&G(3df,2pd)//B3LYP
+""",
+)
+

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -818,3 +818,139 @@ approximate QCISD(T,Full)/6-311&&G(3df,2pd)//B3LYP
 """,
 )
 
+entry(
+    index = 54,
+    label = "C3H3 + H <=> C3H4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.398e+13, 'cm^3/(mol*s)'),
+        n = 0.102,
+        Ea = (-130.54, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 4,
+    reference = Article(
+        authors = ['Harding, L. B.', 'Klippenstein, S. J.', 'Georgievskii, Y.'],
+        title = u'On the Combination Reactions of Hydrogen Atoms with Resonance-Stabilized Hydrocarbon Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '111 (19)',
+        pages = '3789-3801',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CASPT2/cc-pvdz (VRC-TST)
+""",
+)
+
+entry(
+    index = 55,
+    label = "C3H3-2 + H <=> C3H4-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.048e+13, 'cm^3/(mol*s)'),
+        n = 0.206,
+        Ea = (-724.19, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 4,
+    reference = Article(
+        authors = ['Harding, L. B.', 'Klippenstein, S. J.', 'Georgievskii, Y.'],
+        title = u'On the Combination Reactions of Hydrogen Atoms with Resonance-Stabilized Hydrocarbon Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '111 (19)',
+        pages = '3789-3801',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CASPT2/cc-pvdz (VRC-TST)
+""",
+)
+
+entry(
+    index = 56,
+    label = "C3H3-2 + C3H3-2 <=> C6H6",
+    degeneracy = 0.5,
+    kinetics = Arrhenius(
+        A = (4.288e+09, 'cm^3/(mol*s)'),
+        n = 0.795,
+        Ea = (-4303.6, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 4,
+    reference = Article(
+        authors = ['Georgievskii, Y.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Association rate constants for reactions between resonance-stabilized radicals: C3H3 + C3H3, C3H3 + C3H5, and C3H5 + C3H5',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '9 (31)',
+        pages = '4259-4268',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CASPT2/cc-pvdz (VRC-TST)
+""",
+)
+
+entry(
+    index = 57,
+    label = "C3H3 + C3H3-2 <=> C6H6-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.307e+12, 'cm^3/(mol*s)'),
+        n = 0.192,
+        Ea = (-2807, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 4,
+    reference = Article(
+        authors = ['Georgievskii, Y.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Association rate constants for reactions between resonance-stabilized radicals: C3H3 + C3H3, C3H3 + C3H5, and C3H5 + C3H5',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '9 (31)',
+        pages = '4259-4268',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CASPT2/cc-pvdz (VRC-TST)
+""",
+)
+
+entry(
+    index = 58,
+    label = "C3H3 + C3H3 <=> C6H6-3",
+    degeneracy = 0.5,
+    kinetics = Arrhenius(
+        A = (2.945e+13, 'cm^3/(mol*s)'),
+        n = -0.278,
+        Ea = (-1268.8, 'J/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 4,
+    reference = Article(
+        authors = ['Georgievskii, Y.', 'Miller, J. A.', 'Klippenstein, S. J.'],
+        title = u'Association rate constants for reactions between resonance-stabilized radicals: C3H3 + C3H3, C3H3 + C3H5, and C3H5 + C3H5',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '9 (31)',
+        pages = '4259-4268',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CASPT2/cc-pvdz (VRC-TST)
+""",
+)
+
+

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -953,4 +953,84 @@ CASPT2/cc-pvdz (VRC-TST)
 """,
 )
 
+entry(
+    index = 59,
+    label = "CH3 + C3H3-2 <=> C4H6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.705e+09, 'cm^3/(mol*s)'),
+        n = 1.07,
+        Ea = (-2.268, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Huang, C.', 'Yang, B.', 'Zhang, F.'],
+        title = u'Initiation mechanism of 1,3-butadiene combustion and its effect on soot precursors',
+        journal = 'Combustion and Flame',
+        volume = '184',
+        pages = '167-175',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/cc-pVTZ-F12//QCISD/6-311++G(2df,2p)
+""",
+)
+
+entry(
+    index = 60,
+    label = "C4H5 + H <=> C4H6-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.117e+14, 'cm^3/(mol*s)'),
+        n = -0.152,
+        Ea = (1.003, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Huang, C.', 'Yang, B.', 'Zhang, F.'],
+        title = u'Initiation mechanism of 1,3-butadiene combustion and its effect on soot precursors',
+        journal = 'Combustion and Flame',
+        volume = '184',
+        pages = '167-175',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/cc-pVTZ-F12//QCISD/6-311++G(2df,2p)
+""",
+)
+
+entry(
+    index = 61,
+    label = "C4H5-2 + H <=> C4H6-3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.25e+14, 'cm^3/(mol*s)'),
+        n = -0.119,
+        Ea = (-1.012, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 2,
+    reference = Article(
+        authors = ['Huang, C.', 'Yang, B.', 'Zhang, F.'],
+        title = u'Initiation mechanism of 1,3-butadiene combustion and its effect on soot precursors',
+        journal = 'Combustion and Flame',
+        volume = '184',
+        pages = '167-175',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/cc-pVTZ-F12//QCISD/6-311++G(2df,2p)
+""",
+)
 

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -1034,3 +1034,111 @@ CCSD(T)-F12/cc-pVTZ-F12//QCISD/6-311++G(2df,2p)
 """,
 )
 
+entry(
+    index = 62,
+    label = "C6H5 + CH3 <=> C7H8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.87e-10, 'cm^3/(molecule*s)'),
+        n = -0.283,
+        Ea = (-0.191, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Klippenstein, S. J.', 'Harding, L. B.', 'Georgievskii, Y.'],
+        title = u'On the formation and decomposition of C7H8',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '31 (1)',
+        pages = '221-229',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)/aug-cc-pvdz//B3LYP/6-31G* (VRC-TST)
+""",
+)
+
+entry(
+    index = 63,
+    label = "C7H7 + H <=> C7H8-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.2e-10, 'cm^3/(molecule*s)'),
+        n = 0.062,
+        Ea = (-0.044, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Klippenstein, S. J.', 'Harding, L. B.', 'Georgievskii, Y.'],
+        title = u'On the formation and decomposition of C7H8',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '31 (1)',
+        pages = '221-229',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)/aug-cc-pvdz//B3LYP/6-31G* (VRC-TST)
+""",
+)
+
+entry(
+    index = 64,
+    label = "C7H7-2 + H <=> C7H8-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(
+        A = (8.28e-13, 'cm^3/(molecule*s)'),
+        n = 0.611,
+        Ea = (-0.436, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Klippenstein, S. J.', 'Harding, L. B.', 'Georgievskii, Y.'],
+        title = u'On the formation and decomposition of C7H8',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '31 (1)',
+        pages = '221-229',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)/aug-cc-pvdz//B3LYP/6-31G* (VRC-TST)
+""",
+)
+
+entry(
+    index = 65,
+    label = "C7H7-3 + H <=> C7H8-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.07e-11, 'cm^3/(molecule*s)'),
+        n = 0.245,
+        Ea = (-0.333, 'kcal/mol'),
+        T0 = (1, 'K'),
+    ),
+    rank = 3,
+    reference = Article(
+        authors = ['Klippenstein, S. J.', 'Harding, L. B.', 'Georgievskii, Y.'],
+        title = u'On the formation and decomposition of C7H8',
+        journal = 'Proceedings of the Combustion Institute',
+        volume = '31 (1)',
+        pages = '221-229',
+        year = '2007',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)/aug-cc-pvdz//B3LYP/6-31G* (VRC-TST)
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -4724,3 +4724,99 @@ multiplicity 2
 7    H u0 p0 c0 {3,S}
 8    H u0 p0 c0 {5,S}
 
+C4H5
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2 *5 C u0 p0 c0 {1,S} {3,D} {8,S}
+3 *4 C u0 p0 c0 {2,D} {4,D}
+4 *1 C u1 p0 c0 {3,D} {9,S}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-2
+multiplicity 2
+1 *4 C u0 p0 c0 {2,S} {4,D} {5,S}
+2 *1 C u1 p0 c0 {1,S} {6,S} {7,S}
+3 *2 C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *5 C u0 p0 c0 {1,D} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8 *3 H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C4H5-3
+multiplicity 2
+1 *2 C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+2    C u0 p0 c0 {4,D} {8,S} {9,S}
+3 *1 C u1 p0 c0 {1,S} {4,D}
+4    C u0 p0 c0 {2,D} {3,D}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {2,S}
+
+C4H5-4
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {4,D} {5,S}
+2 *1 C u1 p0 c0 {1,S} {6,S} {7,S}
+3    C u0 p0 c0 {4,D} {8,S} {9,S}
+4    C u0 p0 c0 {1,D} {3,D}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+
+C4H5-5
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2 *1 C u1 p0 c0 {1,S} {7,S} {8,S}
+3    C u0 p0 c0 {1,S} {4,T}
+4    C u0 p0 c0 {3,T} {9,S}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-6
+multiplicity 2
+1 *2 C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+2 *1 C u1 p0 c0 {1,S} {3,S} {8,S}
+3    C u0 p0 c0 {2,S} {4,T}
+4    C u0 p0 c0 {3,T} {9,S}
+5 *3 H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-7
+multiplicity 2
+1    C u0 p0 c0 {2,S} {3,D} {5,S}
+2 *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+3    C u0 p0 c0 {1,D} {7,S} {8,S}
+4 *1 C u1 p0 c0 {2,D} {9,S}
+5    H u0 p0 c0 {1,S}
+6 *3 H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {4,S}
+
+C4H5-8
+multiplicity 2
+1    C u0 p0 c0 {2,D} {4,S} {5,S}
+2    C u0 p0 c0 {1,D} {6,S} {7,S}
+3 *2 C u0 p0 c0 {4,D} {8,S} {9,S}
+4 *1 C u1 p0 c0 {1,S} {3,D}
+5    H u0 p0 c0 {1,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8 *3 H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {3,S}
+

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -4820,3 +4820,71 @@ multiplicity 2
 8 *3 H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
+C7H7-11
+multiplicity 2
+1  *1 C u1 p0 c0 {2,D} {8,S}
+2  *4 C u0 p0 c0 {1,D} {6,S} {9,S}
+3     C u0 p0 c0 {4,S} {5,D} {11,S}
+4     C u0 p0 c0 {3,S} {6,D} {10,S}
+5     C u0 p0 c0 {3,D} {7,S} {12,S}
+6  *5 C u0 p0 c0 {2,S} {4,D} {7,S}
+7  *2 C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13 *3 H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-12
+multiplicity 2
+1  *2 C u0 p0 c0 {4,D} {8,S} {9,S}
+2     C u0 p0 c0 {3,D} {5,S} {11,S}
+3     C u0 p0 c0 {2,D} {6,S} {13,S}
+4  *5 C u0 p0 c0 {1,D} {7,S} {14,S}
+5  *1 C u1 p0 c0 {2,S} {7,S} {10,S}
+6     C u0 p0 c0 {3,S} {7,D} {12,S}
+7  *4 C u0 p0 c0 {4,S} {5,S} {6,D}
+8  *3 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+
+C7H7-13
+multiplicity 2
+1  *1 C u1 p0 c0 {2,D} {3,S}
+2     C u0 p0 c0 {1,D} {4,S} {9,S}
+3  *4 C u0 p0 c0 {1,S} {5,D} {8,S}
+4     C u0 p0 c0 {2,S} {6,D} {10,S}
+5  *2 C u0 p0 c0 {3,D} {7,S} {11,S}
+6     C u0 p0 c0 {4,D} {7,S} {12,S}
+7     C u0 p0 c0 {5,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11 *3 H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+
+C7H7-14
+multiplicity 2
+1  *1 C u1 p0 c0 {2,D} {7,S}
+2  *4 C u0 p0 c0 {1,D} {3,S} {8,S}
+3  *2 C u0 p0 c0 {2,S} {4,D} {9,S}
+4     C u0 p0 c0 {3,D} {5,S} {11,S}
+5     C u0 p0 c0 {4,S} {6,D} {10,S}
+6     C u0 p0 c0 {5,D} {7,S} {12,S}
+7     C u0 p0 c0 {1,S} {6,S} {13,S} {14,S}
+8     H u0 p0 c0 {2,S}
+9  *3 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {7,S}
+14    H u0 p0 c0 {7,S}
+

--- a/input/kinetics/families/intra_H_migration/training/dictionary.txt
+++ b/input/kinetics/families/intra_H_migration/training/dictionary.txt
@@ -4702,3 +4702,25 @@ multiplicity 2
 24    H u0 p0 c0 {9,S}
 25    H u0 p0 c0 {9,S}
 
+C3H3O2
+multiplicity 2
+1 *1 O u1 p2 c0 {2,S}
+2 *4 O u0 p2 c0 {1,S} {5,S}
+3 *5 C u0 p0 c0 {4,D} {5,D}
+4 *2 C u0 p0 c0 {3,D} {6,S} {7,S}
+5 *6 C u0 p0 c0 {2,S} {3,D} {8,S}
+6 *3 H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {5,S}
+
+C3H3O2-2
+multiplicity 2
+1 *2 O u0 p2 c0 {2,S} {6,S}
+2 *5 O u0 p2 c0 {1,S} {5,S}
+3 *1 C u1 p0 c0 {4,D} {7,S}
+4 *4 C u0 p0 c0 {3,D} {5,D}
+5 *6 C u0 p0 c0 {2,S} {4,D} {8,S}
+6 *3 H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {5,S}
+

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -481,22 +481,27 @@ Taken from entry: pdt58 <=> pdt20
 """,
 )
 
-
-
 entry(
     index = 33,
-    label = "C6H7-7 <=> C6H7-8",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(0.00218, 's^-1'), n=4.91, Ea=(40.4, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    label = "C6H7-8 <=> C6H7-7",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.107e+09, 's^-1'), n=0.879, Ea=(22.386, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C5H4CH3 <=> C5H5CH2-1
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
-
-
 
 entry(
     index = 34,
@@ -723,22 +728,27 @@ Taken from entry: W7 <=> W20
 """,
 )
 
-
-
 entry(
     index = 51,
     label = "C6H7-9 <=> C6H7-10",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(9220, 's^-1'), n=2.81, Ea=(30.2, 'kcal/mol'), T0=(1, 'K')),
-    rank = 3,
-    shortDesc = u"""Training reaction from kinetics library: Fulvene_H""",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(1.169e+11, 's^-1'), n=0.707, Ea=(27.741, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Krasnoukhov, V. S.', 'Porfiriev, D. P.', 'Zavershinskiy, I. P.', 'Azyazov, V. N.', 'Mebel, A. M.'],
+        title = u'Kinetics of the CH3 + C5H5 Reaction: A Theoretical Study',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '121 (48)',
+        pages = '9191–9200',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
     longDesc = 
 u"""
-Taken from entry: C5H5CH2-3 <=> C5H5CH2-2
+CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ
 """,
 )
-
-
 
 entry(
     index = 52,

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -2171,3 +2171,18 @@ using Gaussian 03 and Gaussian 09.
 Reported A factor from article is multiplied by degeneracy because article A-factors are normalized
 """,
 )
+
+entry(
+    index = 118,
+    label = "C3H3O2 <=> C3H3O2-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(3.427, 's^-1'), n=3.311, Ea=(30.765, 'kcal/mol'), T0=(1, 'K')),
+    rank = 3,
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+Quantum chemistry calculations at the CBS-QB3 level with 1D rotor consideration
+Jim Chu's calculation
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -2361,3 +2361,69 @@ CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
 """,
 )
 
+entry(
+    index = 127,
+    label = "C7H7-11 <=> C7H7-12",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(74200, 's^-1'), n=2.23, Ea=(10.59, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 128,
+    label = "C7H7-7 <=> C7H7-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(11700, 's^-1'), n=2.78, Ea=(62.71, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+
+entry(
+    index = 129,
+    label = "C7H7-13 <=> C7H7-14",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.48e+06, 's^-1'), n=1.85, Ea=(26.83, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['da Silva, G.', 'Cole, J. A.', 'Bozzelli, J. W.'],
+        title = u'Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactions',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (6)',
+        pages = '2275-2283',
+        year = '2010',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+G3SX//B3LYP/6-31G(2df,p)
+""",
+)
+

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -2186,3 +2186,178 @@ Jim Chu's calculation
 """,
 )
 
+entry(
+    index = 119,
+    label = "C4H5 <=> C4H5-2",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(A=(3.992e-05, 's^-1'), n=4.805, Ea=(56.041, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 120,
+    label = "C4H5-3 <=> C4H5-4",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(A=(606700, 's^-1'), n=2.347, Ea=(51.259, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 121,
+    label = "C4H5-5 <=> C4H5-6",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(5.471e+06, 's^-1'), n=1.841, Ea=(29.797, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+entry(
+    index = 122,
+    label = "C4H5-7 <=> C4H5-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(481900, 's^-1'), n=2.375, Ea=(40.143, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 123,
+    label = "C4H5-2 <=> C4H5",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(0.005931, 's^-1'), n=4.271, Ea=(56.912, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 124,
+    label = "C4H5-4 <=> C4H5-3",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.63e+08, 's^-1'), n=1.73, Ea=(49.649, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 125,
+    label = "C4H5-6 <=> C4H5-5",
+    degeneracy = 3.0,
+    kinetics = Arrhenius(A=(5.11e+06, 's^-1'), n=1.95, Ea=(42.693, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+
+entry(
+    index = 126,
+    label = "C4H5-8 <=> C4H5-7",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(2.189e+07, 's^-1'), n=1.951, Ea=(50.732, 'kcal/mol'), T0=(1, 'K')),
+    rank = 2,
+    reference = Article(
+        authors = ['Ribeiro, J. M.', 'Mebel, A. M.'],
+        title = u'Reaction mechanism and product branching ratios of the CH + C3H4 reactions: a theoretical study',
+        journal = 'Physical Chemistry Chemical Physics',
+        volume = '19 (22)',
+        pages = '14543-14554',
+        year = '2017',
+    ),
+    referenceType = 'theory',
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+CCSD(T)-F12/CBS//B2PLYPD3/cc-pVTZ
+""",
+)
+


### PR DESCRIPTION
This is based on #271 which should be merged first.

Add training reaction on C3H3OO surface
1. C3H3O2(II) <=> C3H2OOH calculated by Jim on 05/30/2017, CBS-QB3 with hindered rotor consideration
2. C3H3+O2 <=> C3H3O2(I) Fitted TST rate from Hahn et al. Faraday Discuss., 2001, 119, 79-100 Figure 4
3. C3H3+O2 <=> C3H3O2(II) Fitted TST rate from Hahn et al. Faraday Discuss., 2001, 119, 79-100 Figure 4

Add training reactions of C3H3 + C3H3 and H recombination
1. C3H3+C3H3 <=> three C6H6 products, Phys. Chem. Chem. Phys., 2007, 9, 4259–4268, Georgievskii et al.
2. C3H3 + H <=> propyne and allene, J. Phys. Chem. A 2007, 111, 3789-3801, Harding et al.

Add training reactions of C3H3+H2 H-abstraction
C3H3+H2 <=> propyne or allene+H, both directions
Molecular information from J. Phys. Chem. A 2011, 115, 14209–14214, Narendrapurapu et al.
TST calculation done by CanTherm

Add training reactions on CH3CO surface
1. H + CH2CO <=> CH3CO
2. H + CH2CO <=> CH2CHO, both directions
3. CH3 + CO <=> CH3CO
4. CH3CO <=> CH3 + CO
From J. Phys. Chem. A 2006, 110, 5772-5781, Senosiain et al.

Add training reaction of C4H3 dissociation
1. H + C4H2 <=> i-C4H3
2. H + C4H2 <=> n-C4H3
From J. Phys. Chem. A 2005, 109, 4285-4295, Klippenstein et al.

Add training reactions on C4H5 surface
From Phys.Chem.Chem.Phys.,2017,19,14543, Ribeiro et al.
CCSD(T)-F12//B2PLYPD3

Add training reaction of recombination to C4H6 isomers
1. 2-C4H5+H <=> 2-Butyne
2. i-C4H5+H <=> 1,3-Butadiene
3. C3H3+CH3 <=> 1,2-Butadiene
The rate of vinyl+vinyl <=> 1,3-C4H6 was calculated as well, but number was not reasonable
From Combustion and Flame 184 (2017) 167–175, Huang et al.

Add training reactions of C4H4, C4H6 H-abstraction
Vinylacetylene + H/CH3 <=> C4H3(C#C[C]=C) + H2/CH4
1,2-Butadiene + H/CH3 <=> C4H5(C#C[CH]C) + H2/CH4
1-Butyne + H/CH3 <=> C4H5(C#C[CH]C) + H2/CH4
The rates are calclated in Cantherm based on CBS-QB3 with hindered rotor consideration

Add training reaction on C3H5O surface
All imporant elementary steps on C3H5O surface reported in Fig. 1, Proceedings of the Combustion Institute 35 (2015) 181–188 by Zador et al.

Add training reaction on C7H7 surface
Kinetics of the Cyclopentadienyl + Acetylene, Fulvenallene + H, and 1-Ethynylcyclopentadiene + H Reactionsvinyl
J. Phys. Chem. A 2010, 114, 2275–2283, da Silva et al.,
composite G3SX model chemistry//B3LYP/6-31G(2df,p)
For the reactions duplicated in vinylCPD_H library(CBS-QB3), training reactions are replaced into the rates from this source.

Add training reaciton of recombination on C7H8 surface
1. C6H5 + CH3 <=> Toluene
2. C7H7 + H <=> Toluene
3. C7H7 + H <=> OiT
4. C7H7 + H <=> PiT
From Proceedings of the Combustion Institute 31 (2007) 221–229, Klippenstein et al.
VRC-TST on CCSD(T)/aug-cc-pvdz//B3LYP/6-31G*

Add training reactions on C6H7 surfaces
Most rates replace CBS-QB3 calculation results in fulvene_H library into
the results based on the CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ level theory
From J. Phys. Chem. A, 2017, 121 (48), pp 9191–9200, Krasnoukhov et al.

Add training reactions on C6H8 surfaces
Most rates replace CBS-QB3 calculation results (Sharma et al. 2009) into
the results based on the CCSD(T)-F12/cc-pVTZ-f12//B2PLYPD3/aug-cc-pVDZ level theory
From J. Phys. Chem. A, 2017, 121 (48), pp 9191–9200, Krasnoukhov et al.

Add training reactions of toluene H-abstractions
Hydrogen Abstraction by OH, H, O, CH3, and HO2 Radicals from Toluene
From J. Phys. Chem. A 2016, 120, 3424−3432, Li et al.
The G4//B3LYP/6-31G(2df,p) level of theory, replace two existing training reactions at the G3(MP2,CC)//B3LYP

Add training reactions of C6H6 C12H8 H-abstraction
1. C12H8 + H <=> C12H7-1 + H2, J. Phys. Chem. A 2004, 108, 4846-4852, Violi et al.
    at the B3LYP and BH&HLYP levels of theory using the 6-31G(d,p) basis set, RC-TST/LER
2. C6H6 + OH <=> C6H5 + H2O, J. Phys. Chem. A 2006, 110, 5081-5090, Seta et al.
3. C6H6 + CH3 <=> C6H5 + CH4, Chemical Physics Letters 646 (2016) 102–109, Mai et al.
    CCSD(T)/CBS//BH&HLYP/cc-pVDZ, and canonical variational transition state theory (CVT)
    with corrections for small curvaturetunneling (SCT) and hindered internal rotation (HIR)
4. C6H6 + C2H5 <=> C6H5 + C2H6, Chemical Physics Letters 646 (2016) 102–109, Mai et al.
    CCSD(T)/CBS//BH&HLYP/cc-pVDZ, and canonical variational transition state theory (CVT)
    with corrections for small curvaturetunneling (SCT) and hindered internal rotation (HIR)
5. C6H6+H <=> C6H5+H2, both directions
    From Phys.Chem.Chem.Phys.,2017, 19, 25401, Semenikhin et al., G3(MP2,CC)
6. C10H8+H <=> C10H7-1+H2, both directions
    From Phys.Chem.Chem.Phys.,2017, 19, 25401, Semenikhin et al., G3(MP2,CC)
7. C10H8+H <=> C10H7-2+H2, both directions
    From Phys.Chem.Chem.Phys.,2017, 19, 25401, Semenikhin et al., G3(MP2,CC)

Add training reactions of R_addition_multiple bond
1. Toluene+H <=> C7H9(CC1=CC=C[CH]C1)
2. Toluene+H <=> C7H9(CC1C=C[CH]CC=1)
From J. Am. Chem. Soc. 2016, 138, 2690−2704, Bao et al.
system-specific (SS) QRRK approach is adjusted with SS parameters to agree with multistructural canonical
variational transition state theory with multidimensional tunneling (MS-CVT/SCT) at the high-pressure limit
The MPW1K/MG3S level of theory