### PR TITLE
forbid adjacent radicals in adsorption double family

### DIFF
--- a/input/kinetics/families/Surface_Adsorption_Double/groups.py
+++ b/input/kinetics/families/Surface_Adsorption_Double/groups.py
@@ -57,3 +57,17 @@ L1: Adsorbate
 L1: VacantSite
 """
 )
+
+forbidden(
+    label = "adjacent_radical",
+    group =
+"""
+1 *1 R!H u2 {2,S}
+2    R!H u1 {1,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+forbid atom adjacent to adsorbing atom to have unpaired electrons
+""",
+)


### PR DESCRIPTION
we forbid adjacent radicals in adsorption double family. this is to address issue [220](https://github.com/ReactionMechanismGenerator/RMG-website/issues/220) on the website. longer term we have linked [this](https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2106) issue on RMG-Py to address how we handle forbidden species in surface families, but that requires a more involved PR. 