### PR TITLE
Add Intra_R_Add_Exocyclic training reactions from Wang et al. 2015

### DIFF
--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -196,8 +196,10 @@ entry(
     kinetics = Arrhenius(
         A = (6.6e+07, 's^-1'),
         n = 1.08,
-        Ea = (30.4, 'kcal/mol', '+|-', 1),
+        Ea = (30.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -209,12 +211,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -225,8 +227,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.02e+07, 's^-1'),
         n = 1.34,
-        Ea = (30.1, 'kcal/mol', '+|-', 1),
+        Ea = (30.1, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -238,12 +242,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -254,8 +258,10 @@ entry(
     kinetics = Arrhenius(
         A = (1e+07, 's^-1'),
         n = 1.34,
-        Ea = (29.4, 'kcal/mol', '+|-', 1),
+        Ea = (29.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -267,12 +273,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -283,8 +289,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.61e+08, 's^-1'),
         n = 0.96,
-        Ea = (29.4, 'kcal/mol', '+|-', 1),
+        Ea = (29.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -296,12 +304,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling" Trans conformation of pentenyl.
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of pentenyl.
 """,
 )
 
@@ -312,8 +320,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.01e+08, 's^-1'),
         n = 1.02,
-        Ea = (29.7, 'kcal/mol', '+|-', 1),
+        Ea = (29.7, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -325,12 +335,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -341,8 +351,10 @@ entry(
     kinetics = Arrhenius(
         A = (3.82e+08, 's^-1'),
         n = 0.91,
-        Ea = (30, 'kcal/mol', '+|-', 1),
+        Ea = (30, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -354,12 +366,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -370,8 +382,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.41e+08, 's^-1'),
         n = 0.96,
-        Ea = (29.3, 'kcal/mol', '+|-', 1),
+        Ea = (29.3, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -383,12 +397,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -399,8 +413,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.02e+06, 's^-1'),
         n = 1.58,
-        Ea = (29.7, 'kcal/mol', '+|-', 1),
+        Ea = (29.7, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -412,12 +428,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -428,8 +444,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.71e+08, 's^-1'),
         n = 0.99,
-        Ea = (29.7, 'kcal/mol', '+|-', 1),
+        Ea = (29.7, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -441,12 +459,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -457,8 +475,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.15e+07, 's^-1'),
         n = 1.24,
-        Ea = (30.9, 'kcal/mol', '+|-', 1),
+        Ea = (30.9, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -470,12 +490,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -486,8 +506,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.65e+07, 's^-1'),
         n = 1.02,
-        Ea = (14.2, 'kcal/mol', '+|-', 1),
+        Ea = (14.2, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -499,12 +521,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -515,8 +537,10 @@ entry(
     kinetics = Arrhenius(
         A = (4.64e+06, 's^-1'),
         n = 1.15,
-        Ea = (13.9, 'kcal/mol', '+|-', 1),
+        Ea = (13.9, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -528,12 +552,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -544,8 +568,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.07e+06, 's^-1'),
         n = 1.38,
-        Ea = (12.2, 'kcal/mol', '+|-', 1),
+        Ea = (12.2, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -557,12 +583,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -573,8 +599,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.94e+07, 's^-1'),
         n = 0.93,
-        Ea = (13.9, 'kcal/mol', '+|-', 1),
+        Ea = (13.9, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -586,12 +614,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling" Trans conformation of hexenyl.
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of hexenyl.
 """,
 )
 
@@ -602,8 +630,10 @@ entry(
     kinetics = Arrhenius(
         A = (6.65e+07, 's^-1'),
         n = 0.83,
-        Ea = (13.4, 'kcal/mol', '+|-', 1),
+        Ea = (13.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -615,12 +645,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -631,8 +661,10 @@ entry(
     kinetics = Arrhenius(
         A = (7.25e+07, 's^-1'),
         n = 0.83,
-        Ea = (14.1, 'kcal/mol', '+|-', 1),
+        Ea = (14.1, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -644,12 +676,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -660,8 +692,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.23e+07, 's^-1'),
         n = 1,
-        Ea = (13.5, 'kcal/mol', '+|-', 1),
+        Ea = (13.5, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -673,12 +707,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -689,8 +723,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.38e+08, 's^-1'),
         n = 0.75,
-        Ea = (12.6, 'kcal/mol', '+|-', 1),
+        Ea = (12.6, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -702,12 +738,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -718,8 +754,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.6e+08, 's^-1'),
         n = 0.76,
-        Ea = (13.4, 'kcal/mol', '+|-', 1),
+        Ea = (13.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -731,12 +769,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -747,8 +785,10 @@ entry(
     kinetics = Arrhenius(
         A = (4.9e+06, 's^-1'),
         n = 1.13,
-        Ea = (15.6, 'kcal/mol', '+|-', 1),
+        Ea = (15.6, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -760,12 +800,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -776,8 +816,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.25e+06, 's^-1'),
         n = 1.08,
-        Ea = (6.7, 'kcal/mol', '+|-', 1),
+        Ea = (6.7, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -789,12 +831,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -805,8 +847,10 @@ entry(
     kinetics = Arrhenius(
         A = (487000, 's^-1'),
         n = 1.17,
-        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        Ea = (6.3, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -818,12 +862,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -834,8 +878,10 @@ entry(
     kinetics = Arrhenius(
         A = (33000, 's^-1'),
         n = 1.42,
-        Ea = (4.7, 'kcal/mol', '+|-', 1),
+        Ea = (4.7, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -847,12 +893,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -863,8 +909,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.26e+06, 's^-1'),
         n = 1.02,
-        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        Ea = (6.3, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -876,12 +924,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling" Trans conformation of heptenyl.
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of heptenyl.
 """,
 )
 
@@ -892,8 +940,10 @@ entry(
     kinetics = Arrhenius(
         A = (2.01e+06, 's^-1'),
         n = 1.05,
-        Ea = (5.8, 'kcal/mol', '+|-', 1),
+        Ea = (5.8, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -905,12 +955,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -921,8 +971,10 @@ entry(
     kinetics = Arrhenius(
         A = (7.32e+06, 's^-1'),
         n = 0.84,
-        Ea = (5.9, 'kcal/mol', '+|-', 1),
+        Ea = (5.9, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -934,12 +986,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -950,8 +1002,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.24e+07, 's^-1'),
         n = 0.79,
-        Ea = (6.2, 'kcal/mol', '+|-', 1),
+        Ea = (6.2, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -963,12 +1017,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -979,8 +1033,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.46e+06, 's^-1'),
         n = 1.02,
-        Ea = (6.1, 'kcal/mol', '+|-', 1),
+        Ea = (6.1, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -992,12 +1048,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1008,8 +1064,10 @@ entry(
     kinetics = Arrhenius(
         A = (1.19e+07, 's^-1'),
         n = 0.78,
-        Ea = (6.2, 'kcal/mol', '+|-', 1),
+        Ea = (6.2, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1021,12 +1079,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1037,8 +1095,10 @@ entry(
     kinetics = Arrhenius(
         A = (3.5e+07, 's^-1'),
         n = 0.7,
-        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        Ea = (6.3, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1050,12 +1110,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1066,8 +1126,10 @@ entry(
     kinetics = Arrhenius(
         A = (5.85e+07, 's^-1'),
         n = 0.63,
-        Ea = (6.3, 'kcal/mol', '+|-', 1),
+        Ea = (6.3, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1079,12 +1141,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1095,8 +1157,10 @@ entry(
     kinetics = Arrhenius(
         A = (344000, 's^-1'),
         n = 1.1,
-        Ea = (7.7, 'kcal/mol', '+|-', 1),
+        Ea = (7.7, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1108,12 +1172,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1124,8 +1188,10 @@ entry(
     kinetics = Arrhenius(
         A = (114000, 's^-1'),
         n = 1.2,
-        Ea = (6.5, 'kcal/mol', '+|-', 1),
+        Ea = (6.5, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1137,12 +1203,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1153,8 +1219,10 @@ entry(
     kinetics = Arrhenius(
         A = (21100, 's^-1'),
         n = 1.34,
-        Ea = (6.4, 'kcal/mol', '+|-', 1),
+        Ea = (6.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1166,12 +1234,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1179,7 +1247,14 @@ entry(
     index = 48,
     label = "C_CCCCCCJ(C)C <=> 3,3-dimethylcycloheptyl",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(554, 's^-1'), n=1.66, Ea=(4.9, 'kcal/mol', '+|-', 1), T0=(1, 'K')),
+    kinetics = Arrhenius(
+        A = (554, 's^-1'),
+        n = 1.66,
+        Ea = (4.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
         title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
@@ -1190,12 +1265,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1206,8 +1281,10 @@ entry(
     kinetics = Arrhenius(
         A = (110000, 's^-1'),
         n = 1.18,
-        Ea = (6.5, 'kcal/mol', '+|-', 1),
+        Ea = (6.5, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1219,12 +1296,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1235,8 +1312,10 @@ entry(
     kinetics = Arrhenius(
         A = (185000, 's^-1'),
         n = 1.07,
-        Ea = (6.4, 'kcal/mol', '+|-', 1),
+        Ea = (6.4, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1248,12 +1327,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 
@@ -1264,8 +1343,10 @@ entry(
     kinetics = Arrhenius(
         A = (12200, 's^-1'),
         n = 1.36,
-        Ea = (8.5, 'kcal/mol', '+|-', 1),
+        Ea = (8.5, 'kcal/mol'),
         T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
     ),
     reference = Article(
         authors = ['K. Wang', 'S. Villano', 'A. Dean'],
@@ -1277,12 +1358,12 @@ entry(
     ),
     referenceType = "theory",
     rank = 5,
-    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/631G(d)""",
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
     longDesc = 
 u"""
 Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
-B3LYP/631G(d)" using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
-coefficient computed TST with Eckart Tunnelling"
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
 """,
 )
 

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/dictionary.txt
@@ -14428,66 +14428,66 @@ multiplicity 2
 
 C12H17-16
 multiplicity 2
-1     C u0 p0 c0 {2,S} {14,S} {15,S} {16,S}
-2     C u0 p0 c0 {1,S} {3,S} {17,S} {18,S}
-3     C u0 p0 c0 {2,S} {4,S} {19,S} {20,S}
-4     C u0 p0 c0 {3,S} {5,S} {21,S} {22,S}
-5  *1 C u0 p0 c0 {4,S} {6,S} {7,S} {23,S}
-6  *4 C u0 p0 c0 {5,S} {7,S} {24,S} {25,S}
-7  *2 C u0 p0 c0 {5,S} {6,S} {8,S} {12,S}
-8     C u0 p0 c0 {7,S} {9,D} {26,S}
-9     C u0 p0 c0 {8,D} {10,S} {27,S}
-10    C u0 p0 c0 {9,S} {11,D} {28,S}
-11    C u0 p0 c0 {10,D} {12,S} {29,S}
-12 *3 C u1 p0 c0 {7,S} {11,S} {13,S}
-13    H u0 p0 c0 {12,S}
-14    H u0 p0 c0 {1,S}
-15    H u0 p0 c0 {1,S}
-16    H u0 p0 c0 {1,S}
-17    H u0 p0 c0 {2,S}
-18    H u0 p0 c0 {2,S}
-19    H u0 p0 c0 {3,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {3,S} {4,S} {13,S}
+3  *4 C u0 p0 c0 {1,S} {2,S} {20,S} {21,S}
+4     C u0 p0 c0 {2,S} {5,S} {18,S} {19,S}
+5     C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6     C u0 p0 c0 {5,S} {7,S} {14,S} {15,S}
+7     C u0 p0 c0 {6,S} {22,S} {23,S} {24,S}
+8  *3 C u1 p0 c0 {1,S} {11,S} {25,S}
+9     C u0 p0 c0 {1,S} {10,D} {26,S}
+10    C u0 p0 c0 {9,D} {12,S} {27,S}
+11    C u0 p0 c0 {8,S} {12,D} {29,S}
+12    C u0 p0 c0 {10,S} {11,D} {28,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {4,S}
 20    H u0 p0 c0 {3,S}
-21    H u0 p0 c0 {4,S}
-22    H u0 p0 c0 {4,S}
-23    H u0 p0 c0 {5,S}
-24    H u0 p0 c0 {6,S}
-25    H u0 p0 c0 {6,S}
-26    H u0 p0 c0 {8,S}
-27    H u0 p0 c0 {9,S}
-28    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {3,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {7,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {8,S}
+26    H u0 p0 c0 {9,S}
+27    H u0 p0 c0 {10,S}
+28    H u0 p0 c0 {12,S}
 29    H u0 p0 c0 {11,S}
 
 C12H17-17
 multiplicity 2
-1     C u0 p0 c0 {2,S} {14,S} {15,S} {16,S}
-2     C u0 p0 c0 {1,S} {3,S} {17,S} {18,S}
-3     C u0 p0 c0 {2,S} {4,S} {19,S} {20,S}
-4     C u0 p0 c0 {3,S} {5,S} {21,S} {22,S}
-5  *4 C u0 p0 c0 {4,S} {6,S} {7,S} {23,S}
-6  *1 C u0 p0 c0 {5,S} {7,S} {24,S} {25,S}
-7  *2 C u0 p0 c0 {5,S} {6,S} {8,S} {12,S}
-8     C u0 p0 c0 {7,S} {9,D} {26,S}
-9     C u0 p0 c0 {8,D} {10,S} {27,S}
-10    C u0 p0 c0 {9,S} {11,D} {28,S}
-11    C u0 p0 c0 {10,D} {12,S} {29,S}
-12 *3 C u1 p0 c0 {7,S} {11,S} {13,S}
-13    H u0 p0 c0 {12,S}
-14    H u0 p0 c0 {1,S}
-15    H u0 p0 c0 {1,S}
-16    H u0 p0 c0 {1,S}
-17    H u0 p0 c0 {2,S}
-18    H u0 p0 c0 {2,S}
-19    H u0 p0 c0 {3,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *4 C u0 p0 c0 {1,S} {3,S} {4,S} {13,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {20,S} {21,S}
+4     C u0 p0 c0 {2,S} {5,S} {18,S} {19,S}
+5     C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6     C u0 p0 c0 {5,S} {7,S} {14,S} {15,S}
+7     C u0 p0 c0 {6,S} {22,S} {23,S} {24,S}
+8  *3 C u1 p0 c0 {1,S} {11,S} {25,S}
+9     C u0 p0 c0 {1,S} {10,D} {26,S}
+10    C u0 p0 c0 {9,D} {12,S} {27,S}
+11    C u0 p0 c0 {8,S} {12,D} {29,S}
+12    C u0 p0 c0 {10,S} {11,D} {28,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {4,S}
+19    H u0 p0 c0 {4,S}
 20    H u0 p0 c0 {3,S}
-21    H u0 p0 c0 {4,S}
-22    H u0 p0 c0 {4,S}
-23    H u0 p0 c0 {5,S}
-24    H u0 p0 c0 {6,S}
-25    H u0 p0 c0 {6,S}
-26    H u0 p0 c0 {8,S}
-27    H u0 p0 c0 {9,S}
-28    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {3,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {7,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {8,S}
+26    H u0 p0 c0 {9,S}
+27    H u0 p0 c0 {10,S}
+28    H u0 p0 c0 {12,S}
 29    H u0 p0 c0 {11,S}
 
 C12H17-18
@@ -14556,34 +14556,34 @@ multiplicity 2
 
 C12H17-20
 multiplicity 2
-1     C u0 p0 c0 {2,S} {14,S} {15,S} {16,S}
-2     C u0 p0 c0 {1,S} {3,S} {17,S} {18,S}
-3     C u0 p0 c0 {2,S} {4,S} {19,S} {20,S}
-4  *1 C u0 p0 c0 {3,S} {5,S} {7,S} {21,S}
-5  *4 C u0 p0 c0 {4,S} {6,S} {22,S} {23,S}
-6  *5 C u0 p0 c0 {5,S} {7,S} {24,S} {25,S}
-7  *2 C u0 p0 c0 {4,S} {6,S} {8,S} {12,S}
-8     C u0 p0 c0 {7,S} {9,D} {26,S}
-9     C u0 p0 c0 {8,D} {10,S} {27,S}
-10    C u0 p0 c0 {9,S} {11,D} {28,S}
-11    C u0 p0 c0 {10,D} {12,S} {29,S}
-12 *3 C u1 p0 c0 {7,S} {11,S} {13,S}
-13    H u0 p0 c0 {12,S}
-14    H u0 p0 c0 {1,S}
-15    H u0 p0 c0 {1,S}
-16    H u0 p0 c0 {1,S}
-17    H u0 p0 c0 {2,S}
-18    H u0 p0 c0 {2,S}
-19    H u0 p0 c0 {3,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {5,S} {13,S}
+3  *5 C u0 p0 c0 {1,S} {5,S} {20,S} {21,S}
+4     C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
+5  *4 C u0 p0 c0 {2,S} {3,S} {18,S} {19,S}
+6     C u0 p0 c0 {4,S} {7,S} {14,S} {15,S}
+7     C u0 p0 c0 {6,S} {22,S} {23,S} {24,S}
+8  *3 C u1 p0 c0 {1,S} {11,S} {25,S}
+9     C u0 p0 c0 {1,S} {10,D} {26,S}
+10    C u0 p0 c0 {9,D} {12,S} {27,S}
+11    C u0 p0 c0 {8,S} {12,D} {29,S}
+12    C u0 p0 c0 {10,S} {11,D} {28,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {6,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
 20    H u0 p0 c0 {3,S}
-21    H u0 p0 c0 {4,S}
-22    H u0 p0 c0 {5,S}
-23    H u0 p0 c0 {5,S}
-24    H u0 p0 c0 {6,S}
-25    H u0 p0 c0 {6,S}
-26    H u0 p0 c0 {8,S}
-27    H u0 p0 c0 {9,S}
-28    H u0 p0 c0 {10,S}
+21    H u0 p0 c0 {3,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {7,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {8,S}
+26    H u0 p0 c0 {9,S}
+27    H u0 p0 c0 {10,S}
+28    H u0 p0 c0 {12,S}
 29    H u0 p0 c0 {11,S}
 
 C12H17-21
@@ -14684,34 +14684,34 @@ multiplicity 2
 
 C12H17-24
 multiplicity 2
-1     C u0 p0 c0 {2,S} {14,S} {15,S} {16,S}
-2     C u0 p0 c0 {1,S} {3,S} {17,S} {18,S}
-3  *1 C u0 p0 c0 {2,S} {4,S} {7,S} {19,S}
-4  *4 C u0 p0 c0 {3,S} {5,S} {20,S} {21,S}
-5  *6 C u0 p0 c0 {4,S} {6,S} {22,S} {23,S}
-6  *5 C u0 p0 c0 {5,S} {7,S} {24,S} {25,S}
-7  *2 C u0 p0 c0 {3,S} {6,S} {8,S} {12,S}
-8     C u0 p0 c0 {7,S} {9,D} {26,S}
-9     C u0 p0 c0 {8,D} {10,S} {27,S}
-10    C u0 p0 c0 {9,S} {11,D} {28,S}
-11    C u0 p0 c0 {10,D} {12,S} {29,S}
-12 *3 C u1 p0 c0 {7,S} {11,S} {13,S}
-13    H u0 p0 c0 {12,S}
-14    H u0 p0 c0 {1,S}
-15    H u0 p0 c0 {1,S}
-16    H u0 p0 c0 {1,S}
-17    H u0 p0 c0 {2,S}
-18    H u0 p0 c0 {2,S}
-19    H u0 p0 c0 {3,S}
-20    H u0 p0 c0 {4,S}
-21    H u0 p0 c0 {4,S}
-22    H u0 p0 c0 {5,S}
-23    H u0 p0 c0 {5,S}
-24    H u0 p0 c0 {6,S}
-25    H u0 p0 c0 {6,S}
-26    H u0 p0 c0 {8,S}
-27    H u0 p0 c0 {9,S}
-28    H u0 p0 c0 {10,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {5,S} {13,S}
+3  *5 C u0 p0 c0 {1,S} {6,S} {20,S} {21,S}
+4  *4 C u0 p0 c0 {2,S} {6,S} {16,S} {17,S}
+5     C u0 p0 c0 {2,S} {7,S} {14,S} {15,S}
+6  *6 C u0 p0 c0 {3,S} {4,S} {18,S} {19,S}
+7     C u0 p0 c0 {5,S} {22,S} {23,S} {24,S}
+8  *3 C u1 p0 c0 {1,S} {11,S} {25,S}
+9     C u0 p0 c0 {1,S} {10,D} {26,S}
+10    C u0 p0 c0 {9,D} {12,S} {27,S}
+11    C u0 p0 c0 {8,S} {12,D} {29,S}
+12    C u0 p0 c0 {10,S} {11,D} {28,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {4,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {3,S}
+21    H u0 p0 c0 {3,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {7,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {8,S}
+26    H u0 p0 c0 {9,S}
+27    H u0 p0 c0 {10,S}
+28    H u0 p0 c0 {12,S}
 29    H u0 p0 c0 {11,S}
 
 C12H17-25
@@ -14812,34 +14812,34 @@ multiplicity 2
 
 C12H17-28
 multiplicity 2
-1     C u0 p0 c0 {2,S} {14,S} {15,S} {16,S}
-2  *1 C u0 p0 c0 {1,S} {3,S} {7,S} {17,S}
-3  *4 C u0 p0 c0 {2,S} {4,S} {18,S} {19,S}
-4  *6 C u0 p0 c0 {3,S} {5,S} {20,S} {21,S}
-5  *7 C u0 p0 c0 {4,S} {6,S} {22,S} {23,S}
-6  *5 C u0 p0 c0 {5,S} {7,S} {24,S} {25,S}
-7  *2 C u0 p0 c0 {2,S} {6,S} {8,S} {12,S}
-8     C u0 p0 c0 {7,S} {9,D} {26,S}
-9     C u0 p0 c0 {8,D} {10,S} {27,S}
-10    C u0 p0 c0 {9,S} {11,D} {28,S}
-11    C u0 p0 c0 {10,D} {12,S} {29,S}
-12 *3 C u1 p0 c0 {7,S} {11,S} {13,S}
-13    H u0 p0 c0 {12,S}
-14    H u0 p0 c0 {1,S}
-15    H u0 p0 c0 {1,S}
-16    H u0 p0 c0 {1,S}
-17    H u0 p0 c0 {2,S}
-18    H u0 p0 c0 {3,S}
-19    H u0 p0 c0 {3,S}
-20    H u0 p0 c0 {4,S}
-21    H u0 p0 c0 {4,S}
-22    H u0 p0 c0 {5,S}
-23    H u0 p0 c0 {5,S}
-24    H u0 p0 c0 {6,S}
-25    H u0 p0 c0 {6,S}
-26    H u0 p0 c0 {8,S}
-27    H u0 p0 c0 {9,S}
-28    H u0 p0 c0 {10,S}
+1  *2 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {7,S} {13,S}
+3  *5 C u0 p0 c0 {1,S} {6,S} {20,S} {21,S}
+4  *4 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {16,S} {17,S}
+6  *7 C u0 p0 c0 {3,S} {5,S} {18,S} {19,S}
+7     C u0 p0 c0 {2,S} {22,S} {23,S} {24,S}
+8  *3 C u1 p0 c0 {1,S} {11,S} {25,S}
+9     C u0 p0 c0 {1,S} {10,D} {26,S}
+10    C u0 p0 c0 {9,D} {12,S} {27,S}
+11    C u0 p0 c0 {8,S} {12,D} {29,S}
+12    C u0 p0 c0 {10,S} {11,D} {28,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {3,S}
+21    H u0 p0 c0 {3,S}
+22    H u0 p0 c0 {7,S}
+23    H u0 p0 c0 {7,S}
+24    H u0 p0 c0 {7,S}
+25    H u0 p0 c0 {8,S}
+26    H u0 p0 c0 {9,S}
+27    H u0 p0 c0 {10,S}
+28    H u0 p0 c0 {12,S}
 29    H u0 p0 c0 {11,S}
 
 C12H17-29
@@ -14905,3 +14905,716 @@ multiplicity 2
 27    H u0 p0 c0 {8,S}
 28    H u0 p0 c0 {12,S}
 29    H u0 p0 c0 {12,S}
+
+C5H9-7
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {6,S}
+2     C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+3  *2 C u0 p0 c0 {1,S} {5,D} {10,S}
+4  *1 C u1 p0 c0 {1,S} {11,S} {12,S}
+5  *3 C u0 p0 c0 {3,D} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C5H9-8
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {6,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {5,S} {7,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {8,S} {9,S}
+4     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+5  *3 C u1 p0 c0 {2,S} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C5H9-9
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+2     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+3  *2 C u0 p0 c0 {1,S} {2,S} {5,D}
+4  *1 C u1 p0 c0 {1,S} {11,S} {12,S}
+5  *3 C u0 p0 c0 {3,D} {13,S} {14,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C5H9-10
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  *4 C u0 p0 c0 {1,S} {3,S} {6,S} {7,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {8,S} {9,S}
+4     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+5  *3 C u1 p0 c0 {1,S} {13,S} {14,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C6H11-13
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2     C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4  *2 C u0 p0 c0 {1,S} {6,D} {13,S}
+5  *1 C u1 p0 c0 {1,S} {14,S} {15,S}
+6  *3 C u0 p0 c0 {4,D} {16,S} {17,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-14
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  *2 C u0 p0 c0 {1,S} {3,S} {6,S} {7,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {8,S} {9,S}
+4     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6  *3 C u1 p0 c0 {2,S} {16,S} {17,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-15
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {5,S} {7,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4  *2 C u0 p0 c0 {2,S} {6,D} {13,S}
+5  *1 C u1 p0 c0 {1,S} {14,S} {15,S}
+6  *3 C u0 p0 c0 {4,D} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-16
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+2  *2 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+3  *5 C u0 p0 c0 {1,S} {2,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {1,S} {2,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6  *3 C u1 p0 c0 {2,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-17
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {7,S}
+2  *4 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4  *2 C u0 p0 c0 {1,S} {6,D} {13,S}
+5  *1 C u1 p0 c0 {2,S} {14,S} {15,S}
+6  *3 C u0 p0 c0 {4,D} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-18
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {5,S} {7,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {6,S} {8,S}
+3  *4 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6  *3 C u1 p0 c0 {2,S} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-19
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+2  *4 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+3     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+4  *2 C u0 p0 c0 {1,S} {3,S} {6,D}
+5  *1 C u1 p0 c0 {2,S} {14,S} {15,S}
+6  *3 C u0 p0 c0 {4,D} {16,S} {17,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C6H11-20
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  *1 C u0 p0 c0 {1,S} {4,S} {11,S} {12,S}
+4  *4 C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6  *3 C u1 p0 c0 {1,S} {16,S} {17,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+
+C7H13-17
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {3,S} {4,S} {6,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5  *2 C u0 p0 c0 {2,S} {7,D} {16,S}
+6  *1 C u1 p0 c0 {1,S} {17,S} {18,S}
+7  *3 C u0 p0 c0 {5,D} {19,S} {20,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-18
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+2  *2 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+3  *5 C u0 p0 c0 {1,S} {2,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {1,S} {2,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7  *3 C u1 p0 c0 {2,S} {19,S} {20,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-19
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  *4 C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5  *2 C u0 p0 c0 {1,S} {7,D} {16,S}
+6  *1 C u1 p0 c0 {2,S} {17,S} {18,S}
+7  *3 C u0 p0 c0 {5,D} {19,S} {20,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-20
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {7,S} {8,S}
+3  *4 C u0 p0 c0 {1,S} {4,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7  *3 C u1 p0 c0 {2,S} {19,S} {20,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-21
+multiplicity 2
+1  *6 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+3  *4 C u0 p0 c0 {1,S} {6,S} {12,S} {13,S}
+4     C u0 p0 c0 {5,S} {14,S} {15,S} {16,S}
+5  *2 C u0 p0 c0 {2,S} {4,S} {7,D}
+6  *1 C u1 p0 c0 {3,S} {17,S} {18,S}
+7  *3 C u0 p0 c0 {5,D} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-22
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {10,S} {11,S}
+3  *1 C u0 p0 c0 {1,S} {5,S} {14,S} {15,S}
+4  *6 C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+5  *4 C u0 p0 c0 {3,S} {4,S} {12,S} {13,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7  *3 C u1 p0 c0 {1,S} {19,S} {20,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-23
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {5,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5  *2 C u0 p0 c0 {3,S} {7,D} {16,S}
+6  *1 C u1 p0 c0 {1,S} {17,S} {18,S}
+7  *3 C u0 p0 c0 {5,D} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-24
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {3,S} {5,S} {7,S} {9,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {14,S} {15,S}
+4  *6 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+5  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7  *3 C u1 p0 c0 {2,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-25
+multiplicity 2
+1  *6 C u0 p0 c0 {2,S} {3,S} {4,S} {8,S}
+2  *5 C u0 p0 c0 {1,S} {5,S} {9,S} {10,S}
+3  *4 C u0 p0 c0 {1,S} {6,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5  *2 C u0 p0 c0 {2,S} {7,D} {16,S}
+6  *1 C u1 p0 c0 {3,S} {17,S} {18,S}
+7  *3 C u0 p0 c0 {5,D} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-26
+multiplicity 2
+1  *6 C u0 p0 c0 {3,S} {4,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {3,S} {5,S} {7,S} {9,S}
+3  *5 C u0 p0 c0 {1,S} {2,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+5  *1 C u0 p0 c0 {2,S} {4,S} {14,S} {15,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7  *3 C u1 p0 c0 {2,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-27
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {8,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *4 C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5  *2 C u0 p0 c0 {1,S} {7,D} {16,S}
+6  *1 C u1 p0 c0 {3,S} {17,S} {18,S}
+7  *3 C u0 p0 c0 {5,D} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C7H13-28
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {7,S} {9,S}
+3  *6 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+4  *1 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {3,S} {4,S} {12,S} {13,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7  *3 C u1 p0 c0 {2,S} {19,S} {20,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+
+C8H15-17
+multiplicity 2
+1  *4 C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *5 C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+6  *2 C u0 p0 c0 {3,S} {8,D} {19,S}
+7  *1 C u1 p0 c0 {1,S} {20,S} {21,S}
+8  *3 C u0 p0 c0 {6,D} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-18
+multiplicity 2
+1  *4 C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+2  *2 C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+3  *1 C u0 p0 c0 {1,S} {2,S} {14,S} {15,S}
+4  *6 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+5  *5 C u0 p0 c0 {2,S} {4,S} {12,S} {13,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7     C u0 p0 c0 {1,S} {19,S} {20,S} {21,S}
+8  *3 C u1 p0 c0 {2,S} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-19
+multiplicity 2
+1  *6 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2  *5 C u0 p0 c0 {1,S} {6,S} {9,S} {10,S}
+3  *4 C u0 p0 c0 {1,S} {7,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+6  *2 C u0 p0 c0 {2,S} {8,D} {19,S}
+7  *1 C u1 p0 c0 {3,S} {20,S} {21,S}
+8  *3 C u0 p0 c0 {6,D} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-20
+multiplicity 2
+1  *6 C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+2  *2 C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+3  *5 C u0 p0 c0 {1,S} {2,S} {10,S} {11,S}
+4  *4 C u0 p0 c0 {1,S} {5,S} {12,S} {13,S}
+5  *1 C u0 p0 c0 {2,S} {4,S} {14,S} {15,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7     C u0 p0 c0 {1,S} {19,S} {20,S} {21,S}
+8  *3 C u1 p0 c0 {2,S} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-21
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+2  *6 C u0 p0 c0 {1,S} {3,S} {9,S} {10,S}
+3  *4 C u0 p0 c0 {2,S} {7,S} {11,S} {12,S}
+4     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+5     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+6  *2 C u0 p0 c0 {1,S} {8,D} {19,S}
+7  *1 C u1 p0 c0 {3,S} {20,S} {21,S}
+8  *3 C u0 p0 c0 {6,D} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {6,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-22
+multiplicity 2
+1  *5 C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2  *2 C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+3  *6 C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+4  *1 C u0 p0 c0 {2,S} {5,S} {14,S} {15,S}
+5  *4 C u0 p0 c0 {3,S} {4,S} {12,S} {13,S}
+6     C u0 p0 c0 {1,S} {16,S} {17,S} {18,S}
+7     C u0 p0 c0 {1,S} {19,S} {20,S} {21,S}
+8  *3 C u1 p0 c0 {2,S} {22,S} {23,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {6,S}
+18    H u0 p0 c0 {6,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-23
+multiplicity 2
+1  *7 C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+2  *6 C u0 p0 c0 {1,S} {4,S} {11,S} {12,S}
+3  *5 C u0 p0 c0 {1,S} {6,S} {13,S} {14,S}
+4  *4 C u0 p0 c0 {2,S} {7,S} {15,S} {16,S}
+5     C u0 p0 c0 {6,S} {17,S} {18,S} {19,S}
+6  *2 C u0 p0 c0 {3,S} {5,S} {8,D}
+7  *1 C u1 p0 c0 {4,S} {20,S} {21,S}
+8  *3 C u0 p0 c0 {6,D} {22,S} {23,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {4,S}
+17    H u0 p0 c0 {5,S}
+18    H u0 p0 c0 {5,S}
+19    H u0 p0 c0 {5,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+
+C8H15-24
+multiplicity 2
+1  *2 C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+2  *5 C u0 p0 c0 {1,S} {4,S} {13,S} {14,S}
+3  *1 C u0 p0 c0 {1,S} {6,S} {17,S} {18,S}
+4  *7 C u0 p0 c0 {2,S} {5,S} {9,S} {10,S}
+5  *6 C u0 p0 c0 {4,S} {6,S} {11,S} {12,S}
+6  *4 C u0 p0 c0 {3,S} {5,S} {15,S} {16,S}
+7     C u0 p0 c0 {1,S} {19,S} {20,S} {21,S}
+8  *3 C u1 p0 c0 {1,S} {22,S} {23,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {6,S}
+16    H u0 p0 c0 {6,S}
+17    H u0 p0 c0 {3,S}
+18    H u0 p0 c0 {3,S}
+19    H u0 p0 c0 {7,S}
+20    H u0 p0 c0 {7,S}
+21    H u0 p0 c0 {7,S}
+22    H u0 p0 c0 {8,S}
+23    H u0 p0 c0 {8,S}
+

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
@@ -6824,3 +6824,1119 @@ Reaction: CC1CCCCC12C=C[CH]C=C2 <=> [CH2]CCCC(C)C1C=CC=CC=1
 """,
 )
 
+entry(
+    index = 335,
+    label = "C4H7 <=> C4H7-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.32e+08, 's^-1'),
+        n = 0.97,
+        Ea = (8.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 336,
+    label = "C5H9 <=> C5H9-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (5.56e+08, 's^-1'),
+        n = 1,
+        Ea = (9.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 337,
+    label = "C6H11-3 <=> C6H11-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.47e+08, 's^-1'),
+        n = 1.11,
+        Ea = (9.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 338,
+    label = "C5H9-3 <=> C5H9-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.68e+09, 's^-1'),
+        n = 0.84,
+        Ea = (9.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of pentenyl.
+""",
+)
+
+entry(
+    index = 339,
+    label = "C5H9-7 <=> C5H9-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.08e+09, 's^-1'),
+        n = 0.9,
+        Ea = (7.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 340,
+    label = "C5H9-9 <=> C5H9-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (8.52e+08, 's^-1'),
+        n = 0.89,
+        Ea = (10.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 341,
+    label = "C6H11-13 <=> C6H11-14",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.85e+09, 's^-1'),
+        n = 0.75,
+        Ea = (6.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 342,
+    label = "C6H11-7 <=> C6H11-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.9e+09, 's^-1'),
+        n = 0.79,
+        Ea = (8.5, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 343,
+    label = "C5H9-5 <=> C5H9-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.07e+06, 's^-1'),
+        n = 1.46,
+        Ea = (14.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 344,
+    label = "C6H11-9 <=> C6H11-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (4.73e+06, 's^-1'),
+        n = 1.31,
+        Ea = (13.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 345,
+    label = "C7H13-9 <=> C7H13-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (102000, 's^-1'),
+        n = 1.8,
+        Ea = (11.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 346,
+    label = "C6H11-11 <=> C6H11-12",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (8.65e+06, 's^-1'),
+        n = 1.3,
+        Ea = (13.8, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of hexenyl.
+""",
+)
+
+entry(
+    index = 347,
+    label = "C6H11-15 <=> C6H11-16",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.52e+07, 's^-1'),
+        n = 1,
+        Ea = (13, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 348,
+    label = "C6H11-17 <=> C6H11-18",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.15e+07, 's^-1'),
+        n = 1.08,
+        Ea = (12.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 349,
+    label = "C6H11-19 <=> C6H11-20",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.48e+06, 's^-1'),
+        n = 1.25,
+        Ea = (15, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 350,
+    label = "C7H13-17 <=> C7H13-18",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.2e+06, 's^-1'),
+        n = 1.3,
+        Ea = (11.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 351,
+    label = "C7H13-19 <=> C7H13-20",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.6e+07, 's^-1'),
+        n = 1.13,
+        Ea = (12.4, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 352,
+    label = "C7H13-13 <=> C7H13-14",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (5.53e+07, 's^-1'),
+        n = 1.02,
+        Ea = (13.5, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 353,
+    label = "C6H11 <=> C6H11-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (698000, 's^-1'),
+        n = 1.33,
+        Ea = (4.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 354,
+    label = "C7H13 <=> C7H13-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (187000, 's^-1'),
+        n = 1.48,
+        Ea = (3.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 355,
+    label = "C8H15 <=> C8H15-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (126000, 's^-1'),
+        n = 1.48,
+        Ea = (3.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 356,
+    label = "C7H13-3 <=> C7H13-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.72e+06, 's^-1'),
+        n = 1.2,
+        Ea = (4.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of heptenyl.
+""",
+)
+
+entry(
+    index = 357,
+    label = "C7H13-21 <=> C7H13-22",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (184000, 's^-1'),
+        n = 1.4,
+        Ea = (6.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 358,
+    label = "C7H13-23 <=> C7H13-24",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.25e+06, 's^-1'),
+        n = 1.22,
+        Ea = (3.7, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 359,
+    label = "C7H13-25 <=> C7H13-26",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (8.07e+06, 's^-1'),
+        n = 1.02,
+        Ea = (3.9, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 360,
+    label = "C7H13-27 <=> C7H13-28",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (6.75e+06, 's^-1'),
+        n = 1.04,
+        Ea = (4.5, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 361,
+    label = "C8H15-17 <=> C8H15-18",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (7.05e+06, 's^-1'),
+        n = 1.03,
+        Ea = (3.2, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 362,
+    label = "C8H15-19 <=> C8H15-20",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (3.37e+07, 's^-1'),
+        n = 0.85,
+        Ea = (4.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 363,
+    label = "C8H15-21 <=> C8H15-22",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (1.18e+07, 's^-1'),
+        n = 0.99,
+        Ea = (4.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 364,
+    label = "C8H15-5 <=> C8H15-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2.01e+07, 's^-1'),
+        n = 0.9,
+        Ea = (4.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 365,
+    label = "C7H13-15 <=> C7H13-16",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (153000, 's^-1'),
+        n = 1.26,
+        Ea = (5.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 366,
+    label = "C8H15-13 <=> C8H15-14",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (18700, 's^-1'),
+        n = 1.43,
+        Ea = (4.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 367,
+    label = "C9H17-7 <=> C9H17-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (2020, 's^-1'),
+        n = 1.67,
+        Ea = (2.6, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 368,
+    label = "C8H15-15 <=> C8H15-16",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (414000, 's^-1'),
+        n = 1.14,
+        Ea = (5, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling" Trans conformation of octenyl.
+""",
+)
+
+entry(
+    index = 369,
+    label = "C8H15-23 <=> C8H15-24",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (24600, 's^-1'),
+        n = 1.32,
+        Ea = (6.1, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+
+entry(
+    index = 370,
+    label = "C9H17-11 <=> C9H17-12",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(
+        A = (216000, 's^-1'),
+        n = 1.18,
+        Ea = (4.3, 'kcal/mol'),
+        T0 = (1, 'K'),
+        Tmin = (300, 'K'),
+        Tmax = (2500, 'K'),
+    ),
+    reference = Article(
+        authors = ['K. Wang', 'S. Villano', 'A. Dean'],
+        title = 'Reactivity-Structure-Based Rate Estimation Rules for Alkyl Radical H Atom Shift and Alkenyl Radical Cycloaddition Reactions',
+        journal = 'J. Phys. Chem. A',
+        volume = '119(28)',
+        pages = '7205-7221',
+        year = '2015',
+    ),
+    referenceType = "theory",
+    rank = 5,
+    shortDesc = u"""CBS-QB3 calculation with 1-d rotor treatment at B3LYP/6-31G(d)""",
+    longDesc = 
+u"""
+Quantum chemistry calculations CBS-QB3 calculation with 1-d rotor treatment at 
+B3LYP/6-31G(d) using Gaussian 03 and Gaussian 09. High-pressure-limit rate 
+coefficient computed using TST with Eckart Tunnelling"
+""",
+)
+


### PR DESCRIPTION
Should be pretty straightforward. The Intra_R_Add_Endocyclic reactions were added by me a long time ago. Someone else was supposed to add the Intra_R_Add_Exocyclic reactions, but it never happened. Prior data for these reactions were from rate rules only.

The intra_H_migration reactions from the same paper also do not seem to have been added, but that'll be another PR when I get around to it.

Reference: [Wang, K.; Villano, S. M.; Dean, A. M. J. Phys. Chem. A 2015, 119 (28), 7205–7221.](http://pubs.acs.org/doi/abs/10.1021/jp511017z)