### PR TITLE
adsorptionPt111 nitrogen nodes fix

### DIFF
--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -2332,23 +2332,6 @@ entry(
 )
 
 entry(
-    index = 82,
-    label = "(NR2CR3)*",
-    group =
-"""
-1 X  u0 p0 c0
-2 N  u0 p1 c0 {3,S} {4,S} {5,S}
-3 Cs u0 p0 c0 {2,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-""",
-    thermo=u'(NR3)*',
-    longDesc=u"""Do we have data for this?""",
-    metal = "Pt",
-    facet = "111",
-)
-
-entry(
     index = 83,
     label = "(NR2)*",
     group =
@@ -2633,7 +2616,6 @@ L1: R*
             L4: (CRN)*
             L4: (CRCR)*
         L3: (NR3)*
-            L4: (NR2CR3)*
             L4: (NR2NR2)*
             L4: (NR2OR)*
         L3: (NR2)*

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -2333,13 +2333,13 @@ entry(
 
 entry(
     index = 83,
-    label = "(NR2)*",
+    label = "(N=[O,N]R)*",
     group =
 """
-1 X   u0
-2 N   u0 {3,D} {4,S}
-3 R!H u0 {2,D}
-4 R   u0 {2,S}
+1 X     u0
+2 N     u0 {3,D} {4,S}
+3 [N,O] u0 {2,D}
+4 R     u0 {2,S}
 """,
     thermo=u'(NRO)*',
     longDesc=u"""Parent of (RN=O)* and (RN=NR)*. Should it be an average?""",
@@ -2618,7 +2618,7 @@ L1: R*
         L3: (NR3)*
             L4: (NR2NR2)*
             L4: (NR2OR)*
-        L3: (NR2)*
+        L3: (N=[O,N]R)*
             L4: (NRO)*
             L4: (NRNR)*
         L3: (OR2)*

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -2332,7 +2332,7 @@ entry(
 )
 
 entry(
-    index = 83,
+    index = 82,
     label = "(N=[O,N]R)*",
     group =
 """
@@ -2348,7 +2348,7 @@ entry(
 )
 
 entry(
-    index = 84,
+    index = 83,
     label = "N-*RN=*",
     group =
 """
@@ -2378,7 +2378,7 @@ entry(
 )
 
 entry(
-    index = 85,
+    index = 84,
     label = "(CRCR)*",
     group =
 """
@@ -2409,7 +2409,7 @@ entry(
 )
 
 entry(
-    index = 86,
+    index = 85,
     label = "C-*R2N=*",
     group =
 """
@@ -2440,7 +2440,7 @@ entry(
 )
 
 entry(
-    index = 87,
+    index = 86,
     label = "C-*R2N-*R",
     group =
 """
@@ -2472,7 +2472,7 @@ entry(
 )
 
 entry(
-    index = 88,
+    index = 87,
     label = "C=*(=C)",
     group =
 """
@@ -2505,7 +2505,7 @@ not two, it is not a child of the C=*R2 node
 )
 
 entry(
-    index = 89,
+    index = 88,
     label = "C-*R2O-*",
     group =
 """


### PR DESCRIPTION
When we don't skip nitrogen entries in the database tests, we get the following error in the `adsorptionPt111` thermo tree

```
Thermo groups adsorptionPt111: Entry is accessible? ... ERROR:root:
In group adsorptionPt111, a sample molecule made from node (NR2CR3)* returns node (CR3NR2)* when descending the tree.
Sample molecule AdjList:
1 N u0 p1 c0 {2,S} {6,S} {7,S}
2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
3 H u0 p0 c0 {2,S}
4 H u0 p0 c0 {2,S}
5 H u0 p0 c0 {2,S}
6 H u0 p0 c0 {1,S}
7 H u0 p0 c0 {1,S}
8 X u0 p0 c0
Origin Group AdjList:
1 N  u0 p1 c0 {2,S} {3,S} {4,S}
2 Cs u0 p0 c0 {1,S}
3 R  u0 p0 c0 {1,S}
4 R  u0 p0 c0 {1,S}
5 X  u0 p0 c0
Matched group AdjList:
1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
2 N u0 p1 c0 {1,S} {6,S} {7,S}
3 R u0 p0 c0 {1,S}
4 R u0 p0 c0 {1,S}
5 R u0 p0 c0 {1,S}
6 R u0 p0 c0 {2,S}
7 R u0 p0 c0 {2,S}
8 X u0 p0 c0
ERROR:root:
In group adsorptionPt111, a sample molecule made from node (NR2)* returns node (CR2NR)* when descending the tree.
Sample molecule AdjList:
1 N u0 p1 c0 {2,D} {5,S}
2 C u0 p0 c0 {1,D} {3,S} {4,S}
3 H u0 p0 c0 {2,S}
4 H u0 p0 c0 {2,S}
5 H u0 p0 c0 {1,S}
6 X u0 p0 c0
Origin Group AdjList:
1 N   u0 {2,D} {3,S}
2 R!H u0 {1,D}
3 R   u0 {1,S}
4 X   u0
Matched group AdjList:
1 C u0 p0 c0 {2,D} {3,S} {4,S}
2 N u0 p1 c0 {1,D} {5,S}
3 R u0 p0 c0 {1,S}
4 R u0 p0 c0 {1,S}
5 R u0 p0 c0 {2,S}
6 X u0 p0 c0
ERROR
```

This PR fixes this error.  We are using this Py branch https://github.com/ReactionMechanismGenerator/RMG-Py/pull/1997 to run the tests so we don't skip the nitrogen entries.