### PR TITLE
Correct some units in reaction libraries.

### DIFF
--- a/input/kinetics/libraries/Nitrogen_Dean_and_Bozzelli/reactions.py
+++ b/input/kinetics/libraries/Nitrogen_Dean_and_Bozzelli/reactions.py
@@ -1564,7 +1564,7 @@ entry(
                     Arrhenius(A=(5.9e+32, 's^-1'), n=-6.99, Ea=(51791.1, 'cal/mol'), T0=(1, 'K')),
                     Arrhenius(A=(9.6e+35, 's^-1'), n=-7.57, Ea=(54841.2, 'cal/mol'), T0=(1, 'K')),
                     Arrhenius(
-                        A = (5e+36, 'cm^3/(mol*s)'),
+                        A = (5e+36, 's^-1'),
                         n = -7.43,
                         Ea = (57296, 'cal/mol'),
                         T0 = (1, 'K'),
@@ -1577,7 +1577,7 @@ entry(
                     Arrhenius(A=(7.2e+28, 's^-1'), n=-7.77, Ea=(50757.9, 'cal/mol'), T0=(1, 'K')),
                     Arrhenius(A=(3.2e+31, 's^-1'), n=-6.22, Ea=(52318, 'cal/mol'), T0=(1, 'K')),
                     Arrhenius(
-                        A = (5.1e+33, 'cm^3/(mol*s)'),
+                        A = (5.1e+33, 's^-1'),
                         n = -6.52,
                         Ea = (54215.3, 'cal/mol'),
                         T0 = (1, 'K'),

--- a/input/kinetics/libraries/Sulfur/GlarborgMarshall/reactions.py
+++ b/input/kinetics/libraries/Sulfur/GlarborgMarshall/reactions.py
@@ -885,9 +885,9 @@ entry(
     label = "SO2 + O (+N2) <=> SO3 (+N2)",
     degeneracy = 1,
     kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(3.7e+11, 'cm^6/(mol^2*s)'), n=0, Ea=(1689, 'cal/mol'), T0=(1, 'K')),
+        arrheniusHigh = Arrhenius(A=(3.7e+11, 'cm^3/(mol*s)'), n=0, Ea=(1689, 'cal/mol'), T0=(1, 'K')),
         arrheniusLow = Arrhenius(
-            A = (2.9e+27, 'cm^9/(mol^3*s)'),
+            A = (2.9e+27, 'cm^6/(mol^2*s)'),
             n = -3.58,
             Ea = (5206, 'cal/mol'),
             T0 = (1, 'K'),

--- a/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
@@ -4025,7 +4025,7 @@ entry(
     index = 225,
     label = "C2H5ONO <=> CH3CHO + HNO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(9.85e+15, 'cm^3/(mol*s)'), n=0, Ea=(41760, 'cal/mol'), T0=(1, 'K'),
+    kinetics = Arrhenius(A=(9.85e+15, 's^-1'), n=0, Ea=(41760, 'cal/mol'), T0=(1, 'K'),
                          Tmin=(300, 'K'), Tmax=(2000, 'K')),
     elementary_high_p = True,
     shortDesc = u"""estimated by alongd""",
@@ -4053,15 +4053,15 @@ The latter is given in reverse in the Nitrogen_Glarborg_Zhang_et_al library:
     )
 Reversing the high-P limit rate of this reaction using thermo for CH3CH2O from FFCM-1, NO from NitrogenCurran,
 and CH3CH2ONO from NitrogenCurran gives in 300-2000 K:
-K(T) = 9.85E+15 * exp(46 kcal/mol / RT) cm3/mol*s    (negative Ea)
-A = 9.85E+15 cm3/mol*s
+K(T) = 9.85E+15 * exp(46 kcal/mol / RT)  s^-1   (negative Ea)
+A = 9.85E+15 s^-1
 
 The Ea is taken as the bond energy of C2H5O-NO
 Ea = H(NO) + H(C2H5O) - H(CH3CH2ONO)     (values taken at 1000 K)
 Ea = 26.93 + 14.52 - (-0.31) = 41.76 kcal/mol
 
 This is in agreement with the rate reported by [Green2014] (probably estimated similarly)::
-K(T) = 1.0E+16 * exp(-42 kcal/mol / RT) cm3/mol*s
+K(T) = 1.0E+16 * exp(-42 kcal/mol / RT)  s^-1
 """,
 )
 

--- a/input/kinetics/libraries/primarySulfurLibrary/reactions.py
+++ b/input/kinetics/libraries/primarySulfurLibrary/reactions.py
@@ -197,8 +197,8 @@ entry(
     label = "SO2 + O (+N2) <=> SO3 (+N2)",
     degeneracy = 1,
     kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(3.7e+11, 'cm^6/(mol^2*s)'), n=0, Ea=(1689, 'cal/mol'), T0=(1, 'K')),
-        arrheniusLow = Arrhenius(A=(2.9e+27, 'cm^9/(mol^3*s)'), n=-3.58, Ea=(5206, 'cal/mol'), T0=(1, 'K')),
+        arrheniusHigh = Arrhenius(A=(3.7e+11, 'cm^3/(mol*s)'), n=0, Ea=(1689, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow = Arrhenius(A=(2.9e+27, 'cm^6/(mol^2*s)'), n=-3.58, Ea=(5206, 'cal/mol'), T0=(1, 'K')),
         alpha=0.43, T3=(371, 'K'), T1=(7442, 'K'), efficiencies={}),
     shortDesc = u"""[Marshall2005],[Marshall2006]""",
     longDesc =


### PR DESCRIPTION
Someone should maybe check that these get evaluated
correctly and output to CHEMKIN correctly.

Sulfur/GlarborgMarhsall:
The arrheniusHigh should be the high pressure limit
which is bimolecular (hence around A=3e11).

Nitrogen_Dean_and_Bozzelli:
There's no reason the unimolecular reaction would 
suddenly become bimolecular at higher pressure.

primaryNitrogenLibrary:
It's first order so I'm guessing should just be /s
but maybe Alon can confirm (and fix the longDesc)

primarySulfurLibrary:
Explicit third bodies are clearly a cause of confusion,
perhaps revealing a bug in the CHEMKIN-reading code,
maybe also how it's written, and evaluated?