### PR TITLE
Make directory for metal attributes

### DIFF
--- a/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
@@ -101,7 +101,7 @@ A factor from paper / surface site density of Cu
 #duplicate of 14
 # entry(
 #     index = 29,
-#     label = "H2O* + X_4 <=> CH3* + H*",
+#     label = "H2O* + X_4 <=> OH* + H*",
 #     kinetics = SurfaceArrhenius(
 #         A = (3.67E17, 'm^2/(mol*s)'),
 #         n = -0.086,

--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -1,1 +1,368 @@
-Add atomic binding energies on metals and surface site densities here.
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "Metal Binding Energies"
+shortDesc = u""
+longDesc = """
+Metal binding energies and surface site densities
+"""
+
+entry(
+    index = 1,
+    label = "Pt111",
+    bindingEnergies = {
+    		           'H':(-2.75367887E+00, 'eV/molecule'),
+                       'C':(-7.02515507E+00, 'eV/molecule'),
+                       'N':(-4.63224568E+00, 'eV/molecule'),
+                       'O':(-3.81153179E+00, 'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.483E-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Pt",
+    shortDesc = u"",
+    longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+    """,
+)
+
+entry(
+    index = 2,
+    label = "Ru0001",
+    bindingEnergies = {
+    		           'H':(-2.85191775E+00, 'eV/molecule'),
+                       'C':(-7.59790076E+00, 'eV/molecule'),
+                       'N':(-5.96899731E+00, 'eV/molecule'),
+                       'O':(-5.44919557E+00, 'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.630E-09, 'mol/cm^2'),
+    facet = "0001",
+    metal = "Ru",
+    shortDesc = u"",
+    longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+    """,
+)
+
+entry(
+    index = 3,
+    label = "Rh111",
+    bindingEnergies = {
+    		           'H':(-2.83000775E+00, 'eV/molecule'),
+                       'C':(-7.33483762E+00, 'eV/molecule'),
+                       'N':(-5.30055389E+00, 'eV/molecule'),
+                       'O':(-4.71419163E+00, 'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.656E-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Rh",
+    shortDesc = u"",
+    longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+    """,
+)
+
+entry(
+     index = 4,
+     label = "Ir111",
+     bindingEnergies = {
+     		            'H':(-2.67673532E+00, 'eV/molecule'),
+                        'C':(-7.25234155E+00, 'eV/molecule'),
+                        'N':(-5.06204488E+00, 'eV/molecule'),
+                        'O':(-4.35235655E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.587E-09, 'mol/cm^2'),
+     facet = "111",
+     metal = "Ir",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 5,
+     label = "Au111",
+     bindingEnergies = {
+     		            'H':(-2.20847988E+00, 'eV/molecule'),
+                        'C':(-4.54649977E+00, 'eV/molecule'),
+                        'N':(-2.41077552E+00, 'eV/molecule'),
+                        'O':(-2.71822397E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.270E-09, 'mol/cm^2'),
+     facet = "111",
+     metal = "Au",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 6,
+     label = "Pd111",
+     bindingEnergies = {
+     		            'H':(-2.92248796E+00, 'eV/molecule'),
+                        'C':(-7.16786381E+00, 'eV/molecule'),
+                        'N':(-4.78495869E+00, 'eV/molecule'),
+                        'O':(-4.13577325E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.534E-09, 'mol/cm^2'),
+     facet = "111",
+     metal = "Pd",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 7,
+     label = "Cu111",
+     bindingEnergies = {
+     		            'H':(-2.58383235E+00, 'eV/molecule'),
+                        'C':(-4.96033553E+00, 'eV/molecule'),
+                        'N':(-3.58446699E+00, 'eV/molecule'),
+                        'O':(-4.20763879E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.943E-09, 'mol/cm^2'),
+     facet = "111",
+     metal = "Cu",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 8,
+     label = "Ag111",
+     bindingEnergies = {
+     		            'H':(-2.10526806E+00, 'eV/molecule'),
+                        'C':(-3.50609006E+00, 'eV/molecule'),
+                        'N':(-1.97973590E+00, 'eV/molecule'),
+                        'O':(-3.11159241E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.292E-09, 'mol/cm^2'),
+     facet = "111",
+     metal = "Ag",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 9,
+     label = "Ni111",
+     bindingEnergies = {
+     		            'H':(-2.89202876E+00, 'eV/molecule'),
+                        'C':(-6.79794124E+00, 'eV/molecule'),
+                        'N':(-5.16380660E+00, 'eV/molecule'),
+                        'O':(-4.98902184E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (3.148E-09, 'mol/cm^2'),
+     facet = "111",
+     metal = "Ni",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 10,
+     label = "Co0001",
+     bindingEnergies = {
+     		            'H':(-3.02058996E+00, 'eV/molecule'),
+                        'C':(-7.09132929E+00, 'eV/molecule'),
+                        'N':(-5.58560836E+00, 'eV/molecule'),
+                        'O':(-5.38367940E+00, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (3.118E-09, 'mol/cm^2'),
+     facet = "0001",
+     metal = "Co",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 11,
+     label = "Pt211",
+     bindingEnergies = {
+     		            'H':(-2.890, 'eV/molecule'),
+                        'C':(-7.205, 'eV/molecule'),
+                        'N':(-4.635, 'eV/molecule'),
+                        'O':(-4.150, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.634E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Pt",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 12,
+     label = "Rh211",
+     bindingEnergies = {
+     		            'H':(-2.828048658, 'eV/molecule'),
+                        'C':(-7.805735262, 'eV/molecule'),
+                        'N':(-5.491597358, 'eV/molecule'),
+                        'O':(-4.776603013, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.817E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Rh",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 13,
+     label = "Ag211",
+     bindingEnergies = {
+     		            'H':(-2.036, 'eV/molecule'),
+                        'C':(-4.045, 'eV/molecule'),
+                        'N':(-2.051, 'eV/molecule'),
+                        'O':(-3.126, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.432E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Ag",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 14,
+     label = "Pd211",
+     bindingEnergies = {
+     		            'H':(-2.785, 'eV/molecule'),
+                        'C':(-7.826, 'eV/molecule'),
+                        'N':(-4.774, 'eV/molecule'),
+                        'O':(-3.980, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.688E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Pd",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 15,
+     label = "Au211",
+     bindingEnergies = {
+     		            'H':(-2.191205055, 'eV/molecule'),
+                        'C':(-4.758643121, 'eV/molecule'),
+                        'N':(-2.455006241, 'eV/molecule'),
+                        'O':(-2.753661561, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.408E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Au",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 16,
+     label = "Ir211",
+     bindingEnergies = {
+     		            'H':(-3.049382381, 'eV/molecule'),
+                        'C':(-7.518738006, 'eV/molecule'),
+                        'N':(-5.386894619, 'eV/molecule'),
+                        'O':(-5.153576364, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (2.744E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Ir",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 17,
+     label = "Ru211",
+     bindingEnergies = {
+     		            'H':(-2.990208683, 'eV/molecule'),
+                        'C':(-7.767055243, 'eV/molecule'),
+                        'N':(-6.167927714, 'eV/molecule'),
+                        'O':(-5.858408296, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (3.199E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Ru",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 18,
+     label = "Co211",
+     bindingEnergies = {
+     		            'H':(-2.958578034, 'eV/molecule'),
+                        'C':(-7.517405633, 'eV/molecule'),
+                        'N':(-5.693528936, 'eV/molecule'),
+                        'O':(-5.739466384, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (3.711E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Co",
+     shortDesc = u"Same as Ni211",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 19,
+     label = "Ni211",
+     bindingEnergies = {
+     		            'H':(-2.958578034, 'eV/molecule'),
+                        'C':(-7.517405633, 'eV/molecule'),
+                        'N':(-5.693528936, 'eV/molecule'),
+                        'O':(-5.739466384, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (3.339E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Ni",
+     shortDesc = u"Same as Co211",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)
+
+entry(
+     index = 20,
+     label = "Cu211",
+     bindingEnergies = {
+     		            'H':(-2.582, 'eV/molecule'),
+                        'C':(-5.831, 'eV/molecule'),
+                        'N':(-3.723, 'eV/molecule'),
+                        'O':(-4.307, 'eV/molecule'),
+     },
+     surfaceSiteDensity = (3.121E-09, 'mol/cm^2'),
+     facet = "211",
+     metal = "Cu",
+     shortDesc = u"",
+     longDesc = u"""
+Calculated by Katrin Blondal at Brown University
+     """,
+)

--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -335,10 +335,10 @@ entry(
      index = 19,
      label = "Ni211",
      bindingEnergies = {
-     		            'H':(-2.958578034, 'eV/molecule'),
-                        'C':(-7.517405633, 'eV/molecule'),
-                        'N':(-5.693528936, 'eV/molecule'),
-                        'O':(-5.739466384, 'eV/molecule'),
+     		            'H':(-2.901, 'eV/molecule'),
+                        'C':(-7.775, 'eV/molecule'),
+                        'N':(-5.310, 'eV/molecule'),
+                        'O':(-5.086, 'eV/molecule'),
      },
      surfaceSiteDensity = (3.339E-09, 'mol/cm^2'),
      facet = "211",
@@ -346,8 +346,6 @@ entry(
      shortDesc = u"fcc",
      longDesc = u"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-
-Same as Co211, todo update later
      """,
 )
 

--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -19,9 +19,9 @@ entry(
     surfaceSiteDensity = (2.483E-09, 'mol/cm^2'),
     facet = "111",
     metal = "Pt",
-    shortDesc = u"",
+    shortDesc = u"fcc",
     longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
     """,
 )
 
@@ -37,9 +37,9 @@ entry(
     surfaceSiteDensity = (2.630E-09, 'mol/cm^2'),
     facet = "0001",
     metal = "Ru",
-    shortDesc = u"",
+    shortDesc = u"hcp",
     longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
     """,
 )
 
@@ -55,9 +55,9 @@ entry(
     surfaceSiteDensity = (2.656E-09, 'mol/cm^2'),
     facet = "111",
     metal = "Rh",
-    shortDesc = u"",
+    shortDesc = u"fcc",
     longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
     """,
 )
 
@@ -73,9 +73,9 @@ entry(
      surfaceSiteDensity = (2.587E-09, 'mol/cm^2'),
      facet = "111",
      metal = "Ir",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -91,9 +91,9 @@ entry(
      surfaceSiteDensity = (2.270E-09, 'mol/cm^2'),
      facet = "111",
      metal = "Au",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -109,9 +109,9 @@ entry(
      surfaceSiteDensity = (2.534E-09, 'mol/cm^2'),
      facet = "111",
      metal = "Pd",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -127,9 +127,9 @@ entry(
      surfaceSiteDensity = (2.943E-09, 'mol/cm^2'),
      facet = "111",
      metal = "Cu",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -145,9 +145,9 @@ entry(
      surfaceSiteDensity = (2.292E-09, 'mol/cm^2'),
      facet = "111",
      metal = "Ag",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -163,9 +163,9 @@ entry(
      surfaceSiteDensity = (3.148E-09, 'mol/cm^2'),
      facet = "111",
      metal = "Ni",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -181,9 +181,9 @@ entry(
      surfaceSiteDensity = (3.118E-09, 'mol/cm^2'),
      facet = "0001",
      metal = "Co",
-     shortDesc = u"",
+     shortDesc = u"hcp",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -199,9 +199,9 @@ entry(
      surfaceSiteDensity = (2.634E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Pt",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -217,9 +217,9 @@ entry(
      surfaceSiteDensity = (2.817E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Rh",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -235,9 +235,9 @@ entry(
      surfaceSiteDensity = (2.432E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Ag",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -253,9 +253,9 @@ entry(
      surfaceSiteDensity = (2.688E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Pd",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -271,9 +271,9 @@ entry(
      surfaceSiteDensity = (2.408E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Au",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -289,9 +289,9 @@ entry(
      surfaceSiteDensity = (2.744E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Ir",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -307,9 +307,9 @@ entry(
      surfaceSiteDensity = (3.199E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Ru",
-     shortDesc = u"",
+     shortDesc = u"hcp",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -325,9 +325,9 @@ entry(
      surfaceSiteDensity = (3.711E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Co",
-     shortDesc = u"Same as Ni211",
+     shortDesc = u"hcp",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )
 
@@ -343,9 +343,11 @@ entry(
      surfaceSiteDensity = (3.339E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Ni",
-     shortDesc = u"Same as Co211",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+
+Same as Co211, todo update later
      """,
 )
 
@@ -361,8 +363,8 @@ entry(
      surfaceSiteDensity = (3.121E-09, 'mol/cm^2'),
      facet = "211",
      metal = "Cu",
-     shortDesc = u"",
+     shortDesc = u"fcc",
      longDesc = u"""
-Calculated by Katrin Blondal at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
      """,
 )

--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -1,0 +1,1 @@
+Add atomic binding energies on metals and surface site densities here.

--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -2,367 +2,387 @@
 # encoding: utf-8
 
 name = "Metal Binding Energies"
-shortDesc = u""
+shortDesc = ""
 longDesc = """
 Metal binding energies and surface site densities
 """
+entry(
+    index = 0,
+    label = "Pt111",
+    bindingEnergies = {
+        'H': (-2.75368,'eV/molecule'),
+        'C': (-7.02516,'eV/molecule'),
+        'N': (-4.63225,'eV/molecule'),
+        'O': (-3.81153,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.483e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Pt",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
 
 entry(
     index = 1,
-    label = "Pt111",
+    label = "Ru0001",
     bindingEnergies = {
-    		           'H':(-2.75367887E+00, 'eV/molecule'),
-                       'C':(-7.02515507E+00, 'eV/molecule'),
-                       'N':(-4.63224568E+00, 'eV/molecule'),
-                       'O':(-3.81153179E+00, 'eV/molecule'),
+        'H': (-2.85192,'eV/molecule'),
+        'C': (-7.5979,'eV/molecule'),
+        'N': (-5.969,'eV/molecule'),
+        'O': (-5.4492,'eV/molecule'),
     },
-    surfaceSiteDensity = (2.483E-09, 'mol/cm^2'),
-    facet = "111",
-    metal = "Pt",
-    shortDesc = u"fcc",
-    longDesc = u"""
+    surfaceSiteDensity = (2.6300000000000002e-09, 'mol/cm^2'),
+    facet = "0001",
+    metal = "Ru",
+    shortDesc = """hcp""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-    """,
+""",
 )
 
 entry(
     index = 2,
-    label = "Ru0001",
+    label = "Rh111",
     bindingEnergies = {
-    		           'H':(-2.85191775E+00, 'eV/molecule'),
-                       'C':(-7.59790076E+00, 'eV/molecule'),
-                       'N':(-5.96899731E+00, 'eV/molecule'),
-                       'O':(-5.44919557E+00, 'eV/molecule'),
+        'H': (-2.83001,'eV/molecule'),
+        'C': (-7.33484,'eV/molecule'),
+        'N': (-5.30055,'eV/molecule'),
+        'O': (-4.71419,'eV/molecule'),
     },
-    surfaceSiteDensity = (2.630E-09, 'mol/cm^2'),
-    facet = "0001",
-    metal = "Ru",
-    shortDesc = u"hcp",
-    longDesc = u"""
+    surfaceSiteDensity = (2.656e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Rh",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-    """,
+""",
 )
 
 entry(
     index = 3,
-    label = "Rh111",
+    label = "Ir111",
     bindingEnergies = {
-    		           'H':(-2.83000775E+00, 'eV/molecule'),
-                       'C':(-7.33483762E+00, 'eV/molecule'),
-                       'N':(-5.30055389E+00, 'eV/molecule'),
-                       'O':(-4.71419163E+00, 'eV/molecule'),
+        'H': (-2.67674,'eV/molecule'),
+        'C': (-7.25234,'eV/molecule'),
+        'N': (-5.06204,'eV/molecule'),
+        'O': (-4.35236,'eV/molecule'),
     },
-    surfaceSiteDensity = (2.656E-09, 'mol/cm^2'),
+    surfaceSiteDensity = (2.587e-09, 'mol/cm^2'),
     facet = "111",
+    metal = "Ir",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 4,
+    label = "Au111",
+    bindingEnergies = {
+        'H': (-2.20848,'eV/molecule'),
+        'C': (-4.5465,'eV/molecule'),
+        'N': (-2.41078,'eV/molecule'),
+        'O': (-2.71822,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.2700000000000002e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Au",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 5,
+    label = "Pd111",
+    bindingEnergies = {
+        'H': (-2.92249,'eV/molecule'),
+        'C': (-7.16786,'eV/molecule'),
+        'N': (-4.78496,'eV/molecule'),
+        'O': (-4.13577,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.534e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Pd",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 6,
+    label = "Cu111",
+    bindingEnergies = {
+        'H': (-2.58383,'eV/molecule'),
+        'C': (-4.96034,'eV/molecule'),
+        'N': (-3.58447,'eV/molecule'),
+        'O': (-4.20764,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.943e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Cu",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 7,
+    label = "Ag111",
+    bindingEnergies = {
+        'H': (-2.10527,'eV/molecule'),
+        'C': (-3.50609,'eV/molecule'),
+        'N': (-1.97974,'eV/molecule'),
+        'O': (-3.11159,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.2920000000000004e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Ag",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 8,
+    label = "Ni111",
+    bindingEnergies = {
+        'H': (-2.89203,'eV/molecule'),
+        'C': (-6.79794,'eV/molecule'),
+        'N': (-5.16381,'eV/molecule'),
+        'O': (-4.98902,'eV/molecule'),
+    },
+    surfaceSiteDensity = (3.148e-09, 'mol/cm^2'),
+    facet = "111",
+    metal = "Ni",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 9,
+    label = "Co0001",
+    bindingEnergies = {
+        'H': (-3.02059,'eV/molecule'),
+        'C': (-7.09133,'eV/molecule'),
+        'N': (-5.58561,'eV/molecule'),
+        'O': (-5.38368,'eV/molecule'),
+    },
+    surfaceSiteDensity = (3.1180000000000006e-09, 'mol/cm^2'),
+    facet = "0001",
+    metal = "Co",
+    shortDesc = """hcp""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 10,
+    label = "Pt211",
+    bindingEnergies = {
+        'H': (-2.89,'eV/molecule'),
+        'C': (-7.205,'eV/molecule'),
+        'N': (-4.635,'eV/molecule'),
+        'O': (-4.15,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.634e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Pt",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+""",
+)
+
+entry(
+    index = 11,
+    label = "Rh211",
+    bindingEnergies = {
+        'H': (-2.82805,'eV/molecule'),
+        'C': (-7.80574,'eV/molecule'),
+        'N': (-5.4916,'eV/molecule'),
+        'O': (-4.7766,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.817e-09, 'mol/cm^2'),
+    facet = "211",
     metal = "Rh",
-    shortDesc = u"fcc",
-    longDesc = u"""
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-    """,
+""",
 )
 
 entry(
-     index = 4,
-     label = "Ir111",
-     bindingEnergies = {
-     		            'H':(-2.67673532E+00, 'eV/molecule'),
-                        'C':(-7.25234155E+00, 'eV/molecule'),
-                        'N':(-5.06204488E+00, 'eV/molecule'),
-                        'O':(-4.35235655E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.587E-09, 'mol/cm^2'),
-     facet = "111",
-     metal = "Ir",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 12,
+    label = "Ag211",
+    bindingEnergies = {
+        'H': (-2.036,'eV/molecule'),
+        'C': (-4.045,'eV/molecule'),
+        'N': (-2.051,'eV/molecule'),
+        'O': (-3.126,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.432e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Ag",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 5,
-     label = "Au111",
-     bindingEnergies = {
-     		            'H':(-2.20847988E+00, 'eV/molecule'),
-                        'C':(-4.54649977E+00, 'eV/molecule'),
-                        'N':(-2.41077552E+00, 'eV/molecule'),
-                        'O':(-2.71822397E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.270E-09, 'mol/cm^2'),
-     facet = "111",
-     metal = "Au",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 13,
+    label = "Pd211",
+    bindingEnergies = {
+        'H': (-2.785,'eV/molecule'),
+        'C': (-7.826,'eV/molecule'),
+        'N': (-4.774,'eV/molecule'),
+        'O': (-3.98,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.688e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Pd",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 6,
-     label = "Pd111",
-     bindingEnergies = {
-     		            'H':(-2.92248796E+00, 'eV/molecule'),
-                        'C':(-7.16786381E+00, 'eV/molecule'),
-                        'N':(-4.78495869E+00, 'eV/molecule'),
-                        'O':(-4.13577325E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.534E-09, 'mol/cm^2'),
-     facet = "111",
-     metal = "Pd",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 14,
+    label = "Au211",
+    bindingEnergies = {
+        'H': (-2.19121,'eV/molecule'),
+        'C': (-4.75864,'eV/molecule'),
+        'N': (-2.45501,'eV/molecule'),
+        'O': (-2.75366,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.408e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Au",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 7,
-     label = "Cu111",
-     bindingEnergies = {
-     		            'H':(-2.58383235E+00, 'eV/molecule'),
-                        'C':(-4.96033553E+00, 'eV/molecule'),
-                        'N':(-3.58446699E+00, 'eV/molecule'),
-                        'O':(-4.20763879E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.943E-09, 'mol/cm^2'),
-     facet = "111",
-     metal = "Cu",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 15,
+    label = "Ir211",
+    bindingEnergies = {
+        'H': (-3.04938,'eV/molecule'),
+        'C': (-7.51874,'eV/molecule'),
+        'N': (-5.38689,'eV/molecule'),
+        'O': (-5.15358,'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.7440000000000005e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Ir",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 8,
-     label = "Ag111",
-     bindingEnergies = {
-     		            'H':(-2.10526806E+00, 'eV/molecule'),
-                        'C':(-3.50609006E+00, 'eV/molecule'),
-                        'N':(-1.97973590E+00, 'eV/molecule'),
-                        'O':(-3.11159241E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.292E-09, 'mol/cm^2'),
-     facet = "111",
-     metal = "Ag",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 16,
+    label = "Ru211",
+    bindingEnergies = {
+        'H': (-2.99021,'eV/molecule'),
+        'C': (-7.76706,'eV/molecule'),
+        'N': (-6.16793,'eV/molecule'),
+        'O': (-5.85841,'eV/molecule'),
+    },
+    surfaceSiteDensity = (3.199e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Ru",
+    shortDesc = """hcp""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 9,
-     label = "Ni111",
-     bindingEnergies = {
-     		            'H':(-2.89202876E+00, 'eV/molecule'),
-                        'C':(-6.79794124E+00, 'eV/molecule'),
-                        'N':(-5.16380660E+00, 'eV/molecule'),
-                        'O':(-4.98902184E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (3.148E-09, 'mol/cm^2'),
-     facet = "111",
-     metal = "Ni",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 17,
+    label = "Co211",
+    bindingEnergies = {
+        'H': (-2.95858,'eV/molecule'),
+        'C': (-7.51741,'eV/molecule'),
+        'N': (-5.69353,'eV/molecule'),
+        'O': (-5.73947,'eV/molecule'),
+    },
+    surfaceSiteDensity = (3.7110000000000005e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Co",
+    shortDesc = """hcp""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 10,
-     label = "Co0001",
-     bindingEnergies = {
-     		            'H':(-3.02058996E+00, 'eV/molecule'),
-                        'C':(-7.09132929E+00, 'eV/molecule'),
-                        'N':(-5.58560836E+00, 'eV/molecule'),
-                        'O':(-5.38367940E+00, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (3.118E-09, 'mol/cm^2'),
-     facet = "0001",
-     metal = "Co",
-     shortDesc = u"hcp",
-     longDesc = u"""
+    index = 18,
+    label = "Ni211",
+    bindingEnergies = {
+        'H': (-2.901,'eV/molecule'),
+        'C': (-7.775,'eV/molecule'),
+        'N': (-5.31,'eV/molecule'),
+        'O': (-5.086,'eV/molecule'),
+    },
+    surfaceSiteDensity = (3.3390000000000006e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Ni",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
 entry(
-     index = 11,
-     label = "Pt211",
-     bindingEnergies = {
-     		            'H':(-2.890, 'eV/molecule'),
-                        'C':(-7.205, 'eV/molecule'),
-                        'N':(-4.635, 'eV/molecule'),
-                        'O':(-4.150, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.634E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Pt",
-     shortDesc = u"fcc",
-     longDesc = u"""
+    index = 19,
+    label = "Cu211",
+    bindingEnergies = {
+        'H': (-2.582,'eV/molecule'),
+        'C': (-5.831,'eV/molecule'),
+        'N': (-3.723,'eV/molecule'),
+        'O': (-4.307,'eV/molecule'),
+    },
+    surfaceSiteDensity = (3.1210000000000003e-09, 'mol/cm^2'),
+    facet = "211",
+    metal = "Cu",
+    shortDesc = """fcc""",
+    longDesc = 
+"""
 Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
+""",
 )
 
-entry(
-     index = 12,
-     label = "Rh211",
-     bindingEnergies = {
-     		            'H':(-2.828048658, 'eV/molecule'),
-                        'C':(-7.805735262, 'eV/molecule'),
-                        'N':(-5.491597358, 'eV/molecule'),
-                        'O':(-4.776603013, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.817E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Rh",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 13,
-     label = "Ag211",
-     bindingEnergies = {
-     		            'H':(-2.036, 'eV/molecule'),
-                        'C':(-4.045, 'eV/molecule'),
-                        'N':(-2.051, 'eV/molecule'),
-                        'O':(-3.126, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.432E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Ag",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 14,
-     label = "Pd211",
-     bindingEnergies = {
-     		            'H':(-2.785, 'eV/molecule'),
-                        'C':(-7.826, 'eV/molecule'),
-                        'N':(-4.774, 'eV/molecule'),
-                        'O':(-3.980, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.688E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Pd",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 15,
-     label = "Au211",
-     bindingEnergies = {
-     		            'H':(-2.191205055, 'eV/molecule'),
-                        'C':(-4.758643121, 'eV/molecule'),
-                        'N':(-2.455006241, 'eV/molecule'),
-                        'O':(-2.753661561, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.408E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Au",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 16,
-     label = "Ir211",
-     bindingEnergies = {
-     		            'H':(-3.049382381, 'eV/molecule'),
-                        'C':(-7.518738006, 'eV/molecule'),
-                        'N':(-5.386894619, 'eV/molecule'),
-                        'O':(-5.153576364, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (2.744E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Ir",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 17,
-     label = "Ru211",
-     bindingEnergies = {
-     		            'H':(-2.990208683, 'eV/molecule'),
-                        'C':(-7.767055243, 'eV/molecule'),
-                        'N':(-6.167927714, 'eV/molecule'),
-                        'O':(-5.858408296, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (3.199E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Ru",
-     shortDesc = u"hcp",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 18,
-     label = "Co211",
-     bindingEnergies = {
-     		            'H':(-2.958578034, 'eV/molecule'),
-                        'C':(-7.517405633, 'eV/molecule'),
-                        'N':(-5.693528936, 'eV/molecule'),
-                        'O':(-5.739466384, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (3.711E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Co",
-     shortDesc = u"hcp",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 19,
-     label = "Ni211",
-     bindingEnergies = {
-     		            'H':(-2.901, 'eV/molecule'),
-                        'C':(-7.775, 'eV/molecule'),
-                        'N':(-5.310, 'eV/molecule'),
-                        'O':(-5.086, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (3.339E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Ni",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)
-
-entry(
-     index = 20,
-     label = "Cu211",
-     bindingEnergies = {
-     		            'H':(-2.582, 'eV/molecule'),
-                        'C':(-5.831, 'eV/molecule'),
-                        'N':(-3.723, 'eV/molecule'),
-                        'O':(-4.307, 'eV/molecule'),
-     },
-     surfaceSiteDensity = (3.121E-09, 'mol/cm^2'),
-     facet = "211",
-     metal = "Cu",
-     shortDesc = u"fcc",
-     longDesc = u"""
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
-     """,
-)

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -6,7 +6,7 @@ shortDesc = u"Surface adsorption Pt(111), Blondal 2018"
 longDesc = u"""
 Changes due to adsorbing on a surface.
 Here, Pt(111)
-Note: "-h" means "horizontal".
+Note: "-h" means "horizontal"
 """
 
 entry(
@@ -2296,6 +2296,8 @@ entry(
 2 N  u0 p1 {1,T}
 """,
     thermo=u'N*',
+    metal = "Pt",
+    facet = "111",
 )
 entry(
     index = 80,
@@ -2325,6 +2327,8 @@ entry(
 4 R   u0 {2,S}
 """,
     thermo=u'(CRN)*',
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(


### PR DESCRIPTION
We have atomic binding energies and surface site densities that we would like to add to the RMG database. More specifically, this data is for two facets each of ten metals: Pt, Ni, Au, Ag, Pd, Co, Cu, Rh, Ir, and Ru. It would be great to start a discussion on how this data should be entered in the database so that it can effectively be used for the linear scaling relations etc.

Please comment if you have any thoughts on this. Thanks!