### PR TITLE
Fix Node error for Cds-CdSH

### DIFF
--- a/input/thermo/groups/group.py
+++ b/input/thermo/groups/group.py
@@ -3607,7 +3607,7 @@ entry(
 3   S  u0 {1,S}
 4   H  u0 {1,S}
 """,
-    thermo = u'Cds-CdsSsH',
+    thermo = u'Cds-CdsSH',
     shortDesc = u"""""",
     longDesc = 
 u"""


### PR DESCRIPTION
This fix solves issue #374 and points node Cds-CdSH to an existing group called Cds-CdsSH.
  