### PR TITLE
Removed N5t atomType from the database

### DIFF
--- a/input/kinetics/families/CO_Disproportionation/groups.py
+++ b/input/kinetics/families/CO_Disproportionation/groups.py
@@ -1368,7 +1368,7 @@ entry(
     label = "N5_rad",
     group = 
 """
-1 *1 [N5sc,N5dc,N5t,N5tc,N5b] u1
+1 *1 [N5sc,N5dc,N5tc,N5b] u1
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Disproportionation/groups.py
+++ b/input/kinetics/families/Disproportionation/groups.py
@@ -1357,7 +1357,7 @@ entry(
     label = "N5_rad",
     group = 
 """
-1 *1 [N5sc,N5dc,N5t,N5tc,N5b] u1
+1 *1 [N5sc,N5dc,N5tc,N5b] u1
 """,
     kinetics = None,
 )
@@ -2630,10 +2630,10 @@ entry(
     label = "Cds/H2_d_N5rad",
     group = 
 """
-1 *2 C                     u0 {2,D} {3,S} {4,S}
-2 *3 [N5dc,N5ddc,N5t,N5tc] u1 p0 c+1 {1,D}
-3 *4 H                     u0 {1,S}
-4    H                     u0 {1,S}
+1 *2 C                 u0 {2,D} {3,S} {4,S}
+2 *3 [N5dc,N5ddc,N5tc] u1 p0 c+1 {1,D}
+3 *4 H                 u0 {1,S}
+4    H                 u0 {1,S}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/H_Abstraction/groups.py
+++ b/input/kinetics/families/H_Abstraction/groups.py
@@ -4166,8 +4166,8 @@ entry(
     label = "O_rad/OneDe",
     group = 
 """
-1 *3 O                                 u1 {2,S}
-2    [Cd,Ct,Cb,CO,CS,N3d,N3t,N5dc,N5t] u0 {1,S}
+1 *3 O                             u1 {2,S}
+2    [Cd,Ct,Cb,CO,CS,N3d,N3t,N5dc] u0 {1,S}
 """,
     kinetics = None,
 )
@@ -4290,8 +4290,8 @@ entry(
     label = "O_rad/OneDeN",
     group = 
 """
-1 *3 O                  u1 {2,S}
-2    [N3d,N3t,N5dc,N5t] u0 {1,S}
+1 *3 O              u1 {2,S}
+2    [N3d,N3t,N5dc] u0 {1,S}
 """,
     kinetics = None,
 )


### PR DESCRIPTION
since N5t isn't physical. Note that a charged nitrogen atom with valance 5 and a triple bond (N5tc), which is the physical form, is still allowed.
Should be merged before https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1418.