### PR TITLE
Database Label Fix

### DIFF
--- a/input/kinetics/families/Disproportionation/groups.py
+++ b/input/kinetics/families/Disproportionation/groups.py
@@ -25,14 +25,20 @@ recipe(actions=[
 entry(
     index = 0,
     label = "Y_rad_birad_trirad_quadrad",
-    group = "OR{Y_1centerquadrad, Y_1centertrirad, Y_2centerbirad, Y_1centerbirad, Y_rad}",
+    group = """
+1 *1 R u[1,2,3,4]
+""",
     kinetics = None,
 )
 
 entry(
     index = 1,
     label = "XH_Rrad_birad",
-    group = "OR{XH_Rrad, XH_Rbirad}",
+    group = """
+1 *2 R!H u0 {2,[S,D,B]} {3,S}
+2 *3 R!H u[1,2] {1,[S,D,B]}
+3 *4 H   u0 {1,S}
+""",
     kinetics = None,
 )
 

--- a/input/kinetics/families/Disproportionation/training/dictionary.txt
+++ b/input/kinetics/families/Disproportionation/training/dictionary.txt
@@ -80,6 +80,13 @@ multiplicity 2
 3    H u0 p0 c0 {1,S}
 4 *4 H u0 p0 c0 {1,S}
 
+CH3_r1
+multiplicity 2
+1 *1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
 H
 multiplicity 2
 1 *1 H u1 p0 c0

--- a/input/kinetics/families/Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Disproportionation/training/reactions.py
@@ -159,7 +159,7 @@ Converted to training reaction from rate rule: H_rad;Cmethyl_Csrad
 
 entry(
     index = 5,
-    label = "CH3 + C2H5 <=> CH4 + C2H4",
+    label = "CH3_r1 + C2H5 <=> CH4 + C2H4",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (6.57e+14, 'cm^3/(mol*s)', '*|/', 1.1),
@@ -636,7 +636,7 @@ Converted to training reaction from rate rule: C_rad/H/OneDeC;C/H2/Nd_Srad
 
 entry(
     index = 20,
-    label = "CH3 + C3H7-2 <=> CH4 + C3H6-2",
+    label = "CH3_r1 + C3H7-2 <=> CH4 + C3H6-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.3e+13, 'cm^3/(mol*s)', '*|/', 1.7),
@@ -1151,7 +1151,7 @@ Converted to training reaction from rate rule: H_rad;C/H/NdNd_Csrad
 
 entry(
     index = 37,
-    label = "CH3 + C4H9-2 <=> CH4 + C4H8-2",
+    label = "CH3_r1 + C4H9-2 <=> CH4 + C4H8-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (6.02e+12, 'cm^3/(mol*s)', '*|/', 2),
@@ -1457,7 +1457,7 @@ Converted to training reaction from rate rule: O2b;Cdpri_Csrad
 
 entry(
     index = 46,
-    label = "CH3 + C3H5-2 <=> CH4 + C3H4",
+    label = "CH3_r1 + C3H5-2 <=> CH4 + C3H4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3.01e+12, 'cm^3/(mol*s)', '*|/', 3),
@@ -3186,7 +3186,7 @@ Converted to training reaction from rate rule: N3d_rad/C;O_Orad
 
 entry(
     index = 114,
-    label = "CH3 + CH2N <=> CH4 + CHN",
+    label = "CH3_r1 + CH2N <=> CH4 + CHN",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.62e+06, 'cm^3/(mol*s)'),
@@ -3538,7 +3538,7 @@ Converted to training reaction from rate rule: O_pri_rad;N3s/H2_s_Cssrad
 
 entry(
     index = 130,
-    label = "CH3 + CH4N-2 <=> CH4 + CH3N-3",
+    label = "CH3_r1 + CH4N-2 <=> CH4 + CH3N-3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.2e+06, 'cm^3/(mol*s)'),
@@ -3607,7 +3607,7 @@ Converted to training reaction from rate rule: O_pri_rad;Cds/H2_d_N5dcrad/O
 
 entry(
     index = 133,
-    label = "CH3 + CH2NO <=> CH4 + CHNO",
+    label = "CH3_r1 + CH2NO <=> CH4 + CHNO",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.2e+06, 'cm^3/(mol*s)'),

--- a/input/kinetics/families/H_Abstraction/groups.py
+++ b/input/kinetics/families/H_Abstraction/groups.py
@@ -21,14 +21,19 @@ recipe(actions=[
 entry(
     index = 0,
     label = "X_H_or_Xrad_H_Xbirad_H_Xtrirad_H",
-    group = "OR{Xtrirad_H, Xbirad_H, Xrad_H, X_H}",
+    group = """
+1 *1 R u[0,1,2,3] {2,S}
+2 *2 H u0 {1,S}
+""",
     kinetics = None,
 )
 
 entry(
     index = 1,
     label = "Y_rad_birad_trirad_quadrad",
-    group = "OR{Y_rad, Y_1centerbirad, Y_1centertrirad, Y_1centerquadrad}",
+    group = """
+1 *3 R u[1,2,3,4]
+""",
     kinetics = None,
 )
 

--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -2077,8 +2077,13 @@ H2S
 2 *2 H u0 p0 c0 {1,S}
 3    H u0 p0 c0 {1,S}
 
-H2O
+H2O_r12
 1 *1 O u0 p2 c0 {2,S} {3,S}
+2 *2 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+H2O_p23
+1 *3 O u0 p2 c0 {2,S} {3,S}
 2 *2 H u0 p0 c0 {1,S}
 3    H u0 p0 c0 {1,S}
 
@@ -3765,6 +3770,11 @@ multiplicity 2
 1 *3 O u1 p2 c0 {2,S}
 2 *2 H u0 p0 c0 {1,S}
 
+OH_r3
+multiplicity 2
+1 *3 O u1 p2 c0 {2,S}
+2    H u0 p0 c0 {1,S}
+
 SH_p1
 multiplicity 2
 1 *1 S u1 p2 c0 {2,S}
@@ -3906,11 +3916,6 @@ H2N2
 2    N u0 p1 c0 {1,D} {4,S}
 3 *2 H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {2,S}
-
-OH
-multiplicity 2
-1 *3 O u1 p2 c0 {2,S}
-2    H u0 p0 c0 {1,S}
 
 C2H5OS
 multiplicity 2

--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -251,20 +251,6 @@ CH3N-2
 4    H u0 p0 c0 {2,S}
 5    H u0 p0 c0 {1,S}
 
-CH3_p1
-multiplicity 2
-1 *1 C u1 p0 c0 {2,S} {3,S} {4,S}
-2    H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-
-CH3_r3
-multiplicity 2
-1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
-2    H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-4    H u0 p0 c0 {1,S}
-
 C5H11
 multiplicity 2
 1     C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
@@ -1172,14 +1158,21 @@ H3NO-2
 4    H u0 p0 c0 {2,S}
 5 *2 H u0 p0 c0 {1,S}
 
-CH4b
+CH4
+1    C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+
+CH4_r12
 1 *1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
 2 *2 H u0 p0 c0 {1,S}
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {1,S}
 5    H u0 p0 c0 {1,S}
 
-CH4p
+CH4_p23
 1 *3 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
 2 *2 H u0 p0 c0 {1,S}
 3    H u0 p0 c0 {1,S}
@@ -1292,13 +1285,6 @@ multiplicity 2
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 5 H u0 p0 c0 {2,S}
-
-CH4
-1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
-2 H u0 p0 c0 {1,S}
-3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 H u0 p0 c0 {1,S}
 
 C3H7O2
 multiplicity 2
@@ -2616,6 +2602,27 @@ C4H8-8
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {4,S}
 
+CH3_r12
+multiplicity 2
+1 *1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4 *2 H u0 p0 c0 {1,S}
+
+CH3_r3
+multiplicity 2
+1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+CH3_p1
+multiplicity 2
+1 *1 C u1 p0 c0 {2,S} {3,S} {4,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
 CH3_p23
 multiplicity 2
 1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
@@ -3245,13 +3252,6 @@ NH_p1
 multiplicity 3
 1 *1 N u2 p1 c0 {2,S}
 2    H u0 p0 c0 {1,S}
-
-CH3
-multiplicity 2
-1 *1 C u1 p0 c0 {2,S} {3,S} {4,S}
-2    H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-4 *2 H u0 p0 c0 {1,S}
 
 C2
 multiplicity 3

--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -1102,24 +1102,6 @@ CH2S2-2
 4    H u0 p0 c0 {3,S}
 5 *2 H u0 p0 c0 {1,S}
 
-NH3
-1 N u0 p1 c0 {2,S} {3,S} {4,S}
-2 H u0 p0 c0 {1,S}
-3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-
-NH3_p
-1 *3 N u0 p1 c0 {2,S} {3,S} {4,S}
-2 *2 H u0 p0 c0 {1,S}
-3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-
-NH2
-multiplicity 2
-1 *3 N u1 p1 c0 {2,S} {3,S}
-2    H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-
 C2H6O-2
 1    O u0 p2 c0 {2,S} {9,S}
 2    C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
@@ -1224,12 +1206,6 @@ multiplicity 2
 2    O u0 p3 c-1 {4,S}
 3    O u0 p2 c0 {4,D}
 4    N u0 p0 c+1 {1,S} {2,S} {3,D}
-
-NH2b
-multiplicity 2
-1 *3 N u1 p1 c0 {2,S} {3,S}
-2 *2 H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
 
 CH2OS
 1 *1 S u0 p2 c0 {3,S} {5,S}
@@ -2472,12 +2448,6 @@ C6H6-2
 10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {5,S}
 12    H u0 p0 c0 {6,S}
-
-NH2_p
-multiplicity 2
-1 *1 N u1 p1 c0 {2,S} {3,S}
-2    H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
 
 C2H
 multiplicity 2
@@ -4412,8 +4382,44 @@ C6H12O2-4
 19    H u0 p0 c0 {7,S}
 20    H u0 p0 c0 {7,S}
 
-NH3_r
+NH2
+multiplicity 2
+1    N u1 p1 c0 {2,S} {3,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+NH2_r3
+multiplicity 2
+1 *3 N u1 p1 c0 {2,S} {3,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+NH2_p1
+multiplicity 2
+1 *1 N u1 p1 c0 {2,S} {3,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+NH2_p23
+multiplicity 2
+1 *3 N u1 p1 c0 {2,S} {3,S}
+2 *2 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+NH3
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+
+NH3_r12
 1 *1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 *2 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+
+NH3_p23
+1 *3 N u0 p1 c0 {2,S} {3,S} {4,S}
 2 *2 H u0 p0 c0 {1,S}
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {1,S}

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -1283,7 +1283,7 @@ in good agreement with this expression (within a factor of 3.5 over the valid te
 
 entry(
     index = 42,
-    label = "C3H6O-3 + OH <=> C3H5O-3 + H2O",
+    label = "C3H6O-3 + OH_r3 <=> C3H5O-3 + H2O_p23",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (132.6, 'cm^3/(mol*s)'),
@@ -1313,7 +1313,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 43,
-    label = "C4H8O-4 + OH <=> C4H7O-4 + H2O",
+    label = "C4H8O-4 + OH_r3 <=> C4H7O-4 + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (399, 'cm^3/(mol*s)'),
@@ -1343,7 +1343,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 44,
-    label = "C4H8O-5 + OH <=> C4H7O-5 + H2O",
+    label = "C4H8O-5 + OH_r3 <=> C4H7O-5 + H2O_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (236, 'cm^3/(mol*s)'),
@@ -1373,7 +1373,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 45,
-    label = "C4H8O-6 + OH <=> C4H7O-6 + H2O",
+    label = "C4H8O-6 + OH_r3 <=> C4H7O-6 + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.35, 'cm^3/(mol*s)'),
@@ -1403,7 +1403,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 46,
-    label = "C5H10O + OH <=> C5H9O + H2O",
+    label = "C5H10O + OH_r3 <=> C5H9O + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2568, 'cm^3/(mol*s)'),
@@ -1433,7 +1433,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 47,
-    label = "C5H10O-2 + OH <=> C5H9O-2 + H2O",
+    label = "C5H10O-2 + OH_r3 <=> C5H9O-2 + H2O_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (4920, 'cm^3/(mol*s)'),
@@ -1463,7 +1463,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 48,
-    label = "C5H10O-3 + OH <=> C5H9O-3 + H2O",
+    label = "C5H10O-3 + OH_r3 <=> C5H9O-3 + H2O_p23",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (15.54, 'cm^3/(mol*s)'),
@@ -1493,7 +1493,7 @@ DOI: 10.1039/C0CP02754E
 
 entry(
     index = 49,
-    label = "C4H10O-4 + OH <=> H2O + C4H9O-4",
+    label = "C4H10O-4 + OH_r3 <=> H2O_p23 + C4H9O-4",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3610, 'cm^3/(mol*s)'),
@@ -1824,7 +1824,7 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 
 entry(
     index = 65,
-    label = "HNCN + OH <=> H2O_p + NCN",
+    label = "HNCN + OH_r3 <=> H2O_p23 + NCN",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (104000, 'cm^3/(mol*s)'),
@@ -2254,7 +2254,7 @@ calculations done at the G2M//B3LYP/6-311+G(d,p) and G2M//MPW1PW91/6-311+G(3df,2
 
 entry(
     index = 85,
-    label = "HNO3_r + OH <=> H2O_p + NO3_p",
+    label = "HNO3_r + OH_r3 <=> H2O_p23 + NO3_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (8.73, 'cm^3/(mol*s)'),
@@ -2317,7 +2317,7 @@ Review and reccomendation, based on experimental studies
 
 entry(
     index = 88,
-    label = "HCN_r + OH <=> CN_p + H2O_p",
+    label = "HCN_r + OH_r3 <=> CN_p + H2O_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3.8e+14, 'cm^3/(mol*s)'),
@@ -3011,7 +3011,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 120,
-    label = "CH3CH2NH2_1 + OH <=> CH2CH2NH2 + H2O",
+    label = "CH3CH2NH2_1 + OH_r3 <=> CH2CH2NH2 + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (794, 'cm^3/(mol*s)'),
@@ -3035,7 +3035,7 @@ doi: 10.1021/jp411141w
 
 entry(
     index = 121,
-    label = "CH3CH2NH2_2 + OH <=> CH3CHNH2 + H2O",
+    label = "CH3CH2NH2_2 + OH_r3 <=> CH3CHNH2 + H2O_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (328000, 'cm^3/(mol*s)'),
@@ -3059,7 +3059,7 @@ doi: 10.1021/jp411141w
 
 entry(
     index = 122,
-    label = "CH3CH2NH2_3 + OH <=> CH3CH2NH + H2O",
+    label = "CH3CH2NH2_3 + OH_r3 <=> CH3CH2NH + H2O_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (112000, 'cm^3/(mol*s)'),
@@ -3434,7 +3434,7 @@ entry(
         T0 = (1, 'K'),
     ),
     rank = 1,
-    shortDesc = u"""Cl + CH3OH <=> HCl + CH2OH""",
+    shortDesc = u"""Cl + CH3OH_r3 <=> HCl + CH2OH""",
     longDesc = 
 u"""
 IUPAC recommendation: http://iupac.pole-ether.fr 
@@ -3453,7 +3453,7 @@ entry(
         T0 = (1, 'K'),
     ),
     rank = 5,
-    shortDesc = u"""Cl + CH3OH <=> HCl + CH3O""",
+    shortDesc = u"""Cl + CH3OH_r3 <=> HCl + CH3O""",
     longDesc = 
 u"""
 Theoretical study of the kinetics of the hydrogen abstraction from methanol. 2. Reaction of methanol with chlorine and bromine atoms
@@ -3473,7 +3473,7 @@ entry(
         T0 = (1, 'K'),
     ),
     rank = 1,
-    shortDesc = u"""Cl + C2H5OH <=> HCl + CH3CHOH""",
+    shortDesc = u"""Cl + C2H5OH_r3 <=> HCl + CH3CHOH""",
     longDesc = 
 u"""
 Absolute and Site-Specific Abstraction Rate Coefficients for Reactions of Cl with CH3CH2 OH, CH3CD2OH, and CD3CH2OH Between 295 and 600 K
@@ -3493,7 +3493,7 @@ entry(
         T0 = (1, 'K'),
     ),
     rank = 1,
-    shortDesc = u"""Cl + C2H5OH <=> HCl + CH2CH2OH""",
+    shortDesc = u"""Cl + C2H5OH_r3 <=> HCl + CH2CH2OH""",
     longDesc = 
 u"""
 Absolute and Site-Specific Abstraction Rate Coefficients for Reactions of Cl with CH3CH2 OH, CH3CD2OH, and CD3CH2OH Between 295 and 600 K
@@ -3504,7 +3504,7 @@ LP-IR experiments from 295-600 K
 
 entry(
     index = 144,
-    label = "Cl + H2O <=> HCl + OH",
+    label = "Cl + H2O_r12 <=> HCl + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.79e-11, 'cm^3/(molecule*s)'),
@@ -4336,7 +4336,7 @@ entry(
 
 entry(
     index = 188,
-    label = "CH4_r12 + OH <=> CH3_p1 + H2O_p",
+    label = "CH4_r12 + OH_r3 <=> CH3_p1 + H2O_p23",
     degeneracy = 4.0,
     kinetics = Arrhenius(A=(1e+06, 'cm^3/(mol*s)'), n=2.182, Ea=(2506, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4404,7 +4404,7 @@ entry(
 
 entry(
     index = 195,
-    label = "CH4O + OH <=> CH2OH_p + H2O_p",
+    label = "CH4O + OH_r3 <=> CH2OH_p + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.5e+08, 'cm^3/(mol*s)'),
@@ -4418,7 +4418,7 @@ entry(
 
 entry(
     index = 196,
-    label = "CH4O-2 + OH <=> CH3O_p + H2O_p",
+    label = "CH4O-2 + OH_r3 <=> CH3O_p + H2O_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2.7e+07, 'cm^3/(mol*s)'),
@@ -4535,7 +4535,7 @@ entry(
 
 entry(
     index = 206,
-    label = "CH4O2 + OH <=> CH3OO_p + H2O_p",
+    label = "CH4O2 + OH_r3 <=> CH3OO_p + H2O_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(A=(1.1e+12, 'cm^3/(mol*s)'), n=0, Ea=(-437, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4544,7 +4544,7 @@ entry(
 
 entry(
     index = 207,
-    label = "CH3OOH_rC + OH <=> CH2OOH_p + H2O_p",
+    label = "CH3OOH_rC + OH_r3 <=> CH2OOH_p + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(A=(7.2e+11, 'cm^3/(mol*s)'), n=0, Ea=(-258, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4612,7 +4612,7 @@ entry(
 
 entry(
     index = 212,
-    label = "C2H6 + OH <=> C2H5b + H2O_p",
+    label = "C2H6 + OH_r3 <=> C2H5b + H2O_p23",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.61e+06, 'cm^3/(mol*s)'),
@@ -4683,7 +4683,7 @@ entry(
 
 entry(
     index = 218,
-    label = "C2H4 + OH <=> C2H3_p + H2O_p",
+    label = "C2H4 + OH_r3 <=> C2H3_p + H2O_p23",
     degeneracy = 4.0,
     kinetics = Arrhenius(A=(0.13, 'cm^3/(mol*s)'), n=4.2, Ea=(-860, 'cal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -4755,7 +4755,7 @@ entry(
 
 entry(
     index = 226,
-    label = "C2H6O + OH <=> CH3CHOH_p + H2O_p",
+    label = "C2H6O + OH_r3 <=> CH3CHOH_p + H2O_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(A=(450, 'cm^3/(mol*s)'), n=3.11, Ea=(-2666, 'cal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -4764,7 +4764,7 @@ entry(
 
 entry(
     index = 227,
-    label = "C2H6O-2 + OH <=> CH2CH2OH_p + H2O_p",
+    label = "C2H6O-2 + OH_r3 <=> CH2CH2OH_p + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(A=(9400, 'cm^3/(mol*s)'), n=2.67, Ea=(-1004, 'cal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -4854,7 +4854,7 @@ entry(
 
 entry(
     index = 237,
-    label = "C2H4O + OH <=> CH3CO_p + H2O_p",
+    label = "C2H4O + OH_r3 <=> CH3CO_p + H2O_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(A=(2.8e+12, 'cm^3/(mol*s)'), n=0, Ea=(-709, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4863,7 +4863,7 @@ entry(
 
 entry(
     index = 238,
-    label = "CH3CHO_r1 + OH <=> CH2CHO_p + H2O_p",
+    label = "CH3CHO_r1 + OH_r3 <=> CH2CHO_p + H2O_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(A=(8.5e+13, 'cm^3/(mol*s)'), n=0, Ea=(5313, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -5138,7 +5138,7 @@ Jim Chu's calculation
 
 entry(
     index = 255,
-    label = "C3H4 + OH <=> H2O + C3H3-2",
+    label = "C3H4 + OH_r3 <=> H2O_p23 + C3H3-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (12560, 'cm^3/(mol*s)'),
@@ -5164,7 +5164,7 @@ UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
 
 entry(
     index = 256,
-    label = "C3H4-1 + OH <=> H2O + C3H3",
+    label = "C3H4-1 + OH_r3 <=> H2O_p23 + C3H3",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (33830, 'cm^3/(mol*s)'),
@@ -5190,7 +5190,7 @@ UCCSD(T)-F12b/cc-pVQZ-F12//M06-2X/6-311++G(d,p)
 
 entry(
     index = 257,
-    label = "C7H8 + OH <=> H2O + C7H7",
+    label = "C7H8 + OH_r3 <=> H2O_p23 + C7H7",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (130169, 'cm^3/(mol*s)'),
@@ -5216,7 +5216,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 258,
-    label = "C7H8-2 + OH <=> H2O + C7H7-2",
+    label = "C7H8-2 + OH_r3 <=> H2O_p23 + C7H7-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (277.731, 'cm^3/(mol*s)'),
@@ -5242,7 +5242,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 259,
-    label = "C7H8-3 + OH <=> H2O + C7H7-3",
+    label = "C7H8-3 + OH_r3 <=> H2O_p23 + C7H7-3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (819.665, 'cm^3/(mol*s)'),
@@ -5268,7 +5268,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 260,
-    label = "C7H8-4 + OH <=> H2O + C7H7-4",
+    label = "C7H8-4 + OH_r3 <=> H2O_p23 + C7H7-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (763.895, 'cm^3/(mol*s)'),
@@ -5710,7 +5710,7 @@ B3LYP structural and vibrational information with BH&HLYP corrected barrier
 
 entry(
     index = 277,
-    label = "C6H6 + OH <=> H2O + C6H5",
+    label = "C6H6 + OH_r3 <=> H2O_p23 + C6H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (3.88e-20, 'cm^3/(molecule*s)'),
@@ -5940,7 +5940,7 @@ Converted to training reaction from rate rule: X_H;O_atom_triplet
 
 entry(
     index = 286,
-    label = "H2 + OH <=> H2O_p + H_p",
+    label = "H2 + OH_r3 <=> H2O_p23 + H_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.4e+06, 'cm^3/(mol*s)'),
@@ -6046,7 +6046,7 @@ Converted to training reaction from rate rule: O/H/NonDeC;O2b
 
 entry(
     index = 291,
-    label = "OH + C2H6 <=> H2O_p + C2H5",
+    label = "OH_r3 + C2H6 <=> H2O_p23 + C2H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (3.558e+07, 'cm^3/(mol*s)'),
@@ -6082,7 +6082,7 @@ Converted to training reaction from rate rule: C/H3/Cs;O_pri_rad
 
 entry(
     index = 292,
-    label = "OH + C3H8 <=> H2O + C3H7",
+    label = "OH_r3 + C3H8 <=> H2O_p23 + C3H7",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (900000, 'cm^3/(mol*s)'),
@@ -6117,7 +6117,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC;O_pri_rad
 
 entry(
     index = 293,
-    label = "OH + iC4H10b <=> H2O + C4H9-4",
+    label = "OH_r3 + iC4H10b <=> H2O_p23 + C4H9-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.7e+06, 'cm^3/(mol*s)'),
@@ -6691,7 +6691,7 @@ Converted to training reaction from rate rule: H2;CO_rad/NonDe
 
 entry(
     index = 312,
-    label = "H2 + OH <=> H2O_p + H_p",
+    label = "H2 + OH_r3 <=> H2O_p23 + H_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.82e+09, 'cm^3/(mol*s)'),
@@ -6972,7 +6972,7 @@ Converted to training reaction from rate rule: C_methane;CO_rad/NonDe
 
 entry(
     index = 321,
-    label = "OH + CH4_r12 <=> H2O_p + CH3_p1",
+    label = "OH_r3 + CH4_r12 <=> H2O_p23 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.54, 'cm^3/(mol*s)'),
@@ -7186,7 +7186,7 @@ Converted to training reaction from rate rule: C/H3/Cs;CO_rad/NonDe
 
 entry(
     index = 328,
-    label = "OH + CH3CHO_r1 <=> H2O + C2H3O-2",
+    label = "OH_r3 + CH3CHO_r1 <=> H2O_p23 + C2H3O-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.551e+06, 'cm^3/(mol*s)'),
@@ -7238,7 +7238,7 @@ Converted to training reaction from rate rule: C/H3/O;C_methyl
 
 entry(
     index = 330,
-    label = "OH + CH4O <=> H2O + CH3O",
+    label = "OH_r3 + CH4O <=> H2O_p23 + CH3O",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (24420, 'cm^3/(mol*s)'),
@@ -7773,7 +7773,7 @@ Converted to training reaction from rate rule: Cd_pri;C_rad/H2/Cs
 
 entry(
     index = 345,
-    label = "OH + C2H4 <=> H2O + C2H3",
+    label = "OH_r3 + C2H4 <=> H2O_p23 + C2H3",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (2.052e+13, 'cm^3/(mol*s)', '*|/', 3.16),
@@ -7993,7 +7993,7 @@ Converted to training reaction from rate rule: Cd/H/NonDeC;Ct_rad
 
 entry(
     index = 351,
-    label = "OH + C3H6-2 <=> H2O + C3H5-2",
+    label = "OH_r3 + C3H6-2 <=> H2O_p23 + C3H5-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.11e+06, 'cm^3/(mol*s)', '*|/', 2),
@@ -8100,7 +8100,7 @@ Converted to training reaction from rate rule: Ct_H;C_rad/H2/Cs
 
 entry(
     index = 354,
-    label = "OH + C2H2 <=> H2O + C2H",
+    label = "OH_r3 + C2H2 <=> H2O_p23 + C2H",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (14500, 'cm^3/(mol*s)', '*|/', 10),
@@ -8206,7 +8206,7 @@ Converted to training reaction from rate rule: Cb_H;C_rad/H2/Cs
 
 entry(
     index = 358,
-    label = "OH + C6H6 <=> H2O + C6H5",
+    label = "OH_r3 + C6H6 <=> H2O_p23 + C6H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.632e+08, 'cm^3/(mol*s)', '*|/', 2),
@@ -8554,7 +8554,7 @@ Converted to training reaction from rate rule: CO_pri;CO_rad/NonDe
 
 entry(
     index = 368,
-    label = "OH + CH2O <=> H2O + HCO_r3",
+    label = "OH_r3 + CH2O <=> H2O_p23 + HCO_r3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.44e+09, 'cm^3/(mol*s)', '*|/', 5),
@@ -8816,7 +8816,7 @@ Converted to training reaction from rate rule: CO/H/NonDe;Cd_pri_rad
 
 entry(
     index = 377,
-    label = "OH + C2H4O <=> H2O + C2H3O",
+    label = "OH_r3 + C2H4O <=> H2O_p23 + C2H3O",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2e+06, 'cm^3/(mol*s)'),
@@ -8882,7 +8882,7 @@ Converted to training reaction from rate rule: CO/H/NonDe;O_rad/NonDeO
 
 entry(
     index = 379,
-    label = "H2O + O2 <=> HO2_r12 + OH_p23",
+    label = "H2O_r12 + O2 <=> HO2_r12 + OH_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (9.3e+12, 'cm^3/(mol*s)'),
@@ -8908,7 +8908,7 @@ Converted to training reaction from rate rule: O_pri;O2b
 
 entry(
     index = 380,
-    label = "H2O + O_rad <=> HO + OH_p23",
+    label = "H2O_r12 + O_rad <=> HO + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (5.26e+09, 'cm^3/(mol*s)'),
@@ -8931,7 +8931,7 @@ Converted to training reaction from rate rule: O_pri;O_atom_triplet
 
 entry(
     index = 381,
-    label = "H + H2O <=> H2 + OH_p23",
+    label = "H + H2O_r12 <=> H2 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.52e+08, 'cm^3/(mol*s)', '*|/', 1.6),
@@ -8972,7 +8972,7 @@ Converted to training reaction from rate rule: O_pri;H_rad
 
 entry(
     index = 382,
-    label = "H2O + CH3_r3 <=> CH4_p23 + OH_p1",
+    label = "H2O_r12 + CH3_r3 <=> CH4_p23 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (6.4, 'cm^3/(mol*s)'),
@@ -8995,7 +8995,7 @@ Converted to training reaction from rate rule: O_pri;C_methyl
 
 entry(
     index = 383,
-    label = "H2O + C2H5 <=> C2H6 + OH_p23",
+    label = "H2O_r12 + C2H5 <=> C2H6 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.4e+06, 'cm^3/(mol*s)', '*|/', 2),
@@ -9028,7 +9028,7 @@ Converted to training reaction from rate rule: O_pri;C_rad/H2/Cs
 
 entry(
     index = 384,
-    label = "H2O + C2H3 <=> C2H4 + OH_p23",
+    label = "H2O_r12 + C2H3 <=> C2H4 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (484, 'cm^3/(mol*s)', '*|/', 5),
@@ -9061,7 +9061,7 @@ Converted to training reaction from rate rule: O_pri;Cd_pri_rad
 
 entry(
     index = 385,
-    label = "H2O + HCO_r3 <=> CH2O + OH_p23",
+    label = "H2O_r12 + HCO_r3 <=> CH2O + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.36e+08, 'cm^3/(mol*s)', '*|/', 5),
@@ -9094,7 +9094,7 @@ Converted to training reaction from rate rule: O_pri;CO_pri_rad
 
 entry(
     index = 386,
-    label = "H2O + CH3O-2 <=> CH4O-2 + OH_p23",
+    label = "H2O_r12 + CH3O-2 <=> CH4O-2 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.348, 'cm^3/(mol*s)'),
@@ -9400,7 +9400,7 @@ Converted to training reaction from rate rule: O/H/NonDeC;Ct_rad
 
 entry(
     index = 395,
-    label = "OH + CH4O-2 <=> H2O + CH3O-2",
+    label = "OH_r3 + CH4O-2 <=> H2O_p23 + CH3O-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (17.3, 'cm^3/(mol*s)'),
@@ -10953,7 +10953,7 @@ Converted to training reaction from rate rule: CO/H/Cs\Cs|Cs;O_rad/NonDeO
 
 entry(
     index = 444,
-    label = "OH + C7H8 <=> H2O + C7H7",
+    label = "OH_r3 + C7H8 <=> H2O_p23 + C7H7",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.26e+13, 'cm^3/(mol*s)'),
@@ -11535,7 +11535,7 @@ Converted to training reaction from rate rule: CS_pri;C_methyl
 
 entry(
     index = 472,
-    label = "OH + H2S_r <=> H2O_p + SH_p1",
+    label = "OH_r3 + H2S_r <=> H2O_p23 + SH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.26e+08, 'cm^3/(mol*s)'),
@@ -11555,7 +11555,7 @@ Converted to training reaction from rate rule: S_pri;O_pri_rad
 
 entry(
     index = 473,
-    label = "OH + CH3SH_r1 <=> H2O_p + CH3S",
+    label = "OH_r3 + CH3SH_r1 <=> H2O_p23 + CH3S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (203000, 'cm^3/(mol*s)'),
@@ -11955,7 +11955,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 493,
-    label = "OH + NH3_r12 <=> H2O + NH2_p23",
+    label = "OH_r3 + NH3_r12 <=> H2O_p23 + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -14557,7 +14557,7 @@ Converted to training reaction from rate rule: NH3;H_rad
 
 entry(
     index = 623,
-    label = "OH + NH3_r12 <=> H2O + NH2_p23",
+    label = "OH_r3 + NH3_r12 <=> H2O_p23 + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.5e+08, 'cm^3/(mol*s)'),
@@ -14641,7 +14641,7 @@ Added by Beat Buesser, value for reaction: NH2_r3 + O = NH + OH (B&D #15d2) in '
 
 entry(
     index = 627,
-    label = "OH + H2N <=> H2O + NH_p",
+    label = "OH_r3 + H2N <=> H2O_p23 + NH_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -14771,7 +14771,7 @@ Converted to training reaction from rate rule: NH_triplet_H;NH2_rad
 
 entry(
     index = 633,
-    label = "OH + HN <=> H2O_p + N",
+    label = "OH_r3 + HN <=> H2O_p23 + N",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.2e+06, 'cm^3/(mol*s)'),
@@ -14903,7 +14903,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeN;O_atom_triplet
 
 entry(
     index = 639,
-    label = "OH + H2N2 <=> H2O_p + HN2",
+    label = "OH_r3 + H2N2 <=> H2O_p23 + HN2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -14991,7 +14991,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeN;NH_triplet
 
 entry(
     index = 643,
-    label = "OH + H3N2 <=> H2O_p + H2N2-2",
+    label = "OH_r3 + H3N2 <=> H2O_p23 + H2N2-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3e+13, 'cm^3/(mol*s)'),
@@ -15101,7 +15101,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;O_atom_triplet
 
 entry(
     index = 648,
-    label = "OH + N2H4 <=> H2O + H3N2-2",
+    label = "OH_r3 + N2H4 <=> H2O_p23 + H3N2-2",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.92e+07, 'cm^3/(mol*s)'),
@@ -15167,7 +15167,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;NH2_rad
 
 entry(
     index = 651,
-    label = "OH + HNO_r <=> H2O + NO",
+    label = "OH_r3 + HNO_r <=> H2O_p23 + NO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.3e+07, 'cm^3/(mol*s)'),
@@ -15343,7 +15343,7 @@ Converted to training reaction from rate rule: O/H/OneDeN;O_atom_triplet
 
 entry(
     index = 659,
-    label = "OH + CH3NO <=> H2O_p + CH2NO",
+    label = "OH_r3 + CH3NO <=> H2O_p23 + CH2NO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.2e+06, 'cm^3/(mol*s)'),
@@ -15409,7 +15409,7 @@ Converted to training reaction from rate rule: O/H/OneDeN;NH2_rad
 
 entry(
     index = 662,
-    label = "OH + HCN_r <=> H2O_p + CN",
+    label = "OH_r3 + HCN_r <=> H2O_p23 + CN",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3.9e+06, 'cm^3/(mol*s)'),
@@ -15475,7 +15475,7 @@ Converted to training reaction from rate rule: H2;Ct_rad/N
 
 entry(
     index = 665,
-    label = "H2O + CN <=> HCN_r + OH_p23",
+    label = "H2O_r12 + CN <=> HCN_r + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.56e+13, 'cm^3/(mol*s)'),
@@ -15585,7 +15585,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeC;O_atom_triplet
 
 entry(
     index = 670,
-    label = "OH_p23 + CH3N <=> H2O + CH2N",
+    label = "OH_r3 + CH3N <=> H2O_p23 + CH2N",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.2e+06, 'cm^3/(mol*s)'),
@@ -15695,7 +15695,7 @@ Converted to training reaction from rate rule: Cd/H2/NonDeN;O_atom_triplet
 
 entry(
     index = 675,
-    label = "OH + CH3N-2 <=> H2O_p + CH2N-2",
+    label = "OH_r3 + CH3N-2 <=> H2O_p23 + CH2N-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -15805,7 +15805,7 @@ Converted to training reaction from rate rule: Cs/H3/NonDeN;O_atom_triplet
 
 entry(
     index = 680,
-    label = "OH + CH5N <=> H2O_p + CH4N",
+    label = "OH_r3 + CH5N <=> H2O_p23 + CH4N",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.08e+07, 'cm^3/(mol*s)'),
@@ -15915,7 +15915,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeC;O_atom_triplet
 
 entry(
     index = 685,
-    label = "OH + CH5N-2 <=> H2O_p + CH4N-2",
+    label = "OH_r3 + CH5N-2 <=> H2O_p23 + CH4N-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -16091,7 +16091,7 @@ Converted to training reaction from rate rule: O/H/OneDeC;O_atom_triplet
 
 entry(
     index = 693,
-    label = "OH + C2H4O-2 <=> H2O_p + C2H3O-3",
+    label = "OH_r3 + C2H4O-2 <=> H2O_p23 + C2H3O-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.2e+06, 'cm^3/(mol*s)'),
@@ -16157,7 +16157,7 @@ Converted to training reaction from rate rule: O/H/OneDeC;NH2_rad
 
 entry(
     index = 696,
-    label = "OH + HNCO <=> H2O_p + CNO",
+    label = "OH_r3 + HNCO <=> H2O_p23 + CNO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (5.2e+10, 'cm^3/(mol*s)'),
@@ -16333,7 +16333,7 @@ Converted to training reaction from rate rule: Cs/H3/OneDeN;O_atom_triplet
 
 entry(
     index = 704,
-    label = "OH + C2H5N <=> H2O_p + C2H4N-2",
+    label = "OH_r3 + C2H5N <=> H2O_p23 + C2H4N-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.08e+07, 'cm^3/(mol*s)'),
@@ -16443,7 +16443,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeO;O_atom_triplet
 
 entry(
     index = 709,
-    label = "OH_p23 + H3NO <=> H2O + H2NO",
+    label = "OH_r3 + H3NO <=> H2O_p23 + H2NO",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -16575,7 +16575,7 @@ Converted to training reaction from rate rule: O/H/NonDeN;O_atom_triplet
 
 entry(
     index = 715,
-    label = "OH_p23 + H3NO-2 <=> H2O + H2NO-2",
+    label = "OH_r3 + H3NO-2 <=> H2O_p23 + H2NO-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.2e+06, 'cm^3/(mol*s)'),
@@ -16707,7 +16707,7 @@ Converted to training reaction from rate rule: N3s/H2/OneDeN;O_atom_triplet
 
 entry(
     index = 721,
-    label = "OH_p23 + CH4N2 <=> H2O + CH3N2",
+    label = "OH_r3 + CH4N2 <=> H2O_p23 + CH3N2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -16817,7 +16817,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;O_rad/NonDeO
 
 entry(
     index = 726,
-    label = "OH_p23 + C7H12 <=> H2O + C7H11",
+    label = "OH_r3 + C7H12 <=> H2O_p23 + C7H11",
     degeneracy = 8.0,
     kinetics = Arrhenius(
         A = (688800, 'cm^3/(mol*s)'),
@@ -16837,7 +16837,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;O_pri_
 
 entry(
     index = 727,
-    label = "OH_p23 + C7H12-2 <=> H2O + C7H11-2",
+    label = "OH_r3 + C7H12-2 <=> H2O_p23 + C7H11-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (556000, 'cm^3/(mol*s)'),
@@ -16857,7 +16857,7 @@ Converted to training reaction from rate rule: C/H/Cs3_5ring_fused6;O_pri_rad
 
 entry(
     index = 728,
-    label = "OH_p23 + C7H12-3 <=> H2O + C7H11-3",
+    label = "OH_r3 + C7H12-3 <=> H2O_p23 + C7H11-3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (168800, 'cm^3/(mol*s)'),
@@ -16877,7 +16877,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_2;O_pri_
 
 entry(
     index = 729,
-    label = "OH_p23 + C8H14 <=> H2O + C8H13",
+    label = "OH_r3 + C8H14 <=> H2O_p23 + C8H13",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (113400, 'cm^3/(mol*s)'),
@@ -16897,7 +16897,7 @@ Converted to training reaction from rate rule: C/H/Cs3_5ring_adj5;O_pri_rad
 
 entry(
     index = 730,
-    label = "OH_p23 + C9H16 <=> H2O + C9H15",
+    label = "OH_r3 + C9H16 <=> H2O_p23 + C9H15",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (275200, 'cm^3/(mol*s)'),
@@ -16917,7 +16917,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_alpha6ring;O_pr
 
 entry(
     index = 731,
-    label = "OH_p23 + C9H16-2 <=> H2O + C9H15-2",
+    label = "OH_r3 + C9H16-2 <=> H2O_p23 + C9H15-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (302000, 'cm^3/(mol*s)'),
@@ -17597,7 +17597,7 @@ Converted to training reaction from rate rule: Cd/H/NonDeC;C_rad/Cs3
 
 entry(
     index = 765,
-    label = "OH_p23 + C2H6O <=> H2O + C2H5O",
+    label = "OH_r3 + C2H6O <=> H2O_p23 + C2H5O",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.32e+06, 'cm^3/(mol*s)'),
@@ -17617,7 +17617,7 @@ Converted to training reaction from rate rule: C/H2/CsO;O_pri_rad
 
 entry(
     index = 766,
-    label = "OH_p23 + C4H10O-10 <=> H2O + C4H9O-10",
+    label = "OH_r3 + C4H10O-10 <=> H2O_p23 + C4H9O-10",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (34760, 'cm^3/(mol*s)'),
@@ -17958,7 +17958,7 @@ Converted to training reaction from rate rule: C/H2/Cs/Cs\O;O_atom_triplet
 
 entry(
     index = 783,
-    label = "OH_p23 + C3H8O-4 <=> H2O + C3H7O-4",
+    label = "OH_r3 + C3H8O-4 <=> H2O_p23 + C3H7O-4",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (28.7, 'cm^3/(mol*s)'),
@@ -17981,7 +17981,7 @@ Converted to training reaction from rate rule: C/H2/Cs/Cs\O;O_pri_rad
 
 entry(
     index = 784,
-    label = "OH_p23 + C4H10O-2 <=> H2O + C4H9O-2",
+    label = "OH_r3 + C4H10O-2 <=> H2O_p23 + C4H9O-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (26, 'cm^3/(mol*s)'),
@@ -62547,7 +62547,7 @@ Converted to training reaction from rate rule: Cd_Cdd/H2;O_rad/Cd\H_Cd\H2
 
 entry(
     index = 3012,
-    label = "OH + C2H4O <=> H2O + C2H3O",
+    label = "OH_r3 + C2H4O <=> H2O_p23 + C2H3O",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2e+06, 'cm^3/(mol*s)'),
@@ -62667,7 +62667,7 @@ Converted to training reaction from rate rule: H2O2;C_rad/H/NonDeC
 
 entry(
     index = 3017,
-    label = "OH + C4H8-4 <=> H2O + C4H7-4",
+    label = "OH_r3 + C4H8-4 <=> H2O_p23 + C4H7-4",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (67, 'cm^3/(mol*s)'),
@@ -62690,7 +62690,7 @@ Converted to training reaction from rate rule: C/H2/CdCs;O_pri_rad
 
 entry(
     index = 3018,
-    label = "OH + C4H8-2 <=> H2O + C4H7-2",
+    label = "OH_r3 + C4H8-2 <=> H2O_p23 + C4H7-2",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (12.18, 'cm^3/(mol*s)'),
@@ -62713,7 +62713,7 @@ Converted to training reaction from rate rule: C/H3/Cd\H_Cd\H\Cs;O_pri_rad
 
 entry(
     index = 3019,
-    label = "OH + C4H8 <=> H2O + C4H7",
+    label = "OH_r3 + C4H8 <=> H2O_p23 + C4H7",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (12, 'cm^3/(mol*s)'),
@@ -62760,7 +62760,7 @@ Converted to training reaction from rate rule: X_H;H_rad
 
 entry(
     index = 3021,
-    label = "OH + H2O <=> H2O + OH_p23",
+    label = "OH_r3 + H2O_r12 <=> H2O_p23 + OH_p1",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2.417e-07, 'cm^3/(mol*s)'),
@@ -63970,7 +63970,7 @@ Converted to training reaction manually from rate rule: N5dc/H/NonDeOO;O_atom_tr
     
 entry(
     index = 3076,
-    label = "HNO2 + OH <=> H2O_p + NO2_p",
+    label = "HNO2 + OH_r3 <=> H2O_p23 + NO2_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.2e+06, 'cm^3/(mol*s)'),

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -1845,7 +1845,7 @@ Done at the CCSD(T)/6-311+G(3df,2p)//B3LYP/6-311+G(3df,2p) level of theory
 
 entry(
     index = 66,
-    label = "NH3_r + NO <=> NH2_p + HNO_p",
+    label = "NH3_r12 + NO <=> NH2_p1 + HNO_p",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.04e+07, 'cm^3/(mol*s)'),
@@ -1867,7 +1867,7 @@ calculations done at the UMP2/6-311G-(d,p)//UMP2/6-311G(d,p) level of theory
 
 entry(
     index = 67,
-    label = "NH2 + H2 <=> NH3 + H_p",
+    label = "NH2_r3 + H2 <=> NH3_p23 + H_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (323000, 'cm^3/(mol*s)'),
@@ -1889,7 +1889,7 @@ calculations done at the G2M//B3LYP/6-311G(d,p) level of theory
 
 entry(
     index = 68,
-    label = "NH2 + CH4b <=> NH3 + CH3_p1",
+    label = "NH2_r3 + CH4_r12 <=> NH3_p23 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (13600, 'cm^3/(mol*s)'),
@@ -1911,7 +1911,7 @@ calculations done at the G2M//B3LYP/6-311G(d,p) level of theory
 
 entry(
     index = 69,
-    label = "NH2 + H2O <=> NH3 + OH_p1",
+    label = "NH2_r3 + H2O_r12 <=> NH3_p23 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.62e+13, 'cm^3/(mol*s)'),
@@ -2382,7 +2382,7 @@ calculations done at the QCISD/6-311G(d,p) level
 
 entry(
     index = 91,
-    label = "NH2 + C2H6 <=> NH3 + C2H5b",
+    label = "NH2_r3 + C2H6 <=> NH3_p23 + C2H5b",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (3.46e+13, 'cm^3/(mol*s)'),
@@ -2404,7 +2404,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 92,
-    label = "NH2 + C3H8b <=> NH3 + CH2CH2CH3",
+    label = "NH2_r3 + C3H8b <=> NH3_p23 + CH2CH2CH3",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.37e+13, 'cm^3/(mol*s)'),
@@ -2426,7 +2426,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 93,
-    label = "NH2 + C3H8 <=> NH3 + CH3CHCH3",
+    label = "NH2_r3 + C3H8 <=> NH3_p23 + CH3CHCH3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.48e+13, 'cm^3/(mol*s)'),
@@ -2448,7 +2448,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 94,
-    label = "NH2 + C4H10 <=> NH3 + pC4H9",
+    label = "NH2_r3 + C4H10 <=> NH3_p23 + pC4H9",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (2.11e+13, 'cm^3/(mol*s)'),
@@ -2470,7 +2470,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 95,
-    label = "NH2 + C4H10b <=> NH3 + CH3CHCH2CH3",
+    label = "NH2_r3 + C4H10b <=> NH3_p23 + CH3CHCH2CH3",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.72e+13, 'cm^3/(mol*s)'),
@@ -2492,7 +2492,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 96,
-    label = "NH2 + iC4H10 <=> NH3 + ipC4H9",
+    label = "NH2_r3 + iC4H10 <=> NH3_p23 + ipC4H9",
     degeneracy = 9.0,
     kinetics = Arrhenius(
         A = (1.84e+13, 'cm^3/(mol*s)'),
@@ -2514,7 +2514,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 97,
-    label = "NH2 + iC4H10b <=> NH3 + tC4H9",
+    label = "NH2_r3 + iC4H10b <=> NH3_p23 + tC4H9",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.35e+13, 'cm^3/(mol*s)'),
@@ -2536,7 +2536,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 98,
-    label = "NH2 + C5H12 <=> NH3 + tC5H11",
+    label = "NH2_r3 + C5H12 <=> NH3_p23 + tC5H11",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2.76e+12, 'cm^3/(mol*s)'),
@@ -2558,7 +2558,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 99,
-    label = "NH2 + C3H6-3 <=> NH3 + vC3H5",
+    label = "NH2_r3 + C3H6-3 <=> NH3_p23 + vC3H5",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.42e+13, 'cm^3/(mol*s)'),
@@ -2580,7 +2580,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 100,
-    label = "NH2 + C3H6 <=> NH3 + CH2CHCH2",
+    label = "NH2_r3 + C3H6 <=> NH3_p23 + CH2CHCH2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.5e+13, 'cm^3/(mol*s)'),
@@ -2602,7 +2602,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 101,
-    label = "NH2 + C4H8-7 <=> NH3 + pC4H7",
+    label = "NH2_r3 + C4H8-7 <=> NH3_p23 + pC4H7",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (4.33e+13, 'cm^3/(mol*s)'),
@@ -2624,7 +2624,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 102,
-    label = "NH2 + C4H8-2 <=> NH3 + aC4H7",
+    label = "NH2_r3 + C4H8-2 <=> NH3_p23 + aC4H7",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.37e+13, 'cm^3/(mol*s)'),
@@ -2646,7 +2646,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 103,
-    label = "NH2 + C5H10-1 <=> NH3 + C5H9-1",
+    label = "NH2_r3 + C5H10-1 <=> NH3_p23 + C5H9-1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (6.14e+12, 'cm^3/(mol*s)'),
@@ -2668,7 +2668,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 104,
-    label = "NH2 + C5H10-2 <=> NH3 + C5H9-2",
+    label = "NH2_r3 + C5H10-2 <=> NH3_p23 + C5H9-2",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.54e+13, 'cm^3/(mol*s)'),
@@ -2690,7 +2690,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 105,
-    label = "NH2 + C5H10-3 <=> NH3 + C5H9-3",
+    label = "NH2_r3 + C5H10-3 <=> NH3_p23 + C5H9-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (4.87e+12, 'cm^3/(mol*s)'),
@@ -2712,7 +2712,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 106,
-    label = "NH2 + C5H10-4 <=> NH3 + C5H9-4",
+    label = "NH2_r3 + C5H10-4 <=> NH3_p23 + C5H9-4",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.13e+13, 'cm^3/(mol*s)'),
@@ -2734,7 +2734,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 107,
-    label = "NH2 + C2H4 <=> NH3 + CHCH2",
+    label = "NH2_r3 + C2H4 <=> NH3_p23 + CHCH2",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.56e+13, 'cm^3/(mol*s)'),
@@ -2756,7 +2756,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 108,
-    label = "NH2 + C4H6 <=> NH3 + CHCCHCH3",
+    label = "NH2_r3 + C4H6 <=> NH3_p23 + CHCCHCH3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.62e+13, 'cm^3/(mol*s)'),
@@ -2778,7 +2778,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 109,
-    label = "NH2 + C4H6-2 <=> NH3 + C4H5-2",
+    label = "NH2_r3 + C4H6-2 <=> NH3_p23 + C4H5-2",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (9.94e+13, 'cm^3/(mol*s)'),
@@ -2800,7 +2800,7 @@ doi: 10.1021/acs.jpca.6b12890
 
 entry(
     index = 110,
-    label = "NH2 + C5H8 <=> NH3 + C5H7",
+    label = "NH2_r3 + C5H8 <=> NH3_p23 + C5H7",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2.67e+14, 'cm^3/(mol*s)'),
@@ -2948,7 +2948,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 117,
-    label = "CH3CH2NH2_1 + NH2 <=> CH2CH2NH2 + NH3",
+    label = "CH3CH2NH2_1 + NH2_r3 <=> CH2CH2NH2 + NH3_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (9.21e+12, 'cm^3/(mol*s)'),
@@ -2969,7 +2969,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 118,
-    label = "CH3CH2NH2_2 + NH2 <=> CH3CHNH2 + NH3",
+    label = "CH3CH2NH2_2 + NH2_r3 <=> CH3CHNH2 + NH3_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (8.01e+12, 'cm^3/(mol*s)'),
@@ -2990,7 +2990,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 119,
-    label = "CH3CH2NH2_3 + NH2 <=> CH3CH2NH + NH3",
+    label = "CH3CH2NH2_3 + NH2_r3 <=> CH3CH2NH + NH3_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.14e+12, 'cm^3/(mol*s)'),
@@ -3123,7 +3123,7 @@ CBS-QB3
 
 entry(
     index = 125,
-    label = "N2H4 + NH2 <=> N2H3 + NH3",
+    label = "N2H4 + NH2_r3 <=> N2H3 + NH3_p23",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (2590, 'cm^3/(mol*s)'),
@@ -3183,7 +3183,7 @@ CBS-QB3
 
 entry(
     index = 128,
-    label = "NH + CH4b <=> NH2b + CH3_p1",
+    label = "NH + CH4b <=> NH2_p23 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (9e+13, 'cm^3/(mol*s)', '*|/', 1.5),
@@ -3208,7 +3208,7 @@ DOI: 10.1002/bbpc.19940980615
 
 entry(
     index = 129,
-    label = "NH + C2H6 <=> NH2b + C2H5b",
+    label = "NH + C2H6 <=> NH2_p23 + C2H5b",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (7e+13, 'cm^3/(mol*s)', '*|/', 1.75),
@@ -3233,7 +3233,7 @@ DOI: 10.1002/bbpc.19940980615
 
 entry(
     index = 130,
-    label = "NH + HNCO <=> NH2b + NCO",
+    label = "NH + HNCO <=> NH2_p23 + NCO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (6.26e+12, 'cm^3/(mol*s)'),
@@ -3249,7 +3249,7 @@ entry(
 u"""
 calculated at UQCISD(T)/6-311G** level
 Zhen-Feng Xu and Jia-Zhong Sun
-Theoretical Study on the Reaction Path and Variational Rate Constant of the Reaction HNCO + NH => NCO + NH2
+Theoretical Study on the Reaction Path and Variational Rate Constant of the Reaction HNCO + NH => NCO + NH2_r3
 J. Phys. Chem. A, 1998, 102 (7), pp 1194-1199
 DOI: 10.1021/jp972959n
 """,
@@ -11755,7 +11755,7 @@ Converted to training reaction from rate rule: O/H/OneDe;S_rad/NonDeC
 
 entry(
     index = 483,
-    label = "NH2b + C2H6 <=> NH3_r + C2H5",
+    label = "NH2_r3 + C2H6 <=> NH3_p23 + C2H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (5.52e+06, 'cm^3/(mol*s)'),
@@ -11795,7 +11795,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_meth
 
 entry(
     index = 485,
-    label = "NH2b + C3H8 <=> NH3_r + C3H7",
+    label = "NH2_r3 + C3H8 <=> NH3_p23 + C3H7",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.84e+06, 'cm^3/(mol*s)'),
@@ -11835,7 +11835,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 487,
-    label = "NH2b + iC4H10b <=> NH3_r + C4H9-4",
+    label = "NH2_r3 + iC4H10b <=> NH3_p23 + C4H9-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -11875,7 +11875,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 489,
-    label = "H + NH3_r <=> H2 + NH2b",
+    label = "H + NH3_r12 <=> H2 + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (7.2e+08, 'cm^3/(mol*s)'),
@@ -11915,7 +11915,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 491,
-    label = "NH3_r + O_rad <=> HO + NH2b",
+    label = "NH3_r12 + O_rad <=> HO + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (5.1e+08, 'cm^3/(mol*s)'),
@@ -11955,7 +11955,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 493,
-    label = "OH + NH3_r <=> H2O + NH2b",
+    label = "OH + NH3_r12 <=> H2O + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -11995,7 +11995,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 495,
-    label = "CH3_p23 + NH3_r <=> CH4b + NH2b",
+    label = "CH3_p23 + NH3_r12 <=> CH4b + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2.43e+06, 'cm^3/(mol*s)'),
@@ -14535,7 +14535,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_beta6ring;Cd_ra
 
 entry(
     index = 622,
-    label = "H + NH3_r <=> H2 + NH2b",
+    label = "H + NH3_r12 <=> H2 + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.62e+06, 'cm^3/(mol*s)'),
@@ -14549,7 +14549,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH3 + H = NH2 + H2 (B&D #6) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH3 + H = NH2_r3 + H2 (B&D #6) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH3;H_rad
 """,
@@ -14557,7 +14557,7 @@ Converted to training reaction from rate rule: NH3;H_rad
 
 entry(
     index = 623,
-    label = "OH + NH3_r <=> H2O + NH2b",
+    label = "OH + NH3_r12 <=> H2O + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.5e+08, 'cm^3/(mol*s)'),
@@ -14571,7 +14571,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH3 + OH = NH2 + H2O (B&D #7) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH3 + OH = NH2_r3 + H2O (B&D #7) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH3;O_pri_rad
 """,
@@ -14579,7 +14579,7 @@ Converted to training reaction from rate rule: NH3;O_pri_rad
 
 entry(
     index = 624,
-    label = "NH3_r + O_rad <=> HO + NH2b",
+    label = "NH3_r12 + O_rad <=> HO + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2.82e+07, 'cm^3/(mol*s)'),
@@ -14593,7 +14593,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH3 + O = NH2 + OH (B&D #8) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH3 + O = NH2_r3 + OH (B&D #8) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH3;O_atom_triplet
 """,
@@ -14615,7 +14615,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2 + H = NH + H2 (B&D #9) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2_r3 + H = NH + H2 (B&D #9) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 """,
 )
 
@@ -14635,7 +14635,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2 + O = NH + OH (B&D #15d2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2_r3 + O = NH + OH (B&D #15d2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 """,
 )
 
@@ -14655,13 +14655,13 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2 + OH = NH + H2O (B&D #16b) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2_r3 + OH = NH + H2O (B&D #16b) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 """,
 )
 
 entry(
     index = 628,
-    label = "H2N + NH2 <=> NH3_p + NH_p1",
+    label = "H2N + NH2_r3 <=> NH3_p23 + NH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1e+14, 'cm^3/(mol*s)'),
@@ -14675,7 +14675,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2 + NH2 = NH3 + NH (B&D #17e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2_r3 + NH2_r3 = NH3 + NH (B&D #17e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH2_rad_H;NH2_rad
 """,
@@ -14697,7 +14697,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: CH3 + NH2 = CH4 + NH (B&D #21e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: CH3 + NH2_r3 = CH4 + NH (B&D #21e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH2_rad_H;C_methyl
 """,
@@ -14705,7 +14705,7 @@ Converted to training reaction from rate rule: NH2_rad_H;C_methyl
 
 entry(
     index = 630,
-    label = "NH2 + CH3 <=> NH3_p + CH2_p1",
+    label = "NH2_r3 + CH3 <=> NH3_p23 + CH2_p1",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -14719,7 +14719,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: CH3 + NH2 = CH2 + NH3 (B&D #21f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: CH3 + NH2_r3 = CH2 + NH3 (B&D #21f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: CH3_rad_H;NH2_rad
 """,
@@ -14749,7 +14749,7 @@ Converted to training reaction from rate rule: OH_rad_H;N_atom_quartet
 
 entry(
     index = 632,
-    label = "HN + NH2 <=> NH3_p + N",
+    label = "HN + NH2_r3 <=> NH3_p23 + N",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -14763,7 +14763,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH + NH2 = NH3 + N (B&D #27b2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH + NH2_r3 = NH3 + N (B&D #27b2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH_triplet_H;NH2_rad
 """,
@@ -14925,7 +14925,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeN;O_pri_rad
 
 entry(
     index = 640,
-    label = "NH2 + H2N2 <=> NH3_p + HN2",
+    label = "NH2_r3 + H2N2 <=> NH3_p23 + HN2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -14939,7 +14939,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: N2H2 + NH2 = NNH + NH3 (B&D #29c4) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: N2H2 + NH2_r3 = NNH + NH3 (B&D #29c4) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3d/H/NonDeN;NH2_rad
 """,
@@ -14983,7 +14983,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: N2H2 + NH = NNH + NH2 (B&D #29d) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: N2H2 + NH = NNH + NH2_r3 (B&D #29d) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3d/H/NonDeN;NH_triplet
 """,
@@ -15035,7 +15035,7 @@ Converted to training reaction from rate rule: N3s_rad_H/H/NonDeN;C_methyl
 
 entry(
     index = 645,
-    label = "NH2 + H3N2 <=> NH3_p + H2N2-2",
+    label = "NH2_r3 + H3N2 <=> NH3_p23 + H2N2-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3e+13, 'cm^3/(mol*s)'),
@@ -15049,7 +15049,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: N2H3 + NH2 = H2NN + NH3 (B&D #31f2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: N2H3 + NH2_r3 = H2NN + NH3 (B&D #31f2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3s_rad_H/H/NonDeN;NH2_rad
 """,
@@ -15145,7 +15145,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;C_methyl
 
 entry(
     index = 650,
-    label = "NH2b + N2H4 <=> NH3_r + H3N2-2",
+    label = "NH2_r3 + N2H4 <=> NH3_p23 + H3N2-2",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.48e+07, 'cm^3/(mol*s)'),
@@ -15159,7 +15159,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: N2H4 + NH2 = N2H3 + NH3 (B&D #32e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: N2H4 + NH2_r3 = N2H3 + NH3 (B&D #32e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3s/H2/NonDeN;NH2_rad
 """,
@@ -15233,7 +15233,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeO;O_atom_triplet
 
 entry(
     index = 654,
-    label = "HNO_r + NH2 <=> NH3_p + NO_p",
+    label = "HNO_r + NH2_r3 <=> NH3_p23 + NO_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -15247,7 +15247,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: HNO + NH2 = NH3 + NO (B&D #36f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: HNO + NH2_r3 = NH3 + NO (B&D #36f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3d/H/NonDeO;NH2_rad
 """,
@@ -15387,7 +15387,7 @@ Converted to training reaction from rate rule: O/H/OneDeN;C_methyl
 
 entry(
     index = 661,
-    label = "NH2 + CH3NO <=> NH3_p + CH2NO",
+    label = "NH2_r3 + CH3NO <=> NH3_p23 + CH2NO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -15401,7 +15401,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: HONO + NH2 = NO2 + NH3 (B&D #40f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: HONO + NH2_r3 = NO2 + NH3 (B&D #40f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: O/H/OneDeN;NH2_rad
 """,
@@ -15519,7 +15519,7 @@ Converted to training reaction from rate rule: C_methane;Ct_rad/N
 
 entry(
     index = 667,
-    label = "NH3_r + CN <=> HCN_r + NH2b",
+    label = "NH3_r12 + CN <=> HCN_r + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2.76e+13, 'cm^3/(mol*s)'),
@@ -15533,7 +15533,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: CN + NH3 = HCN + NH2 (B&D #44j) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: CN + NH3 = HCN + NH2_r3 (B&D #44j) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH3;Ct_rad/N
 """,
@@ -15629,7 +15629,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeC;C_methyl
 
 entry(
     index = 672,
-    label = "NH2 + CH3N <=> NH3_p + CH2N",
+    label = "NH2_r3 + CH3N <=> NH3_p23 + CH2N",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -15643,7 +15643,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: H2CNH + NH2 = H2CN + NH3 (B&D #48a5) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: H2CNH + NH2_r3 = H2CN + NH3 (B&D #48a5) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3d/H/NonDeC;NH2_rad
 """,
@@ -15739,7 +15739,7 @@ Converted to training reaction from rate rule: Cd/H2/NonDeN;C_methyl
 
 entry(
     index = 677,
-    label = "NH2 + CH3N-2 <=> NH3_p + CH2N-2",
+    label = "NH2_r3 + CH3N-2 <=> NH3_p23 + CH2N-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -15753,7 +15753,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: H2CNH + NH2 = HCNH + NH3 (B&D #48b5)  in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: H2CNH + NH2_r3 = HCNH + NH3 (B&D #48b5)  in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: Cd/H2/NonDeN;NH2_rad
 """,
@@ -15849,7 +15849,7 @@ Converted to training reaction from rate rule: Cs/H3/NonDeN;C_methyl
 
 entry(
     index = 682,
-    label = "NH2 + CH5N <=> NH3_p + CH4N",
+    label = "NH2_r3 + CH5N <=> NH3_p23 + CH4N",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (8.4e+06, 'cm^3/(mol*s)'),
@@ -15863,7 +15863,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: CH3NH2 + NH2 = CH2NH2 + NH3 (B&D #51a5) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: CH3NH2 + NH2_r3 = CH2NH2 + NH3 (B&D #51a5) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: Cs/H3/NonDeN;NH2_rad
 """,
@@ -15959,7 +15959,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeC;C_methyl
 
 entry(
     index = 687,
-    label = "NH2 + CH5N-2 <=> NH3_p + CH4N-2",
+    label = "NH2_r3 + CH5N-2 <=> NH3_p23 + CH4N-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -15973,7 +15973,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: CH3NH2 + NH2 = CH3NH + NH3 (B&D #51b5) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: CH3NH2 + NH2_r3 = CH3NH + NH3 (B&D #51b5) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3s/H2/NonDeC;NH2_rad
 """,
@@ -16025,7 +16025,7 @@ Converted to training reaction from rate rule: C_methane;N3d_rad/OneDeCdd_O
 
 entry(
     index = 690,
-    label = "NH3_r + CNO <=> HNCO + NH2b",
+    label = "NH3_r12 + CNO <=> HNCO + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (84000, 'cm^3/(mol*s)'),
@@ -16039,7 +16039,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NCO + NH3 = HNCO + NH2 (B&D #53j) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NCO + NH3 = HNCO + NH2_r3 (B&D #53j) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: NH3;N3d_rad/OneDeCdd_O
 """,
@@ -16135,7 +16135,7 @@ Converted to training reaction from rate rule: O/H/OneDeC;C_methyl
 
 entry(
     index = 695,
-    label = "NH2 + C2H4O-2 <=> NH3_p + C2H3O-3",
+    label = "NH2_r3 + C2H4O-2 <=> NH3_p23 + C2H3O-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -16149,7 +16149,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: HOCN + NH2 = NH3 + NCO (B&D #55h) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: HOCN + NH2_r3 = NH3 + NCO (B&D #55h) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: O/H/OneDeC;NH2_rad
 """,
@@ -16245,7 +16245,7 @@ Converted to training reaction from rate rule: N3d/H/CddO;C_methyl
 
 entry(
     index = 700,
-    label = "NH2 + HNCO <=> NH3_p + CNO",
+    label = "NH2_r3 + HNCO <=> NH3_p23 + CNO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1e+12, 'cm^3/(mol*s)'),
@@ -16259,7 +16259,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: HNCO + NH2 = NCO + NH3 (B&D #56i) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: HNCO + NH2_r3 = NCO + NH3 (B&D #56i) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3d/H/CddO;NH2_rad
 """,
@@ -16377,7 +16377,7 @@ Converted to training reaction from rate rule: Cs/H3/OneDeN;C_methyl
 
 entry(
     index = 706,
-    label = "NH2b + C2H5N <=> NH3_r + C2H4N-2",
+    label = "NH2_r3 + C2H5N <=> NH3_p23 + C2H4N-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (8.4e+06, 'cm^3/(mol*s)'),
@@ -16391,7 +16391,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: CH3NO + NH2 = CH2NO + NH3 (B&D #58e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: CH3NO + NH2_r3 = CH2NO + NH3 (B&D #58e) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: Cs/H3/OneDeN;NH2_rad
 """,
@@ -16487,7 +16487,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeO;C_methyl
 
 entry(
     index = 711,
-    label = "NH2b + H3NO <=> NH3_r + H2NO",
+    label = "NH2_r3 + H3NO <=> NH3_p23 + H2NO",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -16501,7 +16501,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2OH + NH2 = HNOH + NH3 (B&D #61f1)  in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2OH + NH2_r3 = HNOH + NH3 (B&D #61f1)  in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3s/H2/NonDeO;NH2_rad
 """,
@@ -16619,7 +16619,7 @@ Converted to training reaction from rate rule: O/H/NonDeN;C_methyl
 
 entry(
     index = 717,
-    label = "NH2b + H3NO-2 <=> NH3_r + H2NO-2",
+    label = "NH2_r3 + H3NO-2 <=> NH3_p23 + H2NO-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -16633,7 +16633,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2OH + NH2 = NH2O + NH3 (B&D #61f2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2OH + NH2_r3 = NH2O + NH3 (B&D #61f2) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: O/H/NonDeN;NH2_rad
 """,
@@ -16751,7 +16751,7 @@ Converted to training reaction from rate rule: N3s/H2/OneDeN;C_methyl
 
 entry(
     index = 723,
-    label = "NH2b + CH4N2 <=> NH3_r + CH3N2",
+    label = "NH2_r3 + CH4N2 <=> NH3_p23 + CH3N2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -16765,7 +16765,7 @@ entry(
     shortDesc = u"""Added by Beat Buesser""",
     longDesc = 
 u"""
-Added by Beat Buesser, value for reaction: NH2NO + NH2 = HNNO + NH3 (B&D #62f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
+Added by Beat Buesser, value for reaction: NH2NO + NH2_r3 = HNNO + NH3 (B&D #62f) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli",
 
 Converted to training reaction from rate rule: N3s/H2/OneDeN;NH2_rad
 """,
@@ -64010,7 +64010,7 @@ Converted to training reaction manually from rate rule: N5dc/H/NonDeOO;C_methyl
     
 entry(
     index = 3078,
-    label = "HNO2 + NH2 <=> NH3_p + NO2_p",
+    label = "HNO2 + NH2_r3 <=> NH3_p23 + NO2_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (920000, 'cm^3/(mol*s)'),
@@ -64021,7 +64021,7 @@ entry(
         Tmax = (2000, 'K'),
     ),
     rank = 1,
-    shortDesc = u"""Added by Beat Buesser, value for reaction: HNO2 + NH2 = NO2 + NH3 (B&D #413) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli""",
+    shortDesc = u"""Added by Beat Buesser, value for reaction: HNO2 + NH2_r3 = NO2 + NH3 (B&D #413) in 'Gas-Phase Combustion Chemistry' (ISBN: 978-1-4612-7088-1), chapter 2, 'Combustion Chemistry of Nitrogen', Anthony M. Dean, Joseph W. Bozzelli""",
     longDesc = 
 u"""
 Converted to training reaction manually from rate rule: N5dc/H/NonDeOO;NH2_rad

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -1514,7 +1514,7 @@ Rate comes from quantum calculation by J. Zador at CCSD(T) level
 
 entry(
     index = 50,
-    label = "CH4b + SH <=> CH3_p1 + H2S",
+    label = "CH4_r12 + SH <=> CH3_p1 + H2S",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (469, 'cm^3/(mol*s)'),
@@ -1999,7 +1999,7 @@ H. Shiina, M. Oya, K. Yamashita, A. Miyoshi, H. Matsui, J. Phys. Chem., 1996, 10
 
 entry(
     index = 73,
-    label = "CH4b + S_rad <=> SH + CH3_p1",
+    label = "CH4_r12 + S_rad <=> SH + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (2.04e+14, 'cm^3/(mol*s)'),
@@ -2885,7 +2885,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 114,
-    label = "CH3CH2NH2_1 + CH3_r3 <=> CH2CH2NH2 + CH4",
+    label = "CH3CH2NH2_1 + CH3_r3 <=> CH2CH2NH2 + CH4_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (6e+12, 'cm^3/(mol*s)'),
@@ -2906,7 +2906,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 115,
-    label = "CH3CH2NH2_2 + CH3_r3 <=> CH3CHNH2 + CH4",
+    label = "CH3CH2NH2_2 + CH3_r3 <=> CH3CHNH2 + CH4_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.23e+13, 'cm^3/(mol*s)'),
@@ -2927,7 +2927,7 @@ doi: 10.1016/j.combustflame.2015.10.032
 
 entry(
     index = 116,
-    label = "CH3CH2NH2_3 + CH3_r3 <=> CH3CH2NH + CH4",
+    label = "CH3CH2NH2_3 + CH3_r3 <=> CH3CH2NH + CH4_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (2.23e+12, 'cm^3/(mol*s)'),
@@ -3103,7 +3103,7 @@ CBS-QB3
 
 entry(
     index = 124,
-    label = "N2H4 + CH3_r3 <=> N2H3 + CH4",
+    label = "N2H4 + CH3_r3 <=> N2H3 + CH4_p23",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (17.7, 'cm^3/(mol*s)'),
@@ -3183,7 +3183,7 @@ CBS-QB3
 
 entry(
     index = 128,
-    label = "NH + CH4b <=> NH2_p23 + CH3_p1",
+    label = "NH + CH4_r12 <=> NH2_p23 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (9e+13, 'cm^3/(mol*s)', '*|/', 1.5),
@@ -3257,7 +3257,7 @@ DOI: 10.1021/jp972959n
 
 entry(
     index = 131,
-    label = "Cl + CH4b <=> HCl + CH3_p23",
+    label = "Cl + CH4_r12 <=> HCl + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.36534e-19, 'cm^3/(molecule*s)'),
@@ -4212,7 +4212,7 @@ Taken from entry: phenyl + 1_3_butadiene <=> benzene + 1_3_butadien_1_yl
 
 entry(
     index = 181,
-    label = "C6H6 + CH3_r3 <=> CH4p + C6H5_p1",
+    label = "C6H6 + CH3_r3 <=> CH4_p23 + C6H5_p1",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (5151, 'cm^3/(mol*s)'),
@@ -4318,7 +4318,7 @@ Taken from entry: C9H8_21 + H_15 <=> C9H7_22 + H2_23
 
 entry(
     index = 186,
-    label = "CH4b + H <=> CH3_p1 + H2_p",
+    label = "CH4_r12 + H <=> CH3_p1 + H2_p",
     degeneracy = 4.0,
     kinetics = Arrhenius(A=(4100, 'cm^3/(mol*s)'), n=3.156, Ea=(8755, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4327,7 +4327,7 @@ entry(
 
 entry(
     index = 187,
-    label = "CH4b + O_rad <=> CH3_p1 + OH_p23",
+    label = "CH4_r12 + O_rad <=> CH3_p1 + OH_p23",
     degeneracy = 4.0,
     kinetics = Arrhenius(A=(440000, 'cm^3/(mol*s)'), n=2.5, Ea=(6577, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4336,7 +4336,7 @@ entry(
 
 entry(
     index = 188,
-    label = "CH4b + OH <=> CH3_p1 + H2O_p",
+    label = "CH4_r12 + OH <=> CH3_p1 + H2O_p",
     degeneracy = 4.0,
     kinetics = Arrhenius(A=(1e+06, 'cm^3/(mol*s)'), n=2.182, Ea=(2506, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4345,7 +4345,7 @@ entry(
 
 entry(
     index = 189,
-    label = "CH4b + HO2_r3 <=> CH3_p1 + H2O2_p13",
+    label = "CH4_r12 + HO2_r3 <=> CH3_p1 + H2O2_p13",
     degeneracy = 4.0,
     kinetics = Arrhenius(A=(47000, 'cm^3/(mol*s)'), n=2.5, Ea=(21000, 'cal/mol'), T0=(1, 'K')),
     rank = 1,
@@ -4354,7 +4354,7 @@ entry(
 
 entry(
     index = 190,
-    label = "CH4b + O2 <=> CH3_p1 + HO2",
+    label = "CH4_r12 + O2 <=> CH3_p1 + HO2",
     degeneracy = 8.0,
     kinetics = Arrhenius(
         A = (203000, 'cm^3/(mol*s)'),
@@ -4485,7 +4485,7 @@ entry(
 
 entry(
     index = 201,
-    label = "CH4O + CH3_r3 <=> CH2OH_p + CH4",
+    label = "CH4O + CH3_r3 <=> CH2OH_p + CH4_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2.19e-07, 'cm^3/(mol*s)'),
@@ -4562,7 +4562,7 @@ entry(
 
 entry(
     index = 209,
-    label = "CH3O2 + CH4b <=> CH3OOH_p + CH3_p1",
+    label = "CH3O2 + CH4_r12 <=> CH3OOH_p + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00445, 'cm^3/(mol*s)'),
@@ -4649,7 +4649,7 @@ entry(
 
 entry(
     index = 215,
-    label = "C2H6 + CH3_r3 <=> C2H5b + CH4",
+    label = "C2H6 + CH3_r3 <=> C2H5b + CH4_p23",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (35, 'cm^3/(mol*s)'),
@@ -4800,7 +4800,7 @@ entry(
 
 entry(
     index = 231,
-    label = "C2H6O + CH3_r3 <=> CH3CHOH_p + CH4",
+    label = "C2H6O + CH3_r3 <=> CH3CHOH_p + CH4_p23",
     degeneracy = 2.0,
     kinetics = Arrhenius(A=(20, 'cm^3/(mol*s)'), n=3.37, Ea=(7630, 'cal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -4809,7 +4809,7 @@ entry(
 
 entry(
     index = 232,
-    label = "C2H6O-2 + CH3_r3 <=> CH2CH2OH_p + CH4",
+    label = "C2H6O-2 + CH3_r3 <=> CH2CH2OH_p + CH4_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(A=(2, 'cm^3/(mol*s)'), n=3.57, Ea=(7717, 'cal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -4818,7 +4818,7 @@ entry(
 
 entry(
     index = 233,
-    label = "CH3CH2OH_rO + CH3_r3 <=> CH3CH2O_p + CH4",
+    label = "CH3CH2OH_rO + CH3_r3 <=> CH3CH2O_p + CH4_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(A=(330, 'cm^3/(mol*s)'), n=3.3, Ea=(12283, 'cal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -4899,7 +4899,7 @@ entry(
 
 entry(
     index = 242,
-    label = "C2H4O + CH3_r3 <=> CH3CO_p + CH4",
+    label = "C2H4O + CH3_r3 <=> CH3CO_p + CH4_p23",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3.5e-08, 'cm^3/(mol*s)'),
@@ -5035,7 +5035,7 @@ Accurate geometries are obtained using coupled cluster theory with single, doubl
 
 entry(
     index = 249,
-    label = "C4H4 + CH3_r3 <=> CH4p + C4H3_p",
+    label = "C4H4 + CH3_r3 <=> CH4_p23 + C4H3_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(A=(9.24, 'cm^3/(mol*s)'), n=3.335, Ea=(7.75, 'kcal/mol'), T0=(1, 'K')),
     rank = 5,
@@ -5066,7 +5066,7 @@ Jim Chu's calculation
 
 entry(
     index = 251,
-    label = "C4H6-5 + CH3_r3 <=> CH4p + C4H5-4_p",
+    label = "C4H6-5 + CH3_r3 <=> CH4_p23 + C4H5-4_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (14.26, 'cm^3/(mol*s)'),
@@ -5102,7 +5102,7 @@ Jim Chu's calculation
 
 entry(
     index = 253,
-    label = "C4H6 + CH3_r3 <=> CH4p + CHCCHCH3",
+    label = "C4H6 + CH3_r3 <=> CH4_p23 + CHCCHCH3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (29.41, 'cm^3/(mol*s)'),
@@ -5450,7 +5450,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 267,
-    label = "C7H8 + CH3_r3 <=> CH4p + C7H7_p",
+    label = "C7H8 + CH3_r3 <=> CH4_p23 + C7H7_p",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.07e+06, 'cm^3/(mol*s)'),
@@ -5476,7 +5476,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 268,
-    label = "C7H8-2 + CH3_r3 <=> CH4p + C7H7-2",
+    label = "C7H8-2 + CH3_r3 <=> CH4_p23 + C7H7-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.21e+07, 'cm^3/(mol*s)'),
@@ -5502,7 +5502,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 269,
-    label = "C7H8-3 + CH3_r3 <=> CH4p + C7H7-3_p",
+    label = "C7H8-3 + CH3_r3 <=> CH4_p23 + C7H7-3_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.11e+08, 'cm^3/(mol*s)'),
@@ -5528,7 +5528,7 @@ G4//B3LYP/6-31G(2df,p)
 
 entry(
     index = 270,
-    label = "C7H8-4 + CH3_r3 <=> CH4p + C7H7-4",
+    label = "C7H8-4 + CH3_r3 <=> CH4_p23 + C7H7-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.05e+08, 'cm^3/(mol*s)'),
@@ -5736,7 +5736,7 @@ CBS-QB3 + Exp.
 
 entry(
     index = 278,
-    label = "C6H6 + CH3_r3 <=> CH4p + C6H5",
+    label = "C6H6 + CH3_r3 <=> CH4_p23 + C6H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (3.07e-21, 'cm^3/(molecule*s)'),
@@ -5984,7 +5984,7 @@ Converted to training reaction from rate rule: X_H;O_sec_rad
 
 entry(
     index = 288,
-    label = "H2 + CH3_r3 <=> CH4p + H_p",
+    label = "H2 + CH3_r3 <=> CH4_p23 + H_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.62e+06, 'cm^3/(mol*s)'),
@@ -6742,7 +6742,7 @@ Converted to training reaction from rate rule: H2;O_rad/NonDeC
 
 entry(
     index = 314,
-    label = "CH4b + O2 <=> HO2_p23 + CH3_p1",
+    label = "CH4_r12 + O2 <=> HO2_p23 + CH3_p1",
     degeneracy = 8.0,
     kinetics = Arrhenius(
         A = (7.94e+13, 'cm^3/(mol*s)', '*|/', 10),
@@ -6778,7 +6778,7 @@ Converted to training reaction from rate rule: C_methane;O2b
 
 entry(
     index = 315,
-    label = "C2H5 + CH4b <=> C2H6 + CH3_p1",
+    label = "C2H5 + CH4_r12 <=> C2H6 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0864, 'cm^3/(mol*s)', '*|/', 2),
@@ -6811,7 +6811,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H2/Cs
 
 entry(
     index = 316,
-    label = "C3H7 + CH4b <=> C3H8 + CH3_p1",
+    label = "C3H7 + CH4_r12 <=> C3H8 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.000724, 'cm^3/(mol*s)', '*|/', 2),
@@ -6845,7 +6845,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/NonDeC
 
 entry(
     index = 317,
-    label = "C2H + CH4b <=> C2H2 + CH3_p1",
+    label = "C2H + CH4_r12 <=> C2H2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.812e+12, 'cm^3/(mol*s)', '*|/', 10),
@@ -6881,7 +6881,7 @@ Converted to training reaction from rate rule: C_methane;Ct_rad
 
 entry(
     index = 318,
-    label = "C6H5 + CH4b <=> C6H6 + CH3_p1",
+    label = "C6H5 + CH4_r12 <=> C6H6 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (2e+12, 'cm^3/(mol*s)'),
@@ -6906,7 +6906,7 @@ Converted to training reaction from rate rule: C_methane;Cb_rad
 
 entry(
     index = 319,
-    label = "HCO_r3 + CH4b <=> CH2O + CH3_p1",
+    label = "HCO_r3 + CH4_r12 <=> CH2O + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (7280, 'cm^3/(mol*s)', '*|/', 5),
@@ -6939,7 +6939,7 @@ Converted to training reaction from rate rule: C_methane;CO_pri_rad
 
 entry(
     index = 320,
-    label = "CH4b + C2H3O <=> C2H4O + CH3_p1",
+    label = "CH4_r12 + C2H3O <=> C2H4O + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (2172, 'cm^3/(mol*s)', '*|/', 5),
@@ -6972,7 +6972,7 @@ Converted to training reaction from rate rule: C_methane;CO_rad/NonDe
 
 entry(
     index = 321,
-    label = "OH + CH4b <=> H2O_p + CH3_p1",
+    label = "OH + CH4_r12 <=> H2O_p + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.54, 'cm^3/(mol*s)'),
@@ -6995,7 +6995,7 @@ Converted to training reaction from rate rule: C_methane;O_pri_rad
 
 entry(
     index = 322,
-    label = "CH3O-2 + CH4b <=> CH4O-2 + CH3_p1",
+    label = "CH3O-2 + CH4_r12 <=> CH4O-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00062, 'cm^3/(mol*s)'),
@@ -7022,7 +7022,7 @@ Converted to training reaction from rate rule: C_methane;O_rad/NonDeC
 
 entry(
     index = 323,
-    label = "HO2_r3 + CH4b <=> H2O2 + CH3_p1",
+    label = "HO2_r3 + CH4_r12 <=> H2O2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.812e+11, 'cm^3/(mol*s)', '*|/', 5),
@@ -7211,7 +7211,7 @@ Converted to training reaction from rate rule: C/H3/CO;O_pri_rad
 
 entry(
     index = 329,
-    label = "CH4O + CH3_r3 <=> CH4p + CH3O_p1",
+    label = "CH4O + CH3_r3 <=> CH4_p23 + CH3O_p1",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.000615, 'cm^3/(mol*s)'),
@@ -7266,7 +7266,7 @@ Converted to training reaction from rate rule: C/H3/O;O_pri_rad
 
 entry(
     index = 331,
-    label = "CH2 + C3H8 <=> CH3 + C3H7",
+    label = "CH2 + C3H8 <=> CH3_p23 + C3H7",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.51, 'cm^3/(mol*s)', '*|/', 10),
@@ -7483,7 +7483,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC;CO_rad/NonDe
 
 entry(
     index = 337,
-    label = "CH2 + iC4H10b <=> CH3 + C4H9-4",
+    label = "CH2 + iC4H10b <=> CH3_p23 + C4H9-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.09e+12, 'cm^3/(mol*s)', '*|/', 5),
@@ -7887,7 +7887,7 @@ Converted to training reaction from rate rule: Cd/H/NonDeC;H_rad
 
 entry(
     index = 348,
-    label = "CH3_r3 + C3H6-2 <=> CH4b + C3H5-2",
+    label = "CH3_r3 + C3H6-2 <=> CH4_p23 + C3H5-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.842, 'cm^3/(mol*s)', '*|/', 6),
@@ -8302,7 +8302,7 @@ Converted to training reaction from rate rule: CO_pri;O_atom_triplet
 
 entry(
     index = 361,
-    label = "CH2 + CH2O <=> CH3 + HCO_r3",
+    label = "CH2 + CH2O <=> CH3_p23 + HCO_r3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (6.04e+09, 'cm^3/(mol*s)'),
@@ -8338,7 +8338,7 @@ Converted to training reaction from rate rule: CO_pri;CH2_triplet
 
 entry(
     index = 362,
-    label = "CH3_r3 + CH2O <=> CH4b + HCO_r3",
+    label = "CH3_r3 + CH2O <=> CH4_p23 + HCO_r3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (7.78e-08, 'cm^3/(mol*s)', '*|/', 1.58),
@@ -8732,7 +8732,7 @@ Converted to training reaction from rate rule: CO/H/NonDe;H_rad
 
 entry(
     index = 374,
-    label = "CH3_r3 + C2H4O <=> CH4b + C2H3O",
+    label = "CH3_r3 + C2H4O <=> CH4_p23 + C2H3O",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.99e-06, 'cm^3/(mol*s)', '*|/', 2),
@@ -8972,7 +8972,7 @@ Converted to training reaction from rate rule: O_pri;H_rad
 
 entry(
     index = 382,
-    label = "H2O + CH3_r3 <=> CH4p + OH_p1",
+    label = "H2O + CH3_r3 <=> CH4_p23 + OH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (6.4, 'cm^3/(mol*s)'),
@@ -9142,7 +9142,7 @@ Converted to training reaction from rate rule: O/H/NonDeC;O_atom_triplet
 
 entry(
     index = 388,
-    label = "CH2 + CH4O-2 <=> CH3 + CH3O-2",
+    label = "CH2 + CH4O-2 <=> CH3_p23 + CH3O-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (14.4, 'cm^3/(mol*s)', '*|/', 3),
@@ -9182,7 +9182,7 @@ Converted to training reaction from rate rule: O/H/NonDeC;CH2_triplet
 
 entry(
     index = 389,
-    label = "CH4O-2 + CH3_r3 <=> CH4p + CH3O-2",
+    label = "CH4O-2 + CH3_r3 <=> CH4_p23 + CH3O-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00037, 'cm^3/(mol*s)'),
@@ -10699,7 +10699,7 @@ Converted to training reaction from rate rule: H2O2;Cd_Cd\H\Cs|H2|Cs_pri_rad
 
 entry(
     index = 437,
-    label = "CH4b + C2 <=> C2H-2 + CH3_p23",
+    label = "CH4_r12 + C2 <=> C2H-2 + CH3_p1",
     degeneracy = 8.0,
     kinetics = Arrhenius(
         A = (6e+13, 'cm^3/(mol*s)', '+|-', 1.6e+12),
@@ -11393,7 +11393,7 @@ Converted to training reaction from rate rule: C/H2/CSCs;S_pri_rad
 
 entry(
     index = 466,
-    label = "CH3_r3 + C3H6S <=> CH4p + C3H5S",
+    label = "CH3_r3 + C3H6S <=> CH4_p23 + C3H5S",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (24.2, 'cm^3/(mol*s)'),
@@ -11515,7 +11515,7 @@ Converted to training reaction from rate rule: S/H/NonDeC;CS_pri_rad
 
 entry(
     index = 471,
-    label = "CH2S + CH3_r3 <=> CH4p + CHS_p1",
+    label = "CH2S + CH3_r3 <=> CH4_p23 + CHS_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (166400, 'cm^3/(mol*s)'),
@@ -11635,7 +11635,7 @@ Converted to training reaction from rate rule: CO/H/NonDe;C_rad/H/CsS
 
 entry(
     index = 477,
-    label = "C2H6OS + CH3_r3 <=> CH4p + C2H5OS",
+    label = "C2H6OS + CH3_r3 <=> CH4_p23 + C2H5OS",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.512, 'cm^3/(mol*s)'),
@@ -11655,7 +11655,7 @@ Converted to training reaction from rate rule: C/H/CsOS;Cs_rad
 
 entry(
     index = 478,
-    label = "CH2OS + CH3_r3 <=> CH4p + CHOS",
+    label = "CH2OS + CH3_r3 <=> CH4_p23 + CHOS",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.34, 'cm^3/(mol*s)'),
@@ -11775,7 +11775,7 @@ Converted to training reaction from rate rule: C_pri;NH2_rad
 
 entry(
     index = 484,
-    label = "CH3_p23 + C7H12 <=> CH4b + C7H11",
+    label = "CH3_r3+ C7H12 <=> CH4_p23 + C7H11",
     degeneracy = 8.0,
     kinetics = Arrhenius(
         A = (0.1016, 'cm^3/(mol*s)'),
@@ -11995,7 +11995,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 495,
-    label = "CH3_p23 + NH3_r12 <=> CH4b + NH2_p23",
+    label = "CH3_r3+ NH3_r12 <=> CH4_p23 + NH2_p23",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2.43e+06, 'cm^3/(mol*s)'),
@@ -12335,7 +12335,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;Cd_rad
 
 entry(
     index = 512,
-    label = "CH3_p23 + C7H12-2 <=> CH4b + C7H11-2",
+    label = "CH3_r3+ C7H12-2 <=> CH4_p23 + C7H11-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.0366, 'cm^3/(mol*s)'),
@@ -12775,7 +12775,7 @@ Converted to training reaction from rate rule: C/H/Cs3_5ring_fused6;Cd_rad/Ct
 
 entry(
     index = 534,
-    label = "CH3_p23 + C7H12-3 <=> CH4b + C7H11-3",
+    label = "CH3_r3+ C7H12-3 <=> CH4_p23 + C7H11-3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.01452, 'cm^3/(mol*s)'),
@@ -13215,7 +13215,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_2;Cd_rad
 
 entry(
     index = 556,
-    label = "CH3_p23 + C8H14 <=> CH4b + C8H13",
+    label = "CH3_r3+ C8H14 <=> CH4_p23 + C8H13",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.0133, 'cm^3/(mol*s)'),
@@ -13655,7 +13655,7 @@ Converted to training reaction from rate rule: C/H/Cs3_5ring_adj5;Cd_rad/Ct
 
 entry(
     index = 578,
-    label = "CH3_p23 + C9H16 <=> CH4b + C9H15",
+    label = "CH3_r3+ C9H16 <=> CH4_p23 + C9H15",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0416, 'cm^3/(mol*s)'),
@@ -14095,7 +14095,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_alpha6ring;Cd_r
 
 entry(
     index = 600,
-    label = "CH3_p23 + C9H16-2 <=> CH4b + C9H15-2",
+    label = "CH3_r3+ C9H16-2 <=> CH4_p23 + C9H15-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.0302, 'cm^3/(mol*s)'),
@@ -14683,7 +14683,7 @@ Converted to training reaction from rate rule: NH2_rad_H;NH2_rad
 
 entry(
     index = 629,
-    label = "H2N + CH3_r3 <=> CH4p + NH_p1",
+    label = "H2N + CH3_r3 <=> CH4_p23 + NH_p1",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (5.6e+06, 'cm^3/(mol*s)'),
@@ -14705,7 +14705,7 @@ Converted to training reaction from rate rule: NH2_rad_H;C_methyl
 
 entry(
     index = 630,
-    label = "NH2_r3 + CH3 <=> NH3_p23 + CH2_p1",
+    label = "NH2_r3 + CH3_r12 <=> NH3_p23 + CH2_p1",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -14837,7 +14837,7 @@ Converted to training reaction from rate rule: NH_triplet_H;O_atom_triplet
 
 entry(
     index = 636,
-    label = "HN + CH3_r3 <=> CH4p + N",
+    label = "HN + CH3_r3 <=> CH4_p23 + N",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (820000, 'cm^3/(mol*s)'),
@@ -14947,7 +14947,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeN;NH2_rad
 
 entry(
     index = 641,
-    label = "H2N2 + CH3_r3 <=> CH4p + HN2",
+    label = "H2N2 + CH3_r3 <=> CH4_p23 + HN2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.2e+06, 'cm^3/(mol*s)'),
@@ -15013,7 +15013,7 @@ Converted to training reaction from rate rule: N3s_rad_H/H/NonDeN;O_pri_rad
 
 entry(
     index = 644,
-    label = "H3N2 + CH3_r3 <=> CH4p + H2N2-2",
+    label = "H3N2 + CH3_r3 <=> CH4_p23 + H2N2-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (3e+13, 'cm^3/(mol*s)'),
@@ -15123,7 +15123,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;O_pri_rad
 
 entry(
     index = 649,
-    label = "CH3_p23 + N2H4 <=> CH4b + H3N2-2",
+    label = "CH3_r3+ N2H4 <=> CH4_p23 + H3N2-2",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.32e+07, 'cm^3/(mol*s)'),
@@ -15277,7 +15277,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeO;O2b
 
 entry(
     index = 656,
-    label = "HNO_r + CH3_r3 <=> CH4p + NO_p",
+    label = "HNO_r + CH3_r3 <=> CH4_p23 + NO_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (820000, 'cm^3/(mol*s)'),
@@ -15365,7 +15365,7 @@ Converted to training reaction from rate rule: O/H/OneDeN;O_pri_rad
 
 entry(
     index = 660,
-    label = "CH3NO + CH3_r3 <=> CH4p + CH2NO",
+    label = "CH3NO + CH3_r3 <=> CH4_p23 + CH2NO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (810000, 'cm^3/(mol*s)'),
@@ -15497,7 +15497,7 @@ Converted to training reaction from rate rule: O_pri;Ct_rad/N
 
 entry(
     index = 666,
-    label = "CH4b + CN <=> HCN_r + CH3_p23",
+    label = "CH4_r12 + CN <=> HCN_r + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (480000, 'cm^3/(mol*s)'),
@@ -15607,7 +15607,7 @@ Converted to training reaction from rate rule: N3d/H/NonDeC;O_pri_rad
 
 entry(
     index = 671,
-    label = "CH3N + CH3_r3 <=> CH4p + CH2N",
+    label = "CH3N + CH3_r3 <=> CH4_p23 + CH2N",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (820000, 'cm^3/(mol*s)'),
@@ -15717,7 +15717,7 @@ Converted to training reaction from rate rule: Cd/H2/NonDeN;O_pri_rad
 
 entry(
     index = 676,
-    label = "CH3N-2 + CH3_r3 <=> CH4p + CH2N-2",
+    label = "CH3N-2 + CH3_r3 <=> CH4_p23 + CH2N-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (1.06e+06, 'cm^3/(mol*s)'),
@@ -15827,7 +15827,7 @@ Converted to training reaction from rate rule: Cs/H3/NonDeN;O_pri_rad
 
 entry(
     index = 681,
-    label = "CH3_r3 + CH5N <=> CH4p + CH4N",
+    label = "CH3_r3 + CH5N <=> CH4_p23 + CH4N",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (4.5e+06, 'cm^3/(mol*s)'),
@@ -15937,7 +15937,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeC;O_pri_rad
 
 entry(
     index = 686,
-    label = "CH3_r3 + CH5N-2 <=> CH4p + CH4N-2",
+    label = "CH3_r3 + CH5N-2 <=> CH4_p23 + CH4N-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.2e+06, 'cm^3/(mol*s)'),
@@ -16003,7 +16003,7 @@ Converted to training reaction from rate rule: H2;N3d_rad/OneDeCdd_O
 
 entry(
     index = 689,
-    label = "CH4b + CNO <=> HNCO + CH3_p23",
+    label = "CH4_r12 + CNO <=> HNCO + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (3.92e+13, 'cm^3/(mol*s)'),
@@ -16113,7 +16113,7 @@ Converted to training reaction from rate rule: O/H/OneDeC;O_pri_rad
 
 entry(
     index = 694,
-    label = "C2H4O-2 + CH3_r3 <=> CH4p + C2H3O-3",
+    label = "C2H4O-2 + CH3_r3 <=> CH4_p23 + C2H3O-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (820000, 'cm^3/(mol*s)'),
@@ -16223,7 +16223,7 @@ Converted to training reaction from rate rule: N3d/H/CddO;O_atom_triplet
 
 entry(
     index = 699,
-    label = "HNCO + CH3_r3 <=> CH4p + CNO",
+    label = "HNCO + CH3_r3 <=> CH4_p23 + CNO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1e+12, 'cm^3/(mol*s)'),
@@ -16355,7 +16355,7 @@ Converted to training reaction from rate rule: Cs/H3/OneDeN;O_pri_rad
 
 entry(
     index = 705,
-    label = "CH3_r3 + C2H5N <=> CH4p + C2H4N-2",
+    label = "CH3_r3 + C2H5N <=> CH4_p23 + C2H4N-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (2.37e+06, 'cm^3/(mol*s)'),
@@ -16465,7 +16465,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeO;O_pri_rad
 
 entry(
     index = 710,
-    label = "H3NO + CH3_r3 <=> CH4b + H2NO",
+    label = "H3NO + CH3_r3 <=> CH4_p23 + H2NO",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.2e+06, 'cm^3/(mol*s)'),
@@ -16597,7 +16597,7 @@ Converted to training reaction from rate rule: O/H/NonDeN;O_pri_rad
 
 entry(
     index = 716,
-    label = "H3NO-2 + CH3_r3 <=> CH4b + H2NO-2",
+    label = "H3NO-2 + CH3_r3 <=> CH4_p23 + H2NO-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (820000, 'cm^3/(mol*s)'),
@@ -16729,7 +16729,7 @@ Converted to training reaction from rate rule: N3s/H2/OneDeN;O_pri_rad
 
 entry(
     index = 722,
-    label = "CH3_r3 + CH4N2 <=> CH4b + CH3N2",
+    label = "CH3_r3 + CH4N2 <=> CH4_p23 + CH3N2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.2e+06, 'cm^3/(mol*s)'),
@@ -17337,7 +17337,7 @@ Converted to training reaction from rate rule: C/H/Cs2O;H_rad
 
 entry(
     index = 752,
-    label = "C3H8O-2 + CH3_r3 <=> CH4b + C3H7O-2",
+    label = "C3H8O-2 + CH3_r3 <=> CH4_p23 + C3H7O-2",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (2.838, 'cm^3/(mol*s)'),
@@ -17357,7 +17357,7 @@ Converted to training reaction from rate rule: C/H3/Cs\H\Cs\O;C_methyl
 
 entry(
     index = 753,
-    label = "C3H8O-3 + CH3_r3 <=> CH4b + C3H7O-3",
+    label = "C3H8O-3 + CH3_r3 <=> CH4_p23 + C3H7O-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.389, 'cm^3/(mol*s)'),
@@ -17397,7 +17397,7 @@ Converted to training reaction from rate rule: C/H2/CdCs;H_rad
 
 entry(
     index = 755,
-    label = "CH3_r3 + C4H8-4 <=> CH4b + C4H7-4",
+    label = "CH3_r3 + C4H8-4 <=> CH4_p23 + C4H7-4",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.204, 'cm^3/(mol*s)'),
@@ -17457,7 +17457,7 @@ Converted to training reaction from rate rule: C/H3/Cd\H_Cd\H\Cs;H_rad
 
 entry(
     index = 758,
-    label = "CH3_r3 + C3H6 <=> CH4b + C3H5",
+    label = "CH3_r3 + C3H6 <=> CH4_p23 + C3H5",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.072, 'cm^3/(mol*s)'),
@@ -17477,7 +17477,7 @@ Converted to training reaction from rate rule: C/H3/Cd\H_Cd\H2;C_methyl
 
 entry(
     index = 759,
-    label = "CH3_r3 + C4H8-2 <=> CH4b + C4H7-2",
+    label = "CH3_r3 + C4H8-2 <=> CH4_p23 + C4H7-2",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (0.144, 'cm^3/(mol*s)'),
@@ -17517,7 +17517,7 @@ Converted to training reaction from rate rule: C/H3/Cd\Cs_Cd\H2;H_rad
 
 entry(
     index = 761,
-    label = "CH3_r3 + C4H8 <=> CH4b + C4H7",
+    label = "CH3_r3 + C4H8 <=> CH4_p23 + C4H7",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (0.1188, 'cm^3/(mol*s)'),
@@ -17717,7 +17717,7 @@ Converted to training reaction from rate rule: C/H3/Cs;H_rad
 
 entry(
     index = 771,
-    label = "CH3_r3 + C2H6 <=> CH4b + C2H5",
+    label = "CH3_r3 + C2H6 <=> CH4_p23 + C2H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (4.488e-05, 'cm^3/(mol*s)'),
@@ -17737,7 +17737,7 @@ Converted to training reaction from rate rule: C/H3/Cs;C_methyl
 
 entry(
     index = 772,
-    label = "C4H10O-10 + CH3_r3 <=> CH4b + C4H9O-10",
+    label = "C4H10O-10 + CH3_r3 <=> CH4_p23 + C4H9O-10",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0146, 'cm^3/(mol*s)'),
@@ -17757,7 +17757,7 @@ Converted to training reaction from rate rule: C/H/Cs2/Cs\O;C_methyl
 
 entry(
     index = 773,
-    label = "C5H12O + CH3_r3 <=> CH4b + C5H11O",
+    label = "C5H12O + CH3_r3 <=> CH4_p23 + C5H11O",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0719, 'cm^3/(mol*s)'),
@@ -17779,7 +17779,7 @@ Converted to training reaction from rate rule: C/H/Cs2/Cs\Cs|O;C_methyl
 
 entry(
     index = 774,
-    label = "C2H6O + CH3_r3 <=> CH4b + C2H5O",
+    label = "C2H6O + CH3_r3 <=> CH4_p23 + C2H5O",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00248, 'cm^3/(mol*s)'),
@@ -18023,7 +18023,7 @@ Converted to training reaction from rate rule: C/H2/Cs/Cs\Cs|O;O_atom_triplet
 
 entry(
     index = 786,
-    label = "H2 + CH3_r3 <=> CH4b + H",
+    label = "H2 + CH3_r3 <=> CH4_p23 + H",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.0224, 'cm^3/(mol*s)'),
@@ -18863,7 +18863,7 @@ Converted to training reaction from rate rule: H2;CS_rad/Ct
 
 entry(
     index = 828,
-    label = "H + CH4b <=> H2 + CH3_p23",
+    label = "H + CH4_r12 <=> H2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.876, 'cm^3/(mol*s)'),
@@ -18883,7 +18883,7 @@ Converted to training reaction from rate rule: C_methane;H_rad
 
 entry(
     index = 829,
-    label = "CH4b + C4H9-4 <=> iC4H10b + CH3_p23",
+    label = "CH4_r12 + C4H9-4 <=> iC4H10b + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00616, 'cm^3/(mol*s)'),
@@ -18903,7 +18903,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/Cs3
 
 entry(
     index = 830,
-    label = "C3H5 + CH4b <=> C3H6 + CH3_p23",
+    label = "C3H5 + CH4_r12 <=> C3H6 + CH3_p1",
     degeneracy = 8.0,
     kinetics = Arrhenius(
         A = (0.112, 'cm^3/(mol*s)'),
@@ -18923,7 +18923,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H2/Cd
 
 entry(
     index = 831,
-    label = "C4H7-4 + CH4b <=> C4H8-4 + CH3_p23",
+    label = "C4H7-4 + CH4_r12 <=> C4H8-4 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0424, 'cm^3/(mol*s)'),
@@ -18943,7 +18943,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CdCs
 
 entry(
     index = 832,
-    label = "C5H9-5 + CH4b <=> C5H10-3 + CH3_p23",
+    label = "C5H9-5 + CH4_r12 <=> C5H10-3 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00804, 'cm^3/(mol*s)'),
@@ -18963,7 +18963,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CdCs2
 
 entry(
     index = 833,
-    label = "C5H7-2 + CH4b <=> C5H8-2 + CH3_p23",
+    label = "C5H7-2 + CH4_r12 <=> C5H8-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.1692, 'cm^3/(mol*s)'),
@@ -18983,7 +18983,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CdCd
 
 entry(
     index = 834,
-    label = "C6H9 + CH4b <=> C6H10 + CH3_p23",
+    label = "C6H9 + CH4_r12 <=> C6H10 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00924, 'cm^3/(mol*s)'),
@@ -19003,7 +19003,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CdCdCs
 
 entry(
     index = 835,
-    label = "C3H3-2 + CH4b <=> C3H4 + CH3_p23",
+    label = "C3H3-2 + CH4_r12 <=> C3H4 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.02864, 'cm^3/(mol*s)'),
@@ -19023,7 +19023,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H2/Ct
 
 entry(
     index = 836,
-    label = "C4H5-5 + CH4b <=> C4H6 + CH3_p23",
+    label = "C4H5-5 + CH4_r12 <=> C4H6 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.01148, 'cm^3/(mol*s)'),
@@ -19043,7 +19043,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CtCs
 
 entry(
     index = 837,
-    label = "C5H7-3 + CH4b <=> C5H8 + CH3_p23",
+    label = "C5H7-3 + CH4_r12 <=> C5H8 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00528, 'cm^3/(mol*s)'),
@@ -19063,7 +19063,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CtCs2
 
 entry(
     index = 838,
-    label = "C5H3 + CH4b <=> C5H4 + CH3_p23",
+    label = "C5H3 + CH4_r12 <=> C5H4 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0512, 'cm^3/(mol*s)'),
@@ -19083,7 +19083,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CtCt
 
 entry(
     index = 839,
-    label = "C6H5-2 + CH4b <=> C6H6-2 + CH3_p23",
+    label = "C6H5-2 + CH4_r12 <=> C6H6-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.002524, 'cm^3/(mol*s)'),
@@ -19103,7 +19103,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CtCtCs
 
 entry(
     index = 840,
-    label = "C7H7 + CH4b <=> C7H8 + CH3_p23",
+    label = "C7H7 + CH4_r12 <=> C7H8 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.052, 'cm^3/(mol*s)'),
@@ -19123,7 +19123,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H2/Cb
 
 entry(
     index = 841,
-    label = "C8H9 + CH4b <=> C8H10 + CH3_p23",
+    label = "C8H9 + CH4_r12 <=> C8H10 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.02676, 'cm^3/(mol*s)'),
@@ -19143,7 +19143,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CbCs
 
 entry(
     index = 842,
-    label = "C9H11 + CH4b <=> C9H12 + CH3_p23",
+    label = "C9H11 + CH4_r12 <=> C9H12 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0016, 'cm^3/(mol*s)'),
@@ -19163,7 +19163,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CbCs2
 
 entry(
     index = 843,
-    label = "C2H3 + CH4b <=> C2H4 + CH3_p23",
+    label = "C2H3 + CH4_r12 <=> C2H4 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.02236, 'cm^3/(mol*s)'),
@@ -19183,7 +19183,7 @@ Converted to training reaction from rate rule: C_methane;Cd_pri_rad
 
 entry(
     index = 844,
-    label = "C3H5-2 + CH4b <=> C3H6-2 + CH3_p23",
+    label = "C3H5-2 + CH4_r12 <=> C3H6-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0154, 'cm^3/(mol*s)'),
@@ -19203,7 +19203,7 @@ Converted to training reaction from rate rule: C_methane;Cd_rad/NonDeC
 
 entry(
     index = 845,
-    label = "C4H5-3 + CH4b <=> C4H6-4 + CH3_p23",
+    label = "C4H5-3 + CH4_r12 <=> C4H6-4 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.01032, 'cm^3/(mol*s)'),
@@ -19223,7 +19223,7 @@ Converted to training reaction from rate rule: C_methane;Cd_rad/Cd
 
 entry(
     index = 846,
-    label = "C3H3 + CH4b <=> C3H4-1 + CH3_p23",
+    label = "C3H3 + CH4_r12 <=> C3H4-1 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0636, 'cm^3/(mol*s)'),
@@ -19243,7 +19243,7 @@ Converted to training reaction from rate rule: C_methane;Cd_Cdd_rad/H
 
 entry(
     index = 847,
-    label = "CH3S-2 + CH4b <=> CH3SH_r2 + CH3_p23",
+    label = "CH3S-2 + CH4_r12 <=> CH3SH_r2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00828, 'cm^3/(mol*s)'),
@@ -19263,7 +19263,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H2/S
 
 entry(
     index = 848,
-    label = "C4H3 + CH4b <=> C4H4 + CH3_p23",
+    label = "C4H3 + CH4_r12 <=> C4H4 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.00242, 'cm^3/(mol*s)'),
@@ -19283,7 +19283,7 @@ Converted to training reaction from rate rule: C_methane;Cd_rad/Ct
 
 entry(
     index = 849,
-    label = "C2H5S + CH4b <=> C2H6S + CH3_p23",
+    label = "C2H5S + CH4_r12 <=> C2H6S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.02832, 'cm^3/(mol*s)'),
@@ -19303,7 +19303,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CsS
 
 entry(
     index = 850,
-    label = "C3H7S + CH4b <=> C3H8S + CH3_p23",
+    label = "C3H7S + CH4_r12 <=> C3H8S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.02004, 'cm^3/(mol*s)'),
@@ -19323,7 +19323,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/Cs2S
 
 entry(
     index = 851,
-    label = "C2H3S-2 + CH4b <=> C2H4S-2 + CH3_p23",
+    label = "C2H3S-2 + CH4_r12 <=> C2H4S-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0676, 'cm^3/(mol*s)'),
@@ -19343,7 +19343,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H2/CS
 
 entry(
     index = 852,
-    label = "C3H5S + CH4b <=> C3H6S + CH3_p23",
+    label = "C3H5S + CH4_r12 <=> C3H6S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.1284, 'cm^3/(mol*s)'),
@@ -19363,7 +19363,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CSCs
 
 entry(
     index = 853,
-    label = "C4H7S + CH4b <=> C4H8S + CH3_p23",
+    label = "C4H7S + CH4_r12 <=> C4H8S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0724, 'cm^3/(mol*s)'),
@@ -19383,7 +19383,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CSCs2
 
 entry(
     index = 854,
-    label = "C2H3S-3 + CH4b <=> C2H4S-3 + CH3_p23",
+    label = "C2H3S-3 + CH4_r12 <=> C2H4S-3 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0532, 'cm^3/(mol*s)'),
@@ -19403,7 +19403,7 @@ Converted to training reaction from rate rule: C_methane;Cd_rad/NonDeS
 
 entry(
     index = 855,
-    label = "C3H3S + CH4b <=> C3H4S + CH3_p23",
+    label = "C3H3S + CH4_r12 <=> C3H4S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0892, 'cm^3/(mol*s)'),
@@ -19423,7 +19423,7 @@ Converted to training reaction from rate rule: C_methane;Cd_rad/CS
 
 entry(
     index = 856,
-    label = "C3H5S-2 + CH4b <=> C3H6S-2 + CH3_p23",
+    label = "C3H5S-2 + CH4_r12 <=> C3H6S-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.134, 'cm^3/(mol*s)'),
@@ -19443,7 +19443,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CdS
 
 entry(
     index = 857,
-    label = "C4H7S-2 + CH4b <=> C4H8S-2 + CH3_p23",
+    label = "C4H7S-2 + CH4_r12 <=> C4H8S-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.021, 'cm^3/(mol*s)'),
@@ -19463,7 +19463,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CdCsS
 
 entry(
     index = 858,
-    label = "C2H3S2 + CH4b <=> C2H4S2 + CH3_p23",
+    label = "C2H3S2 + CH4_r12 <=> C2H4S2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.052, 'cm^3/(mol*s)'),
@@ -19483,7 +19483,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CSS
 
 entry(
     index = 859,
-    label = "C3H5S2 + CH4b <=> C3H6S2 + CH3_p23",
+    label = "C3H5S2 + CH4_r12 <=> C3H6S2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.3412, 'cm^3/(mol*s)'),
@@ -19503,7 +19503,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CSCsS
 
 entry(
     index = 860,
-    label = "C3H3S-2 + CH4b <=> C3H4S-2 + CH3_p23",
+    label = "C3H3S-2 + CH4_r12 <=> C3H4S-2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.068, 'cm^3/(mol*s)'),
@@ -19523,7 +19523,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CtS
 
 entry(
     index = 861,
-    label = "C4H5S + CH4b <=> C4H6S + CH3_p23",
+    label = "C4H5S + CH4_r12 <=> C4H6S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0326, 'cm^3/(mol*s)'),
@@ -19543,7 +19543,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CtCsS
 
 entry(
     index = 862,
-    label = "C7H7S + CH4b <=> C7H8S + CH3_p23",
+    label = "C7H7S + CH4_r12 <=> C7H8S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.03212, 'cm^3/(mol*s)'),
@@ -19563,7 +19563,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/H/CbS
 
 entry(
     index = 863,
-    label = "C8H9S + CH4b <=> C8H10S + CH3_p23",
+    label = "C8H9S + CH4_r12 <=> C8H10S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.01412, 'cm^3/(mol*s)'),
@@ -19583,7 +19583,7 @@ Converted to training reaction from rate rule: C_methane;C_rad/CbCsS
 
 entry(
     index = 864,
-    label = "CHS + CH4b <=> CH2S + CH3_p23",
+    label = "CHS + CH4_r12 <=> CH2S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0768, 'cm^3/(mol*s)'),
@@ -19603,7 +19603,7 @@ Converted to training reaction from rate rule: C_methane;CS_pri_rad
 
 entry(
     index = 865,
-    label = "CH4b + C2H3S <=> C2H4S + CH3_p23",
+    label = "CH4_r12 + C2H3S <=> C2H4S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.06, 'cm^3/(mol*s)'),
@@ -19623,7 +19623,7 @@ Converted to training reaction from rate rule: C_methane;CS_rad/Cs
 
 entry(
     index = 866,
-    label = "CHS2 + CH4b <=> CH2S2 + CH3_p23",
+    label = "CHS2 + CH4_r12 <=> CH2S2 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.0916, 'cm^3/(mol*s)'),
@@ -19643,7 +19643,7 @@ Converted to training reaction from rate rule: C_methane;CS_rad/S
 
 entry(
     index = 867,
-    label = "C3H3S-3 + CH4b <=> C3H4S-3 + CH3_p23",
+    label = "C3H3S-3 + CH4_r12 <=> C3H4S-3 + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.03224, 'cm^3/(mol*s)'),
@@ -19663,7 +19663,7 @@ Converted to training reaction from rate rule: C_methane;CS_rad/Cd
 
 entry(
     index = 868,
-    label = "C3HS + CH4b <=> C3H2S + CH3_p23",
+    label = "C3HS + CH4_r12 <=> C3H2S + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.09, 'cm^3/(mol*s)'),
@@ -20523,7 +20523,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC;H_rad
 
 entry(
     index = 911,
-    label = "CH3_r3 + C3H8 <=> CH4b + C3H7",
+    label = "CH3_r3 + C3H8 <=> CH4_p23 + C3H7",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.01606, 'cm^3/(mol*s)'),
@@ -21383,7 +21383,7 @@ Converted to training reaction from rate rule: C/H/Cs3;H_rad
 
 entry(
     index = 954,
-    label = "CH3_r3 + iC4H10b <=> CH4b + C4H9-4",
+    label = "CH3_r3 + iC4H10b <=> CH4_p23 + C4H9-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0113, 'cm^3/(mol*s)'),
@@ -22243,7 +22243,7 @@ Converted to training reaction from rate rule: C/H3/Cd;H_rad
 
 entry(
     index = 997,
-    label = "CH3_r3 + C3H6 <=> CH4b + C3H5",
+    label = "CH3_r3 + C3H6 <=> CH4_p23 + C3H5",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.00618, 'cm^3/(mol*s)'),
@@ -23963,7 +23963,7 @@ Converted to training reaction from rate rule: C/H/Cs2Cd;H_rad
 
 entry(
     index = 1083,
-    label = "CH3_r3 + C5H10-3 <=> CH4b + C5H9-5",
+    label = "CH3_r3 + C5H10-3 <=> CH4_p23 + C5H9-5",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00587, 'cm^3/(mol*s)'),
@@ -24843,7 +24843,7 @@ Converted to training reaction from rate rule: C/H2/CdCd;H_rad
 
 entry(
     index = 1127,
-    label = "CH3_r3 + C5H8-2 <=> CH4b + C5H7-2",
+    label = "CH3_r3 + C5H8-2 <=> CH4_p23 + C5H7-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.0212, 'cm^3/(mol*s)'),
@@ -25723,7 +25723,7 @@ Converted to training reaction from rate rule: C/H/CdCd;H_rad
 
 entry(
     index = 1171,
-    label = "CH3_r3 + C6H10 <=> CH4b + C6H9",
+    label = "CH3_r3 + C6H10 <=> CH4_p23 + C6H9",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00524, 'cm^3/(mol*s)'),
@@ -26603,7 +26603,7 @@ Converted to training reaction from rate rule: C/H3/Ct;H_rad
 
 entry(
     index = 1215,
-    label = "C3H4 + CH3_r3 <=> CH4b + C3H3-2",
+    label = "C3H4 + CH3_r3 <=> CH4_p23 + C3H3-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.01923, 'cm^3/(mol*s)'),
@@ -27483,7 +27483,7 @@ Converted to training reaction from rate rule: C/H2/CtCs;H_rad
 
 entry(
     index = 1259,
-    label = "C4H6 + CH3_r3 <=> CH4b + C4H5-5",
+    label = "C4H6 + CH3_r3 <=> CH4_p23 + C4H5-5",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.01694, 'cm^3/(mol*s)'),
@@ -28363,7 +28363,7 @@ Converted to training reaction from rate rule: C/H/Cs2Ct;H_rad
 
 entry(
     index = 1303,
-    label = "C5H8 + CH3_r3 <=> CH4b + C5H7-3",
+    label = "C5H8 + CH3_r3 <=> CH4_p23 + C5H7-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0098, 'cm^3/(mol*s)'),
@@ -29243,7 +29243,7 @@ Converted to training reaction from rate rule: C/H2/CtCt;H_rad
 
 entry(
     index = 1347,
-    label = "C5H4 + CH3_r3 <=> CH4b + C5H3",
+    label = "C5H4 + CH3_r3 <=> CH4_p23 + C5H3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.01892, 'cm^3/(mol*s)'),
@@ -30123,7 +30123,7 @@ Converted to training reaction from rate rule: C/H/CtCt;H_rad
 
 entry(
     index = 1391,
-    label = "C6H6-2 + CH3_r3 <=> CH4b + C6H5-2",
+    label = "C6H6-2 + CH3_r3 <=> CH4_p23 + C6H5-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0104, 'cm^3/(mol*s)'),
@@ -31003,7 +31003,7 @@ Converted to training reaction from rate rule: C/H3/Cb;H_rad
 
 entry(
     index = 1435,
-    label = "CH3_r3 + C7H8 <=> CH4b + C7H7",
+    label = "CH3_r3 + C7H8 <=> CH4_p23 + C7H7",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.00525, 'cm^3/(mol*s)'),
@@ -31883,7 +31883,7 @@ Converted to training reaction from rate rule: C/H2/CbCs;H_rad
 
 entry(
     index = 1479,
-    label = "CH3_r3 + C8H10 <=> CH4b + C8H9",
+    label = "CH3_r3 + C8H10 <=> CH4_p23 + C8H9",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00516, 'cm^3/(mol*s)'),
@@ -32763,7 +32763,7 @@ Converted to training reaction from rate rule: C/H/Cs2Cb;H_rad
 
 entry(
     index = 1523,
-    label = "CH3_r3 + C9H12 <=> CH4b + C9H11",
+    label = "CH3_r3 + C9H12 <=> CH4_p23 + C9H11",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00225, 'cm^3/(mol*s)'),
@@ -33643,7 +33643,7 @@ Converted to training reaction from rate rule: Cd_pri;H_rad
 
 entry(
     index = 1567,
-    label = "CH3_r3 + C2H4 <=> CH4b + C2H3",
+    label = "CH3_r3 + C2H4 <=> CH4_p23 + C2H3",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.03432, 'cm^3/(mol*s)'),
@@ -35263,7 +35263,7 @@ Converted to training reaction from rate rule: Cd/H/Cd;H_rad
 
 entry(
     index = 1648,
-    label = "CH3_r3 + C4H6-4 <=> CH4b + C4H5-3",
+    label = "CH3_r3 + C4H6-4 <=> CH4_p23 + C4H5-3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.01728, 'cm^3/(mol*s)'),
@@ -36123,7 +36123,7 @@ Converted to training reaction from rate rule: Cd/H/Cd;CS_rad/Ct
 
 entry(
     index = 1691,
-    label = "CH3_r3 + C6H6 <=> CH4b + C6H5",
+    label = "CH3_r3 + C6H6 <=> CH4_p23 + C6H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (0.063, 'cm^3/(mol*s)'),
@@ -36983,7 +36983,7 @@ Converted to training reaction from rate rule: Cd_Cdd/H2;H_rad
 
 entry(
     index = 1734,
-    label = "C4H4 + CH3_r3 <=> CH4b + C4H3",
+    label = "C4H4 + CH3_r3 <=> CH4_p23 + C4H3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00698, 'cm^3/(mol*s)'),
@@ -37423,7 +37423,7 @@ Converted to training reaction from rate rule: Cd/H/Ct;Cd_Cdd_rad/H
 
 entry(
     index = 1756,
-    label = "CH3_r3 + C3H4-1 <=> CH4b + C3H3",
+    label = "CH3_r3 + C3H4-1 <=> CH4_p23 + C3H3",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (0.1548, 'cm^3/(mol*s)'),
@@ -38303,7 +38303,7 @@ Converted to training reaction from rate rule: Cd_Cdd/H2;Cd_rad/Ct
 
 entry(
     index = 1800,
-    label = "CH3SH_r2 + CH3_r3 <=> CH4b + CH3S-2",
+    label = "CH3SH_r2 + CH3_r3 <=> CH4_p23 + CH3S-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.00396, 'cm^3/(mol*s)'),
@@ -39603,7 +39603,7 @@ Converted to training reaction from rate rule: C/H2/CsS;H_rad
 
 entry(
     index = 1865,
-    label = "C2H6S + CH3_r3 <=> CH4b + C2H5S",
+    label = "C2H6S + CH3_r3 <=> CH4_p23 + C2H5S",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00618, 'cm^3/(mol*s)'),
@@ -40463,7 +40463,7 @@ Converted to training reaction from rate rule: C/H/Cs2S;H_rad
 
 entry(
     index = 1908,
-    label = "C3H8S + CH3_r3 <=> CH4b + C3H7S",
+    label = "C3H8S + CH3_r3 <=> CH4_p23 + C3H7S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00166, 'cm^3/(mol*s)'),
@@ -41343,7 +41343,7 @@ Converted to training reaction from rate rule: C/H3/CS;H_rad
 
 entry(
     index = 1952,
-    label = "CH3_r3 + C2H4S-2 <=> CH4b + C2H3S-2",
+    label = "CH3_r3 + C2H4S-2 <=> CH4_p23 + C2H3S-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (0.0099, 'cm^3/(mol*s)'),
@@ -42223,7 +42223,7 @@ Converted to training reaction from rate rule: C/H2/CSCs;H_rad
 
 entry(
     index = 1996,
-    label = "CH3_r3 + C3H6S <=> CH4b + C3H5S",
+    label = "CH3_r3 + C3H6S <=> CH4_p23 + C3H5S",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00938, 'cm^3/(mol*s)'),
@@ -43103,7 +43103,7 @@ Converted to training reaction from rate rule: C/H/Cs2CS;H_rad
 
 entry(
     index = 2040,
-    label = "CH3_r3 + C4H8S <=> CH4b + C4H7S",
+    label = "CH3_r3 + C4H8S <=> CH4_p23 + C4H7S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0031, 'cm^3/(mol*s)'),
@@ -43983,7 +43983,7 @@ Converted to training reaction from rate rule: Cd/H/NonDeS;H_rad
 
 entry(
     index = 2084,
-    label = "C2H4S-3 + CH3_r3 <=> CH4b + C2H3S-3",
+    label = "C2H4S-3 + CH3_r3 <=> CH4_p23 + C2H3S-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00444, 'cm^3/(mol*s)'),
@@ -44863,7 +44863,7 @@ Converted to training reaction from rate rule: Cd/H/CS;H_rad
 
 entry(
     index = 2128,
-    label = "CH3_r3 + C3H4S <=> CH4b + C3H3S",
+    label = "CH3_r3 + C3H4S <=> CH4_p23 + C3H3S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.0118, 'cm^3/(mol*s)'),
@@ -45743,7 +45743,7 @@ Converted to training reaction from rate rule: C/H2/CdS;H_rad
 
 entry(
     index = 2172,
-    label = "C3H6S-2 + CH3_r3 <=> CH4b + C3H5S-2",
+    label = "C3H6S-2 + CH3_r3 <=> CH4_p23 + C3H5S-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.0097, 'cm^3/(mol*s)'),
@@ -46623,7 +46623,7 @@ Converted to training reaction from rate rule: C/H/CSCsS;H_rad
 
 entry(
     index = 2216,
-    label = "C3H6S2 + CH3_r3 <=> CH4b + C3H5S2",
+    label = "C3H6S2 + CH3_r3 <=> CH4_p23 + C3H5S2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00324, 'cm^3/(mol*s)'),
@@ -47503,7 +47503,7 @@ Converted to training reaction from rate rule: C/H2/CSS;H_rad
 
 entry(
     index = 2260,
-    label = "C2H4S2 + CH3_r3 <=> CH4b + C2H3S2",
+    label = "C2H4S2 + CH3_r3 <=> CH4_p23 + C2H3S2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.01466, 'cm^3/(mol*s)'),
@@ -48403,7 +48403,7 @@ Converted to training reaction from rate rule: C/H2/CtS;H_rad
 
 entry(
     index = 2305,
-    label = "C3H4S-2 + CH3_r3 <=> CH4b + C3H3S-2",
+    label = "C3H4S-2 + CH3_r3 <=> CH4_p23 + C3H3S-2",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00678, 'cm^3/(mol*s)'),
@@ -49283,7 +49283,7 @@ Converted to training reaction from rate rule: C/H/CtCsS;H_rad
 
 entry(
     index = 2349,
-    label = "C4H6S + CH3_r3 <=> CH4b + C4H5S",
+    label = "C4H6S + CH3_r3 <=> CH4_p23 + C4H5S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00416, 'cm^3/(mol*s)'),
@@ -50143,7 +50143,7 @@ Converted to training reaction from rate rule: C/H2/CbS;H_rad
 
 entry(
     index = 2392,
-    label = "C7H8S + CH3_r3 <=> CH4b + C7H7S",
+    label = "C7H8S + CH3_r3 <=> CH4_p23 + C7H7S",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (0.00642, 'cm^3/(mol*s)'),
@@ -51023,7 +51023,7 @@ Converted to training reaction from rate rule: C/H/CbCsS;H_rad
 
 entry(
     index = 2436,
-    label = "C8H10S + CH3_r3 <=> CH4b + C8H9S",
+    label = "C8H10S + CH3_r3 <=> CH4_p23 + C8H9S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00182, 'cm^3/(mol*s)'),
@@ -52763,7 +52763,7 @@ Converted to training reaction from rate rule: CS/H/NonDeC;H_rad
 
 entry(
     index = 2523,
-    label = "CH3_r3 + C2H4S <=> CH4b + C2H3S",
+    label = "CH3_r3 + C2H4S <=> CH4_p23 + C2H3S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00598, 'cm^3/(mol*s)'),
@@ -53603,7 +53603,7 @@ Converted to training reaction from rate rule: CS/H/NonDeS;H_rad
 
 entry(
     index = 2565,
-    label = "CH2S2 + CH3_r3 <=> CH4b + CHS2",
+    label = "CH2S2 + CH3_r3 <=> CH4_p23 + CHS2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00582, 'cm^3/(mol*s)'),
@@ -54483,7 +54483,7 @@ Converted to training reaction from rate rule: CS/H/Cd;H_rad
 
 entry(
     index = 2609,
-    label = "CH3_r3 + C3H4S-3 <=> CH4b + C3H3S-3",
+    label = "CH3_r3 + C3H4S-3 <=> CH4_p23 + C3H3S-3",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00512, 'cm^3/(mol*s)'),
@@ -55363,7 +55363,7 @@ Converted to training reaction from rate rule: CS/H/Ct;H_rad
 
 entry(
     index = 2653,
-    label = "C3H2S + CH3_r3 <=> CH4b + C3HS",
+    label = "C3H2S + CH3_r3 <=> CH4_p23 + C3HS",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00615, 'cm^3/(mol*s)'),
@@ -56263,7 +56263,7 @@ Converted to training reaction from rate rule: S_pri;H_rad
 
 entry(
     index = 2698,
-    label = "H2S_r + CH3_r3 <=> CH4b + SH",
+    label = "H2S_r + CH3_r3 <=> CH4_p23 + SH",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (470, 'cm^3/(mol*s)'),
@@ -57123,7 +57123,7 @@ Converted to training reaction from rate rule: S/H/NonDeC;H_rad
 
 entry(
     index = 2741,
-    label = "CH3SH_r1 + CH3_r3 <=> CH4b + CH3S",
+    label = "CH3SH_r1 + CH3_r3 <=> CH4_p23 + CH3S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (316, 'cm^3/(mol*s)'),
@@ -57943,7 +57943,7 @@ Converted to training reaction from rate rule: S/H/Cd;H_rad
 
 entry(
     index = 2782,
-    label = "C2H4S-4 + CH3_r3 <=> CH4b + C2H3S-4",
+    label = "C2H4S-4 + CH3_r3 <=> CH4_p23 + C2H3S-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (433, 'cm^3/(mol*s)'),
@@ -58783,7 +58783,7 @@ Converted to training reaction from rate rule: S/H/CS;H_rad
 
 entry(
     index = 2824,
-    label = "CH2S2-2 + CH3_r3 <=> CH4b + CHS2-2",
+    label = "CH2S2-2 + CH3_r3 <=> CH4_p23 + CHS2-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (195, 'cm^3/(mol*s)'),
@@ -59623,7 +59623,7 @@ Converted to training reaction from rate rule: S/H/Ct;H_rad
 
 entry(
     index = 2866,
-    label = "C2H2S + CH3_r3 <=> CH4b + C2HS",
+    label = "C2H2S + CH3_r3 <=> CH4_p23 + C2HS",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (438, 'cm^3/(mol*s)'),
@@ -60243,7 +60243,7 @@ Converted to training reaction from rate rule: S/H/Cb;H_rad
 
 entry(
     index = 2897,
-    label = "C6H6S + CH3_r3 <=> CH4b + C6H5S",
+    label = "C6H6S + CH3_r3 <=> CH4_p23 + C6H5S",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (348, 'cm^3/(mol*s)'),
@@ -61083,7 +61083,7 @@ Converted to training reaction from rate rule: S/H/NonDeS;H_rad
 
 entry(
     index = 2939,
-    label = "HSSH_r12 + CH3_r3 <=> CH4b + HSS_r3",
+    label = "HSSH_r12 + CH3_r3 <=> CH4_p23 + HSS_r3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (800, 'cm^3/(mol*s)'),
@@ -62844,7 +62844,7 @@ Converted to training reaction from rate rule: H2;H_rad
 
 entry(
     index = 3024,
-    label = "CH3_r3 + CH4b <=> CH4b + CH3_p23",
+    label = "CH3_r3 + CH4_r12 <=> CH4_p23 + CH3_p1",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.00518, 'cm^3/(mol*s)'),
@@ -63990,7 +63990,7 @@ Converted to training reaction manually from rate rule: N5dc/H/NonDeOO;O_pri_rad
     
 entry(
     index = 3077,
-    label = "HNO2 + CH3_r3 <=> CH4b + NO2_p",
+    label = "HNO2 + CH3_r3 <=> CH4_p23 + NO2_p",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (810000, 'cm^3/(mol*s)'),

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -6046,7 +6046,7 @@ Converted to training reaction from rate rule: O/H/NonDeC;O2b
 
 entry(
     index = 291,
-    label = "OH_p23 + C2H6 <=> H2O_p + C2H5",
+    label = "OH + C2H6 <=> H2O_p + C2H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (3.558e+07, 'cm^3/(mol*s)'),
@@ -6082,7 +6082,7 @@ Converted to training reaction from rate rule: C/H3/Cs;O_pri_rad
 
 entry(
     index = 292,
-    label = "OH_p23 + C3H8 <=> H2O + C3H7",
+    label = "OH + C3H8 <=> H2O + C3H7",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (900000, 'cm^3/(mol*s)'),
@@ -6117,7 +6117,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC;O_pri_rad
 
 entry(
     index = 293,
-    label = "OH_p23 + iC4H10b <=> H2O + C4H9-4",
+    label = "OH + iC4H10b <=> H2O + C4H9-4",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.7e+06, 'cm^3/(mol*s)'),
@@ -6972,7 +6972,7 @@ Converted to training reaction from rate rule: C_methane;CO_rad/NonDe
 
 entry(
     index = 321,
-    label = "OH_p23 + CH4b <=> H2O_p + CH3_p1",
+    label = "OH + CH4b <=> H2O_p + CH3_p1",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.54, 'cm^3/(mol*s)'),
@@ -7186,7 +7186,7 @@ Converted to training reaction from rate rule: C/H3/Cs;CO_rad/NonDe
 
 entry(
     index = 328,
-    label = "OH_p23 + CH3CHO_r1 <=> H2O + C2H3O-2",
+    label = "OH + CH3CHO_r1 <=> H2O + C2H3O-2",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.551e+06, 'cm^3/(mol*s)'),
@@ -7238,7 +7238,7 @@ Converted to training reaction from rate rule: C/H3/O;C_methyl
 
 entry(
     index = 330,
-    label = "OH_p23 + CH4O <=> H2O + CH3O",
+    label = "OH + CH4O <=> H2O + CH3O",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (24420, 'cm^3/(mol*s)'),
@@ -7773,7 +7773,7 @@ Converted to training reaction from rate rule: Cd_pri;C_rad/H2/Cs
 
 entry(
     index = 345,
-    label = "OH_p23 + C2H4 <=> H2O + C2H3",
+    label = "OH + C2H4 <=> H2O + C2H3",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (2.052e+13, 'cm^3/(mol*s)', '*|/', 3.16),
@@ -7887,7 +7887,7 @@ Converted to training reaction from rate rule: Cd/H/NonDeC;H_rad
 
 entry(
     index = 348,
-    label = "CH3_p23 + C3H6-2 <=> CH4b + C3H5-2",
+    label = "CH3_r3 + C3H6-2 <=> CH4b + C3H5-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (0.842, 'cm^3/(mol*s)', '*|/', 6),
@@ -7993,7 +7993,7 @@ Converted to training reaction from rate rule: Cd/H/NonDeC;Ct_rad
 
 entry(
     index = 351,
-    label = "OH_p23 + C3H6-2 <=> H2O + C3H5-2",
+    label = "OH + C3H6-2 <=> H2O + C3H5-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.11e+06, 'cm^3/(mol*s)', '*|/', 2),
@@ -8100,7 +8100,7 @@ Converted to training reaction from rate rule: Ct_H;C_rad/H2/Cs
 
 entry(
     index = 354,
-    label = "OH_p23 + C2H2 <=> H2O + C2H",
+    label = "OH + C2H2 <=> H2O + C2H",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (14500, 'cm^3/(mol*s)', '*|/', 10),
@@ -8206,7 +8206,7 @@ Converted to training reaction from rate rule: Cb_H;C_rad/H2/Cs
 
 entry(
     index = 358,
-    label = "OH_p23 + C6H6 <=> H2O + C6H5",
+    label = "OH + C6H6 <=> H2O + C6H5",
     degeneracy = 6.0,
     kinetics = Arrhenius(
         A = (1.632e+08, 'cm^3/(mol*s)', '*|/', 2),
@@ -8338,7 +8338,7 @@ Converted to training reaction from rate rule: CO_pri;CH2_triplet
 
 entry(
     index = 362,
-    label = "CH3_p23 + CH2O <=> CH4b + HCO_r3",
+    label = "CH3_r3 + CH2O <=> CH4b + HCO_r3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (7.78e-08, 'cm^3/(mol*s)', '*|/', 1.58),
@@ -8554,7 +8554,7 @@ Converted to training reaction from rate rule: CO_pri;CO_rad/NonDe
 
 entry(
     index = 368,
-    label = "OH_p23 + CH2O <=> H2O + HCO_r3",
+    label = "OH + CH2O <=> H2O + HCO_r3",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (3.44e+09, 'cm^3/(mol*s)', '*|/', 5),
@@ -8732,7 +8732,7 @@ Converted to training reaction from rate rule: CO/H/NonDe;H_rad
 
 entry(
     index = 374,
-    label = "CH3_p23 + C2H4O <=> CH4b + C2H3O",
+    label = "CH3_r3 + C2H4O <=> CH4b + C2H3O",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.99e-06, 'cm^3/(mol*s)', '*|/', 2),
@@ -8816,7 +8816,7 @@ Converted to training reaction from rate rule: CO/H/NonDe;Cd_pri_rad
 
 entry(
     index = 377,
-    label = "OH_p23 + C2H4O <=> H2O + C2H3O",
+    label = "OH + C2H4O <=> H2O + C2H3O",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (2e+06, 'cm^3/(mol*s)'),
@@ -9400,7 +9400,7 @@ Converted to training reaction from rate rule: O/H/NonDeC;Ct_rad
 
 entry(
     index = 395,
-    label = "OH_p23 + CH4O-2 <=> H2O + CH3O-2",
+    label = "OH + CH4O-2 <=> H2O + CH3O-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (17.3, 'cm^3/(mol*s)'),
@@ -10953,7 +10953,7 @@ Converted to training reaction from rate rule: CO/H/Cs\Cs|Cs;O_rad/NonDeO
 
 entry(
     index = 444,
-    label = "OH_p23 + C7H8 <=> H2O + C7H7",
+    label = "OH + C7H8 <=> H2O + C7H7",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.26e+13, 'cm^3/(mol*s)'),
@@ -11373,7 +11373,7 @@ Converted to training reaction from rate rule: CS/H/NonDeC;C_rad/H2/Cs
 
 entry(
     index = 465,
-    label = "SH + C3H6S <=> H2S_r + C3H5S",
+    label = "SH + C3H6S <=> H2S + C3H5S",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (192.2, 'cm^3/(mol*s)'),
@@ -11955,7 +11955,7 @@ Converted to training reaction from rate rule: C/H2/NonDeC_5ring_fused6_1;C_rad/
 
 entry(
     index = 493,
-    label = "OH_p23 + NH3_r <=> H2O + NH2b",
+    label = "OH + NH3_r <=> H2O + NH2b",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (3.6e+06, 'cm^3/(mol*s)'),
@@ -14557,7 +14557,7 @@ Converted to training reaction from rate rule: NH3;H_rad
 
 entry(
     index = 623,
-    label = "OH_p23 + NH3_r <=> H2O + NH2b",
+    label = "OH + NH3_r <=> H2O + NH2b",
     degeneracy = 3.0,
     kinetics = Arrhenius(
         A = (1.5e+08, 'cm^3/(mol*s)'),
@@ -14641,7 +14641,7 @@ Added by Beat Buesser, value for reaction: NH2 + O = NH + OH (B&D #15d2) in 'Gas
 
 entry(
     index = 627,
-    label = "OH_p23 + H2N <=> H2O + NH_p",
+    label = "OH + H2N <=> H2O + NH_p",
     degeneracy = 2.0,
     kinetics = Arrhenius(
         A = (4.8e+06, 'cm^3/(mol*s)'),
@@ -15101,7 +15101,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;O_atom_triplet
 
 entry(
     index = 648,
-    label = "OH_p23 + N2H4 <=> H2O + H3N2-2",
+    label = "OH + N2H4 <=> H2O + H3N2-2",
     degeneracy = 4.0,
     kinetics = Arrhenius(
         A = (1.92e+07, 'cm^3/(mol*s)'),
@@ -15167,7 +15167,7 @@ Converted to training reaction from rate rule: N3s/H2/NonDeN;NH2_rad
 
 entry(
     index = 651,
-    label = "OH_p23 + HNO_r <=> H2O + NO",
+    label = "OH + HNO_r <=> H2O + NO",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (1.3e+07, 'cm^3/(mol*s)'),

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/groups.py
@@ -24,7 +24,11 @@ boundaryAtoms = ["*1", "*2"]
 entry(
     index = 0,
     label = "Rn",
-    group = "OR{R3, R4, R5, R6plus}",
+    group = """
+    1 *2 R!H u0 {3,[D,T,B]}
+    2 *1 R!H u1
+    3 *3 R!H u0 c0 {1,[D,T,B]}
+    """,
     kinetics = None,
 )
 

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/groups.py
@@ -24,7 +24,11 @@ boundaryAtoms = ["*1", "*2"]
 entry(
     index = 0,
     label = "Rn",
-    group = "OR{R4, R5, R6, R7plus}",
+    group = """
+    1 *2 R!H u0 {3,[D,T,B]}
+    2 *1 R!H u1
+    3 *3 R!H u0 c0 {1,[D,T,B]}
+    """,
     kinetics = None,
 )
 

--- a/input/kinetics/families/R_Addition_MultipleBond/groups.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/groups.py
@@ -33,7 +33,10 @@ entry(
 entry(
     index = 1,
     label = "YJ",
-    group = "OR{HJ, Y_1centerquadrad, Y_1centertrirad, Y_1centerbirad, CJ, OJ, SJ, NJ}",
+    group = 
+"""
+1 *3 R u[1,2,3,4] px
+""",
     kinetics = None,
 )
 

--- a/input/kinetics/families/Substitution_O/groups.py
+++ b/input/kinetics/families/Substitution_O/groups.py
@@ -22,7 +22,7 @@ entry(
     index = 0,
     label = "O-RR_or_RRrad",
     group = """
-1 *1 O2s u0 {2,S} {3,S}
+1 *1 O u0 {2,S} {3,S}
 2 *2 R   u[0,1] {1,S}
 3    R   u0 {1,S}
 """,
@@ -33,7 +33,7 @@ entry(
     index = 1,
     label = "YJ",
     group = """
-1 *3 [H,C,O2s,N,S] u[1,2]
+1 *3 [H,C,O,N,S] u[1,2]
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Substitution_O/groups.py
+++ b/input/kinetics/families/Substitution_O/groups.py
@@ -21,14 +21,20 @@ recipe(actions=[
 entry(
     index = 0,
     label = "O-RR_or_RRrad",
-    group = "OR{O-RR, O-RRrad}",
+    group = """
+1 *1 O2s u0 {2,S} {3,S}
+2 *2 R   u[0,1] {1,S}
+3    R   u0 {1,S}
+""",
     kinetics = None,
 )
 
 entry(
     index = 1,
     label = "YJ",
-    group = "OR{Y_2centeradjbirad, HJ, CJ, OJ, Y_1centerbirad, NJ, SJ}",
+    group = """
+1 *3 [H,C,O2s,N,S] u[1,2]
+""",
     kinetics = None,
 )
 

--- a/input/kinetics/families/Substitution_O/groups.py
+++ b/input/kinetics/families/Substitution_O/groups.py
@@ -18,6 +18,8 @@ recipe(actions=[
     ['LOSE_RADICAL', '*3', '1'],
 ])
 
+reverseMap = {'*2':'*3','*3':'*2'}
+
 entry(
     index = 0,
     label = "O-RR_or_RRrad",

--- a/input/kinetics/families/Substitution_O/groups.py
+++ b/input/kinetics/families/Substitution_O/groups.py
@@ -20,6 +20,9 @@ recipe(actions=[
 
 reverseMap = {'*2':'*3','*3':'*2'}
 
+reactantNum = 2
+productNum = 2
+
 entry(
     index = 0,
     label = "O-RR_or_RRrad",

--- a/input/kinetics/families/intra_H_migration/groups.py
+++ b/input/kinetics/families/intra_H_migration/groups.py
@@ -18,12 +18,18 @@ recipe(actions=[
     ['LOSE_RADICAL', '*1', '1'],
 ])
 
+reverseMap = {'*1':'*2','*2':'*1'}
+
 boundaryAtoms = ["*1", "*2"]
 
 entry(
     index = 0,
     label = "RnH",
-    group = "OR{R2Hall, R3Hall, R4Hall, R5Hall, R6Hall, R7Hall, R8Hall}",
+    group = """
+1 *2 R!H u0 {3,S}
+2 *1 R!H u1 
+3 *3 H   u0 {1,S}
+""",
     kinetics = None,
 )
 

--- a/input/kinetics/families/ketoenol/training/dictionary.txt
+++ b/input/kinetics/families/ketoenol/training/dictionary.txt
@@ -53,6 +53,13 @@ CH2OS
 4    H u0 p0 c0 {3,S}
 5 *4 H u0 p0 c0 {2,S}
 
+CH2OS-2
+1 *1 S u0 p2 c0 {3,S} {5,S}
+2 *3 O u0 p2 c0 {3,D} 
+3 *2 C u0 p0 c0 {1,S} {2,D} {4,S}
+4    H u0 p0 c0 {3,S}
+5 *4 H u0 p0 c0 {1,S}
+
 C2H4OS
 1 *1 S u0 p2 c0 {4,D}
 2 *3 O u0 p2 c0 {4,S} {8,S}

--- a/input/kinetics/families/ketoenol/training/reactions.py
+++ b/input/kinetics/families/ketoenol/training/reactions.py
@@ -69,7 +69,7 @@ Converted to training reaction from rate rule: R_ROR;R1_doublebond_CH2;R2_double
 
 entry(
     index = 4,
-    label = "CH2OS <=> CH2OS",
+    label = "CH2OS <=> CH2OS-2",
     degeneracy = 1.0,
     kinetics = Arrhenius(
         A = (52, 's^-1'),


### PR DESCRIPTION
This PR fixed problematic database labels for H-Abstraction and disproportionation.

Suggest naming convention for future labeling in database

SpeciesName_ReactantProductFlagWithAtomLabel_(ExtraFlagForDistinguishing)
e.g. For H-Abstraction
CH3_r3
multiplicity 2
1 *3 C u1 p0 c0 {2,S} {3,S} {4,S}
2    H u0 p0 c0 {1,S}
3    H u0 p0 c0 {1,S}
4    H u0 p0 c0 {1,S}

CH3_p1
multiplicity 2
1 *1 C u1 p0 c0 {2,S} {3,S} {4,S}
2    H u0 p0 c0 {1,S}
3    H u0 p0 c0 {1,S}
4    H u0 p0 c0 {1,S}

