### PR TITLE
Distributing catalytic deutschmann rates into vdw families

### DIFF
--- a/input/kinetics/families/Surface_Abstraction_vdW/training/dictionary.txt
+++ b/input/kinetics/families/Surface_Abstraction_vdW/training/dictionary.txt
@@ -78,3 +78,18 @@ HCOO_5*
 3 *3 C u0 p0 c0 {1,S} {2,D} {4,S}
 4    H u0 p0 c0 {3,S}
 5 *5 X u0 p0 c0 {1,S}
+
+CH4*
+1 *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 *3 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6 *1 X u0 p0 c0
+
+CH3*
+1 *2 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5 *1 X u0 p0 c0 {1,S}

--- a/input/kinetics/families/Surface_Abstraction_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Abstraction_vdW/training/reactions.py
@@ -8,6 +8,29 @@ Put kinetic parameters for specific reactions in this file to use as a
 training set for generating rate rules to populate this kinetics family.
 """
 
+# reverse of 16, below
+# entry(
+#     index = 34,
+#     label = "H2O* + O* <=> OH_2* + OH_4*",
+#     degeneracy = 2,
+#     kinetics = SurfaceArrhenius(
+#         A = (8.14E20, 'm^2/(mol*s)'),
+#         n = -0.274,
+#         Ea = (218400, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     rank = 10,
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R34
+#     test surface mechanism: based upon Olaf Deutschmann's work:
+#     "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+#     Delgado et al
+#     Catalysts, 2015, 5, 871-904""",
+# 	  metal = "Ni",
+# )
+
+# reverse of 34, above
 entry(
     index = 16,
     label = "OH_2* + OH_4* <=> H2O* + O*",
@@ -29,6 +52,27 @@ A factor from paper / surface site density of Cu
 1.675e12 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 5.691e16 m^2/(mol*s)
 """,
     metal = "Cu",
+)
+
+entry(
+    index = 21,
+    label = "CH4* + O* <=> CH3* + OH_4*",
+    degeneracy = 4,
+    kinetics = SurfaceArrhenius(
+        A = (5.62E20, 'm^2/(mol*s)'),
+        n = -0.101,
+        Ea = (92700, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""R21
+    test surface mechanism: based upon Olaf Deutschmann's work:
+    "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+    Delgado et al
+    Catalysts, 2015, 5, 871-904""",
+	metal = "Ni",
 )
 
 entry(

--- a/input/kinetics/families/Surface_Addition_Single_vdW/training/dictionary.txt
+++ b/input/kinetics/families/Surface_Addition_Single_vdW/training/dictionary.txt
@@ -8,7 +8,7 @@ CO2*
 3 *3 C u0 p0 c0 {1,D} {2,D}
 4 *1 X u0 p0 c0
 
-Cu5
+X_5
 1 *5 X u0 p0 c0
 
 HCOO*

--- a/input/kinetics/families/Surface_Addition_Single_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Addition_Single_vdW/training/reactions.py
@@ -10,7 +10,7 @@ training set for generating rate rules to populate this kinetics family.
 
 entry(
     index = 11,
-    label = "COOH* + Cu5 <=> CO2_2* + H*",
+    label = "COOH* + X_5 <=> CO2_2* + H*",
     degeneracy = 2,
     kinetics = SurfaceArrhenius(
         A = (8.028e17, 'm^2/(mol*s)'),
@@ -31,9 +31,31 @@ A factor from paper / surface site density of Cu
     metal = "Cu",
 )
 
+#reverse of 11
+# entry(
+#     index = 45,
+#     label = "CO2_2* + H* <=> COOH* + X_5",
+#     degeneracy = 2,
+#     kinetics = SurfaceArrhenius(
+#         A = (6.25E20, 'm^2/(mol*s)'),
+#         n = -0.475,
+#         Ea = (117200, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     rank = 10,
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R45
+#     test surface mechanism: based upon Olaf Deutschmann's work:
+#     "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+#     Delgado et al
+#     Catalysts, 2015, 5, 871-904""",
+# 	  metal = "Ni",
+# )
+
 entry(
     index = 17,
-    label = "CO2* + H* <=> HCOO* + Cu5",
+    label = "CO2* + H* <=> HCOO* + X_5",
     degeneracy = 2,
     kinetics = SurfaceArrhenius(
         A = (1.243e18, 'm^2/(mol*s)'),
@@ -56,7 +78,7 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 20,
-    label = "HCOOH* + H* <=> CH3O2_2* + Cu5",
+    label = "HCOOH* + H* <=> CH3O2_2* + X_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A = (2.122e19, 'm^2/(mol*s)'),
@@ -79,7 +101,7 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 23,
-    label = "CH3O2* + Cu5 <=> CH2O* + OH*",
+    label = "CH3O2* + X_5 <=> CH2O* + OH*",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A = (3.401e17, 'm^2/(mol*s)'),
@@ -102,7 +124,7 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 24,
-    label = "CH2O* + H* <=> CH3O_1* + Cu5",
+    label = "CH2O* + H* <=> CH3O_1* + X_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A = (6.167e17, 'm^2/(mol*s)'),
@@ -125,7 +147,7 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 31,
-    label = "CH2O_2* + H* <=> CH2OH* + Cu5",
+    label = "CH2O_2* + H* <=> CH2OH* + X_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A = (3.234e19, 'm^2/(mol*s)'),
@@ -148,7 +170,7 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 47,
-    label = "CH3O_5* + CH2O* <=> H2COOCH3* + Cu5",
+    label = "CH3O_5* + CH2O* <=> H2COOCH3* + X_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A = (2.176e18, 'm^2/(mol*s)'),
@@ -171,7 +193,7 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 48,
-    label = "HCOOCH3* + H* <=> H2COOCH3_2* + Cu5",
+    label = "HCOOCH3* + H* <=> H2COOCH3_2* + X_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A = (5.219e16, 'm^2/(mol*s)'),

--- a/input/kinetics/families/Surface_Adsorption_vdW/training/dictionary.txt
+++ b/input/kinetics/families/Surface_Adsorption_vdW/training/dictionary.txt
@@ -1,0 +1,39 @@
+X
+1 *2 X u0 p0 c0
+
+H2O
+1 *1 O u0 p2 c0 {2,S} {3,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+
+H2OX
+1 *1 O u0 p2 c0 {2,S} {3,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4 *2 X u0 p0 c0
+
+CO2
+1 *1 C u0 p0 c0 {2,D} {3,D}
+2    O u0 p2 c0 {1,D}
+3    O u0 p2 c0 {1,D}
+
+CO2X
+1 *1 C u0 p0 c0 {2,D} {3,D}
+2    O u0 p2 c0 {1,D}
+3    O u0 p2 c0 {1,D}
+4 *2 X u0 p0 c0
+
+CH4
+1 *1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+
+CH4X
+1 *1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6 *2 X u0 p0 c0

--- a/input/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Adsorption_vdW/training/reactions.py
@@ -7,3 +7,63 @@ longDesc = u"""
 Put kinetic parameters for specific reactions in this file to use as a
 training set for generating rate rules to populate this kinetics family.
 """
+
+entry(
+    index = 5,
+    label = "H2O + X <=> H2OX",
+    kinetics = StickingCoefficient(
+        A = 1.0E-1,
+        n = 0,
+        Ea = (0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""R5
+    test surface mechanism: based upon Olaf Deutschmann's work:
+    "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+    Delgado et al
+    Catalysts, 2015, 5, 871-904""",
+	metal = "Ni",
+)
+
+entry(
+    index = 7,
+    label = "CO2 + X <=> CO2X",
+    kinetics = StickingCoefficient(
+        A = 7.0E-6,
+        n = 0,
+        Ea = (0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""R7
+    test surface mechanism: based upon Olaf Deutschmann's work:
+    "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+    Delgado et al
+    Catalysts, 2015, 5, 871-904""",
+	metal = "Ni",
+)
+
+entry(
+    index = 11,
+    label = "CH4 + X <=> CH4X",
+    kinetics = StickingCoefficient(
+        A = 8.0E-3,
+        n = 0,
+        Ea = (0, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""R11
+    test surface mechanism: based upon Olaf Deutschmann's work:
+    "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+    Delgado et al
+    Catalysts, 2015, 5, 871-904""",
+	metal = "Ni",
+)

--- a/input/kinetics/families/Surface_Dissociation_Double_vdW/training/dictionary.txt
+++ b/input/kinetics/families/Surface_Dissociation_Double_vdW/training/dictionary.txt
@@ -13,7 +13,7 @@ CO2*
 3 *3 C u0 p0 c0 {1,D} {2,D}
 4 *1 X u0 p0 c0
 
-Cu4
+X_4
 1 *4 X u0 p0 c0
 
 HCOOH*

--- a/input/kinetics/families/Surface_Dissociation_Double_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Dissociation_Double_vdW/training/reactions.py
@@ -10,12 +10,12 @@ training set for generating rate rules to populate this kinetics family.
 
 entry(
     index = 9,
-    label = "CO* + O* <=> CO2* + Cu4",
+    label = "CO* + O* <=> CO2* + X_4",
     degeneracy = 2,
     kinetics = SurfaceArrhenius(
-        A=(4.060e16, 'm^2/(mol*s)'),
+        A = (4.060e16, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(14.9893562, 'kcal/mol'),
+        Ea = (14.9893562, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -31,14 +31,35 @@ A factor from paper / surface site density of Cu
     metal = "Cu",
 )
 
+# duplicate of 9
+# entry(
+#     index = 42,
+#     label = "CO2* + X_4 <=> CO* + O*",
+#     kinetics = SurfaceArrhenius(
+#         A = (4.64E19, 'm^2/(mol*s)'),
+#         n = -1.0,
+#         Ea = (89300.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     rank = 10,
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R42
+#     test surface mechanism: based upon Olaf Deutschmann's work:
+#     "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+#     Delgado et al
+#     Catalysts, 2015, 5, 871-904""",
+# 	  metal = "Ni",
+# )
+
 entry(
     index = 35,
-    label = "HCOOH* + Cu4 <=> HCOH* + O*",
+    label = "HCOOH* + X_4 <=> HCOH* + O*",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(1.641e16, 'm^2/(mol*s)'),
+        A = (1.641e16, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(57.65137, 'kcal/mol'),
+        Ea = (57.65137, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),

--- a/input/kinetics/families/Surface_Dissociation_vdW/training/dictionary.txt
+++ b/input/kinetics/families/Surface_Dissociation_vdW/training/dictionary.txt
@@ -15,7 +15,7 @@ CH2O*
 4 *2 H u0 p0 c0 {2,S}
 5 *3 X u0 p0 c0
 
-Cu4
+X_4
 1 *4 X u0 p0 c0
 
 H2O*
@@ -119,3 +119,18 @@ CH3OH_2*
 5    H u0 p0 c0 {2,S}
 6 *2 H u0 p0 c0 {1,S}
 7 *3 X u0 p0 c0
+
+CH4*
+1 *1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 *2 H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5    H u0 p0 c0 {1,S}
+6 *3 X u0 p0 c0
+
+CH3*
+1 *1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2    H u0 p0 c0 {1,S}
+3    H u0 p0 c0 {1,S}
+4    H u0 p0 c0 {1,S}
+5 *3 X u0 p0 c0 {1,S}

--- a/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/training/reactions.py
@@ -10,7 +10,7 @@ training set for generating rate rules to populate this kinetics family.
 
 entry(
     index = 7,
-    label = "NH3_X + Cu4 <=> NH2_X + H*",
+    label = "NH3_X + X_4 <=> NH2_X + H*",
     degeneracy = 3,
     kinetics = SurfaceArrhenius(
         A = (5.723e22, 'cm^2/(mol*s)'),
@@ -32,13 +32,34 @@ entry(
 )
 
 entry(
+    index = 12,
+    label = "CH4* + X_4 <=> CH3* + H*",
+    degeneracy = 4,
+    kinetics = SurfaceArrhenius(
+        A = (1.54E17,'m^2/(mol*s)'),
+        n = 0.087,
+        Ea = (55800, 'J/mol'),
+        Tmin = (200, 'K'),
+        Tmax = (3000, 'K'),
+    ),
+    rank = 10,
+    shortDesc = u"""Default""",
+    longDesc = u"""R13
+    test surface mechanism: based upon Olaf Deutschmann's work:
+    "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+    Delgado et al
+    Catalysts, 2015, 5, 871-904""",
+	metal = "Ni",
+)
+
+entry(
     index = 13,
-    label = "COOH* + H* <=> HCOOH* + Cu4",
+    label = "COOH* + H* <=> HCOOH* + X_4",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(2.308e18, 'm^2/(mol*s)'),
+        A = (2.308e18, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(16.8342, 'kcal/mol'),
+        Ea = (16.8342, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -56,12 +77,12 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 14,
-    label = "H2O* + Cu4 <=> OH* + H*",
+    label = "H2O* + X_4 <=> OH* + H*",
     degeneracy = 2,
     kinetics = SurfaceArrhenius(
-        A=(4.879e15, 'm^2/(mol*s)'),
+        A = (4.879e15, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(4.84271508, 'kcal/mol'),
+        Ea = (4.84271508, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -77,14 +98,35 @@ A factor from paper / surface site density of Cu
     metal = "Cu",
 )
 
+#duplicate of 14
+# entry(
+#     index = 29,
+#     label = "H2O* + X_4 <=> CH3* + H*",
+#     kinetics = SurfaceArrhenius(
+#         A = (3.67E17, 'm^2/(mol*s)'),
+#         n = -0.086,
+#         Ea = (92.9, 'kJ/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     rank = 10,
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R29
+#     test surface mechanism: based upon Olaf Deutschmann's work:
+#     "Surface Reaction Kinetics of Steam- and CO2-Reforming as well as Oxidation of Methane over Nickel-Based Catalysts"
+#     Delgado et al
+#     Catalysts, 2015, 5, 871-904""",
+# 	metal = "Ni",
+# )
+
 entry(
     index = 19,
-    label = "HCOO* + H* <=> HCOOH_1* + Cu4",
+    label = "HCOO* + H* <=> HCOOH_1* + X_4",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(4.424e18, 'm^2/(mol*s)'),
+        A = (4.424e18, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(20.9850987, 'kcal/mol'),
+        Ea = (20.9850987, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -102,12 +144,12 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 25,
-    label = "CH3O* + H* <=> CH3OH_2* + Cu4",
+    label = "CH3O* + H* <=> CH3OH_2* + X_4",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(4.349e22, 'm^2/(mol*s)'),
+        A = (4.349e22, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(10.8384576, 'kcal/mol'),
+        Ea = (10.8384576, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -125,12 +167,12 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 30,
-    label = "HCO* + H* <=> CH2O* + Cu4",
+    label = "HCO* + H* <=> CH2O* + X_4",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(1.932e17, 'm^2/(mol*s)'),
+        A = (1.932e17, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(10.8384576, 'kcal/mol'),
+        Ea = (10.8384576, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -148,12 +190,12 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 33,
-    label = "CH2OH* + H* <=> CH3OH_1* + Cu4",
+    label = "CH2OH* + H* <=> CH3OH_1* + X_4",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(2.783e17, 'm^2/(mol*s)'),
+        A = (2.783e17, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(37.5886933, 'kcal/mol'),
+        Ea = (37.5886933, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
@@ -171,12 +213,12 @@ A factor from paper / surface site density of Cu
 
 entry(
     index = 34,
-    label = "HCOOH_2* + Cu4 <=> HCO* + OH_2*",
+    label = "HCOOH_2* + X_4 <=> HCO* + OH_2*",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
-        A=(1.781e17, 'm^2/(mol*s)'),
+        A = (1.781e17, 'm^2/(mol*s)'),
         n = 0.,
-        Ea=(37.5886933, 'kcal/mol'),
+        Ea = (37.5886933, 'kcal/mol'),
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),

--- a/input/kinetics/libraries/Surface/Deutschmann_Ni/dictionary.txt
+++ b/input/kinetics/libraries/Surface/Deutschmann_Ni/dictionary.txt
@@ -121,4 +121,8 @@ CXHO
 3 H u0 p0 {1,S}
 4 X u0 p0 {1,S}
 
-
+CO2X
+1 C u0 p0 c0 {2,D} {3,D}
+2 O u0 p2 c0 {1,D}
+3 O u0 p2 c0 {1,D}
+4 X u0 p0 c0

--- a/input/kinetics/libraries/Surface/Deutschmann_Ni/reactions.py
+++ b/input/kinetics/libraries/Surface/Deutschmann_Ni/reactions.py
@@ -46,10 +46,10 @@ entry(
 )
 
 #skip R4
-#skip R5 vdW
-#skip R6 vdW
-#skip R7 vdW
-#skip R8 vdW
+#R5 moved to Surface_Adsorption_vdW
+#skip R6 vdW, reverse of R5
+#R7 moved to Surface_Adsorption_vdW
+#skip R8 vdW, reverse of R7
 
 #CFG: CO is a special case: we need to treat it separately
 entry(
@@ -68,26 +68,27 @@ entry(
 )
 
 #skip R10
-#skip R11 vdW
-#skip R12 vdW
-#skip R13
+#R11 moved to Surface_Adsorption_vdW
+#skip R12, reverse of R11
+#R13 moved to Surface_Dissociation_vdW
 
 #CFG: Modified version of R14: reverse of dissociative adsorption
 #since vdW is not yet functioning, we include this reaction in library
-entry(
-    index = 14,
-    label = "CH3X + HX <=> CH4 + Ni + Ni",
-    kinetics = SurfaceArrhenius(
-        A=(1.44E18, 'm^2/(mol*s)'),
-        n = -0.087,
-        Ea=(63400.0, 'J/mol'),
-        Tmin = (200, 'K'),
-        Tmax = (3000, 'K'),
-    ),
-    shortDesc = u"""Default""",
-    longDesc = u"""R14. Deutschmann actually uses vdW CH4 as product, but we skip it and this reaction as the reverse of our adsorption step""",
-	metal = "Ni",
-)
+#now vdW is functioning and R13 was added, this can be commented out
+# entry(
+#     index = 14,
+#     label = "CH3X + HX <=> CH4X + Ni",
+#     kinetics = SurfaceArrhenius(
+#         A=(1.44E18, 'm^2/(mol*s)'),
+#         n = -0.087,
+#         Ea=(63400.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R14. We input reverse direction""",
+# 	metal = "Ni",
+# )
 
 #skip R15
 # moved to Surface_Dissociation/training
@@ -140,24 +141,25 @@ entry(
 #)
 
 #skip R20
-#skip R21
+#moved R21 to Surface_Abstraction_vdW
 
 #CFG: Modified version of R22: CH4* now goes directly to CH4(g)
 #since vdW is not yet functioning, we include this reaction in library
-entry(
-    index = 22,
-    label = "CH3X + HOX <=> CH4 + OX + Ni",
-    kinetics = SurfaceArrhenius(
-        A=(2.98E18, 'm^2/(mol*s)'),
-        n = 0.101,
-        Ea=(25800.0, 'J/mol'),
-        Tmin = (200, 'K'),
-        Tmax = (3000, 'K'),
-    ),
-    shortDesc = u"""Default""",
-    longDesc = u"""R22. Deutschmann actually goes to vdW CH4, but we'll skip that. We input reverse direction""",
-	metal = "Ni",
-)
+#now vdW is functioning and R21 was added, this can be commented out
+# entry(
+#     index = 22,
+#     label = "CH3X + HOX <=> CH4X + OX",
+#     kinetics = SurfaceArrhenius(
+#         A=(2.98E18, 'm^2/(mol*s)'),
+#         n = 0.101,
+#         Ea=(25800.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R22. We input reverse direction""",
+# 	metal = "Ni",
+# )
 
 #skip R23
 #moved R24 to Surface_Abstraction/training
@@ -210,23 +212,24 @@ entry(
 #)
 
 #skip R28
-#skip R29 vdW
+#moved R29 to Surface_Dissociation_vdW
 
 #since vdW is not yet functioning, we include this reaction in library
-entry(
-    index = 30,
-    label = "HX + HOX <=> H2O + Ni + Ni",
-    kinetics = SurfaceArrhenius(
-        A=(1.85E16, 'm^2/(mol*s)'),
-        n = 0.086,
-        Ea=(41500.0, 'J/mol'),
-        Tmin = (200, 'K'),
-        Tmax = (3000, 'K'),
-    ),
-    shortDesc = u"""Default""",
-    longDesc = u"""R30. Deutschmann actually goes to vdW H2O, but we'll skip that. We input reverse direction""",
-	metal = "Ni",
-)
+#now vdW is functioning and R29 was added, this can be commented out
+# entry(
+#     index = 30,
+#     label = "HX + HOX <=> H2OX + Ni",
+#     kinetics = SurfaceArrhenius(
+#         A=(1.85E16, 'm^2/(mol*s)'),
+#         n = 0.086,
+#         Ea=(41500.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R30. We input reverse direction""",
+# 	metal = "Ni",
+# )
 
 #skip R31
 #moved to Surface_Dissociation/training
@@ -246,22 +249,23 @@ entry(
 #)
 
 #since vdW is not yet functioning, we include this reaction in library
-entry(
-    index = 33,
-    label = "HOX + HOX <=> H2O + OX + Ni",
-    kinetics = SurfaceArrhenius(
-        A=(2.34E16, 'm^2/(mol*s)'),
-        n = 0.274,
-        Ea=(92300.0, 'J/mol'),
-        Tmin = (200, 'K'),
-        Tmax = (3000, 'K'),
-    ),
-    shortDesc = u"""Default""",
-    longDesc = u"""R33""",
-	metal = "Ni",
-)
+#now vdW is functioning and R34 was added, this can be commented out
+# entry(
+#     index = 33,
+#     label = "HOX + HOX <=> H2O + OX + Ni",
+#     kinetics = SurfaceArrhenius(
+#         A=(2.34E16, 'm^2/(mol*s)'),
+#         n = 0.274,
+#         Ea=(92300.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R33""",
+# 	metal = "Ni",
+# )
 
-#skip R34 vdW
+#moved R34 to Surface_Abstraction_vdW
 #skip R35
 
 #We don't yet have a template for breaking a double bond for surface dissociation.
@@ -300,9 +304,10 @@ entry(
 )
 
 #since vdW is not yet functioning, we include this reaction in library
+#now vdW is functioning, but we do not have a family for this
 entry(
     index = 39,
-    label = "OCX + OCX <=> CO2 + Ni + CX",
+    label = "OCX + OCX <=> CO2X + CX",
     kinetics = SurfaceArrhenius(
         A=(1.62E10, 'm^2/(mol*s)'),
         n = 0.5,
@@ -311,30 +316,31 @@ entry(
         Tmax = (3000, 'K'),
     ),
     shortDesc = u"""Default""",
-    longDesc = u"""R39 is used instead of R40 to avoid having CO2(s) as reactant""",
+    longDesc = u"""R39. We input reverse direction""",
 	metal = "Ni",
 )
 
-#skip R40
+#skip R40, reverse of R39
 
 #since vdW is not yet functioning, we include this reaction in library
-entry(
-    index = 41,
-    label = "OCX + OX <=> CO2 + Ni + Ni",
-    kinetics = SurfaceArrhenius(
-        A=(2.00E15, 'm^2/(mol*s)'),
-        n = 0.0,
-        Ea=(123600.0, 'J/mol'),
-        Tmin = (200, 'K'),
-        Tmax = (3000, 'K'),
-    ),
-    shortDesc = u"""Default""",
-    longDesc = u"""R41. Deutschmann actually uses vdW CO2, but we skip it and use reverse reaction""",
-	metal = "Ni",
-)
+#now vdW is functioning and R42 was added, this can be commented out
+# entry(
+#     index = 41,
+#     label = "OCX + OX <=> CO2X + Ni",
+#     kinetics = SurfaceArrhenius(
+#         A=(2.00E15, 'm^2/(mol*s)'),
+#         n = 0.0,
+#         Ea=(123600.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R41. We use reverse reaction""",
+# 	metal = "Ni",
+# )
 
 
-#skip R42
+#moved R42 to Surface_Dissociation_Double_vdW
 #skip R43
 # moved to Surface_Dissociation/training
 #entry(
@@ -352,23 +358,24 @@ entry(
 #	 metal = "Ni",
 #)
 
-#skip R45
+#moved R45 to Surface_Addition_Single_vdW
 
 #since vdW is not yet functioning, we include this reaction in library
-entry(
-    index = 46,
-    label = "HOCXO + Ni <=> CO2 + HX + Ni",
-    kinetics = SurfaceArrhenius(
-        A=(3.73E16, 'm^2/(mol*s)'),
-        n = 0.475,
-        Ea=(33600.0, 'J/mol'),
-        Tmin = (200, 'K'),
-        Tmax = (3000, 'K'),
-    ),
-    shortDesc = u"""Default""",
-    longDesc = u"""R46""",
-	metal = "Ni",
-)
+#now vdW is functioning and R45 was added, this can be commented out
+# entry(
+#     index = 46,
+#     label = "HOCXO + Ni <=> CO2X + HX",
+#     kinetics = SurfaceArrhenius(
+#         A=(3.73E16, 'm^2/(mol*s)'),
+#         n = 0.475,
+#         Ea=(33600.0, 'J/mol'),
+#         Tmin = (200, 'K'),
+#         Tmax = (3000, 'K'),
+#     ),
+#     shortDesc = u"""Default""",
+#     longDesc = u"""R46""",
+# 	metal = "Ni",
+# )
 
 
 #skip R47


### PR DESCRIPTION
Now that the new vdw families have been merged in, this PR distributes the rates from the deutschmann library to their corresponding vdw family as training reactions.

this is related to https://github.com/ReactionMechanismGenerator/RMG-database/issues/430 and https://github.com/comocheng/wiki/issues/614 

