### PR TITLE
Allow CO insertion to H--C(R)=O

### DIFF
--- a/input/kinetics/families/1,2_Insertion_CO/groups.py
+++ b/input/kinetics/families/1,2_Insertion_CO/groups.py
@@ -66,8 +66,8 @@ entry(
     label = "R_H",
     group = 
 """
-1 *2 [H,Cs,Cd,Cb,Ct,O,Sis,Sid,N,S] u0 {2,S}
-2 *3 H                             u0 {1,S}
+1 *2 [H,Cs,Cd,Cb,Ct,CO,O,Sis,Sid,N,S] u0 {2,S}
+2 *3 H                                u0 {1,S}
 """,
     kinetics = None,
 )


### PR DESCRIPTION
This is a simple patch to allow `CO + H----C(R)=O  <=> H--C(=O)--C(R)=O` reactions to be generated by `1,2_Insertion_CO`.

I found this type of reaction (actually, TSs) in the training data from Colin et al. (https://pubs.acs.org/doi/full/10.1021/acs.jpclett.0c00500). Due to limited training reactions, only the very top node is modified and no child node is added. If the reviewer thinks it is important, I can make further modifications. 