### PR TITLE
Fix indexing import chemkin library

### DIFF
--- a/scripts/importChemkinLibrary.py
+++ b/scripts/importChemkinLibrary.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
         reaction = reaction_list[i]
         entry = Entry(
                 index = i+1,
-                label = str(reaction),
+                label = reaction.to_labeled_str(),
                 item = reaction,
                 data = reaction.kinetics,
             )

--- a/scripts/importChemkinLibrary.py
+++ b/scripts/importChemkinLibrary.py
@@ -53,10 +53,10 @@ if __name__ == '__main__':
     for i in range(len(reaction_list)):
         reaction = reaction_list[i]
         entry = Entry(
-                index = i+1,
-                label = reaction.to_labeled_str(),
-                item = reaction,
-                data = reaction.kinetics,
+                index=i+1,
+                label=reaction.to_labeled_str(),
+                item=reaction,
+                data=reaction.kinetics,
             )
         try:
             entry.long_desc = 'Originally from reaction library: ' + reaction.library + "\n" + reaction.kinetics.comment


### PR DESCRIPTION
## Motivation of Problem 
The script `importChemkinLibrary.py` created kinetic libraries with inconsistent labeling and indexing; this caused mechanisms to fail immediately when trying to restart them and run them further in RMG using the newly created libraries. Additional details can be found in issue #399 and in #72 as well.

## Description of Changes
Previously, using `str(reaction)`, called the `__str__` method for `RMG-Py/rmgpy/reaction.py` which used the index when creating the kinetics library: `reactions.py`. However, this format was inconsistent with the corresponding `dictionary.txt` that did NOT use indices. 

The fix is to instead call the `to_labeled_str` method, whose default sets the `use_index` flag to `False`, thus making the format consistent. Indeed, this fix allows the merged mechanism to restart without errors.