### PR TITLE
Correct Kinetic libraries with [C]=C

### DIFF
--- a/input/kinetics/libraries/JetSurF2.0/dictionary.txt
+++ b/input/kinetics/libraries/JetSurF2.0/dictionary.txt
@@ -3693,9 +3693,8 @@ multiplicity 2
 26 H u0 p0 c0 {9,S}
 
 H2CC
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 

--- a/input/kinetics/libraries/Klippenstein_Glarborg2016/dictionary.txt
+++ b/input/kinetics/libraries/Klippenstein_Glarborg2016/dictionary.txt
@@ -460,9 +460,8 @@ multiplicity 3
 3 O u1 p2 c0 {1,S}
 
 H2CC
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 

--- a/input/kinetics/libraries/Narayanaswamy/dictionary.txt
+++ b/input/kinetics/libraries/Narayanaswamy/dictionary.txt
@@ -1407,9 +1407,8 @@ multiplicity 2
 2 H u0 p0 c0 {1,S}
 
 H2C2(35)
-multiplicity 3
 1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u2 p0 c0 {1,D}
+2 C u0 p1 c0 {1,D}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 


### PR DESCRIPTION
This is a follow-up PR of H2CC correction (see #435).

Thanks to @mliu49's issue #365, I realize that not only thermo libraries but also kinetic libraries are suffering from this issue. Since kinetic library and thermo library with the same library name (JetSurF2.0, Klippenstein_Glarborg2016, and Narayanaswamy) should come from the same mechanism file, H2CC (with the same label) should be the same species in both libraries. So, I corrected H2CC in the mentioned three libraries. I also checked other kinetic libraries if they have a thermo Lib. counterpart, and their H2CC multiplicities are correctly assigned. 

I didn't further check any other kinetic libraries, since it is hard to tell whether their H2CC should be singlet or triplet. However, I would say singlet H2CC has a higher chance to be the correct one.