### PR TITLE
Atom energy fitting

### DIFF
--- a/input/quantum_corrections/data.py
+++ b/input/quantum_corrections/data.py
@@ -453,6 +453,7 @@ freq_dict = {'hf/sto-3g': 0.817,  # [2]
              'wb97xd/6-311++g(d,p)': 0.988,  # [4]
              'wb97xd/def2tzvp': 0.988,  # [4]
              'wb97xd/def2svp': 0.986,  # [4]
+             'wb97m-v/def2-tzvpd': 1.002,  # [4]
              'apfd/def2tzvp': 0.993,  # [4]
              'apfd/def2tzvpp': 0.992,  # [4]
              'mp2_rmp2_pvdz': 0.953,  # [2], taken as 'MP2/cc-pVDZ'

--- a/input/quantum_corrections/data.py
+++ b/input/quantum_corrections/data.py
@@ -73,20 +73,16 @@ SOC = {'H': 0.0, 'N': 0.0, 'O': -0.000355, 'C': -0.000135, 'S': -0.000893, 'P': 
        'F': -0.000614, 'Si': -0.000682, 'Cl': -0.001338, 'Br': -0.005597, 'B': -0.000046}
 
 # Atomic energies
-# All model chemistries here should be lower-case because the user input is changed to lower-case
 atom_energies = {
-    # Note: If your model chemistry does not include spin orbit coupling, you should add the corrections
-    # to the energies here
-
     'wb97m-v/def2-tzvpd': {
-        'H': -0.4941110259 + SOC['H'],
-        'C': -37.8458797086 + SOC['C'],
-        'N': -54.5915786724 + SOC['N'],
-        'O': -75.0762279005 + SOC['O'],
-        'S': -398.0789126541 + SOC['S'],
-        'F': -99.7434924415 + SOC['F'],
-        'Cl': -460.1100357269 + SOC['Cl'],
-        'Br': -2573.9684615505 + SOC['Br']
+        'H': -0.49338216995809725,
+        'C': -37.84772407774059,
+        'N': -54.59351384873174,
+        'O': -75.0774947462408,
+        'F': -99.74200231175924,
+        'S': -398.0820818202818,
+        'Cl': -460.1117669506163,
+        'Br': -2573.9713149056824
     },
 
     # cbs-qb3 and cbs-qb3-paraskevas have the same corrections

--- a/input/reference_sets/main/Ammonia.yml
+++ b/input/reference_sets/main/Ammonia.yml
@@ -64,5 +64,43 @@ reference_data:
         units: kJ/mol
         value: -45.557
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.5
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 1157.9
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - -0.9377
+          - -0.3816
+        - - 0.8121
+          - 0.4689
+          - -0.3816
+        - - -0.8121
+          - 0.4689
+          - -0.3816
+      isotopes:
+      - 14
+      - 1
+      - 1
+      - 1
+      symbols:
+      - N
+      - H
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 86.305
 smiles: N
 symmetry_number: 3.0

--- a/input/reference_sets/main/Chloromethane.yml
+++ b/input/reference_sets/main/Chloromethane.yml
@@ -70,5 +70,48 @@ reference_data:
         units: kJ/mol
         value: -82.10000000000007
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.8
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 1552.9
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.7810
+        - - 1.0424
+          - 0.0
+          - -0.3901
+        - - -0.5212
+          - 0.9027
+          - -0.3901
+        - - -0.5212
+          - -0.9027
+          - -0.3901
+      isotopes:
+      - 12
+      - 35
+      - 1
+      - 1
+      - 1
+      symbols:
+      - C
+      - Cl
+      - H
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 96.156
 smiles: CCl
 symmetry_number: 3.0

--- a/input/reference_sets/main/Dibromine.yml
+++ b/input/reference_sets/main/Dibromine.yml
@@ -52,5 +52,33 @@ reference_data:
         units: kJ/mol
         value: 30.89
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.3
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 190.2
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 1.1405
+        - - 0.0
+          - 0.0
+          - -1.1405
+      isotopes:
+      - 79
+      - 79
+      symbols:
+      - Br
+      - Br
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 1.9332
 smiles: BrBr
 symmetry_number: 2.0

--- a/input/reference_sets/main/Dichlorine.yml
+++ b/input/reference_sets/main/Dichlorine.yml
@@ -50,5 +50,33 @@ reference_data:
         units: kJ/mol
         value: 0.0
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.0
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 239.3
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.9879
+      isotopes:
+      - 35
+      - 35
+      symbols:
+      - Cl
+      - Cl
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 3.340240
 smiles: '[Cl][Cl]'
 symmetry_number: 2.0

--- a/input/reference_sets/main/Difluorine.yml
+++ b/input/reference_sets/main/Difluorine.yml
@@ -50,5 +50,33 @@ reference_data:
         units: kJ/mol
         value: 0.0
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.6
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 154.5
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.4119
+      isotopes:
+      - 19
+      - 19
+      symbols:
+      - F
+      - F
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 5.447936
 smiles: FF
 symmetry_number: 2.0

--- a/input/reference_sets/main/Dihydrogen.yml
+++ b/input/reference_sets/main/Dihydrogen.yml
@@ -50,5 +50,31 @@ reference_data:
         units: kJ/mol
         value: 0.0
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 432.1
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.7414
+      isotopes:
+      - 1
+      - 1
+      symbols:
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 26.07031
 smiles: '[H][H]'
 symmetry_number: 2.0

--- a/input/reference_sets/main/Dinitrogen.yml
+++ b/input/reference_sets/main/Dinitrogen.yml
@@ -50,5 +50,33 @@ reference_data:
         units: kJ/mol
         value: 0.0
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.8
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 941.6
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.5488
+        - - 0.0
+          - 0.0
+          - -0.5488
+      isotopes:
+      - 14
+      - 14
+      symbols:
+      - N
+      - N
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 14.06543
 smiles: N#N
 symmetry_number: 2.0

--- a/input/reference_sets/main/Dioxygen.yml
+++ b/input/reference_sets/main/Dioxygen.yml
@@ -51,5 +51,33 @@ reference_data:
         units: kJ/mol
         value: 0.0
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.2
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 493.7
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.2075
+      isotopes:
+      - 16
+      - 16
+      symbols:
+      - O
+      - O
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 9.419155
 smiles: '[O][O]'
 symmetry_number: 2.0

--- a/input/reference_sets/main/Disulfur.yml
+++ b/input/reference_sets/main/Disulfur.yml
@@ -43,6 +43,34 @@ molecular_weight:
   value: 64.13000613827143
 multiplicity: 3
 reference_data:
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.4
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 421.6
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.8892
+      isotopes:
+      - 32
+      - 32
+      symbols:
+      - S
+      - S
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 4.33274
   NIST Chemistry WebBook:
     class: ReferenceDataEntry
     thermo_data:

--- a/input/reference_sets/main/Hydrogen bromide.yml
+++ b/input/reference_sets/main/Hydrogen bromide.yml
@@ -52,5 +52,33 @@ reference_data:
         units: kJ/mol
         value: -35.57
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.2
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 362.4
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.4144
+      isotopes:
+      - 79
+      - 1
+      symbols:
+      - Br
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 15.72432
 smiles: Br
 symmetry_number: 1.0

--- a/input/reference_sets/main/Hydrogen chloride.yml
+++ b/input/reference_sets/main/Hydrogen chloride.yml
@@ -52,5 +52,33 @@ reference_data:
         units: kJ/mol
         value: -92.173
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.1
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 427.8
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 1.2746
+      isotopes:
+      - 35
+      - 1
+      symbols:
+      - Cl
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 17.75122
 smiles: Cl
 symmetry_number: 1.0

--- a/input/reference_sets/main/Hydrogen fluoride.yml
+++ b/input/reference_sets/main/Hydrogen fluoride.yml
@@ -52,5 +52,33 @@ reference_data:
         units: kJ/mol
         value: -272.726
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.8
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 566.6
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.9168
+      isotopes:
+      - 19
+      - 1
+      symbols:
+      - F
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 24.5327
 smiles: F
 symmetry_number: 1.0

--- a/input/reference_sets/main/Hydrogen sulfide.yml
+++ b/input/reference_sets/main/Hydrogen sulfide.yml
@@ -49,6 +49,12 @@ molecular_weight:
 multiplicity: 1
 reference_data:
   CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.5
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 724.7
     class: ReferenceDataEntry
     thermo_data:
       H298:
@@ -58,5 +64,30 @@ reference_data:
         units: kJ/mol
         value: -20.6
       class: ThermoData
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.1030
+        - - 0.0
+          - 0.9616
+          - -0.8239
+        - - 0.0
+          - -0.9616
+          - -0.8239
+      isotopes:
+      - 32
+      - 1
+      - 1
+      symbols:
+      - S
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 38.424
 smiles: S
 symmetry_number: 2.0

--- a/input/reference_sets/main/Methane.yml
+++ b/input/reference_sets/main/Methane.yml
@@ -70,5 +70,48 @@ reference_data:
         units: kJ/mol
         value: -74.525
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.5
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 1642.0
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.6276
+          - 0.6276
+          - 0.6276
+        - - 0.6276
+          - -0.6276
+          - -0.6276
+        - - -0.6276
+          - 0.6276
+          - -0.6276
+        - - -0.6276
+          - -0.6276
+          - 0.6276
+      isotopes:
+      - 12
+      - 1
+      - 1
+      - 1
+      - 1
+      symbols:
+      - C
+      - H
+      - H
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 113.41
 smiles: C
 symmetry_number: 12.0

--- a/input/reference_sets/main/Methyl.yml
+++ b/input/reference_sets/main/Methyl.yml
@@ -65,5 +65,43 @@ reference_data:
         units: kJ/mol
         value: 146.41400000000007
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.7
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 1209.3
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 1.0790
+          - 0.0
+          - 0.0
+        - - -0.5395
+          - -0.9344
+          - 0.0
+        - - -0.5395
+          - 0.9344
+          - 0.0
+      isotopes:
+      - 12
+      - 1
+      - 1
+      - 1
+      symbols:
+      - C
+      - H
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 76.110
 smiles: '[CH3]'
 symmetry_number: 6.0

--- a/input/reference_sets/main/Water.yml
+++ b/input/reference_sets/main/Water.yml
@@ -58,5 +58,38 @@ reference_data:
         units: kJ/mol
         value: -241.842
       class: ThermoData
+  CCCBDB:
+    atomization_energy:
+      class: ScalarQuantity
+      uncertainty: 0.1
+      uncertainty_type: +|-
+      units: kJ/mol
+      value: 917.8
+    class: ReferenceDataEntry
+    xyz_dict:
+      coords:
+        class: np_array
+        object:
+        - - 0.0
+          - 0.0
+          - 0.1173
+        - - 0.0
+          - 0.7572
+          - -0.4692
+        - - 0.0
+          - -0.7572
+          - -0.4692
+      isotopes:
+      - 16
+      - 1
+      - 1
+      symbols:
+      - O
+      - H
+      - H
+    zpe:
+      class: ScalarQuantity
+      units: kJ/mol
+      value: 53.880
 smiles: O
 symmetry_number: 2.0


### PR DESCRIPTION
Adds new CCCBDB reference data to the species that will be used for atom energy fitting (experimental geometries, atomization enegies, and zero-point energies). Corresponds to ReactionMechanismGenerator/RMG-Py#1950.

Also adds the updated atom energies for wB97M-V/def2-TZVPD.