### PR TITLE
Change order of unit tests for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ install:
   - make
 
 script:
+  - make test-unittests
+  - make test-functional
   - make test-database
-  - make test-all
 
 after_success:
   - cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
For some reason, the generatePairs unit test fails if the database test is run first. This doesn't seem to make any sense, but switching the order fixes it, so we're going to do that for now.

The behavior is also not reproducible locally