### PR TITLE
Corrected NH structure in GRI libraries

### DIFF
--- a/input/kinetics/libraries/GRI-Mech3.0-N/dictionary.txt
+++ b/input/kinetics/libraries/GRI-Mech3.0-N/dictionary.txt
@@ -169,7 +169,7 @@ multiplicity 3
 3 H u0 p0 c0 {1,S}
 
 NH
-1 N u0 p2 c0 {2,S}
+1 N u2 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 CH

--- a/input/thermo/libraries/GRI-Mech3.0-N.py
+++ b/input/thermo/libraries/GRI-Mech3.0-N.py
@@ -920,7 +920,7 @@ entry(
     label = "NH",
     molecule = 
 """
-1 N u0 p2 c0 {2,S}
+1 N u2 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = ThermoData(

--- a/input/thermo/libraries/GRI-Mech3.0.py
+++ b/input/thermo/libraries/GRI-Mech3.0.py
@@ -1011,7 +1011,7 @@ entry(
     label = "NH",
     molecule = 
 """
-1 N u0 p2 c0 {2,S}
+1 N u2 p1 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 """,
     thermo = NASA(


### PR DESCRIPTION
NH in GRI should be the `NH(T)` form, not the `NH(S)` form.
The H298 of `NH(S)` is about 120 kcal/mol, but the NH structure in the GRI libraries, which currently has the adjList of `NH(S)`, has H298 of 85 kcal/mol, which is the correct value for `NH(T)`.
Values for comparison are available in the primaryNS library (the singlet form) and in the NitrogenCurran library (the triplet form)