### PR TITLE
Add PyCharm Files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 .pydevproject
 .settings/*
 
+# PyCharm project files
+.idea/*
+
 # C-Compiled scripts
 *.pyc
 


### PR DESCRIPTION
Quick PR to add PyCharm to gitignore, since GitKraken no longer reads a User's personal global .gitignore