### PR TITLE
Miscellaneous minor database fixes

### DIFF
--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -32,8 +32,8 @@ entry(
     label = "multiplebond_intra",
     group = 
 """
-1 *2 [Cd,Ct,Cb,Cbf,CO,CS,Cdd,N]   u0 {2,[D,T,B]}
-2 *3 [Cd,Ct,Cb,Cbf,O2d,S2d,Cdd,N] u0 c0 {1,[D,T,B]}
+1 *2 [Cd,Ct,Cb,Cbf,CO,CS,Cdd,N,S4d,S6d,S6dd] u0    {2,[D,T,B]}
+2 *3 [Cd,Ct,Cb,Cbf,O2d,S2d,Cdd,N]            u0 c0 {1,[D,T,B]}
 """,
     kinetics = None,
 )

--- a/input/kinetics/libraries/Sulfur/GlarborgNS/reactions.py
+++ b/input/kinetics/libraries/Sulfur/GlarborgNS/reactions.py
@@ -82,9 +82,9 @@ entry(
     label = "S + NO <=> SNO",
     degeneracy = 1,
     kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(3.4e+13, 's^-1'), n=0.24, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusHigh = Arrhenius(A=(1.3e+14, 'cm^3/(mol*s)'), n=0.24, Ea=(0, 'cal/mol'), T0=(300, 'K')),
         arrheniusLow = Arrhenius(
-            A = (2.2e+15, 'cm^3/(mol*s)'),
+            A = (2.2e+15, 'cm^6/(mol^2*s)'),
             n = 0,
             Ea = (-1870, 'cal/mol'),
             T0 = (1, 'K'),
@@ -96,7 +96,7 @@ entry(
     ),
     longDesc = 
 u"""
-[262]
+https://doi.org/10.1063/1.1806419
 """,
 )
 
@@ -120,6 +120,8 @@ entry(
     longDesc = 
 u"""
 [263,268]
+[263] is https://doi.org/10.5194/acp-4-1461-2004, where the rate is only given at 250-300K
+[268] is https://doi.org/10.1063/1.447287, where the rate is only given at 250-445K
 """,
 )
 

--- a/input/kinetics/libraries/primaryNitrogenLibrary/LowT/reactions.py
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/LowT/reactions.py
@@ -12,7 +12,8 @@ entry(
     index = 1,
     label = "N2O + OH <=> N2 + HO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.87e+08, 'cm^3/(mol*s)'), n=0, Ea=(20436, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1000, 'K')),
+    kinetics = Arrhenius(A=(2.87e+08, 'cm^3/(mol*s)'), n=0, Ea=(20436, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(1000, 'K')),
     shortDesc = u"""[Lin1996b]""",
     longDesc =
 u"""
@@ -27,7 +28,8 @@ entry(
     index = 2,
     label = "N2H4 + NO3 <=> HONO + N2H3O",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.10e+18, 'cm^3/(mol*s)'), n=-1.84, Ea=(-642, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1000, 'K')),
+    kinetics = Arrhenius(A=(1.10e+18, 'cm^3/(mol*s)'), n=-1.84, Ea=(-642, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(1000, 'K')),
     shortDesc = u"""[Lin2014b]""",
     longDesc =
 u"""
@@ -53,7 +55,8 @@ entry(
     index = 3,
     label = "N2H3 + NO2 <=> N2H2 + HONO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.99e+46, 'cm^3/(mol*s)'), n=-11.8, Ea=(6055, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(800, 'K')),
+    kinetics = Arrhenius(A=(4.99e+46, 'cm^3/(mol*s)'), n=-11.8, Ea=(6055, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(800, 'K')),
     shortDesc = u"""[Lin2014b]""",
     longDesc =
 u"""
@@ -68,7 +71,8 @@ entry(
     index = 4,
     label = "N2H3 + NO2 <=> N2H2 + HNO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.07e+08, 'cm^3/(mol*s)'), n=0.5, Ea=(-2395, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1500, 'K')),
+    kinetics = Arrhenius(A=(4.07e+08, 'cm^3/(mol*s)'), n=0.5, Ea=(-2395, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(1500, 'K')),
     shortDesc = u"""[Lin2014b]""",
     longDesc =
 u"""
@@ -83,7 +87,8 @@ entry(
     index = 5,
     label = "N2H3 + NO2 <=> N2H3O + NO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.08e+20, 'cm^3/(mol*s)'), n=-2.9, Ea=(792.3, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1000, 'K')),
+    kinetics = Arrhenius(A=(1.08e+20, 'cm^3/(mol*s)'), n=-2.9, Ea=(792.3, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(1000, 'K')),
     shortDesc = u"""[Lin2014b]""",
     longDesc =
 u"""
@@ -98,7 +103,8 @@ entry(
     index = 6,
     label = "HCO + HNO <=> HNOH + CO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.16e+08, 'cm^3/(mol*s)'), n=1.19, Ea=(914, 'cal/mol'), T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(1000, 'K')),
+    kinetics = Arrhenius(A=(2.16e+08, 'cm^3/(mol*s)'), n=1.19, Ea=(914, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(400, 'K'), Tmax=(1000, 'K')),
     shortDesc = u"""[Lin2004]""",
     longDesc =
 u"""

--- a/input/kinetics/libraries/primaryNitrogenLibrary/LowT/reactions.py
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/LowT/reactions.py
@@ -115,3 +115,17 @@ k4(HNOH+CO), p. 213
 """,
 )
 
+entry(
+    index = 61,
+    label = "CN + NCO <=> NCN + CO",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.29e+13, 'cm^3/(mol*s)'), n=0.155, Ea=(129, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(200, 'K'), Tmax=(1000, 'K')),
+    shortDesc = u"""[Lin2009b]""",
+    longDesc =
+u"""
+Several levels of theory were used:
+G2M//B3LYP/6-311+G(d), QCISD(T)/6-311+G(3df)//QCISD/6-311+G(d), CCSD(T)/6-311+G(3df)//CCSD/6-311+G(d),
+CASPT2(10,10)/6-311+G(d)//CAS(10,10)/6-311+G(d).
+""",
+)


### PR DESCRIPTION
This PR fixes just one error of the many potential TST and collision rate violators reported in #275.
Also, a low-T rate of `CN + NCO <=> NCN + CO` was added to the primaryNitrogenLibrary.
We could either merge, or continue adding related fixes to this PR.