### PR TITLE
Removed DUP tag from HOSO2 + O2 <=> SO3 + HO2 in primarySulfurLibrary

### DIFF
--- a/input/kinetics/libraries/primarySulfurLibrary/reactions.py
+++ b/input/kinetics/libraries/primarySulfurLibrary/reactions.py
@@ -1187,7 +1187,6 @@ entry(
     index = 62,
     label = "HOSO2 + O2 <=> SO3 + HO2",
     degeneracy = 2,
-    duplicate=True,
     kinetics = Arrhenius(A=(1.848e-06, 'cm^3/(mol*s)','*|/',5.17556), n=5.40, Ea=(94.02, 'kJ/mol'), T0=(1, 'K'),
                          Tmin=(300, 'K'), Tmax=(2000, 'K')),
     shortDesc = u"""CBS-QB3""",
@@ -1204,7 +1203,6 @@ entry(
     index = 63,
     label = "HOSO2 + O2 <=> SO3 + HO2",
     degeneracy = 2,
-    duplicate=True,
     kinetics = Chebyshev(
         coeffs = [
             [12.2121, -0.0588331, -0.0369469, -0.0170237],


### PR DESCRIPTION
This minor fix should solve the new sulfur test crush:
```python
Traceback (most recent call last):
  File "/home/travis/build/ReactionMechanismGenerator/RMG-tests/code/benchmark/RMG-Py/scripts/checkModels.py", line 289, in <module>
    main()
  File "/home/travis/build/ReactionMechanismGenerator/RMG-tests/code/benchmark/RMG-Py/scripts/checkModels.py", line 81, in main
    check(name, benchChemkin, benchSpeciesDict, testChemkin, testSpeciesDict)
  File "/home/travis/build/ReactionMechanismGenerator/RMG-tests/code/benchmark/RMG-Py/scripts/checkModels.py", line 93, in check
    execute(benchChemkin, benchSpeciesDict, benchThermo, testChemkin, testSpeciesDict, testThermo, **kwargs)
  File "/home/travis/build/ReactionMechanismGenerator/RMG-tests/code/benchmark/RMG-Py/rmgpy/tools/diff_models.py", line 313, in execute
    model1.species, model1.reactions = loadChemkinFile(chemkin1, speciesDict1, thermoPath = thermo1)
  File "rmgpy/chemkin.pyx", line 907, in rmgpy.chemkin.loadChemkinFile
  File "rmgpy/chemkin.pyx", line 1005, in rmgpy.chemkin._process_duplicate_reactions
rmgpy.exceptions.ChemkinError: Mixed kinetics for duplicate reaction HOSO2(26) + O2(2) <=> HO2(10) + SO3(16).
```

The second entry is pressure-dependent and has `(+M)` in the final Chemkin file. These two entries shouldn't be marked as dups.