### PR TITLE
Add training reaction for -CH2- + OH

### DIFF
--- a/input/kinetics/families/H_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/H_Abstraction/training/dictionary.txt
@@ -4477,10 +4477,10 @@ multiplicity 2
 5 *2 H u0 p0 c0 {2,S}
 
 H2NN(S)_p23
-1 *3 N u0 p0 c+1 {2,S} {3,S} {4,D}
-2 *2 H u0 p0 c0 {1,S}
-3    H u0 p0 c0 {1,S}
-4    N u0 p2 c-1 {1,D}
+1 *3 N u0 p0 c+1 {2,D} {3,S} {4,S}
+2    N u0 p2 c-1 {1,D}
+3 *2 H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
 
 N2H3_r3
 multiplicity 2
@@ -5270,10 +5270,10 @@ C4H8O-7
 
 NO3
 multiplicity 2
-1 *3 O u1 p2 c0 {2,S}
-2    N u0 p0 c+1 {1,S} {3,S} {4,D}
-3    O u0 p3 c-1 {2,S}
-4    O u0 p2 c0 {2,D}
+1 *3 O u1 p2 c0 {4,S}
+2    O u0 p3 c-1 {4,S}
+3    O u0 p2 c0 {4,D}
+4    N u0 p0 c+1 {1,S} {2,S} {3,D}
 
 C3H3-2_p
 multiplicity 2
@@ -5285,17 +5285,17 @@ multiplicity 2
 6    H u0 p0 c0 {3,S}
 
 HNO3_p
-1 *3 O u0 p2 c0 {2,S} {5,S}
-2    N u0 p0 c+1 {1,S} {3,S} {4,D}
-3    O u0 p3 c-1 {2,S}
-4    O u0 p2 c0 {2,D}
+1 *3 O u0 p2 c0 {4,S} {5,S}
+2    O u0 p3 c-1 {4,S}
+3    O u0 p2 c0 {4,D}
+4    N u0 p0 c+1 {1,S} {2,S} {3,D}
 5 *1 H u0 p0 c0 {1,S}
 
 HNO2
-1 *1 N u0 p0 c+1 {2,S} {3,D} {4,S}
-2 *2 H u0 p0 c0 {1,S}
-3    O u0 p2 c0 {1,D}
-4    O u0 p3 c-1 {1,S}
+1    O u0 p3 c-1 {3,S}
+2    O u0 p2 c0 {3,D}
+3 *1 N u0 p0 c+1 {1,S} {2,D} {4,S}
+4 *2 H u0 p0 c0 {3,S}
 
 H2NN(T)_p1
 multiplicity 3
@@ -5330,9 +5330,9 @@ N2H4_p23
 N2H2(T)_r3
 multiplicity 3
 1 *3 N u1 p1 c0 {2,S} {3,S}
-2    H u0 p0 c0 {1,S}
-3    N u1 p1 c0 {1,S} {4,S}
-4    H u0 p0 c0 {3,S}
+2    N u1 p1 c0 {1,S} {4,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {2,S}
 
 N2H3_r12b
 multiplicity 2
@@ -5344,82 +5344,82 @@ multiplicity 2
 
 N2H2(T)_p1
 multiplicity 3
-1 *1 N u2 p0 c+1 {2,S} {3,S}
-2    N u0 p2 c-1 {1,S} {4,S}
+1 *1 N u1 p1 c0 {2,S} {3,S}
+2    N u1 p1 c0 {1,S} {4,S}
 3    H u0 p0 c0 {1,S}
 4    H u0 p0 c0 {2,S}
 
 DMS
-1    C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
-2    S u0 p2 c0 {1,S} {3,S}
-3 *1 C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-4    H u0 p0 c0 {1,S}
-5    H u0 p0 c0 {1,S}
-6    H u0 p0 c0 {1,S}
+1    S u0 p2 c0 {2,S} {3,S}
+2    C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+3 *1 C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
 7 *2 H u0 p0 c0 {3,S}
 8    H u0 p0 c0 {3,S}
 9    H u0 p0 c0 {3,S}
 
 DMSrad
 multiplicity 2
-1    C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
-2    S u0 p2 c0 {1,S} {3,S}
-3 *1 C u1 p0 c0 {2,S} {4,S} {5,S}
-4    H u0 p0 c0 {3,S}
-5    H u0 p0 c0 {3,S}
-6    H u0 p0 c0 {1,S}
-7    H u0 p0 c0 {1,S}
-8    H u0 p0 c0 {1,S}
+1    S u0 p2 c0 {2,S} {3,S}
+2    C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+3 *1 C u1 p0 c0 {1,S} {7,S} {8,S}
+4    H u0 p0 c0 {2,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
 
 DMSO
-1     C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
-2     S u0 p1 c0 {1,S} {3,D} {4,S}
-3     O u0 p2 c0 {2,D}
-4  *1 C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
-5     H u0 p0 c0 {1,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
+1     S u0 p1 c0 {2,D} {3,S} {4,S}
+2     O u0 p2 c0 {1,D}
+3     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4  *1 C u0 p0 c0 {1,S} {8,S} {9,S} {10,S}
+5     H u0 p0 c0 {3,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
 8  *2 H u0 p0 c0 {4,S}
 9     H u0 p0 c0 {4,S}
 10    H u0 p0 c0 {4,S}
 
 DMSOrad
 multiplicity 2
-1    C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-2    S u0 p1 c0 {1,S} {3,D} {4,S}
-3    O u0 p2 c0 {2,D}
-4 *1 C u1 p0 c0 {2,S} {5,S} {6,S}
-5    H u0 p0 c0 {4,S}
-6    H u0 p0 c0 {4,S}
-7    H u0 p0 c0 {1,S}
-8    H u0 p0 c0 {1,S}
-9    H u0 p0 c0 {1,S}
+1    S u0 p1 c0 {2,D} {3,S} {4,S}
+2    O u0 p2 c0 {1,D}
+3    C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+4 *1 C u1 p0 c0 {1,S} {8,S} {9,S}
+5    H u0 p0 c0 {3,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {4,S}
 
 DMSO2
-1     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
-2     S u0 p0 c0 {1,S} {3,D} {4,D} {5,S}
-3     O u0 p2 c0 {2,D}
-4     O u0 p2 c0 {2,D}
-5  *1 C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
-6     H u0 p0 c0 {1,S}
-7     H u0 p0 c0 {1,S}
-8     H u0 p0 c0 {1,S}
+1     S u0 p0 c0 {2,D} {3,D} {4,S} {5,S}
+2     O u0 p2 c0 {1,D}
+3     O u0 p2 c0 {1,D}
+4     C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+5  *1 C u0 p0 c0 {1,S} {9,S} {10,S} {11,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
 9  *2 H u0 p0 c0 {5,S}
 10    H u0 p0 c0 {5,S}
 11    H u0 p0 c0 {5,S}
 
 DMSO2rad
 multiplicity 2
-1     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
-2     S u0 p0 c0 {1,S} {3,D} {4,D} {5,S}
-3     O u0 p2 c0 {2,D}
-4     O u0 p2 c0 {2,D}
-5  *1 C u1 p0 c0 {2,S} {6,S} {7,S}
-6     H u0 p0 c0 {5,S}
-7     H u0 p0 c0 {5,S}
-8     H u0 p0 c0 {1,S}
-9     H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {1,S}
+1     S u0 p0 c0 {2,D} {3,D} {4,S} {5,S}
+2     O u0 p2 c0 {1,D}
+3     O u0 p2 c0 {1,D}
+4     C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+5  *1 C u1 p0 c0 {1,S} {9,S} {10,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
 
 I_r3
 multiplicity 2
@@ -5454,4 +5454,80 @@ C6H6_p23
 10    H u0 p0 c0 {2,S}
 11    H u0 p0 c0 {5,S}
 12    H u0 p0 c0 {6,S}
+
+C5H12-3
+1     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2  *1 C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+3     C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+4     C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5     C u0 p0 c0 {3,S} {15,S} {16,S} {17,S}
+6  *2 H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C5H11-2
+multiplicity 2
+1     C u0 p0 c0 {2,S} {3,S} {6,S} {7,S}
+2     C u0 p0 c0 {1,S} {5,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {5,S} {13,S} {14,S} {15,S}
+5  *3 C u1 p0 c0 {2,S} {4,S} {16,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
+
+C5H12-4
+1  *1 C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+2     C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+3     C u0 p0 c0 {1,S} {5,S} {10,S} {11,S}
+4     C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+5     C u0 p0 c0 {3,S} {15,S} {16,S} {17,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {2,S}
+8  *2 H u0 p0 c0 {1,S}
+9     H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {5,S}
+16    H u0 p0 c0 {5,S}
+17    H u0 p0 c0 {5,S}
+
+C5H11-3
+multiplicity 2
+1     C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+2     C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+3     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {2,S} {13,S} {14,S} {15,S}
+5  *3 C u1 p0 c0 {1,S} {2,S} {16,S}
+6     H u0 p0 c0 {1,S}
+7     H u0 p0 c0 {1,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {4,S}
+15    H u0 p0 c0 {4,S}
+16    H u0 p0 c0 {5,S}
 

--- a/input/kinetics/families/H_Abstraction/training/reactions.py
+++ b/input/kinetics/families/H_Abstraction/training/reactions.py
@@ -43429,3 +43429,46 @@ An estimated temperature-independent rate constant for the reaction between C6H5
 """,
 )
 
+entry(
+    index = 3104,
+    label = "OH + C4H10b <=> H2O + C4H9-2",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(A=(2.80023e+07,'cm^3/(mol*s)'), n=1.6, Ea=(1970.25,'J/mol'), T0=(1,'K'), Tmin=(235,'K'), Tmax=(1407,'K')),
+    rank = 7,
+    shortDesc = """Measured by shock tube experiments.""",
+    longDesc = 
+"""
+Cited from Badra, Jihad, Ehson F. Nasir, and Aamir Farooq. "Site-specific rate constant 
+measurements for primary and secondary h-and d-abstraction by oh radicals: Propane and n-butane." The Journal 
+of PhysicalChemistry A 118.26 (2014): 4652-4660.
+""",
+)
+
+entry(
+    index = 3105,
+    label = "OH + C5H12-3 <=> H2O + C5H11-2",
+    degeneracy = 4.0,
+    kinetics = Arrhenius(A=(1.41e+10,'cm^3/(mol*s)'), n=0.94, Ea=(504.7,'cal/mol'), T0=(1,'K')),
+    rank = 10,
+    shortDesc = """From JetSurF2.0 NC5H12 + OH <=> SXC5H11 + H2O""",
+    longDesc = 
+"""
+From JetSurF2.0 NC5H12 + OH <=> SXC5H11 + H2O
+""",
+)
+
+entry(
+    index = 3106,
+    label = "OH + C5H12-4 <=> H2O + C5H11-3",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(2.86045e+06,'cm^3/(mol*s)'), n=1.811, Ea=(-511,'cal/mol'), T0=(1,'K')),
+    rank = 7,
+    shortDesc = """Measured by shock tube experiments.""",
+    longDesc = 
+"""
+Cited from Sivaramakrishnan, R., and J. V. Michael. "Rate constants for OH with 
+selected large alkanes: shock-tube measurements and an improved group scheme." The 
+Journal of Physical Chemistry A 113.17 (2009): 5047-5060.
+""",
+)
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35771233/90587171-b70b1900-e1a6-11ea-845b-6d89d06dd984.png)
Previously, RMG rate rules did a very poor job of estimating the rate of -CH2- + OH reactions (the bottom purple line).

To improve performance, 3 training reactions are added (-CH2- of n-butane and n-pentane + OH). The sources of the rates coefficients are noted in the description section. Although rate coefficients from a high level of theory calculations are desired, I can only find rates from fittings combining low-T experiment and shock tube results. Since other models like NUIG pentane or LLNL heptane are also using the same set of rate (actually rate rules based on these values), I think these values are acceptable.

The updated estimation is shown as the pink line. As can be seen, it is much closer to the rates of C3 / C4. As a comparison, rates of -CH3 + OH are also listed in the figure, which helps justify the rationale of the updated values.