### PR TITLE
Add empty training depositories to all cat families

### DIFF
--- a/input/kinetics/families/1+2_Cycloaddition/training/reactions.py
+++ b/input/kinetics/families/1+2_Cycloaddition/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1+2_Cycloaddition/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/1,2-Birad_to_alkene/training/reactions.py
+++ b/input/kinetics/families/1,2-Birad_to_alkene/training/reactions.py
@@ -2,9 +2,10 @@
 # encoding: utf-8
 
 name = "1,2-Birad_to_alkene/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/1,2_Insertion_CO/training/reactions.py
+++ b/input/kinetics/families/1,2_Insertion_CO/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,2_Insertion_CO/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/1,2_Insertion_carbene/training/reactions.py
+++ b/input/kinetics/families/1,2_Insertion_carbene/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,2_Insertion_carbene/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/1,2_NH3_elimination/training/reactions.py
+++ b/input/kinetics/families/1,2_NH3_elimination/training/reactions.py
@@ -2,8 +2,11 @@
 # encoding: utf-8
 
 name = "1,2_NH3_elimination/training"
-shortDesc = u"Kinetics used to train group additivity values"
-
+shortDesc = u"Reaction kinetics used to generate rate rules"
+longDesc = u"""
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
+"""
 entry(
     index = 1,
     label = "N4 <=> NH3 + NH2NHN_p",

--- a/input/kinetics/families/1,2_shiftC/training/reactions.py
+++ b/input/kinetics/families/1,2_shiftC/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,2_shiftC/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/1,2_shiftS/training/reactions.py
+++ b/input/kinetics/families/1,2_shiftS/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "1,2_shiftS/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/1,3_Insertion_CO2/training/reactions.py
+++ b/input/kinetics/families/1,3_Insertion_CO2/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,3_Insertion_CO2/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/1,3_Insertion_ROR/training/reactions.py
+++ b/input/kinetics/families/1,3_Insertion_ROR/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,3_Insertion_ROR/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/1,3_Insertion_RSR/training/reactions.py
+++ b/input/kinetics/families/1,3_Insertion_RSR/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,3_Insertion_RSR//training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/1,3_NH3_elimination/training/reactions.py
+++ b/input/kinetics/families/1,3_NH3_elimination/training/reactions.py
@@ -2,8 +2,11 @@
 # encoding: utf-8
 
 name = "1,2_NH3_elimination/training"
-shortDesc = u"Kinetics used to train group additivity values"
-
+shortDesc = u"Reaction kinetics used to generate rate rules"
+longDesc = u"""
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
+"""
 entry(
     index = 1,
     label = "NH2NNH_r <=> NH3 + N2",

--- a/input/kinetics/families/1,4_Cyclic_birad_scission/training/reactions.py
+++ b/input/kinetics/families/1,4_Cyclic_birad_scission/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "1,4_Cyclic_birad_scission/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/1,4_Linear_birad_scission/training/reactions.py
+++ b/input/kinetics/families/1,4_Linear_birad_scission/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "1,4_Linear_birad_scission/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/2+2_cycloaddition_CCO/training/reactions.py
+++ b/input/kinetics/families/2+2_cycloaddition_CCO/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "2+2_cycloaddition_CCO/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/2+2_cycloaddition_CO/training/reactions.py
+++ b/input/kinetics/families/2+2_cycloaddition_CO/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "2+2_cycloaddition_CO/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/2+2_cycloaddition_CS/training/reactions.py
+++ b/input/kinetics/families/2+2_cycloaddition_CS/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "2+2_cycloaddition_CS/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/2+2_cycloaddition_Cd/training/reactions.py
+++ b/input/kinetics/families/2+2_cycloaddition_Cd/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "2+2_cycloaddition_Cd/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/6_membered_central_C-C_shift/training/reactions.py
+++ b/input/kinetics/families/6_membered_central_C-C_shift/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "6_membered_central_C-C_shift/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Baeyer-Villiger_step1_cat/training/reactions.py
+++ b/input/kinetics/families/Baeyer-Villiger_step1_cat/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Baeyer-Villiger_step1_cat/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Baeyer-Villiger_step2/training/reactions.py
+++ b/input/kinetics/families/Baeyer-Villiger_step2/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Baeyer-Villiger_step2/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Baeyer-Villiger_step2_cat/training/reactions.py
+++ b/input/kinetics/families/Baeyer-Villiger_step2_cat/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Baeyer-Villiger_step2_cat/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Bimolec_Hydroperoxide_Decomposition/training/reactions.py
+++ b/input/kinetics/families/Bimolec_Hydroperoxide_Decomposition/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Bimolec_Hydroperoxide_Decomposition/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Birad_R_Recombination/training/reactions.py
+++ b/input/kinetics/families/Birad_R_Recombination/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Birad_R_Recombination/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Birad_recombination/training/reactions.py
+++ b/input/kinetics/families/Birad_recombination/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Birad_recombination/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/CO_Disproportionation/training/reactions.py
+++ b/input/kinetics/families/CO_Disproportionation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "CO_Disproportionation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Concerted_Intra_Diels_alder_monocyclic_1,2_shiftH/training/reactions.py
+++ b/input/kinetics/families/Concerted_Intra_Diels_alder_monocyclic_1,2_shiftH/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Concerted_Intra_Diels_alder_monocyclic_1,2_shiftH/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Cyclic_Ether_Formation/training/reactions.py
+++ b/input/kinetics/families/Cyclic_Ether_Formation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Cyclic_Ether_Formation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Cyclic_Thioether_Formation/training/reactions.py
+++ b/input/kinetics/families/Cyclic_Thioether_Formation/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Cyclic_Ether_Formation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Cyclopentadiene_scission/training/reactions.py
+++ b/input/kinetics/families/Cyclopentadiene_scission/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Cyclopentadiene_scission/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Diels_alder_addition/training/reactions.py
+++ b/input/kinetics/families/Diels_alder_addition/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Diels_alder_addition/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Disproportionation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Disproportionation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/HO2_Elimination_from_PeroxyRadical/training/reactions.py
+++ b/input/kinetics/families/HO2_Elimination_from_PeroxyRadical/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "HO2_Elimination_from_PeroxyRadical/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "H_Abstraction/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_2+2_cycloaddition_Cd/training/reactions.py
+++ b/input/kinetics/families/Intra_2+2_cycloaddition_Cd/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_2+2_cycloaddition_Cd/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_5_membered_conjugated_C=C_C=C_addition/training/reactions.py
+++ b/input/kinetics/families/Intra_5_membered_conjugated_C=C_C=C_addition/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_5_membered_conjugated_C=C_C=C_addition/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_Diels_alder_monocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_Diels_alder_monocyclic/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_Diels_alder_monocyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Intra_Disproportionation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_Disproportionation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_RH_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_RH_Add_Endocyclic/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Intra_RH_Add_Endocyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Intra_RH_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_RH_Add_Exocyclic/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Intra_RH_Add_Exocyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Endocyclic/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_R_Add_Endocyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_R_Add_ExoTetCyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_ExoTetCyclic/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Intra_R_Add_Exocyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Intra_R_Add_Exo_scission/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exo_scission/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_R_Add_Exo_scission/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_R_Add_Exocyclic/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_R_Add_Exocyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Intra_Retro_Diels_alder_bicyclic/training/reactions.py
+++ b/input/kinetics/families/Intra_Retro_Diels_alder_bicyclic/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Intra_Retro_Diels_alder_bicyclic/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Intra_ene_reaction/training/reactions.py
+++ b/input/kinetics/families/Intra_ene_reaction/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Intra_ene_reaction/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Korcek_step1/training/reactions.py
+++ b/input/kinetics/families/Korcek_step1/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Korcek_step1/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Korcek_step1_cat/training/reactions.py
+++ b/input/kinetics/families/Korcek_step1_cat/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Korcek_step1_cat/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Korcek_step2/training/reactions.py
+++ b/input/kinetics/families/Korcek_step2/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Korcek_step2/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Peroxyl_Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Peroxyl_Disproportionation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Peroxyl_Disproportionation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Peroxyl_Termination/training/reactions.py
+++ b/input/kinetics/families/Peroxyl_Termination/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Peroxyl_Termination/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/R_Addition_COm/training/reactions.py
+++ b/input/kinetics/families/R_Addition_COm/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "R_Addition_COm/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/R_Addition_CSm/training/reactions.py
+++ b/input/kinetics/families/R_Addition_CSm/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "R_Addition_CSm/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
+++ b/input/kinetics/families/R_Addition_MultipleBond/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "R_Addition_MultipleBond/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/R_Recombination/training/reactions.py
+++ b/input/kinetics/families/R_Recombination/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "R_Recombination/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Singlet_Carbene_Intra_Disproportionation/training/reactions.py
+++ b/input/kinetics/families/Singlet_Carbene_Intra_Disproportionation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Singlet_Carbene_Intra_Disproportionation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Singlet_Val6_to_triplet/training/reactions.py
+++ b/input/kinetics/families/Singlet_Val6_to_triplet/training/reactions.py
@@ -2,9 +2,10 @@
 # encoding: utf-8
 
 name = "Singlet_Val6_to_triplet/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/SubstitutionS/training/reactions.py
+++ b/input/kinetics/families/SubstitutionS/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "SubstitutionS/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/Substitution_O/training/reactions.py
+++ b/input/kinetics/families/Substitution_O/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Substitution_O/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/Surface_Abstraction/training/reactions.py
+++ b/input/kinetics/families/Surface_Abstraction/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Surface_Abstraction/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Surface_Adsorption_Bidentate/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Bidentate/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_Bidentate/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Adsorption_Bidentate/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Bidentate/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Adsorption_Bidentate/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Surface_Adsorption_Dissociative/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Dissociative/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Surface_Adsorption_Dissociative/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 #entry(

--- a/input/kinetics/families/Surface_Adsorption_Double/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Double/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Adsorption_Double/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Surface_Adsorption_Double/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Double/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_Double/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Adsorption_Single/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Single/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_Single/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Adsorption_Single/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_Single/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Adsorption_Single/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Adsorption_vdW/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Adsorption_vdW/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Bidentate_Dissociation/training/reactions.py
+++ b/input/kinetics/families/Surface_Bidentate_Dissociation/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Bidentate_Dissociation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Surface_Bidentate_Dissociation/training/reactions.py
+++ b/input/kinetics/families/Surface_Bidentate_Dissociation/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Bidentate_Dissociation/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Dissociation/training/reactions.py
+++ b/input/kinetics/families/Surface_Dissociation/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "Surface_Dissociation/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Dissociation_vdW/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Dissociation_vdW/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/Surface_Recombination/training/reactions.py
+++ b/input/kinetics/families/Surface_Recombination/training/reactions.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Surface_Recombination/training"
+shortDesc = u"Kinetics used to train group additivity values"
+longDesc = u"""
+Put kinetic parameters for reactions to use as a training set for fitting
+group additivity values in this file.
+"""

--- a/input/kinetics/families/Surface_Recombination/training/reactions.py
+++ b/input/kinetics/families/Surface_Recombination/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "Surface_Recombination/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/intra_H_migration/training/reactions.py
+++ b/input/kinetics/families/intra_H_migration/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "intra_H_migration/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 0,

--- a/input/kinetics/families/intra_NO2_ONO_conversion/training/reactions.py
+++ b/input/kinetics/families/intra_NO2_ONO_conversion/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "intra_NO2_ONO_conversion/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 
 entry(

--- a/input/kinetics/families/intra_OH_migration/training/reactions.py
+++ b/input/kinetics/families/intra_OH_migration/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "intra_OH_migration/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/intra_substitutionCS_cyclization/training/reactions.py
+++ b/input/kinetics/families/intra_substitutionCS_cyclization/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "intra_substitutionCS_cyclization/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """

--- a/input/kinetics/families/intra_substitutionCS_isomerization/training/reactions.py
+++ b/input/kinetics/families/intra_substitutionCS_isomerization/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "intra_substitutionCS_isomerization/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/intra_substitutionS_cyclization/training/reactions.py
+++ b/input/kinetics/families/intra_substitutionS_cyclization/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "intra_substitutionS_cyclization/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/intra_substitutionS_isomerization/training/reactions.py
+++ b/input/kinetics/families/intra_substitutionS_isomerization/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "intra_substitutionS_isomerization/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/ketoenol/training/reactions.py
+++ b/input/kinetics/families/ketoenol/training/reactions.py
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 name = "ketoenol/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """
 entry(
     index = 1,

--- a/input/kinetics/families/lone_electron_pair_bond/training/reactions.py
+++ b/input/kinetics/families/lone_electron_pair_bond/training/reactions.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 name = "lone_electron_pair_bond/training"
-shortDesc = u"Kinetics used to train group additivity values"
+shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
-Put kinetic parameters for reactions to use as a training set for fitting
-group additivity values in this file.
+Put kinetic parameters for specific reactions in this file to use as a
+training set for generating rate rules to populate this kinetics family.
 """


### PR DESCRIPTION
As the title indicates.

Not having a training depository causes RMG-website to crash. It also generates warnings when loading RMG-database.