### PR TITLE
Modified the 1,2_NH3_elimination root group

### DIFF
--- a/input/kinetics/families/1,2_NH3_elimination/groups.py
+++ b/input/kinetics/families/1,2_NH3_elimination/groups.py
@@ -37,12 +37,12 @@ entry(
     label = "NNHNH2",
     group =
 """
-1 *1 N u0 p1 c0 {2,S} {5,S} {6,S}
-2 *2 N u0 px cx {1,S} {4,S} {3,[S,D]}
-3 *3 N u0 px cx {2,[S,D]}
-4 *4 H u0 p0 c0 {2,S}
-5    H u0 p0 c0 {1,S}
-6    H u0 p0 c0 {1,S}
+1 *1 N u0 p1     c0 {2,S} {5,S} {6,S}
+2 *2 N u0 px     cx {1,S} {4,S} {3,[S,D]}
+3 *3 N u0 p[1,2] cx {2,[S,D]}
+4 *4 H u0 p0     c0 {2,S}
+5    H u0 p0     c0 {1,S}
+6    H u0 p0     c0 {1,S}
 """,
     kinetics = None,
 )

--- a/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/dictionary.txt
+++ b/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/dictionary.txt
@@ -759,9 +759,9 @@ multiplicity 2
 10 O u1 p2 c0 {4,S}
 
 HON
-1 O u0 p2 c0 {2,S} {3,S}
-2 H u0 p0 c0 {1,S}
-3 N u0 p2 c0 {1,S}
+1 O u0 p1 c+1 {2,D} {3,S}
+2 N u0 p2 c-1 {1,D}
+3 H u0 p0 c0 {1,S}
 
 H2CCCH
 multiplicity 2

--- a/input/kinetics/libraries/Nitrogen_Glarborg_Zhang_et_al/dictionary.txt
+++ b/input/kinetics/libraries/Nitrogen_Glarborg_Zhang_et_al/dictionary.txt
@@ -568,9 +568,9 @@ C2H5NO
 9 O u0 p2 c0 {3,D}
 
 HON
-1 O u0 p2 c0 {2,S} {3,S}
-2 H u0 p0 c0 {1,S}
-3 N u0 p2 c0 {1,S}
+1 O u0 p1 c+1 {2,D} {3,S}
+2 N u0 p2 c-1 {1,D}
+3 H u0 p0 c0 {1,S}
 
 NH3
 1 N u0 p1 c0 {2,S} {3,S} {4,S}

--- a/input/kinetics/libraries/primaryNitrogenLibrary/dictionary.txt
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/dictionary.txt
@@ -160,10 +160,9 @@ HNO
 3 H u0 p0 c0 {1,S}
 
 HON
-multiplicity 3
-1 O u0 p2 c0 {2,S} {3,S}
-2 H u0 p0 c0 {1,S}
-3 N u2 p1 c0 {1,S}
+1 O u0 p1 c+1 {2,D} {3,S}
+2 N u0 p2 c-1 {1,D}
+3 H u0 p0 c0 {1,S}
 
 HNOH
 multiplicity 2


### PR DESCRIPTION
`*3 N` cannot have 0 lone pairs, since it looses a lone pair in the recipe.

This fix prohibits species such as
```python
<Molecule "[NH-][NH2+]NN">
1  *3 N u0 p0 c+1 {2,S} {4,S} {5,S} {6,S}
2  *2 N u0 p1 c0 {1,S} {3,S} {7,S}
3  *1 N u0 p1 c0 {2,S} {8,S} {9,S}
4     N u0 p2 c-1 {1,S} {10,S}
5     H u0 p0 c0 {1,S}
6     H u0 p0 c0 {1,S}
7  *4 H u0 p0 c0 {2,S}
8     H u0 p0 c0 {3,S}
9     H u0 p0 c0 {3,S}
10    H u0 p0 c0 {4,S}
```
from reacting in `1,2_NH3_elimination`.

Edit: Also added a minor unrelated commit to update the structure of HON