### PR TITLE
Add benzene bond groups to Disproportionation

### DIFF
--- a/input/kinetics/families/Disproportionation/groups.py
+++ b/input/kinetics/families/Disproportionation/groups.py
@@ -1400,8 +1400,8 @@ entry(
     label = "XH_Rrad",
     group = 
 """
-1 *2 R!H u0 {2,[S,D]} {3,S}
-2 *3 R!H u1 {1,[S,D]}
+1 *2 R!H u0 {2,[S,D,B]} {3,S}
+2 *3 R!H u1 {1,[S,D,B]}
 3 *4 H   u0 {1,S}
 """,
     kinetics = None,
@@ -2766,6 +2766,30 @@ entry(
 
 entry(
     index = 221,
+    label = "XH_b_Rrad",
+    group =
+"""
+1 *2 R!H u0 {2,B} {3,S}
+2 *3 R!H u1 {1,B}
+3 *4 H   u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 222,
+    label = "CH_b_Crad",
+    group =
+"""
+1 *2 C u0 {2,B} {3,S}
+2 *3 C u1 {1,B}
+3 *4 H u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 221,
     label = "XH_Rbirad",
     group = 
 """
@@ -3137,6 +3161,8 @@ L1: XH_Rrad_birad
                     L6: N3d/H_d_Crad
                     L6: N3d/H_d_Nrad
                 L5: N5dc/H_d_Rrad
+        L3: XH_b_Rrad
+            L4: CH_b_Crad
     L2: XH_Rbirad
         L3: XH_s_Rbirad
             L4: CH_s_Rbirad

--- a/input/kinetics/families/Disproportionation/training/dictionary.txt
+++ b/input/kinetics/families/Disproportionation/training/dictionary.txt
@@ -913,3 +913,57 @@ CHNO
 3 *2 C u0 p0 c0 {2,T} {4,S}
 4    H u0 p0 c0 {3,S}
 
+C6H5
+multiplicity 2
+1     C u0 p0 c0 {2,B} {3,B} {8,S}
+2     C u0 p0 c0 {1,B} {4,B} {7,S}
+3     C u0 p0 c0 {1,B} {5,B} {9,S}
+4  *2 C u0 p0 c0 {2,B} {6,B} {10,S}
+5     C u0 p0 c0 {3,B} {6,B} {11,S}
+6  *3 C u1 p0 c0 {4,B} {5,B}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10 *4 H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C6H5-2
+multiplicity 2
+1     C u0 p0 c0 {2,B} {3,B} {8,S}
+2     C u0 p0 c0 {1,B} {4,B} {7,S}
+3     C u0 p0 c0 {1,B} {5,B} {9,S}
+4     C u0 p0 c0 {2,B} {6,B} {10,S}
+5     C u0 p0 c0 {3,B} {6,B} {11,S}
+6  *1 C u1 p0 c0 {4,B} {5,B}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C6H6
+1     C u0 p0 c0 {2,B} {3,B} {7,S}
+2     C u0 p0 c0 {1,B} {4,B} {8,S}
+3  *1 C u0 p0 c0 {1,B} {5,B} {9,S}
+4     C u0 p0 c0 {2,B} {6,B} {10,S}
+5     C u0 p0 c0 {3,B} {6,B} {11,S}
+6     C u0 p0 c0 {4,B} {5,B} {12,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9  *4 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+
+C6H4
+1     C u0 p0 c0 {2,S} {3,D} {7,S}
+2     C u0 p0 c0 {1,S} {4,D} {8,S}
+3     C u0 p0 c0 {1,D} {5,S} {9,S}
+4     C u0 p0 c0 {2,D} {6,S} {10,S}
+5  *2 C u0 p0 c0 {3,S} {6,T}
+6  *3 C u0 p0 c0 {4,S} {5,T}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Disproportionation/training/reactions.py
@@ -3675,3 +3675,24 @@ Converted to training reaction from rate rule: C_rad/H/TwoDe;Cmethyl_Csrad/H/Cd
 """,
 )
 
+entry(
+    index = 136,
+    label = "C6H5 + C6H5-2 <=> C6H6 + C6H4",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(1350, 'cm^3/(mol*s)'), n=2.7, Ea=(-4.403, 'kcal/mol'), T0=(1, 'K')),
+    reference = Article(
+        authors = ['Tranter, R. S.', 'Klippenstein, S. J.', 'Harding, L. B.', 'Giri, B. R.', 'Yang, X.', 'Kiefer, J. H.'],
+        title = 'Experimental and Theoretical Investigation of the Self-Reaction of Phenyl Radicals',
+        journal = 'The Journal of Physical Chemistry A',
+        volume = '114 (32)',
+        pages = '8240-8261',
+        year = '2010',
+    ),
+    referenceType = "theory",
+    rank = 3,
+    longDesc = 
+u"""
+CASPT2(2e,2o)/cc-pvdz (VRC-TST)
+""",
+)
+


### PR DESCRIPTION
This commit was previously in #293. However, we decided that more work still needs to be done for that PR, so I am putting this in its own PR so that it can be merged first.

This commit adds benzene bond groups for the XH tree in disproportionation, thereby allowing formation of arynes in this family starting with aromatic structures. This is especially important given the imminent removal of Kekule structures as being reactive.

For testing, checking RMG-tests should be sufficient. This should only affect the aromatics test, if at all. Changes should be negligible since the Kekule structure could react before.