### PR TITLE
Standardize model chemistry

### DIFF
--- a/input/quantum_corrections/data.py
+++ b/input/quantum_corrections/data.py
@@ -74,7 +74,7 @@ SOC = {'H': 0.0, 'N': 0.0, 'O': -0.000355, 'C': -0.000135, 'S': -0.000893, 'P': 
 
 # Atomic energies
 atom_energies = {
-    'wb97m-v/def2-tzvpd': {
+    "LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem')": {
         'H': -0.49338216995809725,
         'C': -37.84772407774059,
         'N': -54.59351384873174,
@@ -86,97 +86,97 @@ atom_energies = {
     },
 
     # cbs-qb3 and cbs-qb3-paraskevas have the same corrections
-    'cbs-qb3': {
+    "LevelOfTheory(method='cbsqb3',software='gaussian')": {
         'H': -0.499818 + SOC['H'], 'N': -54.520543 + SOC['N'], 'O': -74.987624 + SOC['O'],
         'C': -37.785385 + SOC['C'], 'P': -340.817186 + SOC['P'], 'S': -397.657360 + SOC['S']
     },
-    'cbs-qb3-paraskevas': {
+    "LevelOfTheory(method='cbsqb3paraskevas',software='gaussian')": {
         'H': -0.499818 + SOC['H'], 'N': -54.520543 + SOC['N'], 'O': -74.987624 + SOC['O'],
         'C': -37.785385 + SOC['C'], 'P': -340.817186 + SOC['P'], 'S': -397.657360 + SOC['S']
     },
 
-    'm06-2x/cc-pvtz': {
+    "LevelOfTheory(method='m062x',basis='ccpvtz',software='gaussian')": {
         'H': -0.498135 + SOC['H'], 'N': -54.586780 + SOC['N'], 'O': -75.064242 + SOC['O'],
         'C': -37.842468 + SOC['C'], 'P': -341.246985 + SOC['P'], 'S': -398.101240 + SOC['S']
     },
 
-    'g3': {
+    "LevelOfTheory(method='g3',software='gaussian')": {
         'H': -0.5010030, 'N': -54.564343, 'O': -75.030991, 'C': -37.827717, 'P': -341.116432, 'S': -397.961110
     },
 
     # * indicates that the grid size used in the [QChem] electronic
     # structure calculation utilized 75 radial points and 434 angular points
     # (i.e,, this is specified in the $rem section of the [qchem] input file as: XC_GRID 000075000434)
-    'm08so/mg3s*': {
+    "LevelOfTheory(method='m08so',basis='mg3s*',software='qchem')": {
         'H': -0.5017321350 + SOC['H'], 'N': -54.5574039365 + SOC['N'],
         'O': -75.0382931348 + SOC['O'], 'C': -37.8245648740 + SOC['C'],
         'P': -341.2444299005 + SOC['P'], 'S': -398.0940312227 + SOC['S']
     },
 
-    'klip_1': {
+    "LevelOfTheory(method='klip_1')": {
         'H': -0.50003976 + SOC['H'], 'N': -54.53383153 + SOC['N'], 'O': -75.00935474 + SOC['O'],
         'C': -37.79266591 + SOC['C']
     },
 
     # Klip QCI(tz,qz)
-    'klip_2': {
+    "LevelOfTheory(method='klip_2')": {
         'H': -0.50003976 + SOC['H'], 'N': -54.53169400 + SOC['N'], 'O': -75.00714902 + SOC['O'],
         'C': -37.79060419 + SOC['C']
     },
 
     # Klip QCI(dz,tz)
-    'klip_3': {
+    "LevelOfTheory(method='klip_3')": {
         'H': -0.50005578 + SOC['H'], 'N': -54.53128140 + SOC['N'], 'O': -75.00356581 + SOC['O'],
         'C': -37.79025175 + SOC['C']
     },
 
     # Klip CCSD(T)(tz,qz)
-    'klip_2_cc': {
+    "LevelOfTheory(method='klip_2_cc')": {
         'H': -0.50003976 + SOC['H'], 'O': -75.00681155 + SOC['O'], 'C': -37.79029443 + SOC['C']
     },
 
-    'ccsd(t)-f12/cc-pvdz-f12_h-tz': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvdzf12_htz',software='molpro')": {
         'H': -0.499946213243 + SOC['H'], 'N': -54.526406291655 + SOC['N'],
         'O': -74.995458316117 + SOC['O'], 'C': -37.788203485235 + SOC['C']
     },
 
-    'ccsd(t)-f12/cc-pvdz-f12_h-qz': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvdzf12_hqz',software='molpro')": {
         'H': -0.499994558325 + SOC['H'], 'N': -54.526406291655 + SOC['N'],
         'O': -74.995458316117 + SOC['O'], 'C': -37.788203485235 + SOC['C']
     },
 
     # We are assuming that SOC is included in the Bond Energy Corrections
-    'ccsd(t)-f12/cc-pvdz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvdzf12',software='molpro')": {
         'H': -0.499811124128, 'N': -54.526406291655, 'O': -74.995458316117,
         'C': -37.788203485235, 'S': -397.663040369707
     },
 
-    'ccsd(t)-f12/cc-pvtz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvtzf12',software='molpro')": {
         'H': -0.499946213243, 'N': -54.53000909621, 'O': -75.004127673424,
         'C': -37.789862146471, 'S': -397.675447487865
     },
 
-    'ccsd(t)-f12/cc-pvqz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvqzf12',software='molpro')": {
         'H': -0.499994558325, 'N': -54.530515226371, 'O': -75.005600062003,
         'C': -37.789961656228, 'S': -397.676719774973
     },
 
-    'ccsd(t)-f12/cc-pcvdz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpcvdzf12',software='molpro')": {
         'H': -0.499811124128 + SOC['H'], 'N': -54.582137180344 + SOC['N'],
         'O': -75.053045547421 + SOC['O'], 'C': -37.840869118707 + SOC['C']
     },
 
-    'ccsd(t)-f12/cc-pcvtz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpcvtzf12',software='molpro')": {
         'H': -0.499946213243 + SOC['H'], 'N': -54.588545831900 + SOC['N'],
         'O': -75.065995072347 + SOC['O'], 'C': -37.844662139972 + SOC['C']
     },
 
-    'ccsd(t)-f12/cc-pcvqz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpcvqzf12',software='molpro')": {
         'H': -0.499994558325 + SOC['H'], 'N': -54.589137594139 + SOC['N'],
         'O': -75.067412234737 + SOC['O'], 'C': -37.844893820561 + SOC['C']
     },
 
-    'ccsd(t)-f12/cc-pvtz-f12(-pp)': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvtzf12(pp)',software='molpro')": {
         'H': -0.499946213243 + SOC['H'], 'N': -54.53000909621 + SOC['N'],
         'O': -75.004127673424 + SOC['O'], 'C': -37.789862146471 + SOC['C'],
         'S': -397.675447487865 + SOC['S'], 'I': -294.81781766 + SOC['I']
@@ -184,152 +184,152 @@ atom_energies = {
 
     # ccsd(t)/aug-cc-pvtz(-pp) atomic energies were fit to a set of 8 small molecules:
     # CH4, CH3OH, H2S, H2O, SO2, HI, I2, CH3I
-    'ccsd(t)/aug-cc-pvtz(-pp)': {
+    "LevelOfTheory(method='ccsd(t)',basis='augccpvtz(pp)')": {
         'H': -0.499821176024 + SOC['H'], 'O': -74.96738492 + SOC['O'],
         'C': -37.77385697 + SOC['C'], 'S': -397.6461604 + SOC['S'],
         'I': -294.7958443 + SOC['I']
     },
 
     # note that all atom corrections but S are fitted, the correction for S is calculated
-    'ccsd(t)-f12/aug-cc-pvdz': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='augccpvdz',software='molpro')": {
         'H': -0.499459066131 + SOC['H'], 'N': -54.524279516472 + SOC['N'],
         'O': -74.992097308083 + SOC['O'], 'C': -37.786694171716 + SOC['C'],
         'S': -397.648733842400 + SOC['S']
     },
 
-    'ccsd(t)-f12/aug-cc-pvtz': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='augccpvtz',software='molpro')": {
         'H': -0.499844820798 + SOC['H'], 'N': -54.527419359906 + SOC['N'],
         'O': -75.000001429806 + SOC['O'], 'C': -37.788504810868 + SOC['C'],
         'S': -397.666903000231 + SOC['S']
     },
 
-    'ccsd(t)-f12/aug-cc-pvqz': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='augccpvqz',software='molpro')": {
         'H': -0.499949526073 + SOC['H'], 'N': -54.529569719016 + SOC['N'],
         'O': -75.004026586610 + SOC['O'], 'C': -37.789387892348 + SOC['C'],
         'S': -397.671214204994 + SOC['S']
     },
 
-    'b-ccsd(t)-f12/cc-pvdz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='ccpvdzf12',software='molpro')": {
         'H': -0.499811124128 + SOC['H'], 'N': -54.523269942190 + SOC['N'],
         'O': -74.990725918500 + SOC['O'], 'C': -37.785409916465 + SOC['C'],
         'S': -397.658155086033 + SOC['S']
     },
 
-    'b-ccsd(t)-f12/cc-pvtz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='ccpvtzf12',software='molpro')": {
         'H': -0.499946213243 + SOC['H'], 'N': -54.528135889213 + SOC['N'],
         'O': -75.001094055506 + SOC['O'], 'C': -37.788233578503 + SOC['C'],
         'S': -397.671745425929 + SOC['S']
     },
 
-    'b-ccsd(t)-f12/cc-pvqz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='ccpvqzf12',software='molpro')": {
         'H': -0.499994558325 + SOC['H'], 'N': -54.529425753163 + SOC['N'],
         'O': -75.003820485005 + SOC['O'], 'C': -37.789006506290 + SOC['C'],
         'S': -397.674145126931 + SOC['S']
     },
 
-    'b-ccsd(t)-f12/cc-pcvdz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='ccpcvdzf12',software='molpro')": {
         'H': -0.499811124128 + SOC['H'], 'N': -54.578602780288 + SOC['N'],
         'O': -75.048064317367 + SOC['O'], 'C': -37.837592033417 + SOC['C']
     },
 
-    'b-ccsd(t)-f12/cc-pcvtz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='ccpcvtzf12',software='molpro')": {
         'H': -0.499946213243 + SOC['H'], 'N': -54.586402551258 + SOC['N'],
         'O': -75.062767632757 + SOC['O'], 'C': -37.842729156944 + SOC['C']
     },
 
-    'b-ccsd(t)-f12/cc-pcvqz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='ccpcvqzf12',software='molpro')": {
         'H': -0.49999456 + SOC['H'], 'N': -54.587781507581 + SOC['N'],
         'O': -75.065397706471 + SOC['O'], 'C': -37.843634971592 + SOC['C']
     },
 
-    'b-ccsd(t)-f12/aug-cc-pvdz': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='augccpvdz',software='molpro')": {
         'H': -0.499459066131 + SOC['H'], 'N': -54.520475581942 + SOC['N'],
         'O': -74.986992215049 + SOC['O'], 'C': -37.783294495799 + SOC['C']
     },
 
-    'b-ccsd(t)-f12/aug-cc-pvtz': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='augccpvtz',software='molpro')": {
         'H': -0.499844820798 + SOC['H'], 'N': -54.524927371700 + SOC['N'],
         'O': -74.996328829705 + SOC['O'], 'C': -37.786320700792 + SOC['C']
     },
 
-    'b-ccsd(t)-f12/aug-cc-pvqz': {
+    "LevelOfTheory(method='ccsd(t)f12b',basis='augccpvqz',software='molpro')": {
         'H': -0.499949526073 + SOC['H'], 'N': -54.528189769291 + SOC['N'],
         'O': -75.001879610563 + SOC['O'], 'C': -37.788165047059 + SOC['C']
     },
 
-    'mp2_rmp2_pvdz': {
+    "LevelOfTheory(method='mp2',basis='ccpvdz')": {
         'H': -0.49927840 + SOC['H'], 'N': -54.46141996 + SOC['N'], 'O': -74.89408254 + SOC['O'],
         'C': -37.73792713 + SOC['C']
     },
 
-    'mp2_rmp2_pvtz': {
+    "LevelOfTheory(method='mp2',basis='ccpvtz')": {
         'H': -0.49980981 + SOC['H'], 'N': -54.49615972 + SOC['N'], 'O': -74.95506980 + SOC['O'],
         'C': -37.75833104 + SOC['C']
     },
 
-    'mp2_rmp2_pvqz': {
+    "LevelOfTheory(method='mp2',basis='ccpvqz')": {
         'H': -0.49994557 + SOC['H'], 'N': -54.50715868 + SOC['N'], 'O': -74.97515364 + SOC['O'],
         'C': -37.76533215 + SOC['C']
     },
 
-    'ccsd-f12/cc-pvdz-f12': {
+    "LevelOfTheory(method='ccsdf12',basis='ccpvdzf12',software='molpro')": {
         'H': -0.499811124128 + SOC['H'], 'N': -54.524325513811 + SOC['N'],
         'O': -74.992326577897 + SOC['O'], 'C': -37.786213495943 + SOC['C']
     },
 
-    'ccsd(t)-f12/cc-pvdz-f12_noscale': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvdzf12_noscale',software='molpro')": {
         'H': -0.499811124128 + SOC['H'], 'N': -54.526026290887 + SOC['N'],
         'O': -74.994751897699 + SOC['O'], 'C': -37.787881871511 + SOC['C']
     },
 
-    'g03_pbepbe_6-311++g_d_p': {
+    "LevelOfTheory(method='pbepbe',basis='6311++g(d,p)',software='gaussian')": {
         'H': -0.499812273282 + SOC['H'], 'N': -54.5289567564 + SOC['N'],
         'O': -75.0033596764 + SOC['O'], 'C': -37.7937388736 + SOC['C']
     },
 
-    'fci/cc-pvdz': {
+    "LevelOfTheory(method='fci',basis='ccpvdz')": {
         'C': -37.789527 + SOC['C']
     },
 
-    'fci/cc-pvtz': {
+    "LevelOfTheory(method='fci',basis='ccpvtz')": {
         'C': -37.781266669684 + SOC['C']
     },
 
-    'fci/cc-pvqz': {
+    "LevelOfTheory(method='fci',basis='ccpvqz')": {
         'C': -37.787052110598 + SOC['C']
     },
 
     # 'bmk/cbsb7' and 'bmk/6-311g(2d,d,p)' have the same corrections
-    'bmk/cbsb7': {
+    "LevelOfTheory(method='bmk',basis='cbsb7',software='gaussian')": {
         'H': -0.498618853119 + SOC['H'], 'N': -54.5697851544 + SOC['N'],
         'O': -75.0515210278 + SOC['O'], 'C': -37.8287310027 + SOC['C'],
         'P': -341.167615941 + SOC['P'], 'S': -398.001619915 + SOC['S']
     },
-    'bmk/6-311g(2d,d,p)': {
+    "LevelOfTheory(method='bmk',basis='6311g(2d,d,p)',software='gaussian')": {
         'H': -0.498618853119 + SOC['H'], 'N': -54.5697851544 + SOC['N'],
         'O': -75.0515210278 + SOC['O'], 'C': -37.8287310027 + SOC['C'],
         'P': -341.167615941 + SOC['P'], 'S': -398.001619915 + SOC['S']
     },
 
     # Fitted to small molecules
-    'b3lyp/6-31g(d,p)': {
+    "LevelOfTheory(method='b3lyp',basis='631g(d,p)',software='gaussian')": {
         'H': -0.500426155, 'C': -37.850331697831, 'O': -75.0535872748806, 'S': -398.100820107242
     },
 
     # Calculated atomic energies
-    'b3lyp/6-311+g(3df,2p)': {
+    "LevelOfTheory(method='b3lyp',basis='6311+g(3df,2p)',software='gaussian')": {
         'H': -0.502155915123 + SOC['H'], 'C': -37.8574709934 + SOC['C'],
         'N': -54.6007233609 + SOC['N'], 'O': -75.0909131284 + SOC['O'],
         'P': -341.281730319 + SOC['P'], 'S': -398.134489850 + SOC['S']
     },
 
-    'wb97x-d/aug-cc-pvtz': {
+    "LevelOfTheory(method='wb97xd',basis='augccpvtz',software='gaussian')": {
         'H': -0.502803 + SOC['H'], 'N': -54.585652 + SOC['N'], 'O': -75.068286 + SOC['O'],
         'C': -37.842014 + SOC['C']
     },
 
     # Calculated atomic energies (unfitted)
-    'MRCI+Davidson/aug-cc-pV(T+d)Z': {
+    "LevelOfTheory(method='mrci+davidson',basis='augccpv(t+d)z',software='molpro')": {
         'H': -0.49982118 + SOC['H'], 'C': -37.78321274 + SOC['C'], 'N': -54.51729444 + SOC['N'],
         'O': -74.97847534 + SOC['O'], 'S': -397.6571654 + SOC['S']
     },
@@ -341,7 +341,7 @@ pbac = {
 
     # 'S-H', 'C-S', 'C=S', 'S-S', 'O-S', 'O=S', 'O=S=O' taken from http://hdl.handle.net/1721.1/98155 (both for
     # 'CCSD(T)-F12/cc-pVDZ-F12' and 'CCSD(T)-F12/cc-pVTZ-F12')
-    'ccsd(t)-f12/cc-pvdz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvdzf12',software='molpro')": {
         'C-H': -0.46, 'C-C': -0.68, 'C=C': -1.90, 'C#C': -3.13,
         'O-H': -0.51, 'C-O': -0.23, 'C=O': -0.69, 'O-O': -0.02, 'C-N': -0.67,
         'C=N': -1.46, 'C#N': -2.79, 'N-O': 0.74, 'N_O': -0.23, 'N=O': -0.51,
@@ -350,7 +350,7 @@ pbac = {
         'O=S=O': 1.95
     },
 
-    'ccsd(t)-f12/cc-pvtz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvtzf12',software='molpro')": {
         'C-H': -0.09, 'C-C': -0.27, 'C=C': -1.03, 'C#C': -1.79,
         'O-H': -0.06, 'C-O': 0.14, 'C=O': -0.19, 'O-O': 0.16, 'C-N': -0.18,
         'C=N': -0.41, 'C#N': -1.41, 'N-O': 0.87, 'N_O': -0.09, 'N=O': -0.23,
@@ -359,14 +359,14 @@ pbac = {
         'O=S=O': 0.27
     },
 
-    'ccsd(t)-f12/cc-pvqz-f12': {
+    "LevelOfTheory(method='ccsd(t)f12',basis='ccpvqzf12',software='molpro')": {
         'C-H': -0.08, 'C-C': -0.26, 'C=C': -1.01, 'C#C': -1.66,
         'O-H': 0.07, 'C-O': 0.25, 'C=O': -0.03, 'O-O': 0.26, 'C-N': -0.20,
         'C=N': -0.30, 'C#N': -1.33, 'N-O': 1.01, 'N_O': -0.03, 'N=O': -0.26,
         'N-H': 0.06, 'N-N': -0.23, 'N=N': -0.37, 'N#N': -0.64
     },
 
-    'cbs-qb3': {
+    "LevelOfTheory(method='cbsqb3',software='gaussian')": {
         'C-H': -0.11, 'C-C': -0.30, 'C=C': -0.08, 'C#C': -0.64, 'O-H': 0.02, 'C-O': 0.33, 'C=O': 0.55,
         # Table IX: Petersson GA (1998) J. of Chemical Physics, DOI: 10.1063/1.477794
         'N-H': -0.42, 'C-N': -0.13, 'C#N': -0.89, 'C-F': 0.55, 'C-Cl': 1.29, 'S-H': 0.0, 'C-S': 0.43,
@@ -376,7 +376,7 @@ pbac = {
         'N#N': -2.0, 'O=O': -0.2, 'H-H': 1.1,  # Unknown source
     },
 
-    'cbs-qb3-paraskevas': {
+    "LevelOfTheory(method='cbsqb3paraskevas',software='gaussian')": {
         # NOTE: The Paraskevas corrections are inaccurate for non-oxygenated hydrocarbons,
         # and may do poorly in combination with the Petersson corrections
         'C-C': -0.495, 'C-H': -0.045, 'C=C': -0.825, 'C-O': 0.378, 'C=O': 0.743, 'O-H': -0.423,
@@ -389,22 +389,22 @@ pbac = {
     },
 
     # Identical corrections for 'b3lyp/cbsb7', 'b3lyp/6-311g(2d,d,p)', 'b3lyp/6-311+g(3df,2p)', 'b3lyp/6-31g(d,p)'
-    'b3lyp/cbsb7': {
+    "LevelOfTheory(method='b3lyp',basis='cbsb7',software='gaussian')": {
         'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
         'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44,
         'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52,
     },
-    'b3lyp/6-311g(2d,d,p)': {
+    "LevelOfTheory(method='b3lyp',basis='6311g(2d,d,p)',software='gaussian')": {
         'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
         'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44,
         'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52,
     },
-    'b3lyp/6-311+g(3df,2p)': {
+    "LevelOfTheory(method='b3lyp',basis='6311+g(3df,2p)',software='gaussian')": {
         'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
         'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44,
         'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52,
     },
-    'b3lyp/6-31g(d,p)': {
+    "LevelOfTheory(method='b3lyp',basis='631g(d,p)',software='gaussian')": {
         'C-H': 0.25, 'C-C': -1.89, 'C=C': -0.40, 'C#C': -1.50,
         'O-H': -1.09, 'C-O': -1.18, 'C=O': -0.01, 'N-H': 1.36, 'C-N': -0.44,
         'C#N': 0.22, 'C-S': -2.35, 'O=S': -5.19, 'S-H': -0.52,
@@ -426,55 +426,55 @@ mbac = {}
 #        [4] Calculated as described in 10.1021/ct100326h
 #        [5] J.A. Montgomery, M.J. Frisch, J. Chem. Phys. 1999, 110, 2822–2827, DOI: 10.1063/1.477924
 
-freq_dict = {'hf/sto-3g': 0.817,  # [2]
-             'hf/6-31g': 0.903,  # [2]
-             'hf/6-31g(d)': 0.899,  # [2]
-             'hf/6-31g(d,p)': 0.903,  # [2]
-             'hf/6-31g+(d,p)': 0.904,  # [2]
-             'hf/6-31+g(d,p)': 0.915 * 1.014,  # [1] Table 7
-             'pm3': 0.940 * 1.014,  # [1] Table 7, the 0.940 value is the ZPE scale factor
-             'pm6': 1.078 * 1.014,  # [1] Table 7, the 1.078 value is the ZPE scale factor
-             'b3lyp/6-31g(d,p)': 0.961,  # [2]
-             'b3lyp/6-311g(d,p)': 0.967,  # [2]
-             'b3lyp/6-311+g(3df,2p)': 0.967,  # [2]
-             'b3lyp/6-311+g(3df,2pd)': 0.970,  # [2]
-             'm06-2x/6-31g(d,p)': 0.952,  # [2]
-             'm06-2x/6-31+g(d,p)': 0.979,  # [3]
-             'm06-2x/6-311+g(d,p)': 0.983,  # [3]
-             'm06-2x/6-311++g(d,p)': 0.983,  # [3]
-             'm06-2x/cc-pvtz': 0.955,  # [2]
-             'm06-2x/aug-cc-pvdz': 0.993,  # [3]
-             'm06-2x/aug-cc-pvtz': 0.985,  # [1] Table 3, [3]
-             'm06-2x/def2-tzvp': 0.984,  # [3]
-             'm06-2x/def2-qzvp': 0.983,  # [3]
-             'm06-2x/def2-tzvpp': 0.983,  # [1] Table 3, [3]
-             'm08so/mg3s*': 0.995,  # [1] Table 3, taken as 'M08-SO/MG3S'
-             'wb97x-d/aug-cc-pvtz': 0.988,  # [3], taken as 'ωB97X-D/maug-cc-pVTZ'
-             'wb97xd/6-311++g(d,p)': 0.988,  # [4]
-             'wb97xd/def2tzvp': 0.988,  # [4]
-             'wb97xd/def2svp': 0.986,  # [4]
-             'wb97m-v/def2-tzvpd': 1.002,  # [4]
-             'apfd/def2tzvp': 0.993,  # [4]
-             'apfd/def2tzvpp': 0.992,  # [4]
-             'mp2_rmp2_pvdz': 0.953,  # [2], taken as 'MP2/cc-pVDZ'
-             'mp2_rmp2_pvtz': 0.950,  # [2], taken as 'MP2/cc-pVTZ'
-             'mp2_rmp2_pvqz': 0.962,  # [2], taken as 'MP2/cc-pVQZ'
-             'cbs-qb3': 0.99 * 1.014,  # [5], the 0.99 value is the ZPE scale factor of CBS-QB3
-             'cbs-qb3-paraskevas': 0.99 * 1.014,  # [5], the 0.99 value is the ZPE scale factor of CBS-QB3
-             'ccsd-f12/cc-pvdz-f12': 0.947,  # [2], taken as 'CCSD/cc-pVDZ'
-             'ccsd(t)/cc-pvdz': 0.979,  # [2]
-             'ccsd(t)/cc-pvtz': 0.975,  # [2]
-             'ccsd(t)/cc-pvqz': 0.970,  # [2]
-             'ccsd(t)/aug-cc-pvdz': 0.963,  # [2]
-             'ccsd(t)/aug-cc-pvtz': 1.001,  # [3]
-             'ccsd(t)/aug-cc-pvqz': 0.975,  # [2]
-             'ccsd(t)/cc-pv(t+d)z': 0.965,  # [2]
-             'ccsd(t)-f12/cc-pvdz-f12': 0.997,  # [3], taken as 'CCSD(T)-F12a/cc-pVDZ-F12'
-             'ccsd(t)-f12/cc-pvtz-f12': 0.998,  # [3], taken as 'CCSD(T)-F12a/cc-pVTZ-F12'
-             'ccsd(t)-f12/cc-pvqz-f12': 0.998,  # [3], taken as 'CCSD(T)-F12b/VQZF12//CCSD(T)-F12a/TZF'
-             'ccsd(t)-f12/cc-pcvdz-f12': 0.997,  # [3], taken as 'CCSD(T)-F12a/cc-pVDZ-F12'
-             'ccsd(t)-f12/cc-pcvtz-f12': 0.998,  # [3], taken as 'CCSD(T)-F12a/cc-pVTZ-F12'
-             'ccsd(t)-f12/aug-cc-pvdz': 0.997,  # [3], taken as 'CCSD(T)/cc-pVDZ'
-             'ccsd(t)-f12/aug-cc-pvtz': 0.998,  # [3], taken as CCSD(T)-F12a/cc-pVTZ-F12
-             'ccsd(t)-f12/aug-cc-pvqz': 0.998,  # [3], taken as 'CCSD(T)-F12b/VQZF12//CCSD(T)-F12a/TZF'
+freq_dict = {"LevelOfTheory(method='hf',basis='sto3g')": 0.817,  # [2]
+             "LevelOfTheory(method='hf',basis='631g')": 0.903,  # [2]
+             "LevelOfTheory(method='hf',basis='631g(d)')": 0.899,  # [2]
+             "LevelOfTheory(method='hf',basis='631g(d,p)')": 0.903,  # [2]
+             "LevelOfTheory(method='hf',basis='631g+(d,p)')": 0.904,  # [2]
+             "LevelOfTheory(method='hf',basis='631+g(d,p)')": 0.915 * 1.014,  # [1] Table 7
+             "LevelOfTheory(method='pm3')": 0.940 * 1.014,  # [1] Table 7, the 0.940 value is the ZPE scale factor
+             "LevelOfTheory(method='pm6')": 1.078 * 1.014,  # [1] Table 7, the 1.078 value is the ZPE scale factor
+             "LevelOfTheory(method='b3lyp',basis='631g(d,p)')": 0.961,  # [2]
+             "LevelOfTheory(method='b3lyp',basis='6311g(d,p)')": 0.967,  # [2]
+             "LevelOfTheory(method='b3lyp',basis='6311+g(3df,2p)')": 0.967,  # [2]
+             "LevelOfTheory(method='b3lyp',basis='6311+g(3df,2pd)')": 0.970,  # [2]
+             "LevelOfTheory(method='m062x',basis='631g(d,p)')": 0.952,  # [2]
+             "LevelOfTheory(method='m062x',basis='631+g(d,p)')": 0.979,  # [3]
+             "LevelOfTheory(method='m062x',basis='6311+g(d,p)')": 0.983,  # [3]
+             "LevelOfTheory(method='m062x',basis='6311++g(d,p)')": 0.983,  # [3]
+             "LevelOfTheory(method='m062x',basis='ccpvtz')": 0.955,  # [2]
+             "LevelOfTheory(method='m062x',basis='augccpvdz')": 0.993,  # [3]
+             "LevelOfTheory(method='m062x',basis='augccpvtz')": 0.985,  # [1] Table 3, [3]
+             "LevelOfTheory(method='m062x',basis='def2tzvp')": 0.984,  # [3]
+             "LevelOfTheory(method='m062x',basis='def2qzvp')": 0.983,  # [3]
+             "LevelOfTheory(method='m062x',basis='def2tzvpp')": 0.983,  # [1] Table 3, [3]
+             "LevelOfTheory(method='m08so',basis='mg3s*')": 0.995,  # [1] Table 3, taken as 'M08-SO/MG3S'
+             "LevelOfTheory(method='wb97xd',basis='augccpvtz',software='gaussian')": 0.988,  # [3], taken as 'ωB97X-D/maug-cc-pVTZ'
+             "LevelOfTheory(method='wb97xd',basis='6311++g(d,p)',software='gaussian')": 0.988,  # [4]
+             "LevelOfTheory(method='wb97xd',basis='def2tzvp',software='gaussian')": 0.988,  # [4]
+             "LevelOfTheory(method='wb97xd',basis='def2svp',software='gaussian')": 0.986,  # [4]
+             "LevelOfTheory(method='wb97mv',basis='def2tzvpd')": 1.002,  # [4]
+             "LevelOfTheory(method='apfd',basis='def2tzvp')": 0.993,  # [4]
+             "LevelOfTheory(method='apfd',basis='def2tzvpp')": 0.992,  # [4]
+             "LevelOfTheory(method='mp2',basis='ccpvdz')": 0.953,  # [2]
+             "LevelOfTheory(method='mp2',basis='ccpvtz')": 0.950,  # [2]
+             "LevelOfTheory(method='mp2',basis='ccpvqz')": 0.962,  # [2]
+             "LevelOfTheory(method='cbsqb3')": 0.99 * 1.014,  # [5], the 0.99 value is the ZPE scale factor of CBS-QB3
+             "LevelOfTheory(method='cbsqb3paraskevas')": 0.99 * 1.014,  # [5], the 0.99 value is the ZPE scale factor of CBS-QB3
+             "LevelOfTheory(method='ccsdf12',basis='ccpvdzf12')": 0.947,  # [2], taken as 'CCSD/cc-pVDZ'
+             "LevelOfTheory(method='ccsd(t)',basis='ccpvdz')": 0.979,  # [2]
+             "LevelOfTheory(method='ccsd(t)',basis='ccpvtz')": 0.975,  # [2]
+             "LevelOfTheory(method='ccsd(t)',basis='ccpvqz')": 0.970,  # [2]
+             "LevelOfTheory(method='ccsd(t)',basis='augccpvdz')": 0.963,  # [2]
+             "LevelOfTheory(method='ccsd(t)',basis='augccpvtz')": 1.001,  # [3]
+             "LevelOfTheory(method='ccsd(t)',basis='augccpvqz')": 0.975,  # [2]
+             "LevelOfTheory(method='ccsd(t)',basis='ccpv(t+d)z')": 0.965,  # [2]
+             "LevelOfTheory(method='ccsd(t)f12',basis='ccpvdzf12')": 0.997,  # [3], taken as 'CCSD(T)-F12a/cc-pVDZ-F12'
+             "LevelOfTheory(method='ccsd(t)f12',basis='ccpvtzf12')": 0.998,  # [3], taken as 'CCSD(T)-F12a/cc-pVTZ-F12'
+             "LevelOfTheory(method='ccsd(t)f12',basis='ccpvqzf12',)": 0.998,  # [3], taken as 'CCSD(T)-F12b/VQZF12//CCSD(T)-F12a/TZF'
+             "LevelOfTheory(method='ccsd(t)f12',basis='ccpcvdzf12')": 0.997,  # [3], taken as 'CCSD(T)-F12a/cc-pVDZ-F12'
+             "LevelOfTheory(method='ccsd(t)f12',basis='ccpcvtzf12')": 0.998,  # [3], taken as 'CCSD(T)-F12a/cc-pVTZ-F12'
+             "LevelOfTheory(method='ccsd(t)f12',basis='augccpvdz')": 0.997,  # [3], taken as 'CCSD(T)/cc-pVDZ'
+             "LevelOfTheory(method='ccsd(t)f12',basis='augccpvtz')": 0.998,  # [3], taken as CCSD(T)-F12a/cc-pVTZ-F12
+             "LevelOfTheory(method='ccsd(t)f12',basis='augccpvqz')": 0.998,  # [3], taken as 'CCSD(T)-F12b/VQZF12//CCSD(T)-F12a/TZF'
              }

--- a/input/quantum_corrections/lot_constraints.yml
+++ b/input/quantum_corrections/lot_constraints.yml
@@ -1,0 +1,6 @@
+# [1]: Dispersion model in Q-Chem and Gaussian are different
+METHODS_THAT_REQUIRE_SOFTWARE:
+    - B97-D,  # [1]
+    - B97-D3  # [1]
+    - wB97X-D  # [1]
+    - wB97X-D3  # [1]

--- a/input/reference_sets/main/(E)-Diazene.yml
+++ b/input/reference_sets/main/(E)-Diazene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2N2
 inchi: InChI=1S/H2N2/c1-2/h1-2H
 inchi_key: RAABOESOVLLHRU-UHFFFAOYSA-N

--- a/input/reference_sets/main/(Methylamino)methyl.yml
+++ b/input/reference_sets/main/(Methylamino)methyl.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -73,7 +73,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6N
 inchi: InChI=1S/C2H6N/c1-3-2/h3H,1H2,2H3
 inchi_key: AQIAIZBHFAKICS-UHFFFAOYSA-N

--- a/input/reference_sets/main/(Methylthio)cyclopentane.yml
+++ b/input/reference_sets/main/(Methylthio)cyclopentane.yml
@@ -20,7 +20,7 @@ adjacency_list: |
   18 H u0 p0 c0 {7,S}
   19 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -132,7 +132,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H12S
 inchi: InChI=1S/C6H12S/c1-7-6-4-2-3-5-6/h6H,2-5H2,1H3
 inchi_key: OTQVGYMGQKHLMY-UHFFFAOYSA-N

--- a/input/reference_sets/main/(Methylthio)ethane.yml
+++ b/input/reference_sets/main/(Methylthio)ethane.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8S
 inchi: InChI=1S/C3H8S/c1-3-4-2/h3H2,1-2H3
 inchi_key: WXEHBUMAEPOYKP-UHFFFAOYSA-N

--- a/input/reference_sets/main/(R)-(-)-2-Butanol.yml
+++ b/input/reference_sets/main/(R)-(-)-2-Butanol.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {4,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10O
 inchi: InChI=1S/C4H10O/c1-3-4(2)5/h4-5H,3H2,1-2H3
 inchi_key: BTANRVKWQNVYAZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/(Z)-2-Pentene.yml
+++ b/input/reference_sets/main/(Z)-2-Pentene.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10
 inchi: InChI=1S/C5H10/c1-3-5-4-2/h3,5H,4H2,1-2H3
 inchi_key: QMMOXUPEWRXHJS-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-(Methylthio)butane.yml
+++ b/input/reference_sets/main/1-(Methylthio)butane.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-3-4-5-6-2/h3-5H2,1-2H3
 inchi_key: WCXXISMIJBRDQK-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Butanethiol.yml
+++ b/input/reference_sets/main/1-Butanethiol.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10S
 inchi: InChI=1S/C4H10S/c1-2-3-4-5/h5H,2-4H2,1H3
 inchi_key: WQAQPCDUOCURKW-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Butene.yml
+++ b/input/reference_sets/main/1-Butene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8
 inchi: InChI=1S/C4H8/c1-3-4-2/h3H,1,4H2,2H3
 inchi_key: VXNZUUAINFGPBY-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Butyne.yml
+++ b/input/reference_sets/main/1-Butyne.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {2,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6
 inchi: InChI=1S/C4H6/c1-3-4-2/h1H,4H2,2H3
 inchi_key: KDKYADYSIPSCCQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Hydroxyethyl.yml
+++ b/input/reference_sets/main/1-Hydroxyethyl.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -67,7 +67,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5O
 inchi: InChI=1S/C2H5O/c1-2-3/h2-3H,1H3
 inchi_key: GAWIXWVDTYZWAW-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Methyl-1H-Pyrrole.yml
+++ b/input/reference_sets/main/1-Methyl-1H-Pyrrole.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {6,S}
   13 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H7N
 inchi: InChI=1S/C5H7N/c1-6-4-2-3-5-6/h2-5H,1H3
 inchi_key: OXHNLMTVIGZXSG-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Methylcyclopentene.yml
+++ b/input/reference_sets/main/1-Methylcyclopentene.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {4,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H10
 inchi: InChI=1S/C6H10/c1-6-4-2-3-5-6/h4H,2-3,5H2,1H3
 inchi_key: ATQUFXWBVZUTKO-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Methylethenyl.yml
+++ b/input/reference_sets/main/1-Methylethenyl.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   7 H u0 p0 c0 {2,S}
   8 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -67,7 +67,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H5
 inchi: InChI=1S/C3H5/c1-3-2/h1H2,2H3
 inchi_key: NMTZQIYQFZGXQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Pentanethiol.yml
+++ b/input/reference_sets/main/1-Pentanethiol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-2-3-4-5-6/h6H,2-5H2,1H3
 inchi_key: ZRKMQKLGEQPLNS-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Pentanol.yml
+++ b/input/reference_sets/main/1-Pentanol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12O
 inchi: InChI=1S/C5H12O/c1-2-3-4-5-6/h6H,2-5H2,1H3
 inchi_key: AMQJEAYHLZJPGS-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Propanethiol.yml
+++ b/input/reference_sets/main/1-Propanethiol.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8S
 inchi: InChI=1S/C3H8S/c1-2-3-4/h4H,2-3H2,1H3
 inchi_key: SUVIGLJNEAMWEG-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Propanol.yml
+++ b/input/reference_sets/main/1-Propanol.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8O
 inchi: InChI=1S/C3H8O/c1-2-3-4/h4H,2-3H2,1H3
 inchi_key: BDERNNFJNOPAEC-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Propenyl.yml
+++ b/input/reference_sets/main/1-Propenyl.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   7 H u0 p0 c0 {2,S}
   8 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -67,7 +67,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H5
 inchi: InChI=1S/C3H5/c1-3-2/h1,3H,2H3
 inchi_key: ZLRGTQBGRLOXCT-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Propynyl anion.yml
+++ b/input/reference_sets/main/1-Propynyl anion.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3
 inchi: InChI=1S/C3H3/c1-3-2/h1H3/q-1
 inchi_key: GFCLUZSGMYOHRM-UHFFFAOYSA-N

--- a/input/reference_sets/main/1-Propynyl.yml
+++ b/input/reference_sets/main/1-Propynyl.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3
 inchi: InChI=1S/C3H3/c1-3-2/h1H3
 inchi_key: ZMQKJSOLVPOQHR-UHFFFAOYSA-N

--- a/input/reference_sets/main/11-Dichloroethane.yml
+++ b/input/reference_sets/main/11-Dichloroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H  u0 p0 c0 {3,S}
   8 H  u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4Cl2
 inchi: InChI=1S/C2H4Cl2/c1-2(3)4/h2H,1H3
 inchi_key: SCYULBFZEHDVBN-UHFFFAOYSA-N

--- a/input/reference_sets/main/11-Dichloroethene.yml
+++ b/input/reference_sets/main/11-Dichloroethene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H  u0 p0 c0 {3,S}
   6 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2Cl2
 inchi: InChI=1S/C2H2Cl2/c1-2(3)4/h1H2
 inchi_key: LGXVIGDEPROXKC-UHFFFAOYSA-N

--- a/input/reference_sets/main/11-Difluoroethane.yml
+++ b/input/reference_sets/main/11-Difluoroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4F2
 inchi: InChI=1S/C2H4F2/c1-2(3)4/h2H,1H3
 inchi_key: NPNPZTNLOVBDOC-UHFFFAOYSA-N

--- a/input/reference_sets/main/11-Difluoroethene.yml
+++ b/input/reference_sets/main/11-Difluoroethene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {3,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2F2
 inchi: InChI=1S/C2H2F2/c1-2(3)4/h1H2
 inchi_key: BQCIDUSAKPWEOX-UHFFFAOYSA-N

--- a/input/reference_sets/main/11-Dimethoxyethane.yml
+++ b/input/reference_sets/main/11-Dimethoxyethane.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10O2
 inchi: InChI=1S/C4H10O2/c1-4(5-2)6-3/h4H,1-3H3
 inchi_key: SPEUIVXLLWOEMJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/111-Trichloroethane.yml
+++ b/input/reference_sets/main/111-Trichloroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H  u0 p0 c0 {4,S}
   8 H  u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3Cl3
 inchi: InChI=1S/C2H3Cl3/c1-2(3,4)5/h1H3
 inchi_key: UOCLXMDMGBRAIB-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Butadiene.yml
+++ b/input/reference_sets/main/12-Butadiene.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6
 inchi: InChI=1S/C4H6/c1-3-4-2/h4H,1H2,2H3
 inchi_key: QNRMTGGDHLBXQZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Butanediamine.yml
+++ b/input/reference_sets/main/12-Butanediamine.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {1,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H12N2
 inchi: InChI=1S/C4H12N2/c1-2-4(6)3-5/h4H,2-3,5-6H2,1H3
 inchi_key: ULEAQRIQMIQDPJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Diaminopropane.yml
+++ b/input/reference_sets/main/12-Diaminopropane.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {1,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H10N2
 inchi: InChI=1S/C3H10N2/c1-3(5)2-4/h3H,2,4-5H2,1H3
 inchi_key: AOHJOMMDDJHIJH-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Dichloroethane.yml
+++ b/input/reference_sets/main/12-Dichloroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H  u0 p0 c0 {4,S}
   8 H  u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4Cl2
 inchi: InChI=1S/C2H4Cl2/c3-1-2-4/h1-2H2
 inchi_key: WSLDOOZREJYCGB-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Difluoroacetylene.yml
+++ b/input/reference_sets/main/12-Difluoroacetylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,S} {4,T}
   4 C u0 p0 c0 {2,S} {3,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2F2
 inchi: InChI=1S/C2F2/c3-1-2-4
 inchi_key: BWTZYYGAOGUPFQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Difluoroethane.yml
+++ b/input/reference_sets/main/12-Difluoroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {4,S}
   8 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4F2
 inchi: InChI=1S/C2H4F2/c3-1-2-4/h1-2H2
 inchi_key: AHFMSNDOYCFEPH-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Dimethoxyethane.yml
+++ b/input/reference_sets/main/12-Dimethoxyethane.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10O2
 inchi: InChI=1S/C4H10O2/c1-5-3-4-6-2/h3-4H2,1-2H3
 inchi_key: XTHFKEDIFFGKHM-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Ethanedithiol.yml
+++ b/input/reference_sets/main/12-Ethanedithiol.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {1,S}
   10 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6S2
 inchi: InChI=1S/C2H6S2/c3-1-2-4/h3-4H,1-2H2
 inchi_key: VYMPLPIFKRHAAC-UHFFFAOYSA-N

--- a/input/reference_sets/main/12-Propadienyl anion.yml
+++ b/input/reference_sets/main/12-Propadienyl anion.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3
 inchi: InChI=1S/C3H3/c1-3-2/h1H,2H2/q-1
 inchi_key: XPVBHDCWRJTAOG-UHFFFAOYSA-N

--- a/input/reference_sets/main/13-Benzodithiole-2-thione.yml
+++ b/input/reference_sets/main/13-Benzodithiole-2-thione.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {9,S}
   14 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H4S3
 inchi: InChI=1S/C7H4S3/c8-7-9-5-3-1-2-4-6(5)10-7/h1-4H
 inchi_key: PTYIRFMMOVOESN-UHFFFAOYSA-N

--- a/input/reference_sets/main/13-Butadiene.yml
+++ b/input/reference_sets/main/13-Butadiene.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6
 inchi: InChI=1S/C4H6/c1-3-4-2/h3-4H,1-2H2
 inchi_key: KAKZBPTYRLMSJV-UHFFFAOYSA-N

--- a/input/reference_sets/main/13-Butadiyne.yml
+++ b/input/reference_sets/main/13-Butadiyne.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {3,S}
   6 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H2
 inchi: InChI=1S/C4H2/c1-3-4-2/h1-2H
 inchi_key: LLCSWKVOHICRDD-UHFFFAOYSA-N

--- a/input/reference_sets/main/13-Dithiane-2-thione.yml
+++ b/input/reference_sets/main/13-Dithiane-2-thione.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {5,S}
   10 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H4S3
 inchi: InChI=1S/C3H4S3/c4-3-5-1-2-6-3/h1-2H2
 inchi_key: XCWPBWWTGHQKDR-UHFFFAOYSA-N

--- a/input/reference_sets/main/13-Propanedithiol.yml
+++ b/input/reference_sets/main/13-Propanedithiol.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {1,S}
   13 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8S2
 inchi: InChI=1S/C3H8S2/c4-2-1-3-5/h4-5H,1-3H2
 inchi_key: ZJLMKPKYJBQJNH-UHFFFAOYSA-N

--- a/input/reference_sets/main/135-Triazine.yml
+++ b/input/reference_sets/main/135-Triazine.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {5,S}
   9 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3N3
 inchi: InChI=1S/C3H3N3/c1-4-2-6-3-5-1/h1-3H
 inchi_key: JIHQDMXYYFUGFV-UHFFFAOYSA-N

--- a/input/reference_sets/main/135-Trioxane.yml
+++ b/input/reference_sets/main/135-Trioxane.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6O3
 inchi: InChI=1S/C3H6O3/c1-4-2-6-3-5-1/h1-3H2
 inchi_key: BGJSXRVXTHVRSN-UHFFFAOYSA-N

--- a/input/reference_sets/main/14-Butanedithiol.yml
+++ b/input/reference_sets/main/14-Butanedithiol.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {1,S}
   16 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10S2
 inchi: InChI=1S/C4H10S2/c5-3-1-2-4-6/h5-6H,1-4H2
 inchi_key: SMTOKHQOVJRXLK-UHFFFAOYSA-N

--- a/input/reference_sets/main/14-Difluorobenzene.yml
+++ b/input/reference_sets/main/14-Difluorobenzene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {7,S}
   12 H u0 p0 c0 {8,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H4F2
 inchi: InChI=1S/C6H4F2/c7-5-1-2-6(8)4-3-5/h1-4H
 inchi_key: QUGUFLJIAFISSW-UHFFFAOYSA-N

--- a/input/reference_sets/main/14-Dioxane.yml
+++ b/input/reference_sets/main/14-Dioxane.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {6,S}
   14 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8O2
 inchi: InChI=1S/C4H8O2/c1-2-6-4-3-5-1/h1-4H2
 inchi_key: RYHBNJHYFVUHQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/15-Hexadiene.yml
+++ b/input/reference_sets/main/15-Hexadiene.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H10
 inchi: InChI=1S/C6H10/c1-3-5-6-4-2/h3-4H,1-2,5-6H2
 inchi_key: PYGSKMBEVAICCR-UHFFFAOYSA-N

--- a/input/reference_sets/main/1H-124-Triazole.yml
+++ b/input/reference_sets/main/1H-124-Triazole.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {4,S}
   8 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3N3
 inchi: InChI=1S/C2H3N3/c1-3-2-5-4-1/h1-2H,(H,3,4,5)
 inchi_key: NSPMIYGKQJPBQR-UHFFFAOYSA-N

--- a/input/reference_sets/main/1H-Imidazole.yml
+++ b/input/reference_sets/main/1H-Imidazole.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {4,S}
   9 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H4N2
 inchi: InChI=1S/C3H4N2/c1-2-5-3-4-1/h1-3H,(H,4,5)
 inchi_key: RAXXELZNTBOGNW-UHFFFAOYSA-N

--- a/input/reference_sets/main/1H-Pyrazole.yml
+++ b/input/reference_sets/main/1H-Pyrazole.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {1,S}
   9 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H4N2
 inchi: InChI=1S/C3H4N2/c1-2-4-5-3-1/h1-3H,(H,4,5)
 inchi_key: WTKZEGDFNFYCGP-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-(Methylthio)propane.yml
+++ b/input/reference_sets/main/2-(Methylthio)propane.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10S
 inchi: InChI=1S/C4H10S/c1-4(2)5-3/h4H,1-3H3
 inchi_key: ROSSIHMZZJOVOU-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Bromoethanol.yml
+++ b/input/reference_sets/main/2-Bromoethanol.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H  u0 p0 c0 {4,S}
   9 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5BrO
 inchi: InChI=1S/C2H5BrO/c3-1-2-4/h4H,1-2H2
 inchi_key: LDLCZOVUSADOIV-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Butanethiol.yml
+++ b/input/reference_sets/main/2-Butanethiol.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {4,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10S
 inchi: InChI=1S/C4H10S/c1-3-4(2)5/h4-5H,3H2,1-2H3
 inchi_key: LOCHFZBWPCLPAN-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Butyne.yml
+++ b/input/reference_sets/main/2-Butyne.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {2,S}
   10 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6
 inchi: InChI=1S/C4H6/c1-3-4-2/h1-2H3
 inchi_key: XNMQEEKYCVKGBD-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Butynedinitrile.yml
+++ b/input/reference_sets/main/2-Butynedinitrile.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 C u0 p0 c0 {1,T} {3,S}
   6 C u0 p0 c0 {2,T} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4N2
 inchi: InChI=1S/C4N2/c5-3-1-2-4-6
 inchi_key: ZEHZNAXXOOYTJM-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Chlorobutane.yml
+++ b/input/reference_sets/main/2-Chlorobutane.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H  u0 p0 c0 {5,S}
   14 H  u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9Cl
 inchi: InChI=1S/C4H9Cl/c1-3-4(2)5/h4H,3H2,1-2H3
 inchi_key: BSPCSKHALVHRSR-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Chloroethanol.yml
+++ b/input/reference_sets/main/2-Chloroethanol.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H  u0 p0 c0 {4,S}
   9 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5ClO
 inchi: InChI=1S/C2H5ClO/c3-1-2-4/h4H,1-2H2
 inchi_key: SZIFAVKTNFCBPC-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Hydroxyethyl.yml
+++ b/input/reference_sets/main/2-Hydroxyethyl.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -67,7 +67,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5O
 inchi: InChI=1S/C2H5O/c1-2-3/h3H,1-2H2
 inchi_key: HVFGPIFTSJJAKK-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methoxypropane.yml
+++ b/input/reference_sets/main/2-Methoxypropane.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10O
 inchi: InChI=1S/C4H10O/c1-4(2)5-3/h4H,1-3H3
 inchi_key: RMGHERXMTMUMMV-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-1-butanethiol.yml
+++ b/input/reference_sets/main/2-Methyl-1-butanethiol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {5,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-3-5(2)4-6/h5-6H,3-4H2,1-2H3
 inchi_key: WGQKBCSACFQGQY-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-1-propanamine.yml
+++ b/input/reference_sets/main/2-Methyl-1-propanamine.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {1,S}
   16 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H11N
 inchi: InChI=1S/C4H11N/c1-4(2)3-5/h4H,3,5H2,1-2H3
 inchi_key: KDSNLYIMUZNERS-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-1-propanethiol.yml
+++ b/input/reference_sets/main/2-Methyl-1-propanethiol.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10S
 inchi: InChI=1S/C4H10S/c1-4(2)3-5/h4-5H,3H2,1-2H3
 inchi_key: BDFAOUQQXJIZDG-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-1-propanol.yml
+++ b/input/reference_sets/main/2-Methyl-1-propanol.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10O
 inchi: InChI=1S/C4H10O/c1-4(2)3-5/h4-5H,3H2,1-2H3
 inchi_key: ZXEKIIBDNHEJCQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-12-propanediamine.yml
+++ b/input/reference_sets/main/2-Methyl-12-propanediamine.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {1,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H12N2
 inchi: InChI=1S/C4H12N2/c1-4(2,6)3-5/h3,5-6H2,1-2H3
 inchi_key: OPCJOXGBLDJWRM-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-2-(methylthio)propane.yml
+++ b/input/reference_sets/main/2-Methyl-2-(methylthio)propane.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-5(2,3)6-4/h1-4H3
 inchi_key: CJFVCTVYZFTORU-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-2-butanethiol.yml
+++ b/input/reference_sets/main/2-Methyl-2-butanethiol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {5,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-4-5(2,3)6/h6H,4H2,1-3H3
 inchi_key: IQIBYAHJXQVQGB-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-2-propanamine.yml
+++ b/input/reference_sets/main/2-Methyl-2-propanamine.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {1,S}
   16 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H11N
 inchi: InChI=1S/C4H11N/c1-4(2,3)5/h5H2,1-3H3
 inchi_key: YBRBMKDOPFTVDT-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-2-propanethiol.yml
+++ b/input/reference_sets/main/2-Methyl-2-propanethiol.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10S
 inchi: InChI=1S/C4H10S/c1-4(2,3)5/h5H,1-3H3
 inchi_key: WMXCDAVJEZZYLT-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methyl-2H-tetrazole.yml
+++ b/input/reference_sets/main/2-Methyl-2H-tetrazole.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {5,S}
   10 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4N4
 inchi: InChI=1S/C2H4N4/c1-6-4-2-3-5-6/h2H,1H3
 inchi_key: VRESBNUEIKZECD-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methylpropanamide.yml
+++ b/input/reference_sets/main/2-Methylpropanamide.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {2,S}
   15 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9NO
 inchi: InChI=1S/C4H9NO/c1-3(2)4(5)6/h3H,1-2H3,(H2,5,6)
 inchi_key: WFKAJVHLWXSISD-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Methylthiophene.yml
+++ b/input/reference_sets/main/2-Methylthiophene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {5,S}
   12 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H6S
 inchi: InChI=1S/C5H6S/c1-5-3-2-4-6-5/h2-4H,1H3
 inchi_key: XQQBUAPQHNYYRS-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Propanethiol.yml
+++ b/input/reference_sets/main/2-Propanethiol.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8S
 inchi: InChI=1S/C3H8S/c1-3(2)4/h3-4H,1-2H3
 inchi_key: KJRCEJOSASVSRA-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Propanol.yml
+++ b/input/reference_sets/main/2-Propanol.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8O
 inchi: InChI=1S/C3H8O/c1-3(2)4/h3-4H,1-2H3
 inchi_key: KFZMGEQAYNKOFK-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Propynyl.yml
+++ b/input/reference_sets/main/2-Propynyl.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3
 inchi: InChI=1S/C3H3/c1-3-2/h1H,2H2
 inchi_key: DITHIFQMPPCBCU-UHFFFAOYSA-N

--- a/input/reference_sets/main/2-Propynylidyne.yml
+++ b/input/reference_sets/main/2-Propynylidyne.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 C u1 p1 c0 {1,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H
 inchi: InChI=1S/C3H/c1-3-2/h1H
 inchi_key: WWDRUPNDOSDMRD-UHFFFAOYSA-N

--- a/input/reference_sets/main/22-Dimethyl-1-propanethiol.yml
+++ b/input/reference_sets/main/22-Dimethyl-1-propanethiol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-5(2,3)4-6/h6H,4H2,1-3H3
 inchi_key: LSUXMVNABVPWMF-UHFFFAOYSA-N

--- a/input/reference_sets/main/23-Butanedione.yml
+++ b/input/reference_sets/main/23-Butanedione.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6O2
 inchi: InChI=1S/C4H6O2/c1-3(5)4(2)6/h1-2H3
 inchi_key: QSJXEFYPDANLFS-UHFFFAOYSA-N

--- a/input/reference_sets/main/23-Dihydrothiophene.yml
+++ b/input/reference_sets/main/23-Dihydrothiophene.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {4,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6S
 inchi: InChI=1S/C4H6S/c1-2-4-5-3-1/h1,3H,2,4H2
 inchi_key: OXBLVCZKDOZZOJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/23-Dimethylbutane.yml
+++ b/input/reference_sets/main/23-Dimethylbutane.yml
@@ -21,7 +21,7 @@ adjacency_list: |
   19 H u0 p0 c0 {6,S}
   20 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -138,7 +138,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H14
 inchi: InChI=1S/C6H14/c1-5(2)6(3)4/h5-6H,1-4H3
 inchi_key: ZFFMLCVRJBZUDZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/25-Dihydrothiophene.yml
+++ b/input/reference_sets/main/25-Dihydrothiophene.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {4,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6S
 inchi: InChI=1S/C4H6S/c1-2-4-5-3-1/h1-2H,3-4H2
 inchi_key: WURYWHAKEJHAOV-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Ethylsulphinyl-1-propene.yml
+++ b/input/reference_sets/main/3-Ethylsulphinyl-1-propene.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {7,S}
   17 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10OS
 inchi: InChI=1S/C5H10OS/c1-3-5-7(6)4-2/h3H,1,4-5H2,2H3
 inchi_key: VKINGXBHBOPFOA-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Methyl-1-butanethiol.yml
+++ b/input/reference_sets/main/3-Methyl-1-butanethiol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-5(2)3-4-6/h5-6H,3-4H2,1-2H3
 inchi_key: GIJGXNFNUUFEGH-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Methyl-2-butanethiol.yml
+++ b/input/reference_sets/main/3-Methyl-2-butanethiol.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {5,S}
   18 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-4(2)5(3)6/h4-6H,1-3H3
 inchi_key: BFLXFRNPNMTTAA-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Methyl-2-butanone.yml
+++ b/input/reference_sets/main/3-Methyl-2-butanone.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {5,S}
   16 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10O
 inchi: InChI=1S/C5H10O/c1-4(2)5(3)6/h4H,1-3H3
 inchi_key: SYBYTAAJFKOIEJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Methylenepentane.yml
+++ b/input/reference_sets/main/3-Methylenepentane.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H12
 inchi: InChI=1S/C6H12/c1-4-6(3)5-2/h3-5H2,1-2H3
 inchi_key: RYKZRKKEYSRDNF-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Methylisoxazole.yml
+++ b/input/reference_sets/main/3-Methylisoxazole.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {5,S}
   11 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H5NO
 inchi: InChI=1S/C4H5NO/c1-4-2-3-6-5-4/h2-3H,1H3
 inchi_key: CUMCMYMKECWGHO-UHFFFAOYSA-N

--- a/input/reference_sets/main/3-Methylthiophene.yml
+++ b/input/reference_sets/main/3-Methylthiophene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {5,S}
   12 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H6S
 inchi: InChI=1S/C5H6S/c1-5-2-3-6-4-5/h2-4H,1H3
 inchi_key: QENGPZGAWFQWCZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/34-Dihydro-2H-pyran.yml
+++ b/input/reference_sets/main/34-Dihydro-2H-pyran.yml
@@ -15,13 +15,13 @@ adjacency_list: |
   13 H u0 p0 c0 {5,S}
   14 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -29.4061561397096
+        value: -29.40615613970959
       class: ThermoData
     xyz_dict:
       coords:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H8O
 inchi: InChI=1S/C5H8O/c1-2-4-6-5-3-1/h2,4H,1,3,5H2
 inchi_key: BUDQDWGNQVEFAC-UHFFFAOYSA-N

--- a/input/reference_sets/main/4-Methylene-2-oxetanone.yml
+++ b/input/reference_sets/main/4-Methylene-2-oxetanone.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {6,S}
   10 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H4O2
 inchi: InChI=1S/C4H4O2/c1-3-2-4(5)6-3/h1-2H2
 inchi_key: WASQWSOJHCZDFK-UHFFFAOYSA-N

--- a/input/reference_sets/main/4-Methylthiazole.yml
+++ b/input/reference_sets/main/4-Methylthiazole.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {5,S}
   11 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H5NS
 inchi: InChI=1S/C4H5NS/c1-4-2-6-3-5-4/h2-3H,1H3
 inchi_key: QMHIMXFNBOYPND-UHFFFAOYSA-N

--- a/input/reference_sets/main/4-Thiazolecarbonitrile.yml
+++ b/input/reference_sets/main/4-Thiazolecarbonitrile.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {5,S}
   9 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H2N2S
 inchi: InChI=1S/C4H2N2S/c5-1-4-2-7-3-6-4/h2-3H
 inchi_key: PNAFRZGWUVQUKH-UHFFFAOYSA-N

--- a/input/reference_sets/main/45-Dihydro-2-methyl-oxazole.yml
+++ b/input/reference_sets/main/45-Dihydro-2-methyl-oxazole.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {5,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H7NO
 inchi: InChI=1S/C4H7NO/c1-4-5-2-3-6-4/h2-3H2,1H3
 inchi_key: GUXJXWKCUUWCLX-UHFFFAOYSA-N

--- a/input/reference_sets/main/5-Methylisoxazole.yml
+++ b/input/reference_sets/main/5-Methylisoxazole.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {5,S}
   11 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H5NO
 inchi: InChI=1S/C4H5NO/c1-4-2-3-5-6-4/h2-3H,1H3
 inchi_key: AGQOIYCTCOEHGR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetaldehyde.yml
+++ b/input/reference_sets/main/Acetaldehyde.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {2,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4O
 inchi: InChI=1S/C2H4O/c1-2-3/h2H,1H3
 inchi_key: IKHGUXGNUITLKF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetaldoxime.yml
+++ b/input/reference_sets/main/Acetaldoxime.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {4,S}
   9 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5NO
 inchi: InChI=1S/C2H5NO/c1-2-3-4/h2,4H,1H3
 inchi_key: FZENGILVLUJGJX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetic acid.yml
+++ b/input/reference_sets/main/Acetic acid.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4O2
 inchi: InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)
 inchi_key: QTBSBXVTEAMEQO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetone.yml
+++ b/input/reference_sets/main/Acetone.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6O
 inchi: InChI=1S/C3H6O/c1-3(2)4/h1-2H3
 inchi_key: CSCPPACGZOOCGX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetonyl.yml
+++ b/input/reference_sets/main/Acetonyl.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   8 H u0 p0 c0 {4,S}
   9 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -73,7 +73,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H5O
 inchi: InChI=1S/C3H5O/c1-3(2)4/h1H2,2H3
 inchi_key: HNUKTDKISXPDPA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetyl chloride.yml
+++ b/input/reference_sets/main/Acetyl chloride.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H  u0 p0 c0 {3,S}
   7 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3ClO
 inchi: InChI=1S/C2H3ClO/c1-2(3)4/h1H3
 inchi_key: WETWJCDKMRHUPV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetyl.yml
+++ b/input/reference_sets/main/Acetyl.yml
@@ -8,13 +8,13 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -3.4784267734293204
+        value: -3.47842677342932
       class: ThermoData
     xyz_dict:
       coords:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3O
 inchi: InChI=1S/C2H3O/c1-2-3/h1H3
 inchi_key: TUCNEACPLKLKNU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Acetylene.yml
+++ b/input/reference_sets/main/Acetylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2
 inchi: InChI=1S/C2H2/c1-2/h1-2H
 inchi_key: HSFWRNGVRCDJHI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Adamantane.yml
+++ b/input/reference_sets/main/Adamantane.yml
@@ -27,7 +27,7 @@ adjacency_list: |
   25 H u0 p0 c0 {10,S}
   26 H u0 p0 c0 {10,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -174,7 +174,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C10H16
 inchi: InChI=1S/C10H16/c1-7-2-9-4-8(1)5-10(3-7)6-9/h7-10H,1-6H2
 inchi_key: ORILYTVJVMAKLC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Allene.yml
+++ b/input/reference_sets/main/Allene.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {2,S}
   7 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H4
 inchi: InChI=1S/C3H4/c1-3-2/h1-2H2
 inchi_key: IYABWNGZIDDRAK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Allyl.yml
+++ b/input/reference_sets/main/Allyl.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -67,7 +67,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H5
 inchi: InChI=1S/C3H5/c1-3-2/h3H,1-2H2
 inchi_key: RMRFFCXPLWYOOY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Amidogen.yml
+++ b/input/reference_sets/main/Amidogen.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 H u0 p0 c0 {1,S}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2N
 inchi: InChI=1S/H2N/h1H2
 inchi_key: MDFFNEOEWAXZRQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Aminomethyl.yml
+++ b/input/reference_sets/main/Aminomethyl.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4N
 inchi: InChI=1S/CH4N/c1-2/h1-2H2
 inchi_key: XXJGBENTLXFVFI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Aminomethylium.yml
+++ b/input/reference_sets/main/Aminomethylium.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4N
 inchi: InChI=1S/CH4N/c1-2/h1-2H2/q+1
 inchi_key: LEOYJZAFSUBIBE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ammonia.yml
+++ b/input/reference_sets/main/Ammonia.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H3N
 inchi: InChI=1S/H3N/h1H3
 inchi_key: QGZKDVFQNNGYKY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ammonium.yml
+++ b/input/reference_sets/main/Ammonium.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H4N
 inchi_key: QGZKDVFQNNGYKY-UHFFFAOYSA-O
 index: 20

--- a/input/reference_sets/main/Aniline.yml
+++ b/input/reference_sets/main/Aniline.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {1,S}
   14 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H7N
 inchi: InChI=1S/C6H7N/c7-6-4-2-1-3-5-6/h1-5H,7H2
 inchi_key: PAYRUJLWNCNPSJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Anisole.yml
+++ b/input/reference_sets/main/Anisole.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {8,S}
   16 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H8O
 inchi: InChI=1S/C7H8O/c1-8-7-5-3-2-4-6-7/h2-6H,1H3
 inchi_key: RDOXTESZEPMUJZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Azanide.yml
+++ b/input/reference_sets/main/Azanide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 H u0 p0 c0 {1,S}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2N
 inchi: InChI=1S/H2N/h1H2/q-1
 inchi_key: HYGWNUKOUCZBND-UHFFFAOYSA-N

--- a/input/reference_sets/main/Benzaldehyde.yml
+++ b/input/reference_sets/main/Benzaldehyde.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {4,S}
   14 H u0 p0 c0 {8,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H6O
 inchi: InChI=1S/C7H6O/c8-6-7-4-2-1-3-5-7/h1-6H
 inchi_key: HUMNYLRZRPPJDN-UHFFFAOYSA-N

--- a/input/reference_sets/main/Benzene.yml
+++ b/input/reference_sets/main/Benzene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {5,S}
   12 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H6
 inchi: InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H
 inchi_key: UHOVQNZJYSORNB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Benzenethiol.yml
+++ b/input/reference_sets/main/Benzenethiol.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H6S
 inchi: InChI=1S/C6H6S/c7-6-4-2-1-3-5-6/h1-5,7H
 inchi_key: RMVRSNDYEFQCLF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Benzyl.yml
+++ b/input/reference_sets/main/Benzyl.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   13 H u0 p0 c0 {7,S}
   14 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -103,7 +103,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H7
 inchi: InChI=1S/C7H7/c1-7-5-3-2-4-6-7/h2-6H,1H2
 inchi_key: SLRMQYXOBQWXCR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Benzylide.yml
+++ b/input/reference_sets/main/Benzylide.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {5,S}
   14 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H7
 inchi: InChI=1S/C7H7/c1-7-5-3-2-4-6-7/h2-6H,1H2/q-1
 inchi_key: QJHNLKRMBCYQKX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bicyclo1.1.0butane.yml
+++ b/input/reference_sets/main/Bicyclo1.1.0butane.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6
 inchi: InChI=1S/C4H6/c1-3-2-4(1)3/h3-4H,1-2H2
 inchi_key: LASLVGACQUUOEB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bromine monochloride.yml
+++ b/input/reference_sets/main/Bromine monochloride.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Br u0 p3 c0 {2,S}
   2 Cl u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: BrCl
 inchi: InChI=1S/BrCl/c1-2
 inchi_key: CODNYICXDISAEA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bromine monofluoride.yml
+++ b/input/reference_sets/main/Bromine monofluoride.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Br u0 p3 c0 {2,S}
   2 F  u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: BrF
 inchi: InChI=1S/BrF/c1-2
 inchi_key: MZJUGRUTVANEDW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bromine monoxide.yml
+++ b/input/reference_sets/main/Bromine monoxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 Br u0 p3 c0 {2,S}
   2 O  u1 p2 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: BrO
 inchi: InChI=1S/BrO/c1-2
 inchi_key: FMSOWMGJJIHFTQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bromodifluoromethane.yml
+++ b/input/reference_sets/main/Bromodifluoromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 C  u0 p0 c0 {1,S} {2,S} {3,S} {5,S}
   5 H  u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHBrF2
 inchi: InChI=1S/CHBrF2/c2-1(3)4/h1H
 inchi_key: GRCDJFHYVYUNHM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bromotrichloromethane.yml
+++ b/input/reference_sets/main/Bromotrichloromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 Cl u0 p3 c0 {5,S}
   5 C  u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CBrCl3
 inchi: InChI=1S/CBrCl3/c2-1(3,4)5
 inchi_key: XNNQFQFUQLJSQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Bromotrifluoromethane.yml
+++ b/input/reference_sets/main/Bromotrifluoromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 F  u0 p3 c0 {5,S}
   5 C  u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CBrF3
 inchi: InChI=1S/CBrF3/c2-1(3,4)5
 inchi_key: RJCQBQGAPKAMLL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Butanamide.yml
+++ b/input/reference_sets/main/Butanamide.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {2,S}
   15 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9NO
 inchi: InChI=1S/C4H9NO/c1-2-3-4(5)6/h2-3H2,1H3,(H2,5,6)
 inchi_key: DNSISZSEWVHGLH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Carbon dioxide.yml
+++ b/input/reference_sets/main/Carbon dioxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p2 c0 {3,D}
   3 C u0 p0 c0 {1,D} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CO2
 inchi: InChI=1S/CO2/c2-1-3
 inchi_key: CURLTUGMZLYLDI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Carbon disulfide.yml
+++ b/input/reference_sets/main/Carbon disulfide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 S u0 p2 c0 {3,D}
   3 C u0 p0 c0 {1,D} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CS2
 inchi: InChI=1S/CS2/c2-1-3
 inchi_key: QGJOPFRUJISHPQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Carbon monoxide.yml
+++ b/input/reference_sets/main/Carbon monoxide.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 C u0 p1 c-1 {2,T}
   2 O u0 p1 c+1 {1,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CO
 inchi: InChI=1S/CO/c1-2
 inchi_key: UGFAIRIUMAVXCW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Carbonic acid.yml
+++ b/input/reference_sets/main/Carbonic acid.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O3
 inchi: InChI=1S/CH2O3/c2-1(3)4/h(H2,2,3,4)
 inchi_key: BVKZGUZCCUSVTD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Carbonoxidesulfide.yml
+++ b/input/reference_sets/main/Carbonoxidesulfide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p2 c0 {3,D}
   3 C u0 p0 c0 {1,D} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: COS
 inchi: InChI=1S/COS/c2-1-3
 inchi_key: JJWKPURADFRFRB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chlorine fluoride.yml
+++ b/input/reference_sets/main/Chlorine fluoride.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Cl u0 p3 c0 {2,S}
   2 F  u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClF
 inchi: InChI=1S/ClF/c1-2
 inchi_key: OMRRUNXAWXNVFW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chlorine monoxide.yml
+++ b/input/reference_sets/main/Chlorine monoxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 Cl u0 p3 c0 {2,S}
   2 O  u1 p2 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClO
 inchi: InChI=1S/ClO/c1-2
 inchi_key: NHYCGSASNAIGLD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloro hypochlorite.yml
+++ b/input/reference_sets/main/Chloro hypochlorite.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 Cl u0 p3 c0 {3,S}
   3 O  u0 p2 c0 {1,S} {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: Cl2O
 inchi: InChI=1S/Cl2O/c1-3-2
 inchi_key: RCJVRSBWZCNNQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloroacetylene.yml
+++ b/input/reference_sets/main/Chloroacetylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C  u0 p0 c0 {1,S} {2,T}
   4 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2HCl
 inchi: InChI=1S/C2HCl/c1-2-3/h1H
 inchi_key: DIWKDXFZXXCDLF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chlorobenzene.yml
+++ b/input/reference_sets/main/Chlorobenzene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H  u0 p0 c0 {6,S}
   12 H  u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5Cl
 inchi: InChI=1S/C6H5Cl/c7-6-4-2-1-3-5-6/h1-5H
 inchi_key: MVPPADPHJFYWMZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chlorodioxidanyl.yml
+++ b/input/reference_sets/main/Chlorodioxidanyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 O  u0 p2 c0 {1,S} {3,S}
   3 O  u1 p2 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClO2
 inchi: InChI=1S/ClO2/c1-3-2
 inchi_key: ASCHNMXUWBEZDM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloroethane.yml
+++ b/input/reference_sets/main/Chloroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H  u0 p0 c0 {3,S}
   8 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5Cl
 inchi: InChI=1S/C2H5Cl/c1-2-3/h2H2,1H3
 inchi_key: HRYZWHHZPQKTII-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloroform.yml
+++ b/input/reference_sets/main/Chloroform.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 C  u0 p0 c0 {1,S} {2,S} {3,S} {5,S}
   5 H  u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHCl3
 inchi: InChI=1S/CHCl3/c2-1(3)4/h1H
 inchi_key: HEDRZPFGACZZDS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloroformyl.yml
+++ b/input/reference_sets/main/Chloroformyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 O  u0 p2 c0 {3,D}
   3 C  u1 p0 c0 {1,S} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CClO
 inchi: InChI=1S/CClO/c2-1-3
 inchi_key: DDKMFOUTRRODRE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloromethane.yml
+++ b/input/reference_sets/main/Chloromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H  u0 p0 c0 {2,S}
   5 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3Cl
 inchi: InChI=1S/CH3Cl/c1-2/h1H3
 inchi_key: NEHMKBQYUWJMIP-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloromethyl.yml
+++ b/input/reference_sets/main/Chloromethyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H  u0 p0 c0 {2,S}
   4 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2Cl
 inchi: InChI=1S/CH2Cl/c1-2/h1H2
 inchi_key: WBLIXGSTEMXDSM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chloromethylene.yml
+++ b/input/reference_sets/main/Chloromethylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 C  u0 p1 c0 {1,S} {3,S}
   3 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHCl
 inchi: InChI=1S/CHCl/c1-2/h1H
 inchi_key: LKYXEULZVGJVTG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chlorooxy hypochlorite.yml
+++ b/input/reference_sets/main/Chlorooxy hypochlorite.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O  u0 p2 c0 {1,S} {4,S}
   4 O  u0 p2 c0 {2,S} {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: Cl2O2
 inchi: InChI=1S/Cl2O2/c1-3-4-2
 inchi_key: MAYPHUUCLRDEAZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Chlorotrifluoromethane.yml
+++ b/input/reference_sets/main/Chlorotrifluoromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 F  u0 p3 c0 {5,S}
   5 C  u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CClF3
 inchi: InChI=1S/CClF3/c2-1(3,4)5
 inchi_key: AFYPFACVUDMOHA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyanato.yml
+++ b/input/reference_sets/main/Cyanato.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 N u0 p1 c0 {3,T}
   3 C u0 p0 c0 {1,S} {2,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CNO
 inchi: InChI=1S/CNO/c2-1-3
 inchi_key: HKKDKUMUWRTAIA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyanic acid.yml
+++ b/input/reference_sets/main/Cyanic acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,S} {2,T}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHNO
 inchi: InChI=1S/CHNO/c2-1-3/h3H
 inchi_key: XLJMAIOERFSOGZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyanic fluoride.yml
+++ b/input/reference_sets/main/Cyanic fluoride.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 N u0 p1 c0 {3,T}
   3 C u0 p0 c0 {1,S} {2,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CFN
 inchi: InChI=1S/CFN/c2-1-3
 inchi_key: CPPKAGUPTKIMNP-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyanide.yml
+++ b/input/reference_sets/main/Cyanide.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 N u0 p1 c0 {2,T}
   2 C u0 p1 c-1 {1,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CN
 inchi: InChI=1S/CN/c1-2/q-1
 inchi_key: XFXPMWWXUTWYJX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyanogen chloride.yml
+++ b/input/reference_sets/main/Cyanogen chloride.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 N  u0 p1 c0 {3,T}
   3 C  u0 p0 c0 {1,S} {2,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CClN
 inchi: InChI=1S/CClN/c2-1-3
 inchi_key: QPJDMGCKMHUXFD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyanogen.yml
+++ b/input/reference_sets/main/Cyanogen.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,T} {4,S}
   4 C u0 p0 c0 {2,T} {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2N2
 inchi: InChI=1S/C2N2/c3-1-2-4
 inchi_key: JMANVNJQNLATNU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclobutane.yml
+++ b/input/reference_sets/main/Cyclobutane.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8
 inchi: InChI=1S/C4H8/c1-2-4-3-1/h1-4H2
 inchi_key: PMPVIKIVABFJJI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclobutene.yml
+++ b/input/reference_sets/main/Cyclobutene.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6
 inchi: InChI=1S/C4H6/c1-2-4-3-1/h1-2H,3-4H2
 inchi_key: CFBGXYDUODCMNS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclobutylamine.yml
+++ b/input/reference_sets/main/Cyclobutylamine.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {1,S}
   14 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9N
 inchi: InChI=1S/C4H9N/c5-4-2-1-3-4/h4H,1-3,5H2
 inchi_key: KZZKOVLJUKWSKX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclohexane.yml
+++ b/input/reference_sets/main/Cyclohexane.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H12
 inchi: InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2
 inchi_key: XDTMQSROBMDMFD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclohexanone.yml
+++ b/input/reference_sets/main/Cyclohexanone.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {6,S}
   17 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H10O
 inchi: InChI=1S/C6H10O/c7-6-4-2-1-3-5-6/h1-5H2
 inchi_key: JHIVVAPYMSGYDF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopentadiene.yml
+++ b/input/reference_sets/main/Cyclopentadiene.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {4,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H6
 inchi: InChI=1S/C5H6/c1-2-4-5-3-1/h1-4H,5H2
 inchi_key: ZSWFCLXCOIISFI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopentanamine.yml
+++ b/input/reference_sets/main/Cyclopentanamine.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {1,S}
   17 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H11N
 inchi: InChI=1S/C5H11N/c6-5-3-1-2-4-5/h5H,1-4,6H2
 inchi_key: NISGSNTVMOOSJQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopentane.yml
+++ b/input/reference_sets/main/Cyclopentane.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10
 inchi: InChI=1S/C5H10/c1-2-4-5-3-1/h1-5H2
 inchi_key: RGSFGYAAUTVSQA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopentanethiol.yml
+++ b/input/reference_sets/main/Cyclopentanethiol.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {4,S}
   16 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10S
 inchi: InChI=1S/C5H10S/c6-5-3-1-2-4-5/h5-6H,1-4H2
 inchi_key: WVDYBOADDMMFIY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopentene.yml
+++ b/input/reference_sets/main/Cyclopentene.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H8
 inchi: InChI=1S/C5H8/c1-2-4-5-3-1/h1-2H,3-5H2
 inchi_key: LPIQUOYDBNQMRZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cycloprop-1-enyl.yml
+++ b/input/reference_sets/main/Cycloprop-1-enyl.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3
 inchi: InChI=1S/C3H3/c1-2-3-1/h1H,2H2
 inchi_key: WRZQDSZUHZJIHC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cycloprop-2-enyl.yml
+++ b/input/reference_sets/main/Cycloprop-2-enyl.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H3
 inchi: InChI=1S/C3H3/c1-2-3-1/h1-3H
 inchi_key: UKPXULFIISGBHG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopropane.yml
+++ b/input/reference_sets/main/Cyclopropane.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6
 inchi: InChI=1S/C3H6/c1-2-3-1/h1-3H2
 inchi_key: LVZWSLJZHVFIQJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopropanecarbonitrile.yml
+++ b/input/reference_sets/main/Cyclopropanecarbonitrile.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H5N
 inchi: InChI=1S/C4H5N/c5-3-4-1-2-4/h4H,1-2H2
 inchi_key: AUQDITHEDVOTCU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopropene.yml
+++ b/input/reference_sets/main/Cyclopropene.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {2,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H4
 inchi: InChI=1S/C3H4/c1-2-3-1/h1-2H,3H2
 inchi_key: OOXWYYGXTJLWHA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Cyclopropenylidene.yml
+++ b/input/reference_sets/main/Cyclopropenylidene.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H2
 inchi: InChI=1S/C3H2/c1-2-3-1/h1-2H
 inchi_key: VVLPCWSYZYKZKR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Diazenyl.yml
+++ b/input/reference_sets/main/Diazenyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 N u1 p1 c0 {1,D}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HN2
 inchi: InChI=1S/HN2/c1-2/h1H
 inchi_key: NALBLJLOBICXRH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Diazynium.yml
+++ b/input/reference_sets/main/Diazynium.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 N u0 p1 c0 {1,T}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HN2
 inchi_key: IJGRMHOSHXDMSA-UHFFFAOYSA-O
 index: 50

--- a/input/reference_sets/main/Dibromine.yml
+++ b/input/reference_sets/main/Dibromine.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Br u0 p3 c0 {2,S}
   2 Br u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: Br2
 inchi: InChI=1S/Br2/c1-2
 inchi_key: GDTBXPJZTBHREO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dibromophosgene.yml
+++ b/input/reference_sets/main/Dibromophosgene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O  u0 p2 c0 {4,D}
   4 C  u0 p0 c0 {1,S} {2,S} {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CBr2O
 inchi: InChI=1S/CBr2O/c2-1(3)4
 inchi_key: MOIPGXQKZSZOQX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dichlorine.yml
+++ b/input/reference_sets/main/Dichlorine.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Cl u0 p3 c0 {2,S}
   2 Cl u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: Cl2
 inchi: InChI=1S/Cl2/c1-2
 inchi_key: KZBUYRJDOAKODT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dichloroacetylene.yml
+++ b/input/reference_sets/main/Dichloroacetylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C  u0 p0 c0 {1,S} {4,T}
   4 C  u0 p0 c0 {2,S} {3,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2Cl2
 inchi: InChI=1S/C2Cl2/c3-1-2-4
 inchi_key: ZMJOVJSTYLQINE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dichloromethane.yml
+++ b/input/reference_sets/main/Dichloromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H  u0 p0 c0 {3,S}
   5 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2Cl2
 inchi: InChI=1S/CH2Cl2/c2-1-3/h1H2
 inchi_key: YMWUJEATGCHHMB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dichloromethyl.yml
+++ b/input/reference_sets/main/Dichloromethyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 C  u1 p0 c0 {1,S} {2,S} {4,S}
   4 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHCl2
 inchi: InChI=1S/CHCl2/c2-1-3/h1H
 inchi_key: ZJULYDCRWUEPTK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dichloromethylene.yml
+++ b/input/reference_sets/main/Dichloromethylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 Cl u0 p3 c0 {3,S}
   3 C  u0 p1 c0 {1,S} {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CCl2
 inchi: InChI=1S/CCl2/c2-1-3
 inchi_key: PFBUKDPBVNJDEW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Diethyl sulfoxide.yml
+++ b/input/reference_sets/main/Diethyl sulfoxide.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10OS
 inchi: InChI=1S/C4H10OS/c1-3-6(5)4-2/h3-4H2,1-2H3
 inchi_key: CCAFPWNGIUBUSD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Diethylhydroxylamine.yml
+++ b/input/reference_sets/main/Diethylhydroxylamine.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {6,S}
   17 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H11NO
 inchi: InChI=1S/C4H11NO/c1-3-5(6)4-2/h6H,3-4H2,1-2H3
 inchi_key: FVCOIAYSJZGECG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Difluorine.yml
+++ b/input/reference_sets/main/Difluorine.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 F u0 p3 c0 {2,S}
   2 F u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: F2
 inchi: InChI=1S/F2/c1-2
 inchi_key: PXGOKWXKJXAPGV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Difluorodichloromethane.yml
+++ b/input/reference_sets/main/Difluorodichloromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 F  u0 p3 c0 {5,S}
   5 C  u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CCl2F2
 inchi: InChI=1S/CCl2F2/c2-1(3,4)5
 inchi_key: PXBRQCKWGAHEHS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Difluorodioxidane.yml
+++ b/input/reference_sets/main/Difluorodioxidane.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O u0 p2 c0 {1,S} {4,S}
   4 O u0 p2 c0 {2,S} {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: F2O2
 inchi: InChI=1S/F2O2/c1-3-4-2
 inchi_key: REAOZOPEJGPVCB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Difluoromethylene.yml
+++ b/input/reference_sets/main/Difluoromethylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 F u0 p3 c0 {3,S}
   3 C u0 p1 c0 {1,S} {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CF2
 inchi: InChI=1S/CF2/c2-1-3
 inchi_key: LTVOKYUPTHZZQH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Difluorophosgene.yml
+++ b/input/reference_sets/main/Difluorophosgene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O u0 p2 c0 {4,D}
   4 C u0 p0 c0 {1,S} {2,S} {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CF2O
 inchi: InChI=1S/CF2O/c2-1(3)4
 inchi_key: IYRWEQXVUNLMAY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dihydro-2-(3H)-thiophenone.yml
+++ b/input/reference_sets/main/Dihydro-2-(3H)-thiophenone.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {5,S}
   12 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6OS
 inchi: InChI=1S/C4H6OS/c5-4-2-1-3-6-4/h1-3H2
 inchi_key: KMSNYNIWEORQDJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dihydro-3-(2H)-thiophenone.yml
+++ b/input/reference_sets/main/Dihydro-3-(2H)-thiophenone.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {5,S}
   12 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6OS
 inchi: InChI=1S/C4H6OS/c5-4-1-2-6-3-4/h1-3H2
 inchi_key: DSXFPRKPFJRPIB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dihydrogen.yml
+++ b/input/reference_sets/main/Dihydrogen.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 H u0 p0 c0 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2
 inchi: InChI=1S/H2/h1H
 inchi_key: UFHFLCQGNIYNRP-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethoxymethane.yml
+++ b/input/reference_sets/main/Dimethoxymethane.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {5,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8O2
 inchi: InChI=1S/C3H8O2/c1-4-3-5-2/h3H2,1-2H3
 inchi_key: NKDDWNXOKDWJAK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethyl disulfide.yml
+++ b/input/reference_sets/main/Dimethyl disulfide.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6S2
 inchi: InChI=1S/C2H6S2/c1-3-4-2/h1-2H3
 inchi_key: WQOXQRCZOLPYPM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethyl ester sulfurous acid.yml
+++ b/input/reference_sets/main/Dimethyl ester sulfurous acid.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6O3S
 inchi: InChI=1S/C2H6O3S/c1-4-6(3)5-2/h1-2H3
 inchi_key: BDUPRNVPXOHWIL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethyl ether.yml
+++ b/input/reference_sets/main/Dimethyl ether.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6O
 inchi: InChI=1S/C2H6O/c1-3-2/h1-2H3
 inchi_key: LCGLNKUTAGEVQW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethyl sulfate.yml
+++ b/input/reference_sets/main/Dimethyl sulfate.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {7,S}
   13 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6O4S
 inchi: InChI=1S/C2H6O4S/c1-5-7(3,4)6-2/h1-2H3
 inchi_key: VAYGXNSJCAHWJZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethyl sulfide.yml
+++ b/input/reference_sets/main/Dimethyl sulfide.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6S
 inchi: InChI=1S/C2H6S/c1-3-2/h1-2H3
 inchi_key: QMMFVYPAHWMCMS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethyl sulfoxide.yml
+++ b/input/reference_sets/main/Dimethyl sulfoxide.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6OS
 inchi: InChI=1S/C2H6OS/c1-4(2)3/h1-2H3
 inchi_key: IAZDPXIOMUYVGZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dimethylamine.yml
+++ b/input/reference_sets/main/Dimethylamine.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H7N
 inchi: InChI=1S/C2H7N/c1-3-2/h3H,1-2H3
 inchi_key: ROSDSFDQCJNGOL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dinitrogen dioxide.yml
+++ b/input/reference_sets/main/Dinitrogen dioxide.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 N u0 p1 c0 {1,D} {4,S}
   4 N u0 p1 c0 {2,D} {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: N2O2
 inchi: InChI=1S/N2O2/c3-1-2-4
 inchi_key: AZLYZRGJCVQKKK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dinitrogen pentoxide.yml
+++ b/input/reference_sets/main/Dinitrogen pentoxide.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 N u0 p0 c+1 {1,S} {2,S} {4,D}
   7 N u0 p0 c+1 {1,S} {3,S} {5,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: N2O5
 inchi: InChI=1S/N2O5/c3-1(4)7-2(5)6
 inchi_key: ZWWCURLKEXEFQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dinitrogen tetraoxide.yml
+++ b/input/reference_sets/main/Dinitrogen tetraoxide.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 N u0 p0 c+1 {1,S} {3,D} {6,S}
   6 N u0 p0 c+1 {2,S} {4,D} {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: N2O4
 inchi: InChI=1S/N2O4/c3-1(4)2(5)6
 inchi_key: WFPZPJSADLPSON-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dinitrogen trioxide.yml
+++ b/input/reference_sets/main/Dinitrogen trioxide.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 N u0 p0 c+1 {1,S} {2,D} {5,S}
   5 N u0 p1 c0 {3,D} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: N2O3
 inchi: InChI=1S/N2O3/c3-1-2(4)5
 inchi_key: LZDSILRDTDCIQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dinitrogen.yml
+++ b/input/reference_sets/main/Dinitrogen.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 N u0 p1 c0 {2,T}
   2 N u0 p1 c0 {1,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: N2
 inchi: InChI=1S/N2/c1-2
 inchi_key: IJGRMHOSHXDMSA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dioxidanide.yml
+++ b/input/reference_sets/main/Dioxidanide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p3 c-1 {1,S}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HO2
 inchi_key: MHAJPDPJQMAIIY-UHFFFAOYSA-M
 index: 46

--- a/input/reference_sets/main/Dioxidanyl.yml
+++ b/input/reference_sets/main/Dioxidanyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 O u0 p2 c0 {1,S} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HO2
 inchi: InChI=1S/HO2/c1-2/h1H
 inchi_key: OUUQCZGPVNCOIJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dioxirane.yml
+++ b/input/reference_sets/main/Dioxirane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {3,S}
   5 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O2
 inchi: InChI=1S/CH2O2/c1-2-3-1/h1H2
 inchi_key: ASQQEOXYFGEFKQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dioxygen.yml
+++ b/input/reference_sets/main/Dioxygen.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 O u1 p2 c0 {2,S}
   2 O u1 p2 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: O2
 inchi: InChI=1S/O2/c1-2
 inchi_key: MYMOFIZGZYHOMD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Dioxymethyl.yml
+++ b/input/reference_sets/main/Dioxymethyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {3,S}
   5 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O2
 inchi: InChI=1S/CH2O2/c1-3-2/h1H2
 inchi_key: SBHHFAIXPSFQLT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Disulfur monoxide.yml
+++ b/input/reference_sets/main/Disulfur monoxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 S u0 p2 c0 {1,D}
   3 O u0 p2 c0 {1,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: OS2
 inchi: InChI=1S/OS2/c1-3-2
 inchi_key: TXKMVPPZCYKFAC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Disulfur.yml
+++ b/input/reference_sets/main/Disulfur.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 S u1 p2 c0 {2,S}
   2 S u1 p2 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: S2
 inchi: InChI=1S/S2/c1-2
 inchi_key: MAHNFPMIPQKPPI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethane.yml
+++ b/input/reference_sets/main/Ethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {2,S}
   8 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6
 inchi: InChI=1S/C2H6/c1-2/h1-2H3
 inchi_key: OTMSDBZUPAUEDD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethanedithioamide.yml
+++ b/input/reference_sets/main/Ethanedithioamide.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4N2S2
 inchi: InChI=1S/C2H4N2S2/c3-1(5)2(4)6/h(H2,3,5)(H2,4,6)
 inchi_key: OAEGRYMCJYIXQT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethanethiol.yml
+++ b/input/reference_sets/main/Ethanethiol.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6S
 inchi: InChI=1S/C2H6S/c1-2-3/h3H,2H2,1H3
 inchi_key: DNJIEGIFACGWOD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethanol.yml
+++ b/input/reference_sets/main/Ethanol.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6O
 inchi: InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3
 inchi_key: LFQSCWFLJHTTHZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethenol.yml
+++ b/input/reference_sets/main/Ethenol.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {3,S}
   7 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4O
 inchi: InChI=1S/C2H4O/c1-2-3/h2-3H,1H2
 inchi_key: IMROMDMJAWUWLK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethoxide.yml
+++ b/input/reference_sets/main/Ethoxide.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5O
 inchi: InChI=1S/C2H5O/c1-2-3/h2H2,1H3/q-1
 inchi_key: HHFAWKCIHAUFRX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethoxy.yml
+++ b/input/reference_sets/main/Ethoxy.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -67,7 +67,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5O
 inchi: InChI=1S/C2H5O/c1-2-3/h2H2,1H3
 inchi_key: VOLGAXAGEUPBDM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethoxyacetonitrile.yml
+++ b/input/reference_sets/main/Ethoxyacetonitrile.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {5,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H7NO
 inchi: InChI=1S/C4H7NO/c1-2-6-4-3-5/h2,4H2,1H3
 inchi_key: WPYUCWSMVJJWFI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethoxyethene.yml
+++ b/input/reference_sets/main/Ethoxyethene.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {5,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8O
 inchi: InChI=1S/C4H8O/c1-3-5-4-2/h3H,1,4H2,2H3
 inchi_key: FJKIXWOMBXYWOQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethyl acetate.yml
+++ b/input/reference_sets/main/Ethyl acetate.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {5,S}
   14 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8O2
 inchi: InChI=1S/C4H8O2/c1-3-6-4(2)5/h3H2,1-2H3
 inchi_key: XEKOWRVHYACXOJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethyl bromide.yml
+++ b/input/reference_sets/main/Ethyl bromide.yml
@@ -9,13 +9,13 @@ adjacency_list: |
   7 H  u0 p0 c0 {3,S}
   8 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -15.330396538813995
+        value: -15.33039653881399
       class: ThermoData
     xyz_dict:
       coords:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5Br
 inchi: InChI=1S/C2H5Br/c1-2-3/h2H2,1H3
 inchi_key: RDHPKYGYEGBMSE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethyl methyl sulfite.yml
+++ b/input/reference_sets/main/Ethyl methyl sulfite.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {7,S}
   15 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8O3S
 inchi: InChI=1S/C3H8O3S/c1-3-6-7(4)5-2/h3H2,1-2H3
 inchi_key: FMQCKJHUYDYTMA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethyl propyl sulfide.yml
+++ b/input/reference_sets/main/Ethyl propyl sulfide.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {5,S}
   18 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12S
 inchi: InChI=1S/C5H12S/c1-3-5-6-4-2/h3-5H2,1-2H3
 inchi_key: ZDDDFDQTSXYYSE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethyl.yml
+++ b/input/reference_sets/main/Ethyl.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   6 H u0 p0 c0 {1,S}
   7 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -61,7 +61,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5
 inchi: InChI=1S/C2H5/c1-2/h1H2,2H3
 inchi_key: QUPDWYMUPZLYJZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylbenzene.yml
+++ b/input/reference_sets/main/Ethylbenzene.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {8,S}
   18 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C8H10
 inchi: InChI=1S/C8H10/c1-2-8-6-4-3-5-7-8/h3-7H,2H2,1H3
 inchi_key: YNQLUTRBYVCPMQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylcyclobutane.yml
+++ b/input/reference_sets/main/Ethylcyclobutane.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H12
 inchi: InChI=1S/C6H12/c1-2-6-4-3-5-6/h6H,2-5H2,1H3
 inchi_key: NEZRFXZYPAIZAD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylene glycol.yml
+++ b/input/reference_sets/main/Ethylene glycol.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {1,S}
   10 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H6O2
 inchi: InChI=1S/C2H6O2/c3-1-2-4/h3-4H,1-2H2
 inchi_key: LYCAIKOWRPUZTN-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylene.yml
+++ b/input/reference_sets/main/Ethylene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4
 inchi: InChI=1S/C2H4/c1-2/h1-2H2
 inchi_key: VGGSQFUCUMXWEO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylenediamine.yml
+++ b/input/reference_sets/main/Ethylenediamine.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {2,S}
   12 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H8N2
 inchi: InChI=1S/C2H8N2/c3-1-2-4/h1-4H2
 inchi_key: PIICEJLVQHRZGT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylidene.yml
+++ b/input/reference_sets/main/Ethylidene.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4
 inchi: InChI=1S/C2H4/c1-2/h1H,2H3
 inchi_key: UUFQTNFCRMXOAE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethylidyne.yml
+++ b/input/reference_sets/main/Ethylidyne.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3
 inchi: InChI=1S/C2H3/c1-2/h1H3
 inchi_key: ADLIKHXOGUAKPM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ethynol anion.yml
+++ b/input/reference_sets/main/Ethynol anion.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,D} {4,D}
   4 O u0 p2 c0 {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2HO
 inchi: InChI=1S/C2HO/c1-2-3/h1H/q-1
 inchi_key: BSJVBKBNZLEKLO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluoroacetylene.yml
+++ b/input/reference_sets/main/Fluoroacetylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,S} {2,T}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2HF
 inchi: InChI=1S/C2HF/c1-2-3/h1H
 inchi_key: IAWCIZWLKMTPLL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluorobenzene.yml
+++ b/input/reference_sets/main/Fluorobenzene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5F
 inchi: InChI=1S/C6H5F/c7-6-4-2-1-3-5-6/h1-5H
 inchi_key: PYLWMHQQBFSUBP-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluorodioxidanyl.yml
+++ b/input/reference_sets/main/Fluorodioxidanyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 O u0 p2 c0 {1,S} {3,S}
   3 O u1 p2 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: FO2
 inchi: InChI=1S/FO2/c1-3-2
 inchi_key: GQRAHKRZRKCZPQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluoroethane.yml
+++ b/input/reference_sets/main/Fluoroethane.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5F
 inchi: InChI=1S/C2H5F/c1-2-3/h2H2,1H3
 inchi_key: UHCBBWUQDAVSMS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluoroform.yml
+++ b/input/reference_sets/main/Fluoroform.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 C u0 p0 c0 {1,S} {2,S} {3,S} {5,S}
   5 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHF3
 inchi: InChI=1S/CHF3/c2-1(3)4/h1H
 inchi_key: XPDWGBQVDMORPB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluoroformyl.yml
+++ b/input/reference_sets/main/Fluoroformyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 O u0 p2 c0 {3,D}
   3 C u1 p0 c0 {1,S} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CFO
 inchi: InChI=1S/CFO/c2-1-3
 inchi_key: CJXGPJZUDUOZDX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluoromethylene.yml
+++ b/input/reference_sets/main/Fluoromethylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 C u0 p1 c0 {1,S} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHF
 inchi: InChI=1S/CHF/c1-2/h1H
 inchi_key: YUCFVHQCAFKDQG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluoromethylidyne.yml
+++ b/input/reference_sets/main/Fluoromethylidyne.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 F u0 p3 c0 {2,S}
   2 C u1 p1 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CF
 inchi: InChI=1S/CF/c1-2
 inchi_key: ISOSXCFSIDVNNC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fluorooxidanyl.yml
+++ b/input/reference_sets/main/Fluorooxidanyl.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 F u0 p3 c0 {2,S}
   2 O u1 p2 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: FO
 inchi: InChI=1S/FO/c1-2
 inchi_key: FXOFAYKVTOLJTJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formaldehyde cation.yml
+++ b/input/reference_sets/main/Formaldehyde cation.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O
 inchi: InChI=1S/CH2O/c1-2/h1H2/q+1
 inchi_key: SAJCHROCEMQFHF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formaldehyde.yml
+++ b/input/reference_sets/main/Formaldehyde.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {2,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O
 inchi: InChI=1S/CH2O/c1-2/h1H2
 inchi_key: WSFSSNUMVMOOMR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formate.yml
+++ b/input/reference_sets/main/Formate.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,S} {2,D} {4,S}
   4 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO2
 inchi_key: BDAGIHXWWSANSR-UHFFFAOYSA-M
 index: 121

--- a/input/reference_sets/main/Formic acid.yml
+++ b/input/reference_sets/main/Formic acid.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {3,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O2
 inchi: InChI=1S/CH2O2/c2-1-3/h1H,(H,2,3)
 inchi_key: BDAGIHXWWSANSR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formyl anion.yml
+++ b/input/reference_sets/main/Formyl anion.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 H u0 p0 c0 {1,S}
   3 O u0 p2 c0 {1,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO
 inchi: InChI=1S/CHO/c1-2/h1H/q-1
 inchi_key: CKJNUZNMWOVDFN-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formyl chloride.yml
+++ b/input/reference_sets/main/Formyl chloride.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C  u0 p0 c0 {1,S} {2,D} {4,S}
   4 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHClO
 inchi: InChI=1S/CHClO/c2-1-3/h1H
 inchi_key: GFAUNYMRSKVDJL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formyl fluoride.yml
+++ b/input/reference_sets/main/Formyl fluoride.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,S} {2,D} {4,S}
   4 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHFO
 inchi: InChI=1S/CHFO/c2-1-3/h1H
 inchi_key: NHGVZTMBVDFPHJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formyl.yml
+++ b/input/reference_sets/main/Formyl.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 C u1 p0 c0 {1,D} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO
 inchi: InChI=1S/CHO/c1-2/h1H
 inchi_key: CFHIDWOYWUOIHU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Formyloxidanyl.yml
+++ b/input/reference_sets/main/Formyloxidanyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,S} {2,D} {4,S}
   4 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO2
 inchi: InChI=1S/CHO2/c2-1-3/h1H
 inchi_key: JRCLCXAVSVCEQC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fulminic acid.yml
+++ b/input/reference_sets/main/Fulminic acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p1 c-1 {2,T}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHNO
 inchi: InChI=1S/CHNO/c1-2-3/h3H
 inchi_key: OTXBWGUYZNKPMG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Fulvene.yml
+++ b/input/reference_sets/main/Fulvene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H6
 inchi: InChI=1S/C6H6/c1-6-4-2-3-5-6/h2-5H,1H2
 inchi_key: PGTKVMVZBBZCKQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Furan.yml
+++ b/input/reference_sets/main/Furan.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {4,S}
   9 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H4O
 inchi: InChI=1S/C4H4O/c1-2-4-5-3-1/h1-4H
 inchi_key: YLQBMQCUIZJEEH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Glyoxal.yml
+++ b/input/reference_sets/main/Glyoxal.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {3,S}
   6 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2O2
 inchi: InChI=1S/C2H2O2/c3-1-2-4/h1-2H
 inchi_key: LEQAOMBKQFMDFZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrazine.yml
+++ b/input/reference_sets/main/Hydrazine.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H4N2
 inchi: InChI=1S/H4N2/c1-2/h1-2H2
 inchi_key: OAKJQQAXSVQMHS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrazinecarbothioamide.yml
+++ b/input/reference_sets/main/Hydrazinecarbothioamide.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH5N3S
 inchi: InChI=1S/CH5N3S/c2-1(5)4-3/h3H2,(H3,2,4,5)
 inchi_key: BRWIZMBXBAOCCF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrazino.yml
+++ b/input/reference_sets/main/Hydrazino.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H3N2
 inchi: InChI=1S/H3N2/c1-2/h1H,2H2
 inchi_key: LURQBQNWDYASPJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrazoic acid.yml
+++ b/input/reference_sets/main/Hydrazoic acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 N u0 p2 c-1 {2,D}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HN3
 inchi: InChI=1S/HN3/c1-3-2/h1H
 inchi_key: JUINSXZKUKVTMD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen bromide.yml
+++ b/input/reference_sets/main/Hydrogen bromide.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Br u0 p3 c0 {2,S}
   2 H  u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: BrH
 inchi: InChI=1S/BrH/h1H
 inchi_key: CPELXLSAUQHCOX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen chloride.yml
+++ b/input/reference_sets/main/Hydrogen chloride.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Cl u0 p3 c0 {2,S}
   2 H  u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClH
 inchi: InChI=1S/ClH/h1H
 inchi_key: VEXZGXHMUGYJMC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen cyanide.yml
+++ b/input/reference_sets/main/Hydrogen cyanide.yml
@@ -4,13 +4,13 @@ adjacency_list: |
   2 C u0 p0 c0 {1,T} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: 30.90145886796683
+        value: 30.901458867966817
       class: ThermoData
     xyz_dict:
       coords:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHN
 inchi: InChI=1S/CHN/c1-2/h1H
 inchi_key: LELOWRISYMNNSU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen fluoride.yml
+++ b/input/reference_sets/main/Hydrogen fluoride.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 F u0 p3 c0 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: FH
 inchi: InChI=1S/FH/h1H
 inchi_key: KRHYYFGTRYWZRS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen isocyanide.yml
+++ b/input/reference_sets/main/Hydrogen isocyanide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 C u0 p1 c-1 {1,T}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHN
 inchi: InChI=1S/CHN/c1-2/h2H
 inchi_key: QIUBLANJVAOHHY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen peroxide.yml
+++ b/input/reference_sets/main/Hydrogen peroxide.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2O2
 inchi: InChI=1S/H2O2/c1-2/h1-2H
 inchi_key: MHAJPDPJQMAIIY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydrogen sulfide.yml
+++ b/input/reference_sets/main/Hydrogen sulfide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 H u0 p0 c0 {1,S}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2S
 inchi: InChI=1S/H2S/h1H2
 inchi_key: RWSOTUBLDIXVET-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxide.yml
+++ b/input/reference_sets/main/Hydroxide.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 O u0 p3 c-1 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HO
 inchi_key: XLYOFNOQVPJJNP-UHFFFAOYSA-M
 index: 3

--- a/input/reference_sets/main/Hydroxyformyl.yml
+++ b/input/reference_sets/main/Hydroxyformyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 C u1 p0 c0 {1,S} {2,D}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO2
 inchi: InChI=1S/CHO2/c2-1-3/h(H,2,3)
 inchi_key: ORTFAQDWJHRMNX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxyl.yml
+++ b/input/reference_sets/main/Hydroxyl.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 O u1 p2 c0 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HO
 inchi: InChI=1S/HO/h1H
 inchi_key: TUJKJAMUKRIRHC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxylamine.yml
+++ b/input/reference_sets/main/Hydroxylamine.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H3NO
 inchi: InChI=1S/H3NO/c1-2/h2H,1H2
 inchi_key: AVXURJPOCDRRFD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxymethyl.yml
+++ b/input/reference_sets/main/Hydroxymethyl.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3O
 inchi: InChI=1S/CH3O/c1-2/h2H,1H2
 inchi_key: CBOIHMRHGLHBPB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxymethylene.yml
+++ b/input/reference_sets/main/Hydroxymethylene.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {2,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2O
 inchi: InChI=1S/CH2O/c1-2/h1-2H
 inchi_key: UUOIGPDTLYBNGY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxymethylium.yml
+++ b/input/reference_sets/main/Hydroxymethylium.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3O
 inchi: InChI=1S/CH3O/c1-2/h2H,1H2/q+1
 inchi_key: NRCYHMDIJIIHBJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hydroxyoxomethylium.yml
+++ b/input/reference_sets/main/Hydroxyoxomethylium.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c+1 {1,S} {2,D}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO2
 inchi: InChI=1S/CHO2/c2-1-3/h(H,2,3)/q+1
 inchi_key: CLJFDRKGHKJAKZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hypobromite.yml
+++ b/input/reference_sets/main/Hypobromite.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 Br u0 p3 c0 {2,S}
   2 O  u0 p3 c-1 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: BrO
 inchi: InChI=1S/BrO/c1-2/q-1
 inchi_key: JGJLWPGRMCADHB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hypobromous acid.yml
+++ b/input/reference_sets/main/Hypobromous acid.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O  u0 p2 c0 {1,S} {3,S}
   3 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: BrHO
 inchi: InChI=1S/BrHO/c1-2/h2H
 inchi_key: CUILPNURFADTPE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hypochlorous acid.yml
+++ b/input/reference_sets/main/Hypochlorous acid.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O  u0 p2 c0 {1,S} {3,S}
   3 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClHO
 inchi: InChI=1S/ClHO/c1-2/h2H
 inchi_key: QWPPOHNGKGFGJK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hypoflorous acid.yml
+++ b/input/reference_sets/main/Hypoflorous acid.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p2 c0 {1,S} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: FHO
 inchi: InChI=1S/FHO/c1-2/h2H
 inchi_key: AQYSYJUIMQTRMV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Hypofluorite.yml
+++ b/input/reference_sets/main/Hypofluorite.yml
@@ -3,7 +3,7 @@ adjacency_list: |
   1 F u0 p3 c0 {2,S}
   2 O u0 p3 c-1 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -30,7 +30,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: FO
 inchi: InChI=1S/FO/c1-2/q-1
 inchi_key: VMUWIFNDNXXSQA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Imidogen.yml
+++ b/input/reference_sets/main/Imidogen.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 N u2 p1 c0 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HN
 inchi: InChI=1S/HN/h1H
 inchi_key: PDCKRJPYJMCOFO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Iminomethyl.yml
+++ b/input/reference_sets/main/Iminomethyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {2,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2N
 inchi: InChI=1S/CH2N/c1-2/h1-2H
 inchi_key: GNMFKYYLBRTFHL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Isobutene.yml
+++ b/input/reference_sets/main/Isobutene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {4,S}
   12 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8
 inchi: InChI=1S/C4H8/c1-4(2)3/h1H2,2-3H3
 inchi_key: VQTUBCCKSQIDNK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Isocyanic acid.yml
+++ b/input/reference_sets/main/Isocyanic acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,D} {2,D}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHNO
 inchi: InChI=1S/CHNO/c2-1-3/h2H
 inchi_key: OWIKHYCFFJSOEH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Isofulminic acid.yml
+++ b/input/reference_sets/main/Isofulminic acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 C u0 p0 c0 {2,T} {4,S}
   4 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHNO
 inchi: InChI=1S/CHNO/c1-2-3/h1H
 inchi_key: UXKUODQYLDZXDL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Isoprene.yml
+++ b/input/reference_sets/main/Isoprene.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H8
 inchi: InChI=1S/C5H8/c1-4-5(2)3/h4H,1-2H2,3H3
 inchi_key: RRHGJUQNOFWUDK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ketene.yml
+++ b/input/reference_sets/main/Ketene.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2O
 inchi: InChI=1S/C2H2O/c1-2-3/h1H2
 inchi_key: CCGKOQOJPYTBIH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Malononitrile.yml
+++ b/input/reference_sets/main/Malononitrile.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {3,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H2N2
 inchi: InChI=1S/C3H2N2/c4-2-1-3-5/h1H2
 inchi_key: CUONGYYJJVDODC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Metadifluorobenzene.yml
+++ b/input/reference_sets/main/Metadifluorobenzene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {8,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H4F2
 inchi: InChI=1S/C6H4F2/c7-5-2-1-3-6(8)4-5/h1-4H
 inchi_key: UEMGWPRHOOEKTA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methane.yml
+++ b/input/reference_sets/main/Methane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4
 inchi: InChI=1S/CH4/h1H4
 inchi_key: VNWKTOKETHGBQD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methanethiol.yml
+++ b/input/reference_sets/main/Methanethiol.yml
@@ -7,13 +7,13 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -7.039550217165975
+        value: -7.039550217165974
       class: ThermoData
     xyz_dict:
       coords:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4S
 inchi: InChI=1S/CH4S/c1-2/h2H,1H3
 inchi_key: LSDPWZHWYPCBBB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methanide.yml
+++ b/input/reference_sets/main/Methanide.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3
 inchi: InChI=1S/CH3/h1H3/q-1
 inchi_key: LGRLWUINFJPLSH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methanimine.yml
+++ b/input/reference_sets/main/Methanimine.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3N
 inchi: InChI=1S/CH3N/c1-2/h2H,1H2
 inchi_key: WDWDWGRYHDPSDS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methanol.yml
+++ b/input/reference_sets/main/Methanol.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {1,S}
   6 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4O
 inchi: InChI=1S/CH4O/c1-2/h2H,1H3
 inchi_key: OKKJLVBELUTLKV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methoxide.yml
+++ b/input/reference_sets/main/Methoxide.yml
@@ -6,13 +6,13 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -30.5880090181618
+        value: -30.588009018161788
       class: ThermoData
     xyz_dict:
       coords:
@@ -48,7 +48,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3O
 inchi: InChI=1S/CH3O/c1-2/h1H3/q-1
 inchi_key: NBTOZLQBSIZIKS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methoxy.yml
+++ b/input/reference_sets/main/Methoxy.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3O
 inchi: InChI=1S/CH3O/c1-2/h1H3
 inchi_key: GRVDJDISBSALJP-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methoxyacetonitrile.yml
+++ b/input/reference_sets/main/Methoxyacetonitrile.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H5NO
 inchi: InChI=1S/C3H5NO/c1-5-3-2-4/h3H2,1H3
 inchi_key: QKPVEISEHYYHRH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl bromide.yml
+++ b/input/reference_sets/main/Methyl bromide.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H  u0 p0 c0 {2,S}
   5 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3Br
 inchi: InChI=1S/CH3Br/c1-2/h1H3
 inchi_key: GZUXJHMPEANEGY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl fluoride.yml
+++ b/input/reference_sets/main/Methyl fluoride.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3F
 inchi: InChI=1S/CH3F/c1-2/h1H3
 inchi_key: NBVXSUQYWXRMNV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl formate.yml
+++ b/input/reference_sets/main/Methyl formate.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4O2
 inchi: InChI=1S/C2H4O2/c1-4-2-3/h2H,1H3
 inchi_key: TZIHFWKZFHZASV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl hydroperoxide.yml
+++ b/input/reference_sets/main/Methyl hydroperoxide.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {3,S}
   7 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4O2
 inchi: InChI=1S/CH4O2/c1-3-2/h2H,1H3
 inchi_key: MEUKEBNAABNAEX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl nitrate.yml
+++ b/input/reference_sets/main/Methyl nitrate.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {5,S}
   8 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3NO3
 inchi: InChI=1S/CH3NO3/c1-5-2(3)4/h1H3
 inchi_key: LRMHVVPPGGOAJQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl nitrite.yml
+++ b/input/reference_sets/main/Methyl nitrite.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {4,S}
   7 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3NO2
 inchi: InChI=1S/CH3NO2/c1-4-2-3/h1H3
 inchi_key: BLLFVUPNHCTMSV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl propyl ether.yml
+++ b/input/reference_sets/main/Methyl propyl ether.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {5,S}
   15 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10O
 inchi: InChI=1S/C4H10O/c1-3-4-5-2/h3-4H2,1-2H3
 inchi_key: VNKYTQGIUYNRMY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyl.yml
+++ b/input/reference_sets/main/Methyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3
 inchi: InChI=1S/CH3/h1H3
 inchi_key: WCYWZMWISLQXQU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylamidogen anion.yml
+++ b/input/reference_sets/main/Methylamidogen anion.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4N
 inchi: InChI=1S/CH4N/c1-2/h2H,1H3/q-1
 inchi_key: MGJXBDMLVWIYOQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylamidogen.yml
+++ b/input/reference_sets/main/Methylamidogen.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4N
 inchi: InChI=1S/CH4N/c1-2/h2H,1H3
 inchi_key: YKPQUSLRUFLVDA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylamine.yml
+++ b/input/reference_sets/main/Methylamine.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {1,S}
   7 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH5N
 inchi: InChI=1S/CH5N/c1-2/h2H2,1H3
 inchi_key: BAVYZALUXZFZLV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylcyclopentane.yml
+++ b/input/reference_sets/main/Methylcyclopentane.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {6,S}
   18 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H12
 inchi: InChI=1S/C6H12/c1-6-4-2-3-5-6/h6H,2-5H2,1H3
 inchi_key: GDOPTJXRTPNYNR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylene fluoride.yml
+++ b/input/reference_sets/main/Methylene fluoride.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {3,S}
   5 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2F2
 inchi: InChI=1S/CH2F2/c2-1-3/h1H2
 inchi_key: RWRIWBAIICGTTQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylene.yml
+++ b/input/reference_sets/main/Methylene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 H u0 p0 c0 {1,S}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2
 inchi: InChI=1S/CH2/h1H2
 inchi_key: HZVOZRGWRWCICA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyleneamidogen anion.yml
+++ b/input/reference_sets/main/Methyleneamidogen anion.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {2,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2N
 inchi: InChI=1S/CH2N/c1-2/h1H2/q-1
 inchi_key: BUKKEXYZFWWAOA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methyleneamidogen.yml
+++ b/input/reference_sets/main/Methyleneamidogen.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {2,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH2N
 inchi: InChI=1S/CH2N/c1-2/h1H2
 inchi_key: PZIDJKOIMRBQLL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylidyne.yml
+++ b/input/reference_sets/main/Methylidyne.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 C u1 p1 c0 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH
 inchi: InChI=1S/CH/h1H
 inchi_key: VRLIPUYDFBXWCH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylium.yml
+++ b/input/reference_sets/main/Methylium.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3
 inchi: InChI=1S/CH3/h1H3/q+1
 inchi_key: JUHDUIDUEUEQND-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylperoxy anion.yml
+++ b/input/reference_sets/main/Methylperoxy anion.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {3,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3O2
 inchi_key: MEUKEBNAABNAEX-UHFFFAOYSA-M
 index: 159

--- a/input/reference_sets/main/Methylperoxy.yml
+++ b/input/reference_sets/main/Methylperoxy.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {3,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3O2
 inchi: InChI=1S/CH3O2/c1-3-2/h1H3
 inchi_key: WTFNSXYULBQCQV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Methylthiirane.yml
+++ b/input/reference_sets/main/Methylthiirane.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6S
 inchi: InChI=1S/C3H6S/c1-3-2-4-3/h3H,2H2,1H3
 inchi_key: MBNVSWHUJDDZRH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrate.yml
+++ b/input/reference_sets/main/Nitrate.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O u0 p2 c0 {4,D}
   4 N u0 p0 c+1 {1,S} {2,S} {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: NO3
 inchi: InChI=1S/NO3/c2-1(3)4/q-1
 inchi_key: NHNBFGGVMKEFGY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitric acid.yml
+++ b/input/reference_sets/main/Nitric acid.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 N u0 p0 c+1 {1,S} {2,S} {3,D}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HNO3
 inchi: InChI=1S/HNO3/c2-1(3)4/h(H,2,3,4)
 inchi_key: GRYLNZFGIOXLOG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitric oxide.yml
+++ b/input/reference_sets/main/Nitric oxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 N u1 p1 c0 {2,D}
   2 O u0 p2 c0 {1,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: 'NO'
 inchi: InChI=1S/NO/c1-2
 inchi_key: MWUXSHHQAYIFBG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrilomethyl.yml
+++ b/input/reference_sets/main/Nitrilomethyl.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 N u0 p1 c0 {2,T}
   2 C u1 p0 c0 {1,T}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CN
 inchi: InChI=1S/CN/c1-2
 inchi_key: JEVCWSUVFOYBFI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrite.yml
+++ b/input/reference_sets/main/Nitrite.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p2 c0 {3,D}
   3 N u0 p1 c0 {1,S} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: NO2
 inchi_key: IOVCWXUNBOPUCH-UHFFFAOYSA-M
 index: 99

--- a/input/reference_sets/main/Nitrobenzene.yml
+++ b/input/reference_sets/main/Nitrobenzene.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {9,S}
   14 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5NO2
 inchi: InChI=1S/C6H5NO2/c8-7(9)6-4-2-1-3-5-6/h1-5H
 inchi_key: LQNUZADURLCDLV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrogen dioxide.yml
+++ b/input/reference_sets/main/Nitrogen dioxide.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   2 O u0 p2 c0 {3,D}
   3 N u0 p1 c0 {1,S} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -37,7 +37,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: NO2
 inchi: InChI=1S/NO2/c2-1-3
 inchi_key: JCXJVPUVTGWSNB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitromethane.yml
+++ b/input/reference_sets/main/Nitromethane.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {4,S}
   7 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH3NO2
 inchi: InChI=1S/CH3NO2/c1-2(3)4/h1H3
 inchi_key: LYGJENNIWJXYER-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitronium.yml
+++ b/input/reference_sets/main/Nitronium.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p2 c0 {3,D}
   3 N u0 p0 c+1 {1,D} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: NO2
 inchi: InChI=1S/NO2/c2-1-3/q+1
 inchi_key: OMBRFUXPXNIUCZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrooxidanyl.yml
+++ b/input/reference_sets/main/Nitrooxidanyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 O u0 p2 c0 {4,D}
   4 N u0 p0 c+1 {1,S} {2,S} {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: NO3
 inchi: InChI=1S/NO3/c2-1(3)4
 inchi_key: YPJKMVATUPSWOH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrosyl chloride.yml
+++ b/input/reference_sets/main/Nitrosyl chloride.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O  u0 p2 c0 {3,D}
   3 N  u0 p1 c0 {1,S} {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClNO
 inchi: InChI=1S/ClNO/c1-2-3
 inchi_key: VPCDQGACGWYTMC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrosyl hydride.yml
+++ b/input/reference_sets/main/Nitrosyl hydride.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 N u0 p1 c0 {1,D} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HNO
 inchi: InChI=1S/HNO/c1-2/h1H
 inchi_key: ODUCDPQEXGNKDN-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrous acid.yml
+++ b/input/reference_sets/main/Nitrous acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 N u0 p1 c0 {1,S} {2,D}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HNO2
 inchi: InChI=1S/HNO2/c2-1-3/h(H,2,3)
 inchi_key: IOVCWXUNBOPUCH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitrous oxide.yml
+++ b/input/reference_sets/main/Nitrous oxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 N u0 p0 c+1 {1,D} {3,D}
   3 N u0 p2 c-1 {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: N2O
 inchi: InChI=1S/N2O/c1-2-3
 inchi_key: GQPLMRYTRLFLPF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitroxyl.yml
+++ b/input/reference_sets/main/Nitroxyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {2,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2NO
 inchi: InChI=1S/H2NO/c1-2/h1H2
 inchi_key: YLFIGGHWWPSIEG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Nitryl chloride.yml
+++ b/input/reference_sets/main/Nitryl chloride.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O  u0 p2 c0 {4,D}
   4 N  u0 p0 c+1 {1,S} {2,S} {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClNO2
 inchi: InChI=1S/ClNO2/c1-2(3)4
 inchi_key: HVZWVEKIQMJYIK-UHFFFAOYSA-N

--- a/input/reference_sets/main/Octasulfur.yml
+++ b/input/reference_sets/main/Octasulfur.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 S u0 p2 c0 {6,S} {8,S}
   8 S u0 p2 c0 {1,S} {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: S8
 inchi: InChI=1S/S8/c1-2-4-6-8-7-5-3-1
 inchi_key: JLQNHALFVCURHW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Orthodifluorobenzene.yml
+++ b/input/reference_sets/main/Orthodifluorobenzene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H4F2
 inchi: InChI=1S/C6H4F2/c7-5-3-1-2-4-6(5)8/h1-4H
 inchi_key: GOYDNIKZWGIXJT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Oxetane.yml
+++ b/input/reference_sets/main/Oxetane.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6O
 inchi: InChI=1S/C3H6O/c1-2-4-3-1/h1-3H2
 inchi_key: AHHWIHXENZJRFG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Oxirane.yml
+++ b/input/reference_sets/main/Oxirane.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {3,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4O
 inchi: InChI=1S/C2H4O/c1-2-3-1/h1-2H2
 inchi_key: IAYPIBMASNFSPL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Oxoethenyl.yml
+++ b/input/reference_sets/main/Oxoethenyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 C u0 p0 c0 {1,D} {2,D}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2HO
 inchi: InChI=1S/C2HO/c1-2-3/h1H
 inchi_key: QEJQAPYSVNHDJF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Oxomethylium.yml
+++ b/input/reference_sets/main/Oxomethylium.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 C u0 p0 c+1 {1,D} {3,S}
   3 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CHO
 inchi: InChI=1S/CHO/c1-2/h1H/q+1
 inchi_key: XPRMKTHGXOVKEH-UHFFFAOYSA-N

--- a/input/reference_sets/main/Oxonium.yml
+++ b/input/reference_sets/main/Oxonium.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H3O
 inchi_key: XLYOFNOQVPJJNP-UHFFFAOYSA-O
 index: 17

--- a/input/reference_sets/main/Oxygen difluoride.yml
+++ b/input/reference_sets/main/Oxygen difluoride.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 F u0 p3 c0 {3,S}
   3 O u0 p2 c0 {1,S} {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: F2O
 inchi: InChI=1S/F2O/c1-3-2
 inchi_key: UJMWVICAENGCRF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Ozone.yml
+++ b/input/reference_sets/main/Ozone.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p1 c+1 {1,S} {3,D}
   3 O u0 p2 c0 {2,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: O3
 inchi: InChI=1S/O3/c1-3-2
 inchi_key: CBENFWSGALASAD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Peroxyhypochlorous acid.yml
+++ b/input/reference_sets/main/Peroxyhypochlorous acid.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O  u0 p2 c0 {1,S} {2,S}
   4 H  u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: ClHO2
 inchi: InChI=1S/ClHO2/c1-3-2/h2H
 inchi_key: HSLBPQGVXMOSRA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Peroxynitrous acid.yml
+++ b/input/reference_sets/main/Peroxynitrous acid.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 N u0 p1 c0 {1,S} {3,D}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HNO3
 inchi: InChI=1S/HNO3/c2-1-4-3/h3H
 inchi_key: CMFNMSMUKZHDEY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phenide.yml
+++ b/input/reference_sets/main/Phenide.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {4,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5
 inchi: InChI=1S/C6H5/c1-2-4-6-5-3-1/h1-5H/q-1
 inchi_key: BJISZDCMBMQNIY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phenol.yml
+++ b/input/reference_sets/main/Phenol.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H6O
 inchi: InChI=1S/C6H6O/c7-6-4-2-1-3-5-6/h1-5,7H
 inchi_key: ISWSIDIOOBJBQZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phenolate.yml
+++ b/input/reference_sets/main/Phenolate.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5O
 inchi_key: ISWSIDIOOBJBQZ-UHFFFAOYSA-M
 index: 393

--- a/input/reference_sets/main/Phenoxy.yml
+++ b/input/reference_sets/main/Phenoxy.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   11 H u0 p0 c0 {6,S}
   12 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -91,7 +91,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5O
 inchi: InChI=1S/C6H5O/c7-6-4-2-1-3-5-6/h1-5H
 inchi_key: KHUXNRRPPZOJPT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phenyl.yml
+++ b/input/reference_sets/main/Phenyl.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   10 H u0 p0 c0 {4,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -85,7 +85,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5
 inchi: InChI=1S/C6H5/c1-2-4-6-5-3-1/h1-5H
 inchi_key: CIUQDSCDWFSTQR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phenylethene.yml
+++ b/input/reference_sets/main/Phenylethene.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {8,S}
   16 H u0 p0 c0 {8,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C8H8
 inchi: InChI=1S/C8H8/c1-2-8-6-4-3-5-7-8/h2-7H,1H2
 inchi_key: PPBRXRYQALVLMV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phenylium.yml
+++ b/input/reference_sets/main/Phenylium.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {4,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H5
 inchi: InChI=1S/C6H5/c1-2-4-6-5-3-1/h1-5H/q+1
 inchi_key: UEDBHEFYEKZZBA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Phosgene.yml
+++ b/input/reference_sets/main/Phosgene.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O  u0 p2 c0 {4,D}
   4 C  u0 p0 c0 {1,S} {2,S} {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CCl2O
 inchi: InChI=1S/CCl2O/c2-1(3)4
 inchi_key: YGYAWVDWMABLBF-UHFFFAOYSA-N

--- a/input/reference_sets/main/Piperidine.yml
+++ b/input/reference_sets/main/Piperidine.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {6,S}
   17 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H11N
 inchi: InChI=1S/C5H11N/c1-2-4-6-5-3-1/h6H,1-5H2
 inchi_key: NQRYJNQNLNOLGT-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propadienylidene.yml
+++ b/input/reference_sets/main/Propadienylidene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H2
 inchi: InChI=1S/C3H2/c1-3-2/h1H2
 inchi_key: LPUFMQSFYARLPQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propanamide.yml
+++ b/input/reference_sets/main/Propanamide.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {2,S}
   12 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H7NO
 inchi: InChI=1S/C3H7NO/c1-2-3(4)5/h2H2,1H3,(H2,4,5)
 inchi_key: QLNJFJADRCOGBJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propane.yml
+++ b/input/reference_sets/main/Propane.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {3,S}
   11 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H8
 inchi: InChI=1S/C3H8/c1-3-2/h3H2,1-2H3
 inchi_key: ATUOYWHBWRKTHZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propene.yml
+++ b/input/reference_sets/main/Propene.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {3,S}
   9 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6
 inchi: InChI=1S/C3H6/c1-3-2/h3H,1H2,2H3
 inchi_key: QQONPFPTGQHPMA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propionaldehyde.yml
+++ b/input/reference_sets/main/Propionaldehyde.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6O
 inchi: InChI=1S/C3H6O/c1-2-3-4/h3H,2H2,1H3
 inchi_key: NBBJYMSMWIIQGU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propyl.yml
+++ b/input/reference_sets/main/Propyl.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -79,7 +79,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H7
 inchi: InChI=1S/C3H7/c1-3-2/h1,3H2,2H3
 inchi_key: OCBFFGCSTGGPSQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propylene oxide.yml
+++ b/input/reference_sets/main/Propylene oxide.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6O
 inchi: InChI=1S/C3H6O/c1-3-2-4-3/h3H,2H2,1H3
 inchi_key: GOOHAUXETOMSMM-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propyne.yml
+++ b/input/reference_sets/main/Propyne.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {1,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H4
 inchi: InChI=1S/C3H4/c1-3-2/h1H,2H3
 inchi_key: MWWATHDPGQKSAR-UHFFFAOYSA-N

--- a/input/reference_sets/main/Propynylidene.yml
+++ b/input/reference_sets/main/Propynylidene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H2
 inchi: InChI=1S/C3H2/c1-3-2/h1-2H
 inchi_key: OUSWHEMIRJJMAW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Pyridine.yml
+++ b/input/reference_sets/main/Pyridine.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {5,S}
   11 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H5N
 inchi: InChI=1S/C5H5N/c1-2-4-6-5-3-1/h1-5H
 inchi_key: JUJWROOIHBZHMG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Pyrrolidine.yml
+++ b/input/reference_sets/main/Pyrrolidine.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {5,S}
   14 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9N
 inchi: InChI=1S/C4H9N/c1-2-4-5-3-1/h5H,1-4H2
 inchi_key: RWRDLPDLKQPQOW-UHFFFAOYSA-N

--- a/input/reference_sets/main/S-Ethyl thioacetate.yml
+++ b/input/reference_sets/main/S-Ethyl thioacetate.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {5,S}
   14 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8OS
 inchi: InChI=1S/C4H8OS/c1-3-6-4(2)5/h3H2,1-2H3
 inchi_key: APTGPWJUOYMUCE-UHFFFAOYSA-N

--- a/input/reference_sets/main/S-Isopropyl thioacetate.yml
+++ b/input/reference_sets/main/S-Isopropyl thioacetate.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {6,S}
   17 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10OS
 inchi: InChI=1S/C5H10OS/c1-4(2)7-5(3)6/h4H,1-3H3
 inchi_key: XBSWGFUCFLITEY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Succinic acid.yml
+++ b/input/reference_sets/main/Succinic acid.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {1,S}
   14 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6O4
 inchi: InChI=1S/C4H6O4/c5-3(6)1-2-4(7)8/h1-2H2,(H,5,6)(H,7,8)
 inchi_key: KDYFGRWQOYBRFD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Succinonitrile.yml
+++ b/input/reference_sets/main/Succinonitrile.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H4N2
 inchi: InChI=1S/C4H4N2/c5-3-1-2-4-6/h1-2H2
 inchi_key: IAHFWCOBPZCAEA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfanyl.yml
+++ b/input/reference_sets/main/Sulfanyl.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 S u1 p2 c0 {2,S}
   2 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HS
 inchi: InChI=1S/HS/h1H
 inchi_key: PXQLVRUNWNTZOS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfur Hexafluoride.yml
+++ b/input/reference_sets/main/Sulfur Hexafluoride.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 F u0 p3 c0 {1,S}
   7 F u0 p3 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: F6S
 inchi: InChI=1S/F6S/c1-7(2,3,4,5)6
 inchi_key: SFZCNBIFKDRMGX-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfur dioxide.yml
+++ b/input/reference_sets/main/Sulfur dioxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 O u0 p2 c0 {1,D}
   3 O u0 p2 c0 {1,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: O2S
 inchi: InChI=1S/O2S/c1-3-2
 inchi_key: RAHZWNYVWXNFOC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfur monoxide.yml
+++ b/input/reference_sets/main/Sulfur monoxide.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   1 S u1 p2 c0 {2,S}
   2 O u1 p2 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -31,7 +31,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: OS
 inchi: InChI=1S/OS/c1-2
 inchi_key: XTQHKBHJIVJGKJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfur trioxide.yml
+++ b/input/reference_sets/main/Sulfur trioxide.yml
@@ -5,7 +5,7 @@ adjacency_list: |
   3 O u0 p2 c0 {1,D}
   4 O u0 p2 c0 {1,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -42,7 +42,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: O3S
 inchi: InChI=1S/O3S/c1-4(2)3
 inchi_key: AKEJUJNQAAGONA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfuric acid.yml
+++ b/input/reference_sets/main/Sulfuric acid.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {2,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2O4S
 inchi: InChI=1S/H2O4S/c1-5(2,3)4/h(H2,1,2,3,4)
 inchi_key: QAOWNCQODCNURD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Sulfuryl chloride.yml
+++ b/input/reference_sets/main/Sulfuryl chloride.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 O  u0 p2 c0 {3,D}
   5 O  u0 p2 c0 {3,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: Cl2O2S
 inchi: InChI=1S/Cl2O2S/c1-5(2,3)4
 inchi_key: YBBRCQOCSYXUOC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrachloromethane.yml
+++ b/input/reference_sets/main/Tetrachloromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 Cl u0 p3 c0 {5,S}
   5 C  u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CCl4
 inchi: InChI=1S/CCl4/c2-1(3,4)5
 inchi_key: VZGDMQKNWNREIO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrafluoroethylene.yml
+++ b/input/reference_sets/main/Tetrafluoroethylene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 C u0 p0 c0 {1,S} {2,S} {6,D}
   6 C u0 p0 c0 {3,S} {4,S} {5,D}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2F4
 inchi: InChI=1S/C2F4/c3-1(4)2(5)6
 inchi_key: BFKJFAAPBSQJPD-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrafluoromethane.yml
+++ b/input/reference_sets/main/Tetrafluoromethane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 F u0 p3 c0 {5,S}
   5 C u0 p0 c0 {1,S} {2,S} {3,S} {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CF4
 inchi: InChI=1S/CF4/c2-1(3,4)5
 inchi_key: TXEYQDLBPFQVAA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrahydro-2-methylthiophene.yml
+++ b/input/reference_sets/main/Tetrahydro-2-methylthiophene.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10S
 inchi: InChI=1S/C5H10S/c1-5-3-2-4-6-5/h5H,2-4H2,1H3
 inchi_key: AJPGNQYBSTXCJE-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrahydro-2H-pyran.yml
+++ b/input/reference_sets/main/Tetrahydro-2H-pyran.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10O
 inchi: InChI=1S/C5H10O/c1-2-4-6-5-3-1/h1-5H2
 inchi_key: DHXVGJBLRPWPCS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrahydro-2H-thiopyran.yml
+++ b/input/reference_sets/main/Tetrahydro-2H-thiopyran.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10S
 inchi: InChI=1S/C5H10S/c1-2-4-6-5-3-1/h1-5H2
 inchi_key: YPWFISCTZQNZAU-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrahydro-3-methylthiophene.yml
+++ b/input/reference_sets/main/Tetrahydro-3-methylthiophene.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {6,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10S
 inchi: InChI=1S/C5H10S/c1-5-2-3-6-4-5/h5H,2-4H2,1H3
 inchi_key: DLABLFPCTXRQMY-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrahydrofuran.yml
+++ b/input/reference_sets/main/Tetrahydrofuran.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {5,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8O
 inchi: InChI=1S/C4H8O/c1-2-4-5-3-1/h1-4H2
 inchi_key: WYURNTSHIVDZCO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetrahydrothiophene.yml
+++ b/input/reference_sets/main/Tetrahydrothiophene.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {5,S}
   13 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8S
 inchi: InChI=1S/C4H8S/c1-2-4-5-3-1/h1-4H2
 inchi_key: RAOIDOHSFRTOEL-UHFFFAOYSA-N

--- a/input/reference_sets/main/Tetramethylthiourea.yml
+++ b/input/reference_sets/main/Tetramethylthiourea.yml
@@ -21,7 +21,7 @@ adjacency_list: |
   19 H u0 p0 c0 {7,S}
   20 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -138,7 +138,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12N2S
 inchi: InChI=1S/C5H12N2S/c1-6(2)5(8)7(3)4/h1-4H3
 inchi_key: MNOILHPDHOHILI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Thietane.yml
+++ b/input/reference_sets/main/Thietane.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {4,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H6S
 inchi: InChI=1S/C3H6S/c1-2-4-3-1/h1-3H2
 inchi_key: XSROQCDVUIHRSI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Thiirane.yml
+++ b/input/reference_sets/main/Thiirane.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   6 H u0 p0 c0 {3,S}
   7 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -60,7 +60,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H4S
 inchi: InChI=1S/C2H4S/c1-2-3-1/h1-2H2
 inchi_key: VOVUARRWDCVURC-UHFFFAOYSA-N

--- a/input/reference_sets/main/Thioacetamide.yml
+++ b/input/reference_sets/main/Thioacetamide.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {2,S}
   9 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H5NS
 inchi: InChI=1S/C2H5NS/c1-2(3)4/h1H3,(H2,3,4)
 inchi_key: YUKQRDCYNOVPGJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Thiophene.yml
+++ b/input/reference_sets/main/Thiophene.yml
@@ -10,7 +10,7 @@ adjacency_list: |
   8 H u0 p0 c0 {4,S}
   9 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -72,7 +72,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H4S
 inchi: InChI=1S/C4H4S/c1-2-4-5-3-1/h1-4H
 inchi_key: YTPLMLYBLZKORZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Thiourea.yml
+++ b/input/reference_sets/main/Thiourea.yml
@@ -9,7 +9,7 @@ adjacency_list: |
   7 H u0 p0 c0 {3,S}
   8 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -66,7 +66,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CH4N2S
 inchi: InChI=1S/CH4N2S/c2-1(3)4/h(H4,2,3,4)
 inchi_key: UMGDCJDMYOKAJW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Toluene.yml
+++ b/input/reference_sets/main/Toluene.yml
@@ -16,7 +16,7 @@ adjacency_list: |
   14 H u0 p0 c0 {7,S}
   15 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -108,7 +108,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H8
 inchi: InChI=1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
 inchi_key: YXFVVABEGXRONW-UHFFFAOYSA-N

--- a/input/reference_sets/main/Trichloromethyl.yml
+++ b/input/reference_sets/main/Trichloromethyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 Cl u0 p3 c0 {4,S}
   4 C  u1 p0 c0 {1,S} {2,S} {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CCl3
 inchi: InChI=1S/CCl3/c2-1(3)4
 inchi_key: ZBZJXHCVGLJWFG-UHFFFAOYSA-N

--- a/input/reference_sets/main/Trifluoromethyl.yml
+++ b/input/reference_sets/main/Trifluoromethyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 F u0 p3 c0 {4,S}
   4 C u1 p0 c0 {1,S} {2,S} {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: CF3
 inchi: InChI=1S/CF3/c2-1(3)4
 inchi_key: WZKSXHQDXQKIQJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Trimethylamine.yml
+++ b/input/reference_sets/main/Trimethylamine.yml
@@ -14,7 +14,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -96,7 +96,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H9N
 inchi: InChI=1S/C3H9N/c1-4(2)3/h1-3H3
 inchi_key: GETQZCLCWQTVFV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Trimethylthiirane.yml
+++ b/input/reference_sets/main/Trimethylthiirane.yml
@@ -17,7 +17,7 @@ adjacency_list: |
   15 H u0 p0 c0 {5,S}
   16 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H10S
 inchi: InChI=1S/C5H10S/c1-4-5(2,3)6-4/h4H,1-3H3
 inchi_key: TWNJQGQIVBDVAB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Trioxidane.yml
+++ b/input/reference_sets/main/Trioxidane.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {2,S}
   5 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2O3
 inchi: InChI=1S/H2O3/c1-3-2/h1-2H
 inchi_key: JSPLKZUTYZBBKA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Trioxidanyl.yml
+++ b/input/reference_sets/main/Trioxidanyl.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 O u1 p2 c0 {1,S}
   4 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: HO3
 inchi: InChI=1S/HO3/c1-3-2/h1H
 inchi_key: WURFKUQACINBSI-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinoxide.yml
+++ b/input/reference_sets/main/Vinoxide.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 O u0 p2 c0 {4,D}
   6 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3O
 inchi: InChI=1S/C2H3O/c1-2-3/h2H,1H2/q-1
 inchi_key: MGKBHFTXPZTTHS-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinoxy.yml
+++ b/input/reference_sets/main/Vinoxy.yml
@@ -8,7 +8,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -55,7 +55,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3O
 inchi: InChI=1S/C2H3O/c1-2-3/h2H,1H2
 inchi_key: FATAVLOOLIRUNA-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinyl anion.yml
+++ b/input/reference_sets/main/Vinyl anion.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -48,7 +48,11 @@ calculated_data:
 charge: -1
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3
 inchi: InChI=1S/C2H3/c1-2/h1H,2H2/q-1
 inchi_key: IEARPTNIYZTWOZ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinyl bromide.yml
+++ b/input/reference_sets/main/Vinyl bromide.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H  u0 p0 c0 {2,S}
   6 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3Br
 inchi: InChI=1S/C2H3Br/c1-2-3/h2H,1H2
 inchi_key: INLLPKCGLOXCIV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinyl chloride.yml
+++ b/input/reference_sets/main/Vinyl chloride.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H  u0 p0 c0 {2,S}
   6 H  u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3Cl
 inchi: InChI=1S/C2H3Cl/c1-2-3/h2H,1H2
 inchi_key: BZHJMEDXRYGGRV-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinyl ether.yml
+++ b/input/reference_sets/main/Vinyl ether.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   10 H u0 p0 c0 {5,S}
   11 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -84,7 +84,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6O
 inchi: InChI=1S/C4H6O/c1-3-5-4-2/h3-4H,1-2H2
 inchi_key: QYKIQEUNHZKYBP-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinyl fluoride.yml
+++ b/input/reference_sets/main/Vinyl fluoride.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H u0 p0 c0 {2,S}
   6 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3F
 inchi: InChI=1S/C2H3F/c1-2-3/h2H,1H2
 inchi_key: XUCNUKMRBVNAPB-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinyl.yml
+++ b/input/reference_sets/main/Vinyl.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   4 H u0 p0 c0 {1,S}
   5 H u0 p0 c0 {2,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -49,7 +49,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H3
 inchi: InChI=1S/C2H3/c1-2/h1H,2H2
 inchi_key: ORGHESHFQPYLAO-UHFFFAOYSA-N

--- a/input/reference_sets/main/Vinylidene.yml
+++ b/input/reference_sets/main/Vinylidene.yml
@@ -6,7 +6,7 @@ adjacency_list: |
   3 H u0 p0 c0 {1,S}
   4 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -43,7 +43,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2
 inchi: InChI=1S/C2H2/c1-2/h1H2
 inchi_key: SNVLJLYUUXKWOJ-UHFFFAOYSA-N

--- a/input/reference_sets/main/Water.yml
+++ b/input/reference_sets/main/Water.yml
@@ -4,7 +4,7 @@ adjacency_list: |
   2 H u0 p0 c0 {1,S}
   3 H u0 p0 c0 {1,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -36,7 +36,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: H2O
 inchi: InChI=1S/H2O/h1H2
 inchi_key: XLYOFNOQVPJJNP-UHFFFAOYSA-N

--- a/input/reference_sets/main/cis-12-Dichloroethene.yml
+++ b/input/reference_sets/main/cis-12-Dichloroethene.yml
@@ -7,7 +7,7 @@ adjacency_list: |
   5 H  u0 p0 c0 {3,S}
   6 H  u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -54,7 +54,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C2H2Cl2
 inchi: InChI=1S/C2H2Cl2/c3-1-2-4/h1-2H
 inchi_key: KFUSEUYYWQURPO-UHFFFAOYSA-N

--- a/input/reference_sets/main/cyclohexene.yml
+++ b/input/reference_sets/main/cyclohexene.yml
@@ -17,13 +17,13 @@ adjacency_list: |
   15 H u0 p0 c0 {5,S}
   16 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -1.8082054838888784
+        value: -1.808205483888878
       class: ThermoData
     xyz_dict:
       coords:
@@ -114,7 +114,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H10
 inchi: InChI=1S/C6H10/c1-2-4-6-5-3-1/h1-2H,3-6H2
 inchi_key: HGCIXCUEYOPUTN-UHFFFAOYSA-N

--- a/input/reference_sets/main/gammaButyrolactone.yml
+++ b/input/reference_sets/main/gammaButyrolactone.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {5,S}
   12 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H6O2
 inchi: InChI=1S/C4H6O2/c5-4-2-1-3-6-4/h1-3H2
 inchi_key: YEJRWHAVMIAJKC-UHFFFAOYSA-N

--- a/input/reference_sets/main/iso-Butane.yml
+++ b/input/reference_sets/main/iso-Butane.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   13 H u0 p0 c0 {4,S}
   14 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10
 inchi: InChI=1S/C4H10/c1-4(2)3/h4H,1-3H3
 inchi_key: NNPPMTNAJDCUHE-UHFFFAOYSA-N

--- a/input/reference_sets/main/iso-Butyl.yml
+++ b/input/reference_sets/main/iso-Butyl.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -97,7 +97,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9
 inchi: InChI=1S/C4H9/c1-4(2)3/h4H,1H2,2-3H3
 inchi_key: KTOQRRDVVIDEAA-UHFFFAOYSA-N

--- a/input/reference_sets/main/iso-Pentane.yml
+++ b/input/reference_sets/main/iso-Pentane.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {4,S}
   17 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12
 inchi: InChI=1S/C5H12/c1-4-5(2)3/h5H,4H2,1-3H3
 inchi_key: QWTDNUCVQCZILF-UHFFFAOYSA-N

--- a/input/reference_sets/main/iso-Propyl.yml
+++ b/input/reference_sets/main/iso-Propyl.yml
@@ -12,7 +12,7 @@ adjacency_list: |
   9  H u0 p0 c0 {2,S}
   10 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -79,7 +79,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C3H7
 inchi: InChI=1S/C3H7/c1-3-2/h3H,1-2H3
 inchi_key: HNUALPPJLMYHDK-UHFFFAOYSA-N

--- a/input/reference_sets/main/meta-Xylene.yml
+++ b/input/reference_sets/main/meta-Xylene.yml
@@ -19,7 +19,7 @@ adjacency_list: |
   17 H u0 p0 c0 {7,S}
   18 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -126,7 +126,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C8H10
 inchi: InChI=1S/C8H10/c1-7-4-3-5-8(2)6-7/h3-6H,1-2H3
 inchi_key: IVSZLXZYQVIEFR-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Butane.yml
+++ b/input/reference_sets/main/n-Butane.yml
@@ -15,13 +15,13 @@ adjacency_list: |
   13 H u0 p0 c0 {4,S}
   14 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
         class: ScalarQuantity
         units: kcal/mol
-        value: -30.026199438602603
+        value: -30.0261994386026
       class: ThermoData
     xyz_dict:
       coords:
@@ -102,7 +102,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H10
 inchi: InChI=1S/C4H10/c1-3-4-2/h3-4H2,1-2H3
 inchi_key: IJDNQMDRQITEOD-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Butyl.yml
+++ b/input/reference_sets/main/n-Butyl.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   12 H u0 p0 c0 {4,S}
   13 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -97,7 +97,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9
 inchi: InChI=1S/C4H9/c1-3-4-2/h1,3-4H2,2H3
 inchi_key: WPWHSFAFEBZWBB-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Heptane.yml
+++ b/input/reference_sets/main/n-Heptane.yml
@@ -24,7 +24,7 @@ adjacency_list: |
   22 H u0 p0 c0 {7,S}
   23 H u0 p0 c0 {7,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -156,7 +156,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C7H16
 inchi: InChI=1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
 inchi_key: IMNFDUFMRHMDMM-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Hexane.yml
+++ b/input/reference_sets/main/n-Hexane.yml
@@ -21,7 +21,7 @@ adjacency_list: |
   19 H u0 p0 c0 {6,S}
   20 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -138,7 +138,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H14
 inchi: InChI=1S/C6H14/c1-3-5-6-4-2/h3-6H2,1-2H3
 inchi_key: VLKZOEOYAKHREP-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Octane.yml
+++ b/input/reference_sets/main/n-Octane.yml
@@ -27,7 +27,7 @@ adjacency_list: |
   25 H u0 p0 c0 {8,S}
   26 H u0 p0 c0 {8,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -174,7 +174,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C8H18
 inchi: InChI=1S/C8H18/c1-3-5-7-8-6-4-2/h3-8H2,1-2H3
 inchi_key: TVMXDCGIABBOFY-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Pentane.yml
+++ b/input/reference_sets/main/n-Pentane.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {5,S}
   17 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12
 inchi: InChI=1S/C5H12/c1-3-5-4-2/h3-5H2,1-2H3
 inchi_key: OFBQJSOFQDEBGM-UHFFFAOYSA-N

--- a/input/reference_sets/main/n-Propyl benzene.yml
+++ b/input/reference_sets/main/n-Propyl benzene.yml
@@ -22,7 +22,7 @@ adjacency_list: |
   20 H u0 p0 c0 {9,S}
   21 H u0 p0 c0 {6,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -144,7 +144,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C9H12
 inchi: InChI=1S/C9H12/c1-2-6-9-7-4-3-5-8-9/h3-5,7-8H,2,6H2,1H3
 inchi_key: ODLMAHJVESYWTB-UHFFFAOYSA-N

--- a/input/reference_sets/main/neo-Pentane.yml
+++ b/input/reference_sets/main/neo-Pentane.yml
@@ -18,7 +18,7 @@ adjacency_list: |
   16 H u0 p0 c0 {5,S}
   17 H u0 p0 c0 {5,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -120,7 +120,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C5H12
 inchi: InChI=1S/C5H12/c1-5(2,3)4/h1-4H3
 inchi_key: CRSOQBOWXPBRES-UHFFFAOYSA-N

--- a/input/reference_sets/main/o-Benzyne.yml
+++ b/input/reference_sets/main/o-Benzyne.yml
@@ -11,7 +11,7 @@ adjacency_list: |
   9  H u0 p0 c0 {3,S}
   10 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -78,7 +78,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C6H4
 inchi: InChI=1S/C6H4/c1-2-4-6-5-3-1/h1-4H
 inchi_key: KLYCPFXDDDMZNQ-UHFFFAOYSA-N

--- a/input/reference_sets/main/sec-Butyl.yml
+++ b/input/reference_sets/main/sec-Butyl.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   12 H u0 p0 c0 {3,S}
   13 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -97,7 +97,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9
 inchi: InChI=1S/C4H9/c1-3-4-2/h3H,4H2,1-2H3
 inchi_key: ULOIAOPTGWSNHU-UHFFFAOYSA-N

--- a/input/reference_sets/main/t-Butyl.yml
+++ b/input/reference_sets/main/t-Butyl.yml
@@ -15,7 +15,7 @@ adjacency_list: |
   12 H u0 p0 c0 {3,S}
   13 H u0 p0 c0 {3,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -97,7 +97,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H9
 inchi: InChI=1S/C4H9/c1-4(2)3/h1-3H3
 inchi_key: IIVWHGMLFGNMOW-UHFFFAOYSA-N

--- a/input/reference_sets/main/trans-2-Butene.yml
+++ b/input/reference_sets/main/trans-2-Butene.yml
@@ -13,7 +13,7 @@ adjacency_list: |
   11 H u0 p0 c0 {3,S}
   12 H u0 p0 c0 {4,S}
 calculated_data:
-  wb97m-v/def2-tzvpd:
+  LevelOfTheory(method='wb97mv',basis='def2tzvpd',software='qchem'):
     class: CalculatedDataEntry
     thermo_data:
       H298:
@@ -90,7 +90,11 @@ calculated_data:
 charge: 0
 class: ReferenceSpecies
 datetime: 2020-02-24 11:05
-default_xyz_chemistry: wb97m-v/def2-tzvpd
+default_xyz_chemistry:
+  basis: def2tzvpd
+  class: LevelOfTheory
+  method: wb97mv
+  software: qchem
 formula: C4H8
 inchi: InChI=1S/C4H8/c1-3-4-2/h3-4H,1-2H3
 inchi_key: IAQRGUVFOMOMEM-UHFFFAOYSA-N


### PR DESCRIPTION
Corresponds to ReactionMechanismGenerator/RMG-Py#1940.
Updates reference species to use level of theory string representations as keys and updates the quantum corrections file to also use that representation.