### PR TITLE
Filter crit per react family

### DIFF
--- a/input/FilterArrheniusFits
+++ b/input/FilterArrheniusFits
@@ -1,0 +1,2055 @@
+bimol:
+  1+2_Cycloaddition:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 6973448.616751813
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -4.14944420726416
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.3711, dn = +|- 0.0399488, dEa =
+      +|- 0.278503 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.16490305733559382
+  1,2-Birad_to_alkene: null
+  1,2_Insertion_CO:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1.2699999999974447e-07
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 223.25799999999984
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 4.94183e-15, dEa = +|-
+      3.44519e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.700000000000273
+  1,2_Insertion_carbene:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 42784.49742787641
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -10.148365761649554
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.71295, dn = +|- 0.0681251, dEa =
+      +|- 0.474933 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.7050338410323506
+  1,2_NH3_elimination:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 3.522327947445343e-48
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -38.92839152568806
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1494.39, dn = +|- 0.9252, dEa = +|-
+      6.45003 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 18.078986265011153
+  1,2_shiftC: null
+  1,2_shiftS: null
+  1,3_Insertion_CO2:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1.196667299996247
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 304.1967531799928
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 2.96206, dn = +|- 0.137446, dEa =
+      +|- 0.958206 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.169820588913792
+  1,3_Insertion_ROR:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 4.859999999995768e-07
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 101.79699999999995
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.95098e-15, dEa = +|-
+      1.36012e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.55000000000012
+  1,3_Insertion_RSR:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 4.804002674428579e-13
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 141.89276718581058
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 3.56717, dn = +|- 0.160975, dEa =
+      +|- 1.12224 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 5.95138146224542
+  1,3_NH3_elimination:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 0.000560776447644816
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 151.08501704774272
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 4.03794e-15, dEa = +|-
+      2.81505e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 5.760935808022377
+  1,4_Cyclic_birad_scission: null
+  1,4_Linear_birad_scission: null
+  2+2_cycloaddition_CCO: null
+  2+2_cycloaddition_CO:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 2.318999999993418e-07
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 322.6159999999999
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 5.62224e-15, dEa = +|-
+      3.91954e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.4160000000003823
+  2+2_cycloaddition_CS: null
+  2+2_cycloaddition_Cd:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 4.659999999990221
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 226.56399999999988
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 4.95431e-15, dEa = +|-
+      3.45389e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.6500000000002832
+  6_membered_central_C-C_shift: null
+  Baeyer-Villiger_step1_cat:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 5491274.0988474265
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 42.60059267840721
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 7.31597e-16, dEa = +|-
+      5.10032e-15 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.990861473516876
+  Baeyer-Villiger_step2:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1.3227148559382934e-17
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 205.43084745238383
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 6.44181e-15, dEa = +|-
+      4.4909e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 6.696840192626264
+  Baeyer-Villiger_step2_cat:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 4.748579999996473e-09
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 83.3222999999999
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.50389e-15, dEa = +|-
+      1.74559e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 4.242470000000104
+  Bimolec_Hydroperoxide_Decomposition:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 383894.3684465919
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 112.68878528333865
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 3.37839, dn = +|- 0.154093, dEa =
+      +|- 1.07426 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.7976967611016131
+  Birad_R_Recombination:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 130000000.00000003
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 3.583313689668532e-15
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 9.5687e-16, dEa = +|-
+      6.67082e-15 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.24000000000000005
+  Birad_recombination: null
+  CO_Disproportionation:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 44347.91988678379
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 134.51011911219027
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.3337, dn = +|- 0.0364479, dEa =
+      +|- 0.254096 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.883022724789958
+  Concerted_Intra_Diels_alder_monocyclic_1,2_shiftH: null
+  Cyclic_Ether_Formation:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 0.00021298977203255644
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 25.853153003690093
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 2.03302, dn = +|- 0.0898079, dEa =
+      +|- 0.626096 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.2781269090968013
+  Cyclic_Thioether_Formation: null
+  Cyclopentadiene_scission: null
+  Diels_alder_addition:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1.0663091333555968e-07
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 54.19669499199683
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 5.49242, dn = +|- 0.215605, dEa =
+      +|- 1.50309 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.1903293756421194
+  Disproportionation:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 357.8077894492433
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 22.48682834822175
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.75021e-15, dEa = +|-
+      1.91731e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.2450868562531565
+  HO2_Elimination_from_PeroxyRadical:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1.5626919066004212e-07
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 20.97564110983411
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 2.67628, dn = +|- 0.124604, dEa =
+      +|- 0.868678 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.8087784898197756
+  H_Abstraction:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 5.64567629639524e-55
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -341.90947144399524
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 73695.3, dn = +|- 1.41862, dEa = +|-
+      9.88989 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 17.799108630363296
+  Intra_2+2_cycloaddition_Cd: null
+  Intra_5_membered_conjugated_C=C_C=C_addition: null
+  Intra_Diels_alder_monocyclic: null
+  Intra_Disproportionation: null
+  Intra_RH_Add_Endocyclic: null
+  Intra_RH_Add_Exocyclic: null
+  Intra_R_Add_Endocyclic: null
+  Intra_R_Add_ExoTetCyclic: null
+  Intra_R_Add_Exo_scission: null
+  Intra_R_Add_Exocyclic: null
+  Intra_Retro_Diels_alder_bicyclic: null
+  Intra_ene_reaction: null
+  Korcek_step1: null
+  Korcek_step1_cat: null
+  Korcek_step2: null
+  Peroxyl_Disproportionation:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1100000.0000000647
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -4.183999999999968
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 9.6832e-16, dEa = +|-
+      6.75064e-15 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -6.80329876436653e-15
+  Peroxyl_Termination:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 120000.0000000058
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -4.183999999999989
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 4.77574e-16, dEa = +|-
+      3.3294e-15 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -5.693075739916035e-15
+  R_Addition_COm:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 0.013261652283743904
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 2.479113348592401
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 2.30182, dn = +|- 0.105526, dEa =
+      +|- 0.735674 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.5053177109713283
+  R_Addition_CSm:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 11999999.999999072
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 10.292600000000002
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.41997e-15, dEa = +|-
+      9.89933e-15 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.110000000000014
+  R_Addition_MultipleBond:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 4.59220548455441e-19
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -121.60048636488216
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 12.2306, dn = +|- 0.316937, dEa =
+      +|- 2.20952 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 7.588262230909506
+  R_Recombination:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 55302003467.17288
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -191.1137646225133
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.79035e-15, dEa = +|-
+      2.64244e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.01630416632391288
+  Singlet_Carbene_Intra_Disproportionation: null
+  Singlet_Val6_to_triplet: null
+  SubstitutionS:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 4.1451265070016785e-05
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -13.572625785510082
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 13.6, dn = +|- 0.330371, dEa = +|-
+      2.30318 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.8940389785594953
+  Substitution_O:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 1.5962449990889564e-07
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -85.76122892179552
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.77756e-15, dEa = +|-
+      1.93638e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 4.7516058009307605
+  Surface_Abstraction: null
+  Surface_Adsorption_Bidentate: null
+  Surface_Adsorption_Dissociative: null
+  Surface_Adsorption_Double: null
+  Surface_Adsorption_Single: null
+  Surface_Adsorption_vdW: null
+  Surface_Bidentate_Dissociation: null
+  Surface_Dissociation: null
+  Surface_Dissociation_vdW: null
+  Surface_Recombination: null
+  intra_H_migration: null
+  intra_NO2_ONO_conversion: null
+  intra_OH_migration: null
+  intra_substitutionCS_cyclization: null
+  intra_substitutionCS_isomerization: null
+  intra_substitutionS_cyclization:
+    A:
+      class: ScalarQuantity
+      units: m^3/(mol*s)
+      value: 2960119.487845655
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -103.51692801246162
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.5362e-15, dEa = +|-
+      1.76811e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.2857274295512786
+  intra_substitutionS_isomerization: null
+  ketoenol: null
+  lone_electron_pair_bond: null
+class: ArrheniusRMGObject
+unimol:
+  1+2_Cycloaddition:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 1.540193549559284e+25
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 362.4129669658604
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.08547, dn = +|- 0.0103806, dEa =
+      +|- 0.0723683 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -2.6978263250956314
+  1,2-Birad_to_alkene:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 1.413472604504545e-21
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 69.32325401895007
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 13.5368, dn = +|- 0.329781, dEa =
+      +|- 2.29907 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 9.311822720746878
+  1,2_Insertion_CO:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 482930257.75357294
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 274.65192021655884
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.83589e-15, dEa = +|-
+      2.67419e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.534546848602179
+  1,2_Insertion_carbene:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 9.85554881212048e+17
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 447.0496412149412
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.32452, dn = +|- 0.0355737, dEa =
+      +|- 0.248002 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.7594049874841067
+  1,2_NH3_elimination:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 716999999.9995996
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 48.19999999999983
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 6.20111e-15, dEa = +|-
+      4.3231e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.5400000000000786
+  1,2_shiftC:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2581862240257.2456
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 38.43977393320208
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.12681e-15, dEa = +|-
+      2.17985e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.21641431555088517
+  1,2_shiftS: null
+  1,3_Insertion_CO2:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 16801.11330231476
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 287.4647322707818
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 3.0595, dn = +|- 0.141543, dEa = +|-
+      0.986767 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.1382715059333064
+  1,3_Insertion_ROR:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 4709761.802137904
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 123.41371222237765
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.52562e-15, dEa = +|-
+      1.76073e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.180523068019403
+  1,3_Insertion_RSR:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2334956495.4975133
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 134.44631496368987
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.63715e-15, dEa = +|-
+      1.83849e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.5613738827544608
+  1,3_NH3_elimination:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 4899999999.994004
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 142.19999999999996
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.98561e-15, dEa = +|-
+      1.38426e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.340000000000166
+  1,4_Cyclic_birad_scission:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 1579207264007.4563
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 44.67373863003256
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.08948e-15, dEa = +|-
+      1.45668e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.11063123671281613
+  1,4_Linear_birad_scission: null
+  2+2_cycloaddition_CCO: null
+  2+2_cycloaddition_CO:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 13722118438.658182
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 51.38902222394021
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.9078e-15, dEa = +|-
+      1.33002e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.1159319396098348
+  2+2_cycloaddition_CS: null
+  2+2_cycloaddition_Cd:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 5804649307277810.0
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 253.33850302208293
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 4.54676e-15, dEa = +|-
+      3.16977e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.08220474419177065
+  6_membered_central_C-C_shift:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2323174004.4205785
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 69.79172767465188
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.16914, dn = +|- 0.0197801, dEa =
+      +|- 0.137897 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.6291214912926265
+  Baeyer-Villiger_step1_cat: null
+  Baeyer-Villiger_step2:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2733779814.9365234
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 90.79749852307913
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.97758, dn = +|- 0.0863085, dEa =
+      +|- 0.601699 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.100478796941278
+  Baeyer-Villiger_step2_cat: null
+  Bimolec_Hydroperoxide_Decomposition: null
+  Birad_R_Recombination:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2.642687299867251e+24
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 207.56120313072827
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 4.10722e-15, dEa = +|-
+      2.86335e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -2.381267676685851
+  Birad_recombination:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 3.646734160450863e+16
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 189.12148150618125
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.35418e-15, dEa = +|-
+      1.64122e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.33292107106098834
+  CO_Disproportionation: null
+  Concerted_Intra_Diels_alder_monocyclic_1,2_shiftH:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 5.095299599860816e+16
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 118.99536591985832
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.11423e-15, dEa = +|-
+      1.47393e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.5334854647094728
+  Cyclic_Ether_Formation:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 0.04898206515641135
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 5.322869674561736
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 15.5339, dn = +|- 0.347199, dEa =
+      +|- 2.4205 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.991593615865218
+  Cyclic_Thioether_Formation: null
+  Cyclopentadiene_scission:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2.8700581863809782e+17
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 95.78684813395384
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.81933e-15, dEa = +|-
+      1.26834e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -1.5043509094926262
+  Diels_alder_addition:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 3484358477056778.0
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 174.50490480245716
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.80006e-15, dEa = +|-
+      1.95206e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.1467446110239919
+  Disproportionation: null
+  HO2_Elimination_from_PeroxyRadical:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 46898.63475399366
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 107.29777492518214
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 4.34316, dn = +|- 0.185889, dEa =
+      +|- 1.29592 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.8143596321951168
+  H_Abstraction: null
+  Intra_2+2_cycloaddition_Cd:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 167569967479.81198
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 172.41273038118106
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.23919e-15, dEa = +|-
+      1.56105e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.8390520972208055
+  Intra_5_membered_conjugated_C=C_C=C_addition:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 117291532504.76039
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 79.39058631689453
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.53628e-15, dEa = +|-
+      1.07102e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.8164890758352589
+  Intra_Diels_alder_monocyclic:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 558459156082.2854
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -3.5878176642274022
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.18641e-15, dEa = +|-
+      8.27108e-15 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.584737399285818
+  Intra_Disproportionation:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 119917289.50235069
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 287.1418494382427
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.27533e-15, dEa = +|-
+      2.2834e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 2.3624358924673667
+  Intra_RH_Add_Endocyclic: null
+  Intra_RH_Add_Exocyclic: null
+  Intra_R_Add_Endocyclic:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 37210560830773.54
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -178.13977653223736
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 6.51522e-15, dEa = +|-
+      4.54208e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.1070939921781432
+  Intra_R_Add_ExoTetCyclic: null
+  Intra_R_Add_Exo_scission:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 488372311.0320346
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 52.80071420766272
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 2.03067e-15, dEa = +|-
+      1.41568e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.8180152786888442
+  Intra_R_Add_Exocyclic:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 1.9835471756706455
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -107.71233901873832
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 4.74945, dn = +|- 0.197208, dEa =
+      +|- 1.37484 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.872602119613764
+  Intra_Retro_Diels_alder_bicyclic: null
+  Intra_ene_reaction:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2844964.2670039963
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 36.05019319436879
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 3.36478, dn = +|- 0.153582, dEa =
+      +|- 1.07069 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.8743992337276225
+  Korcek_step1: null
+  Korcek_step1_cat: null
+  Korcek_step2: null
+  Peroxyl_Disproportionation: null
+  Peroxyl_Termination: null
+  R_Addition_COm:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 3095804403.188089
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 7.296245525343774
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 3.29786, dn = +|- 0.151039, dEa =
+      +|- 1.05297 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.5851220253445115
+  R_Addition_CSm:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 66764554.40136586
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 365.56711650773417
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 2.47437, dn = +|- 0.114676, dEa =
+      +|- 0.799461 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.958908826432179
+  R_Addition_MultipleBond:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2.529057219332942e-38
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -75.39904954259427
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 13.6141, dn = +|- 0.330502, dEa =
+      +|- 2.30409 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 16.503782847112653
+  R_Recombination:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 2.7846105472847868e-43
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -123.70542011099862
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 217409, dn = +|- 1.55555, dEa = +|-
+      10.8445 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 16.677749227237694
+  Singlet_Carbene_Intra_Disproportionation:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 8.537790282570042e-11
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -2.492801306499868
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 10.24, dn = +|- 0.294453, dEa = +|-
+      2.05278 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 6.353740886636271
+  Singlet_Val6_to_triplet:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 4.589800601324217e+17
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -17.259314260791477
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.54471e-15, dEa = +|-
+      2.47119e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.6227847915385674
+  SubstitutionS: null
+  Substitution_O: null
+  Surface_Abstraction: null
+  Surface_Adsorption_Bidentate: null
+  Surface_Adsorption_Dissociative: null
+  Surface_Adsorption_Double: null
+  Surface_Adsorption_Single: null
+  Surface_Adsorption_vdW: null
+  Surface_Bidentate_Dissociation: null
+  Surface_Dissociation: null
+  Surface_Dissociation_vdW: null
+  Surface_Recombination: null
+  intra_H_migration:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 505474.688173363
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: -55.09148695769535
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.97693e-15, dEa = +|-
+      1.37822e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.9505777663014554
+  intra_NO2_ONO_conversion:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 10447444285606.541
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 247.04985903012107
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 5.0857e-15, dEa = +|-
+      3.5455e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: -0.07215787389155534
+  intra_OH_migration:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 54539238.116515145
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 270.77025167803777
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 2.36779, dn = +|- 0.109103, dEa =
+      +|- 0.760608 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 0.7801102121006003
+  intra_substitutionCS_cyclization: null
+  intra_substitutionCS_isomerization:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 6510463733.575617
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 234.3159937650802
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.23974e-15, dEa = +|-
+      2.25858e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.2578980444412668
+  intra_substitutionS_cyclization:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 3.631728307623057
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 31.913620404393384
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 21.1111, dn = +|- 0.386029, dEa =
+      +|- 2.6912 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.712695225790473
+  intra_substitutionS_isomerization:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 1519014825.5628555
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 131.40823893851635
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1.86025, dn = +|- 0.0785668, dEa =
+      +|- 0.547728 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 1.2505729804682149
+  ketoenol:
+    A:
+      class: ScalarQuantity
+      units: s^-1
+      value: 103.99999999982153
+    Ea:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 82.04819999999995
+    T0:
+      class: ScalarQuantity
+      units: K
+      value: 1.0
+    Tmax:
+      class: ScalarQuantity
+      units: K
+      value: 2500.0
+    Tmin:
+      class: ScalarQuantity
+      units: K
+      value: 300.0
+    class: Arrhenius
+    comment: Fitted to 50 data points; dA = *|/ 1, dn = +|- 1.85001e-15, dEa = +|-
+      1.28973e-14 kJ/mol
+    n:
+      class: ScalarQuantity
+      value: 3.2100000000002473
+  lone_electron_pair_bond: null

--- a/scripts/generateFilterArrheniusFits.ipynb
+++ b/scripts/generateFilterArrheniusFits.ipynb
@@ -1,0 +1,441 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fit Arrhenius for reaction filtering in RMG from fastest training reactions per reaction family.\n",
+    "\n",
+    "This script iterates through all RMG families besides surface reaction families. For each reaction family the fastest \n",
+    "training reaction for a temperature range between 300 and 2500 K are fitted into an Arrhenius fit for unimolecular\n",
+    "and bimolecular reactions seperately. \n",
+    "\n",
+    "The Arrhenius fits are stored in a YAML file called `FilterArrheniusFits` that is read once at the beginning of an RMG run and used at each iteration to identify family specific filter criteria for reaction generation. \n",
+    "\n",
+    "For verification, the Arrhenius fits are stored as .png files in the folder `ArrheniusFits`.\n",
+    "\n",
+    "Currently, the highest rate from forward or reverse is used for the Arrhenius fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using Theano backend.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import numpy\n",
+    "import operator\n",
+    "import yaml\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from rmgpy import settings\n",
+    "from rmgpy.data.rmg import RMGDatabase, getDB\n",
+    "from rmgpy.kinetics.arrhenius import Arrhenius\n",
+    "from rmgpy.thermo.thermoengine import submit\n",
+    "from rmgpy.rmgobject import RMGObject"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the database with RMG reaction families"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "database = RMGDatabase()\n",
+    "database.load(\n",
+    "    settings['database.directory'], \n",
+    "    thermoLibraries = [\n",
+    "                'primaryThermoLibrary',\n",
+    "                'Klippenstein_Glarborg2016',\n",
+    "                'BurkeH2O2',\n",
+    "                'thermo_DFT_CCSDTF12_BAC',\n",
+    "                'CBS_QB3_1dHR', \n",
+    "                'DFT_QCI_thermo',\n",
+    "                'Narayanaswamy',\n",
+    "                'Lai_Hexylbenzene',\n",
+    "                'SABIC_aromatics',\n",
+    "                'vinylCPD_H'],\n",
+    "    transportLibraries = [],\n",
+    "    reactionLibraries = [],\n",
+    "    seedMechanisms = [],\n",
+    "    kineticsFamilies = 'all',\n",
+    "    kineticsDepositories = ['training'],\n",
+    "    depository = False,  \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Arrhenius fits for all RMG families\n",
+    "families = getDB('kinetics').families.keys()\n",
+    "#families = ['H_Abstraction', 'R_Recombination', 'Surface_Dissociation_vdW']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Temperature range to fit Arrhenius\n",
+    "Ts = numpy.linspace(300,2500,50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate the Arrhenius fits and print .png figures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper function\n",
+    "def analyze_reactions(fam_name, molecularity=1):\n",
+    "    print fam_name\n",
+    "    \n",
+    "    fam = database.kinetics.families[fam_name]\n",
+    "    dep = fam.getTrainingDepository()\n",
+    "    rxns = []\n",
+    "    list_indices = []\n",
+    "\n",
+    "    # Extract all training reactions for selected family\n",
+    "    for entry in dep.entries.values():\n",
+    "        r = entry.item\n",
+    "        r.kinetics = entry.data\n",
+    "        r.index = entry.index\n",
+    "        for spc in r.reactants+r.products:\n",
+    "            if spc.thermo is None:\n",
+    "                submit(spc)\n",
+    "        rxns.append(r)\n",
+    "\n",
+    "    # Only proceed if at least one training reaction is available\n",
+    "    if rxns:         \n",
+    "        # Get kinetic rates for unimolecular reactions\n",
+    "        k_list = []\n",
+    "        index_list = []\n",
+    "        for rxn in rxns:\n",
+    "            if len(rxn.reactants) == molecularity:\n",
+    "                k_list.append(rxn.kinetics)\n",
+    "                index_list.append(rxn.index)\n",
+    "            if len(rxn.products) == molecularity:\n",
+    "                k_list.append(rxn.generateReverseRateCoefficient())\n",
+    "                index_list.append(rxn.index)\n",
+    "\n",
+    "        # Get max. kinetic rates at each discrete temperature\n",
+    "        if k_list:\n",
+    "            k_max_list = []\n",
+    "            max_rxn_list = set()\n",
+    "            for T in Ts:\n",
+    "                mydict = {}\n",
+    "                kvals = [k.getRateCoefficient(T) for k in k_list]\n",
+    "                mydict = dict(zip(index_list, kvals))\n",
+    "\n",
+    "                # Find key and value of max rate coefficient\n",
+    "                key_max_rate = max(mydict.iteritems(), key=operator.itemgetter(1))[0]\n",
+    "                \n",
+    "                max_entry = dep.entries.get(key_max_rate)\n",
+    "                max_rxn = max_entry.item\n",
+    "                max_rxn_list.add(max_rxn)\n",
+    "                \n",
+    "                kval = mydict[key_max_rate]\n",
+    "                k_max_list.append(kval)\n",
+    "                \n",
+    "                #print \"\"\"For {0} 1/K training reaction {1} with index {2} has the highest rate \n",
+    "                #of {3}.\"\"\".format(1000.0/T, max_entry, key_max_rate, kval)\n",
+    "                \n",
+    "                #if molecularity == 2:\n",
+    "                #    display(max_rxn)\n",
+    "                #    print \"collision limit:  {}\".format(max_rxn.calculate_coll_limit(T))\n",
+    "                #    print \"collision limit agrees?\"\n",
+    "                #    print [] == max_rxn.check_collision_limit_violation(300.0, 2000.0, 0.1, 100.0)\n",
+    "\n",
+    "            units = 's^-1' if molecularity == 1 else 'm^3/(mol*s)'\n",
+    "                \n",
+    "            arr = Arrhenius().fitToData(Ts,numpy.array(k_max_list), units)\n",
+    "            \n",
+    "            fig = plt.figure()\n",
+    "            fig_name = fam_name\n",
+    "            fig_name += ' Unimolecular' if molecularity == 1 else ' Bimolecular'\n",
+    "            save_path = 'ArrheniusFits/'\n",
+    "            plt.semilogy(1000.0/Ts, k_max_list, label=fig_name)\n",
+    "            plt.xlabel(\"1000/T (1/K)\")\n",
+    "            plt.ylabel(\"k ({0})\".format(units))\n",
+    "            plt.legend(loc='upper left')\n",
+    "            if molecularity == 1:\n",
+    "                fig.savefig((save_path + fig_name + '_Unimolecular' + '.png'), bbox_inches='tight')\n",
+    "            elif molecularity == 2:\n",
+    "                fig.savefig((save_path + fig_name + '_Unimolecular' + '.png'), bbox_inches='tight')\n",
+    "\n",
+    "            plt.close(\"all\")\n",
+    "            \n",
+    "            return arr\n",
+    "        \n",
+    "    else:\n",
+    "        arr = None\n",
+    "        return arr\n",
+    "\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "H_Abstraction\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/agnes/PycharmProjects/RMG-Py/rmgpy/tools/plot.py:36: UserWarning: \n",
+      "This call to matplotlib.use() has no effect because the backend has already\n",
+      "been chosen; matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
+      "or matplotlib.backends is imported for the first time.\n",
+      "\n",
+      "The backend was *originally* set to 'module://ipykernel.pylab.backend_inline' by the following code:\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/runpy.py\", line 174, in _run_module_as_main\n",
+      "    \"__main__\", fname, loader, pkg_name)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/runpy.py\", line 72, in _run_code\n",
+      "    exec code in run_globals\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel_launcher.py\", line 16, in <module>\n",
+      "    app.launch_new_instance()\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/traitlets/config/application.py\", line 658, in launch_instance\n",
+      "    app.start()\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/kernelapp.py\", line 499, in start\n",
+      "    self.io_loop.start()\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/tornado/ioloop.py\", line 1073, in start\n",
+      "    handler_func(fd_obj, events)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/tornado/stack_context.py\", line 300, in null_wrapper\n",
+      "    return fn(*args, **kwargs)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py\", line 456, in _handle_events\n",
+      "    self._handle_recv()\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py\", line 486, in _handle_recv\n",
+      "    self._run_callback(callback, msg)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/zmq/eventloop/zmqstream.py\", line 438, in _run_callback\n",
+      "    callback(*args, **kwargs)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/tornado/stack_context.py\", line 300, in null_wrapper\n",
+      "    return fn(*args, **kwargs)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/kernelbase.py\", line 283, in dispatcher\n",
+      "    return self.dispatch_shell(stream, msg)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/kernelbase.py\", line 233, in dispatch_shell\n",
+      "    handler(stream, idents, msg)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/kernelbase.py\", line 399, in execute_request\n",
+      "    user_expressions, allow_stdin)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/ipkernel.py\", line 208, in do_execute\n",
+      "    res = shell.run_cell(code, store_history=store_history, silent=silent)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/zmqshell.py\", line 537, in run_cell\n",
+      "    return super(ZMQInteractiveShell, self).run_cell(*args, **kwargs)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/IPython/core/interactiveshell.py\", line 2724, in run_cell\n",
+      "    self.events.trigger('post_run_cell')\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/IPython/core/events.py\", line 74, in trigger\n",
+      "    func(*args, **kwargs)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel/pylab/backend_inline.py\", line 164, in configure_once\n",
+      "    activate_matplotlib(backend)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/IPython/core/pylabtools.py\", line 315, in activate_matplotlib\n",
+      "    matplotlib.pyplot.switch_backend(backend)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/matplotlib/pyplot.py\", line 231, in switch_backend\n",
+      "    matplotlib.use(newbackend, warn=False, force=True)\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/matplotlib/__init__.py\", line 1422, in use\n",
+      "    reload(sys.modules['matplotlib.backends'])\n",
+      "  File \"/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/matplotlib/backends/__init__.py\", line 16, in <module>\n",
+      "    line for line in traceback.format_stack()\n",
+      "\n",
+      "\n",
+      "  mpl.use('Agg')\n",
+      "/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/scipy/optimize/optimize.py:1748: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
+      "  fx = func(x, *args)\n",
+      "/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/scipy/optimize/optimize.py:1800: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
+      "  fu = func(x, *args)\n",
+      "/Users/agnes/PycharmProjects/RMG-Py/rmgpy/thermo/thermoengine.py:56: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
+      "  wilhoit = thermo0.toWilhoit(B=1000.)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*uni_mol None\n",
+      "H_Abstraction\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel_launcher.py:30: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n",
+      "/Users/agnes/Documents/Software/Miniconda3/envs/rmg_env/lib/python2.7/site-packages/ipykernel_launcher.py:63: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.\n",
+      "To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*bi_mol Arrhenius(A=(5.64568e-55,'m^3/(mol*s)'), n=17.7991, Ea=(-341.909,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2500,'K'), comment=\"\"\"Fitted to 50 data points; dA = *|/ 73695.3, dn = +|- 1.41862, dEa = +|- 9.88989 kJ/mol\"\"\")\n",
+      "R_Recombination\n",
+      "*uni_mol Arrhenius(A=(2.78461e-43,'s^-1'), n=16.6777, Ea=(-123.705,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2500,'K'), comment=\"\"\"Fitted to 50 data points; dA = *|/ 217409, dn = +|- 1.55555, dEa = +|- 10.8445 kJ/mol\"\"\")\n",
+      "R_Recombination\n",
+      "*bi_mol Arrhenius(A=(5.5302e+10,'m^3/(mol*s)'), n=-0.0163042, Ea=(-191.114,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2500,'K'), comment=\"\"\"Fitted to 50 data points; dA = *|/ 1, dn = +|- 3.79035e-15, dEa = +|- 2.64244e-14 kJ/mol\"\"\")\n",
+      "Surface_Dissociation_vdW\n",
+      "*uni_mol None\n",
+      "*bi_mol None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Main - Arrhenius fitting\n",
+    "families_unimol = []\n",
+    "fits_unimol = []\n",
+    "families_bimol = []\n",
+    "fits_bimol = []\n",
+    "\n",
+    "for family in families:\n",
+    "    # Update this script once training reaction generation for surface families works better\n",
+    "    if 'Surface' not in family:\n",
+    "        # Unimolecular reactions\n",
+    "        arr_uni = analyze_reactions(family, molecularity=1)\n",
+    "        families_unimol.append(family)\n",
+    "        fits_unimol.append(arr_uni)\n",
+    "        print \"*uni_mol {0}\".format(arr_uni)\n",
+    "        \n",
+    "        # Bimolecular reactions\n",
+    "        arr_bi = analyze_reactions(family, molecularity=2)\n",
+    "        families_bimol.append(family)\n",
+    "        fits_bimol.append(arr_bi)\n",
+    "        print \"*bi_mol {0}\".format(arr_bi)\n",
+    "    else:\n",
+    "        print family\n",
+    "        families_unimol.append(family)\n",
+    "        fits_unimol.append(None)\n",
+    "        print \"*uni_mol {0}\".format(None)\n",
+    "        \n",
+    "        families_bimol.append(family)\n",
+    "        fits_bimol.append(None)\n",
+    "        print \"*bi_mol {0}\".format(None)\n",
+    "        \n",
+    "# Generate a dictionary for unimolecular and bimolecular Arrhenius fits and the corresponding reaction family name\n",
+    "dict_unimol = dict(zip(families_unimol, fits_unimol))\n",
+    "dict_bimol = dict(zip(families_bimol, fits_bimol))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save Arrhenius fits in YAML file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper functions for ArrheniusRMGObject\n",
+    "class ArrheniusRMGObject(RMGObject):\n",
+    "    \"\"\"\n",
+    "    Child class of RMG Object for storing filter Arrhenius fits.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, unimol=None, bimol=None):\n",
+    "        if unimol:\n",
+    "            self.unimol = unimol\n",
+    "        else:\n",
+    "            self.unimol = {}\n",
+    "        if bimol:\n",
+    "            self.bimol = bimol\n",
+    "        else:\n",
+    "            self.bimol = {}\n",
+    "        \n",
+    "    def save_yaml(self, path):\n",
+    "        \"\"\"\n",
+    "        Save the data to a .yml file\n",
+    "        \"\"\"\n",
+    "        full_path = os.path.join(path)\n",
+    "        with open(full_path, 'a+') as f:\n",
+    "            yaml.dump(data=self.as_dict(), stream=f)\n",
+    "          "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate empty ArrheniusRMGObject\n",
+    "obj = ArrheniusRMGObject(unimol=dict_unimol, bimol=dict_bimol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Path to YAML file with stored Arrhenius fits\n",
+    "path = '../input/FilterArrheniusFits'\n",
+    "f = open(path, 'w')\n",
+    "\n",
+    "obj.save_yaml(path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Motivation or Problem
By filtering reactions we add a pre-filtering step before the step of reacting species together (slow), which prevents species from reacting together when the reactions are expected to be negligible throughout the simulation. Currently, unimolecularThreshold, bimolecularThreshold, and trimolecularThreshold are binary arrays storing flags for whether a species or a pair of species are above a reaction threshold. For a unimolecular rate, this threshold is set to True if the unimolecular rate of reaction 𝑘 reaction  k for a species A 
![image](https://user-images.githubusercontent.com/35771165/56226970-734c5080-6042-11e9-9873-c273024482b5.png) 
at any given time 𝑡 t in the reaction system, where
![image](https://user-images.githubusercontent.com/35771165/56226986-7b0bf500-6042-11e9-91b4-537b21fcdcf5.png)
For a bimolecular reaction occuring between species A and B, this threshold is set to True if the bimolecular rate
![image](https://user-images.githubusercontent.com/35771165/56227060-9d057780-6042-11e9-8bb2-ac72c3a20bcd.png)
where 𝑘𝑡ℎ𝑟𝑒𝑠ℎ𝑜𝑙𝑑=filterThreshold is set by the user in the input file and its default value is 
![image](https://user-images.githubusercontent.com/35771165/56227116-b9a1af80-6042-11e9-8122-bcb200e132e1.png).
Similarly, for a trimolecular reaction, the following expression is used:
![image](https://user-images.githubusercontent.com/35771165/56227149-caeabc00-6042-11e9-9c29-07f694827931.png)
where
![image](https://user-images.githubusercontent.com/35771165/56227182-ddfd8c00-6042-11e9-8cf5-349fd6a40ac9.png)
The threshold values can be refined for each reaction family to speed reaction generation up.

### Description of Changes
This pull request is a joint pull request with RMG-Py #1577. The iphython notebook to generate the file with Arrhenius fits that is read at the beginning of each RMG run is stored here. The file with the Arrhenius fits is also stored here.