### PR TITLE
Correct Thermo of [C]=C

### DIFF
--- a/input/thermo/libraries/JetSurF2.0.py
+++ b/input/thermo/libraries/JetSurF2.0.py
@@ -6927,9 +6927,8 @@ entry(
     label = "H2CC",
     molecule = 
 """
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 """,

--- a/input/thermo/libraries/Klippenstein_Glarborg2016.py
+++ b/input/thermo/libraries/Klippenstein_Glarborg2016.py
@@ -2615,9 +2615,8 @@ entry(
     label = "H2CC",
     molecule = 
 """
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 """,

--- a/input/thermo/libraries/Narayanaswamy.py
+++ b/input/thermo/libraries/Narayanaswamy.py
@@ -870,9 +870,8 @@ entry(
     label = "H2C2_35",
     molecule = 
 """
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 """,


### PR DESCRIPTION
This PR aims to correct the thermo entries of [C]=C. some of them are incorrectly marked as values for triplet [C]=C.

**How to distinguish?**
According to my calculation and values in QCI_DFT, [C]=C values in JetSurF2.0, Klippenstein_Glarborg2016, and Narayanaswamy are very close to the value of singlet [C]=C in QCI_DFT, instead of triplet [C]=C.

E.g.,
dG(triplet, 1000K) ~ 84 kcal/mol
dG(singlet, 1000K) ~  39 kcal/mol