### PR TITLE
Corrected the adjlist (and multiplicity) of N2O in GRI_Mech

### DIFF
--- a/input/thermo/libraries/GRI-Mech3.0.py
+++ b/input/thermo/libraries/GRI-Mech3.0.py
@@ -984,10 +984,9 @@ entry(
     label = "N2O",
     molecule = 
 """
-multiplicity 3
-1 N u1 p1 c0 {2,D}
-2 N u0 p1 c0 {1,D} {3,S}
-3 O u1 p2 c0 {2,S}
+1 O u0 p2 c0 {2,D}
+2 N u0 p0 c+1 {1,D} {3,D}
+3 N u0 p2 c-1 {2,D}
 """,
     thermo = NASA(
         polynomials = [


### PR DESCRIPTION
While N2O triplet exists, according to the data here, this entry was meant to be the singlet.

The triplet N2O (GRI-Mech vs. NNOJJ):
![image](https://user-images.githubusercontent.com/16158262/59160191-80fddf80-8aa1-11e9-89a8-804e6ab2074b.png)
Singlet N2O:
![image](https://user-images.githubusercontent.com/16158262/59160222-a559bc00-8aa1-11e9-9604-2c38c33c0d3b.png)

Tag @dranasinghe for discovering this