### PR TITLE
Upgrade solvation thermo GAV and solute & solvent libraries

### DIFF
--- a/input/solvation/groups/group.py
+++ b/input/solvation/groups/group.py
@@ -1,0 +1,32414 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "group"
+shortDesc = u""
+longDesc = u""" 
+All groups are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter data (manuscript in preparation)
+unless written otherwise.
+"""
+
+entry(
+	index = -1,
+	label = "R",
+	group = 
+"""
+1 * R ux
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1,
+	label = "C",
+	group = 
+"""
+1 * C u0
+""",
+	solute = u'Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 2,
+	label = "C2tc",
+	group = 
+"""
+1 * C2tc u0 p1 c-1
+""",
+	solute = u'C2tc-N5tc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 3,
+	label = "C2tc-N5tc",
+	group = 
+"""
+1 * C2tc u0 p1 c-1 {2,T}
+2   N5tc u0 c+1 {1,T}
+""",
+	solute = SoluteData(
+		S = 0.08110,
+		B = 0.01778,
+		E = 0.08002,
+		L = 0.37429,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 4,
+	label = "Cbf",
+	group = 
+"""
+1 * Cbf u0
+""",
+	solute = u'Cbf-CbCbCbf',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 5,
+	label = "Cbf-CbCbCbf",
+	group = 
+"""
+1 * Cbf u0 {2,B} {3,B} {4,B}
+2   Cb  u0 {1,B}
+3   Cb  u0 {1,B}
+4   Cbf u0 {1,B}
+""",
+	solute = SoluteData(
+		S = 0.07856,
+		B = 0.01187,
+		E = 0.24563,
+		L = 0.75301,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 335,
+		B = 330,
+		E = 373,
+		L = 333,
+		A = 373,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 6,
+	label = "Cbf-CbCbfCbf",
+	group = 
+"""
+1 * Cbf u0 {2,B} {3,B} {4,B}
+2   Cb  u0 {1,B}
+3   Cbf u0 {1,B}
+4   Cbf u0 {1,B}
+""",
+	solute = SoluteData(
+		S = 0.06907,
+		B = 0.03191,
+		E = 0.30385,
+		L = 0.64169,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 51,
+		B = 50,
+		E = 73,
+		L = 67,
+		A = 74,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 7,
+	label = "Cbf-CbfCbfCbf",
+	group = 
+"""
+1 * Cbf u0 {2,B} {3,B} {4,B}
+2   Cbf u0 {1,B}
+3   Cbf u0 {1,B}
+4   Cbf u0 {1,B}
+""",
+	solute = SoluteData(
+		S = 0.06184,
+		B = 0.05644,
+		E = 0.22728,
+		L = 0.45812,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 25,
+		E = 30,
+		L = 28,
+		A = 30,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 8,
+	label = "Cb",
+	group = 
+"""
+1 * Cb u0
+""",
+	solute = u'Cb-C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 9,
+	label = "Cb-H",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10974,
+		B = 0.01468,
+		E = 0.11814,
+		L = 0.53417,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3841,
+		B = 3704,
+		E = 4058,
+		L = 3525,
+		A = 4039,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 10,
+	label = "Cb-P",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   P  u0 {1,S}
+""",
+	solute = u'Cb-P5d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 11,
+	label = "Cb-P3s",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   P3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05477,
+		B = 0.07566,
+		E = 0.13338,
+		L = 0.85899,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 12,
+	label = "Cb-P5d",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   P5d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06238,
+		B = 0.20534,
+		E = 0.12145,
+		L = 0.72083,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 13,
+	label = "Cb-O",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   O  u0 {1,S}
+""",
+	solute = u'Cb-O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 14,
+	label = "Cb-O2s",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08806,
+		B = 0.08873,
+		E = 0.11740,
+		L = 0.77137,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1100,
+		B = 1055,
+		E = 1145,
+		L = 1053,
+		A = 1127,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 15,
+	label = "Cb-O2rs",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   O2s u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.14959,
+		B = 0.01886,
+		E = 0.14037,
+		L = 0.78052,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 193,
+		B = 193,
+		E = 196,
+		L = 185,
+		A = 193,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 16,
+	label = "Cb-S",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   S u0 {1,S}
+""",
+	solute = u'Cb-S6dd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 17,
+	label = "Cb-S2s",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   S2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.17680,
+		B = 0.03402,
+		E = 0.25607,
+		L = 0.94701,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 24,
+		L = 19,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 18,
+	label = "Cb-S2rs",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   S2s u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07275,
+		B = 0.03881,
+		E = 0.30204,
+		L = 0.98441,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 129,
+		B = 129,
+		E = 132,
+		L = 128,
+		A = 132,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 19,
+	label = "Cb-S4d",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   S4d u0 p1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10827,
+		B = 0.13776,
+		E = 0.10492,
+		L = 0.53771,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 12,
+		L = 11,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 20,
+	label = "Cb-S6dd",
+	group = 
+"""
+1 * Cb   u0 {2,S}
+2   S6dd u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11593,
+		B = 0.01448,
+		E = 0.11357,
+		L = 0.53224,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 153,
+		B = 152,
+		E = 161,
+		L = 141,
+		A = 157,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 21,
+	label = "Cb-N",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   N   u0 {1,S}
+""",
+	solute = u'Cb-N3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 22,
+	label = "Cb-N3s",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12621,
+		B = 0.11692,
+		E = 0.21711,
+		L = 1.02731,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 540,
+		B = 504,
+		E = 567,
+		L = 421,
+		A = 561,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 23,
+	label = "Cb-N3rs",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   N3s u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11872,
+		B = 0.11746,
+		E = 0.22711,
+		L = 0.98327,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 252,
+		B = 242,
+		E = 267,
+		L = 233,
+		A = 254,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 24,
+	label = "Cb-N3d",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   N3d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04532,
+		B = 0.03414,
+		E = 0.10585,
+		L = 0.37962,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 32,
+		B = 32,
+		E = 34,
+		L = 29,
+		A = 33,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 25,
+	label = "Cb-N3rd",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   N3d u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.18304,
+		B = 0.14874,
+		E = 0.25906,
+		L = 0.88577,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 127,
+		B = 119,
+		E = 134,
+		L = 126,
+		A = 128,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 26,
+	label = "Cb-N5dc",
+	group = 
+"""
+1 * Cb   u0 {2,S}
+2   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09953,
+		B = -0.03875,
+		E = 0.13249,
+		L = 0.42484,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 302,
+		B = 300,
+		E = 305,
+		L = 259,
+		A = 308,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 27,
+	label = "Cb-N5tc",
+	group = 
+"""
+1 * Cb   u0 {2,S}
+2   N5tc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03915,
+		B = 0.02085,
+		E = 0.04258,
+		L = 0.24081,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 28,
+	label = "Cb-C",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   C  u0 {1,S}
+""",
+	solute = u'Cb-Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 29,
+	label = "Cb-Cb",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06988,
+		B = 0.02674,
+		E = 0.17229,
+		L = 0.40857,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 379,
+		B = 367,
+		E = 401,
+		L = 385,
+		A = 398,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 30,
+	label = "Cb-Cr",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   C  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07086,
+		B = 0.06486,
+		E = 0.13979,
+		L = 0.71759,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 686,
+		B = 662,
+		E = 731,
+		L = 656,
+		A = 715,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 31,
+	label = "Cb-Cs",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08305,
+		B = 0.09566,
+		E = 0.11012,
+		L = 0.84210,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1440,
+		B = 1362,
+		E = 1529,
+		L = 1301,
+		A = 1507,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 32,
+	label = "Cb-(Cs-Cb)",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Cs u0 {1,S} {3,S}
+3   Cb u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.01163,
+		B = 0.07540,
+		E = 0.09593,
+		L = 0.57243,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 48,
+		B = 47,
+		E = 52,
+		L = 46,
+		A = 49,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 33,
+	label = "Cb-(Cs-Cr)",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Cs u0 {1,S} {3,S}
+3   C  u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.02437,
+		B = 0.13040,
+		E = 0.09298,
+		L = 0.90955,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 23,
+		E = 26,
+		L = 24,
+		A = 26,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 34,
+	label = "Cb-Cds",
+	group = 
+"""
+1 * Cb      u0 {2,S}
+2   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = u'Cb-(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 35,
+	label = "Cb-(Cds-O2d)",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   CO u0 {1,S} {3,D}
+3   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04055,
+		B = 0.01613,
+		E = 0.12083,
+		L = 0.54122,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 317,
+		B = 314,
+		E = 333,
+		L = 262,
+		A = 334,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 36,
+	label = "Cb-(Cds-O2dOs)",
+	group = 
+"""
+1   CO  u0 {2,S} {3,D} {4,S}
+2 * Cb  u0 {1,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.12480,
+		B = 0.00772,
+		E = 0.11354,
+		L = 0.34015,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 365,
+		B = 358,
+		E = 376,
+		L = 345,
+		A = 379,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 37,
+	label = "Cb-(Cds-Cd)",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Cd u0 {1,S} {3,D}
+3   C  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07357,
+		B = 0.06763,
+		E = 0.12021,
+		L = 0.75313,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 84,
+		B = 80,
+		E = 108,
+		L = 97,
+		A = 95,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 38,
+	label = "Cb-(Cds-N3d)",
+	group = 
+"""
+1 * Cb   u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   N3d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.07287,
+		B = 0.14192,
+		E = 0.10959,
+		L = 0.47070,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 29,
+		L = 26,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 39,
+	label = "Cb-(Cds-S2d)",
+	group = 
+"""
+1 * Cb   u0 {2,S}
+2   CS   u0 {1,S} {3,D}
+3   S2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.19617,
+		B = 0.00422,
+		E = 0.07767,
+		L = 0.70680,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 40,
+	label = "Cb-Ct",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Ct u0 {1,S}
+""",
+	solute = u'Cb-(CtN3t)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 41,
+	label = "Cb-(CtCt)",
+	group = 
+"""
+1 * Cb u0 {2,S}
+2   Ct u0 {1,S} {3,T}
+3   Ct u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.00563,
+		B = 0.01953,
+		E = 0.07725,
+		L = 0.26644,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 42,
+	label = "Cb-(CtN3t)",
+	group = 
+"""
+1 * Cb  u0 {2,S}
+2   Ct  u0 {1,S} {3,T}
+3   N3t u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.11598,
+		B = 0.00278,
+		E = 0.04079,
+		L = 0.23385,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 41,
+		E = 46,
+		L = 35,
+		A = 54,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 43,
+	label = "Ct",
+	group = 
+"""
+1 * Ct u0
+""",
+	solute = u'Ct-CtC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 44,
+	label = "Ct-N3tN",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   N   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02836,
+		B = 0.05170,
+		E = 0.00114,
+		L = 0.24359,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 12,
+		L = 2,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 45,
+	label = "Ct-N3tS",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   S   u0 {1,S}
+""",
+	solute = u'Ct-N3tS2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 46,
+	label = "Ct-N3tS2s",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   S2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06822,
+		B = 0.03635,
+		E = 0.11788,
+		L = 0.46689,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 8,
+		E = 8,
+		L = 4,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 47,
+	label = "Ct-CtH",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.16979,
+		B = 0.05857,
+		E = 0.09432,
+		L = 0.51536,
+		A = 0.08872,
+	),
+	dataCount = DataCountGAV(
+		S = 43,
+		B = 46,
+		E = 47,
+		L = 36,
+		A = 48,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 48,
+	label = "Ct-N3tO",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   O   u0 {1,S}
+""",
+	solute = u'Ct-N3tOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 49,
+	label = "Ct-N3tOs",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   O2s  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02528,
+		B = 0.01601,
+		E = -0.00086,
+		L = -0.00928,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 50,
+	label = "Ct-N3tC",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   C   u0 {1,S}
+""",
+	solute = u'Ct-N3tCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 51,
+	label = "Ct-N3tCb",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11598,
+		B = 0.00278,
+		E = 0.04079,
+		L = 0.23385,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 41,
+		E = 46,
+		L = 35,
+		A = 54,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 52,
+	label = "Ct-N3tCs",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.20222,
+		B = 0.09272,
+		E = -0.00212,
+		L = 0.26366,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 56,
+		B = 55,
+		E = 55,
+		L = 52,
+		A = 56,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 53,
+	label = "Ct-N3tCd",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   Cd  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01538,
+		B = 0.02984,
+		E = 0.03048,
+		L = 0.05675,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 23,
+		B = 23,
+		E = 39,
+		L = 36,
+		A = 19,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 54,
+	label = "Ct-N3tCt",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   Ct  u0 {1,S}
+""",
+	solute = u'Ct-N3t(CtN3t)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 55,
+	label = "Ct-N3t(CtN3t)",
+	group = 
+"""
+1 * Ct  u0 {2,T} {3,S}
+2   N3t u0 {1,T}
+3   Ct  u0 {1,S} {4,T}
+4   N3t u0 {3,T}
+""",
+	solute = SoluteData(
+		S = 0.06988,
+		B = -0.05615,
+		E = -0.00092,
+		L = -0.04818,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 56,
+	label = "Ct-CtC",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   C  u0 {1,S}
+""",
+	solute = u'Ct-CtCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 57,
+	label = "Ct-CtCs",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.15051,
+		B = 0.12324,
+		E = 0.11750,
+		L = 0.95445,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 81,
+		B = 84,
+		E = 89,
+		L = 53,
+		A = 86,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 58,
+	label = "Ct-CtCds",
+	group = 
+"""
+1 * Ct      u0 {2,T} {3,S}
+2   Ct      u0 {1,T}
+3   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = u'Ct-Ct(Cds-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 59,
+	label = "Ct-Ct(Cds-O2d)",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   CO u0 {1,S} {4,D}
+4   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.03378,
+		B = 0.03713,
+		E = 0.04079,
+		L = 0.18477,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 60,
+	label = "Ct-Ct(Cds-Cd)",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   Cd u0 {1,S} {4,D}
+4   C  u0 {3,D}
+""",
+	solute = u'Ct-Ct(Cds-Cds)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 61,
+	label = "Ct-Ct(Cds-Cds)",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   Cd u0 {1,S} {4,D}
+4   Cd u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.05273,
+		B = 0.01072,
+		E = 0.09964,
+		L = 0.45881,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 62,
+	label = "Ct-CtCt",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   Ct u0 {1,S}
+""",
+	solute = u'Ct-Ct(CtCt)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 63,
+	label = "Ct-Ct(CtCt)",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   Ct u0 {1,S} {4,T}
+4   Ct u0 {3,T}
+""",
+	solute = SoluteData(
+		S = 0.02917,
+		B = 0.01510,
+		E = 0.07612,
+		L = 0.29643,
+		A = -0.00186,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 64,
+	label = "Ct-CtCb",
+	group = 
+"""
+1 * Ct u0 {2,T} {3,S}
+2   Ct u0 {1,T}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00563,
+		B = 0.01953,
+		E = 0.07725,
+		L = 0.26644,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 65,
+	label = "Cdd",
+	group = 
+"""
+1 * Cdd u0
+""",
+	solute = u'Cdd-CdCd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 66,
+	label = "Cdd-CdCd",
+	group = 
+"""
+1 * Cdd u0 {2,D} {3,D}
+2   C   u0 {1,D}
+3   C   u0 {1,D}
+""",
+	solute = u'Cdd-CdsCds',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 67,
+	label = "Cdd-CdsCds",
+	group = 
+"""
+1 * Cdd u0 {2,D} {3,D}
+2   Cd  u0 {1,D}
+3   Cd  u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.05704,
+		B = 0.02777,
+		E = 0.08002,
+		L = 0.54157,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 10,
+		L = 6,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 68,
+	label = "Cdd-N3dO2d",
+	group = 
+"""
+1 * Cdd u0 {2,D} {3,D}
+2   N3d u0 {1,D}
+3   O2d  u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.16925,
+		B = 0.04807,
+		E = 0.06879,
+		L = 0.50992,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 69,
+	label = "Cdd-N3dS",
+	group = 
+"""
+1 * Cdd u0 {2,D} {3,D}
+2   N3d u0 {1,D}
+3   S   u0 {1,D}
+""",
+	solute = u'Cdd-N3dS2d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 70,
+	label = "Cdd-N3dS2d",
+	group = 
+"""
+1 * Cdd u0 {2,D} {3,D}
+2   N3d u0 {1,D}
+3   S2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.03743,
+		B = -0.02447,
+		E = 0.08017,
+		L = 0.23881,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 10,
+		E = 9,
+		L = 7,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 71,
+	label = "Cds",
+	group = 
+"""
+1 * [Cd,CO,CS] u0
+""",
+	solute = u'Cds-Cd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 72,
+	label = "Cds-Od",
+	group = 
+"""
+1 * CO u0 {2,D}
+2   O  u0 {1,D}
+""",
+	solute = u'Cds-OdCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 73,
+	label = "Cds-OdNC",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N   u0 {1,S}
+3   C   u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = u'Cds-OdN3sC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 74,
+	label = "Cds-OdN3sC",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S}
+3   C   u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = u'Cds-OdN3sCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 75,
+	label = "Crds-OdN3rsCr",
+	group = 
+"""
+1 * CO  u0 r1 {2,S} {3,S} {4,D}
+2   N3s u0 r1 {1,S}
+3   C   u0 r1 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.06281,
+		B = 0.10749,
+		E = 0.07240,
+		L = 0.44045,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 339,
+		B = 337,
+		E = 347,
+		L = 254,
+		A = 340,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 76,
+	label = "Cds-OdN3sCb",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S}
+3   Cb  u0 {1,S}
+4   O2d  u0 {1,D}
+""",
+	solute = u'Cds-Od(N3s-RH)Cb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 77,
+	label = "Cds-Od(N3s-HH)Cb",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   Cb  u0 {1,S}
+4   O2d  u0 {1,D}
+5   H   u0 {2,S}
+6   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.07519,
+		B = 0.02264,
+		E = 0.03618,
+		L = 0.02914,
+		A = 0.01906,
+	),
+	dataCount = DataCountGAV(
+		S = 33,
+		B = 33,
+		E = 35,
+		L = 24,
+		A = 34,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 78,
+	label = "Cds-Od(N3s-RH)Cb",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   Cb  u0 {1,S}
+4   O2d  u0 {1,D}
+5   R!H  u0 {2,S}
+6   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00408,
+		B = 0.04293,
+		E = 0.02920,
+		L = 0.13768,
+		A = 0.01839,
+	),
+	dataCount = DataCountGAV(
+		S = 47,
+		B = 47,
+		E = 47,
+		L = 43,
+		A = 47,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 79,
+	label = "Cds-Od(N3s-RR)Cb",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   Cb  u0 {1,S}
+4   O2d  u0 {1,D}
+5   R!H  u0 {2,S}
+6   R!H  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.06084,
+		B = 0.12192,
+		E = 0.01750,
+		L = -0.00533,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 31,
+		B = 31,
+		E = 31,
+		L = 26,
+		A = 37,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 80,
+	label = "Cds-OdN3sCs",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S}
+3   Cs  u0 {1,S}
+4   O2d  u0 {1,D}
+""",
+	solute = u'Cds-Od(N3s-RH)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 81,
+	label = "Cds-OdN3rsCs",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 r1 {1,S}
+3   Cs  u0 {1,S}
+4   O2d  u0 {1,D}
+""",
+	solute = SoluteData(
+		S = -0.03050,
+		B = -0.02876,
+		E = -0.03080,
+		L = -0.13201,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 41,
+		B = 41,
+		E = 45,
+		L = 35,
+		A = 46,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 82,
+	label = "Cds-Od(N3s-HH)Cs",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   Cs  u0 {1,S}
+4   O2d  u0 {1,D}
+5   H  u0 {2,S}
+6   H  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.12285,
+		B = 0.08867,
+		E = 0.08413,
+		L = 0.40012,
+		A = 0.09053,
+	),
+	dataCount = DataCountGAV(
+		S = 36,
+		B = 36,
+		E = 38,
+		L = 32,
+		A = 36,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 83,
+	label = "Cds-Od(N3s-RH)Cs",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   Cs  u0 {1,S}
+4   O2d  u0 {1,D}
+5   R!H u0 {2,S}
+6   H  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.19227,
+		B = 0.08960,
+		E = 0.00140,
+		L = 0.33521,
+		A = 0.05293,
+	),
+	dataCount = DataCountGAV(
+		S = 157,
+		B = 156,
+		E = 160,
+		L = 139,
+		A = 156,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 84,
+	label = "Cds-Od(N3s-RR)Cs",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   Cs  u0 {1,S}
+4   O2d  u0 {1,D}
+5   R!H u0 {2,S}
+6   R!H u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.13994,
+		B = 0.04639,
+		E = 0.00550,
+		L = 0.38090,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 43,
+		E = 45,
+		L = 39,
+		A = 57,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 85,
+	label = "Cds-OdN3sCd",
+	group = 
+"""
+1 * CO            u0 {2,S} {3,S} {4,D}
+2   N3s           u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   O2d           u0 {1,D}
+""",
+	solute = SoluteData(
+		S = -0.09423,
+		B = 0.04519,
+		E = 0.05442,
+		L = 0.13761,
+		A = 0.05485,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 86,
+	label = "Cds-OdN3rsCd",
+	group = 
+"""
+1 * CO            u0 {2,S} {3,S} {4,D}
+2   N3s           u0 r1 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   O2d           u0 {1,D}
+""",
+	solute = SoluteData(
+		S = -0.08133,
+		B = 0.09407,
+		E = 0.00996,
+		L = 0.03761,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 87,
+	label = "Cds-OdN3sCrd",
+	group = 
+"""
+1 * CO            u0 {2,S} {3,S} {4,D}
+2   N3s           u0 {1,S}
+3   [Cd,CO,CS]  u0 r1 {1,S}
+4   O2d           u0 {1,D}
+""",
+	solute = SoluteData(
+		S = -0.02549,
+		B = 0.03455,
+		E = 0.07157,
+		L = 0.23470,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 66,
+		B = 66,
+		E = 69,
+		L = 59,
+		A = 70,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 88,
+	label = "Cds-OdN3dC",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3d u0 {1,S}
+3   C   u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = u'Crds-OdN3rdCr',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 89,
+	label = "Crds-OdN3rdCr",
+	group = 
+"""
+1 * CO  u0 r1 {2,S} {3,S} {4,D}
+2   N3d u0 r1 {1,S}
+3   C   u0 r1 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.02795,
+		B = 0.05094,
+		E = 0.03857,
+		L = 0.13208,
+		A = 0.00452,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 90,
+	label = "Cds-OdNH",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N   u0 {1,S}
+3   H   u0 {1,S}
+4   O2d  u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.32063,
+		B = 0.00340,
+		E = 0.05844,
+		L = 0.24039,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 17,
+		L = 13,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 91,
+	label = "Cds-OdNN",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N   u0 {1,S}
+3   N   u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = u'Cds-OdN3sN',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 92,
+	label = "Cds-OdN3sN",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S}
+3   N   u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = u'Cds-OdN3sN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 93,
+	label = "Cds-OdN3sN3s",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S}
+3   N3s u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = -0.05725,
+		B = 0.01418,
+		E = 0.02108,
+		L = 0.11667,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 109,
+		B = 103,
+		E = 111,
+		L = 60,
+		A = 110,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 94,
+	label = "Crds-OdN3rsN3rs",
+	group = 
+"""
+1 * CO  u0 r1 {2,S} {3,S} {4,D}
+2   N3s u0 r1 {1,S}
+3   N3s u0 r1 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.00217,
+		B = -0.03735,
+		E = -0.03977,
+		L = 0.22237,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 165,
+		B = 165,
+		E = 170,
+		L = 110,
+		A = 166,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 95,
+	label = "Cds-OdN3rsN3s",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 r1 {1,S}
+3   N3s u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = -0.14401,
+		B = -0.13850,
+		E = 0.03368,
+		L = -0.14794,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 17,
+		L = 16,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 96,
+	label = "Cds-OdN3sN3d",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,S} {4,D}
+2   N3s u0 {1,S}
+3   N3d u0 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = u'Crds-OdN3rsN3rd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 97,
+	label = "Crds-OdN3rsN3rd",
+	group = 
+"""
+1 * CO  u0 r1 {2,S} {3,S} {4,D}
+2   N3s u0 r1 {1,S}
+3   N3d u0 r1 {1,S}
+4   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.06347,
+		B = 0.03769,
+		E = 0.11461,
+		L = 0.37581,
+		A = 0.01779,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 98,
+	label = "Cds-OdNOs",
+	group = 
+"""
+1 * CO  u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   N   u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = u'Cds-Od(N3sCH)Os',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 99,
+	label = "Cds-OdN3rsOs",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,D} {4,S}
+2   N3s u0 r1 {1,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.08418,
+		B = -0.00225,
+		E = 0.01188,
+		L = -0.05354,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 100,
+	label = "Cds-Od(N3sHH)Os",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,D} {4,S}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S}
+5   H   u0 {2,S}
+6   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.10967,
+		B = -0.04988,
+		E = 0.05205,
+		L = 0.28493,
+		A = 0.05565,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 16,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 101,
+	label = "Cds-Od(N3sCH)Os",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,D} {4,S}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S}
+5   C   u0 {2,S}
+6   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.03357,
+		B = 0.01532,
+		E = -0.03313,
+		L = -0.07412,
+		A = -0.01274,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 28,
+		L = 26,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 102,
+	label = "Cds-Od(N3sCC)Os",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,D} {4,S}
+2   N3s u0 {1,S} {5,S} {6,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S}
+5   C   u0 {2,S}
+6   C   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.03350,
+		B = -0.08006,
+		E = -0.00704,
+		L = -0.07948,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 5,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 103,
+	label = "Cds-OdNS",
+	group = 
+"""
+1 * CO  u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   N   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02841,
+		B = 0.02223,
+		E = 0.08891,
+		L = 0.22034,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 104,
+	label = "Cds-OdOsH",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02503,
+		B = 0.02072,
+		E = -0.01810,
+		L = -0.29483,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 25,
+		E = 26,
+		L = 25,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 105,
+	label = "Cds-OdOsOs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01559,
+		B = 0.03222,
+		E = -0.01775,
+		L = -0.13747,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 106,
+	label = "Cds-OdCS",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   S  u0 {1,S}
+4   C  u0 {1,S}
+""",
+	solute = u'Cds-OdCsSs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 107,
+	label = "Cds-OdCsSs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   S2s u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02704,
+		B = 0.03807,
+		E = 0.04191,
+		L = 0.11996,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 3,
+		E = 7,
+		L = 2,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 108,
+	label = "Cds-OdCH",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   C  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-OdCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 109,
+	label = "Cds-OdCsH",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04357,
+		B = 0.04890,
+		E = 0.00355,
+		L = -0.18553,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 57,
+		B = 57,
+		E = 62,
+		L = 58,
+		A = 64,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 110,
+	label = "Cds-OdCdsH",
+	group = 
+"""
+1 * CO      u0 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   H       u0 {1,S}
+""",
+	solute = u'Cds-O2d(Cds-Cd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 111,
+	label = "Cds-O2d(Cds-O2d)H",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   H  u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.01962,
+		B = -0.00898,
+		E = 0.00618,
+		L = -0.32615,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 112,
+	label = "Cds-O2d(Cds-Cd)H",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   H  u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = u'Cds-O2d(Cds-Cds)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 113,
+	label = "Cds-O2d(Cds-Cds)H",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   H  u0 {1,S}
+5   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.22078,
+		B = 0.01338,
+		E = 0.06920,
+		L = 0.08112,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 43,
+		B = 43,
+		E = 44,
+		L = 43,
+		A = 44,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 114,
+	label = "Cds-OdCtH",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Ct u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-Od(Ct-(Ct-H))H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 115,
+	label = "Cds-Od(Ct-(Ct-H))H",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Ct u0 {1,S} {5,T}
+4   H  u0 {1,S}
+5   Ct u0 {3,T} {6,S}
+6   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02798,
+		B = 0.00501,
+		E = 0.01823,
+		L = -0.01933,
+		A = 0.00026,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 116,
+	label = "Cds-OdCbH",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07491,
+		B = -0.03993,
+		E = 0.05398,
+		L = -0.21798,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 74,
+		B = 71,
+		E = 85,
+		L = 70,
+		A = 79,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 117,
+	label = "Cds-OdPOs",
+	group = 
+"""
+1 * CO  u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   P   u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 118,
+	label = "Cds-OdP5dOs",
+	group = 
+"""
+1 * CO  u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   P5d u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 119,
+	label = "Cds-OdP5d(OsH)",
+	group = 
+"""
+1 * CO  u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   P5d u0 {1,S}
+4   O2s u0 {1,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00496,
+		B = 0.04553,
+		E = 0.00847,
+		L = -0.06074,
+		A = 0.03725,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 120,
+	label = "Cds-OdCOs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   C  u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = u'Cds-OdCsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 121,
+	label = "Cds-OdCtOs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Ct u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00581,
+		B = 0.03213,
+		E = 0.02256,
+		L = 0.20410,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 122,
+	label = "Cds-OdC(OsH)",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,D} {4,S}
+2   C   u0 {1,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = u'Cds-OdCs(OsH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 123,
+	label = "Cds-OdCs(OsH)",
+	group = 
+"""
+1 * CO  u0 {2,S} {3,D} {4,S}
+2   Cs  u0 {1,S}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.01149,
+		B = 0.03832,
+		E = -0.02591,
+		L = 0.01317,
+		A = 0.11724,
+	),
+	dataCount = DataCountGAV(
+		S = 280,
+		B = 280,
+		E = 286,
+		L = 252,
+		A = 280,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 124,
+	label = "Cds-OdCds(OsH)",
+	group = 
+"""
+1 * CO      u0 {2,S} {3,D} {4,S}
+2   [Cd,CO] u0 {1,S}
+3   O2d     u0 {1,D}
+4   O2s     u0 {1,S} {5,S}
+5   H       u0 {4,S}
+""",
+	solute = u'Cds-Od(Cds-Cd)(OsH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 125,
+	label = "Cds-Od(Cds-O2d)(OsH)",
+	group = 
+"""
+1 * CO   u0 {2,S} {3,D} {4,S}
+2   CO   u0 {1,S} {6,D}
+3   O2d  u0 {1,D}
+4   O2s  u0 {1,S} {5,S}
+5   H    u0 {4,S}
+6   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07834,
+		B = -0.06728,
+		E = 0.01477,
+		L = -0.04321,
+		A = 0.03969,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 126,
+	label = "Cds-Od(Cds-Cd)(OsH)",
+	group = 
+"""
+1 * CO   u0 {2,S} {3,D} {4,S}
+2   Cd   u0 {1,S} {6,D}
+3   O2d  u0 {1,D}
+4   O2s  u0 {1,S} {5,S}
+5   H    u0 {4,S}
+6   C    u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.08075,
+		B = -0.02867,
+		E = -0.00374,
+		L = -0.06622,
+		A = 0.03418,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 28,
+		L = 26,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 127,
+	label = "Cds-Od(Crds-Crd)(OsH)",
+	group = 
+"""
+1 * CO   u0 {2,S} {3,D} {4,S}
+2   Cd   u0 r1 {1,S} {6,D}
+3   O2d  u0 {1,D}
+4   O2s  u0 {1,S} {5,S}
+5   H    u0 {4,S}
+6   C    u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00400,
+		B = 0.00940,
+		E = 0.05806,
+		L = 0.06004,
+		A = 0.00477,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 30,
+		E = 32,
+		L = 30,
+		A = 30,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 128,
+	label = "Cds-Od(Cds-N3d)(OsH)",
+	group = 
+"""
+1 * CO   u0 {2,S} {3,D} {4,S}
+2   Cd   u0 {1,S} {6,D}
+3   O2d  u0 {1,D}
+4   O2s  u0 {1,S} {5,S}
+5   H    u0 {4,S}
+6   N3d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09564,
+		B = 0.06623,
+		E = 0.01328,
+		L = 0.08165,
+		A = 0.02479,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 129,
+	label = "Cds-OdCb(OsH)",
+	group = 
+"""
+1 * CO   u0 {2,S} {3,D} {4,S}
+2   Cb   u0 {1,S}
+3   O2d  u0 {1,D}
+4   O2s  u0 {1,S} {5,S}
+5   H    u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00562,
+		B = -0.07988,
+		E = -0.03377,
+		L = -0.09524,
+		A = 0.09476,
+	),
+	dataCount = DataCountGAV(
+		S = 194,
+		B = 194,
+		E = 197,
+		L = 182,
+		A = 194,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 130,
+	label = "Cds-OdCsOs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {5,S}
+5   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.12167,
+		B = 0.02031,
+		E = -0.08476,
+		L = -0.16654,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 585,
+		B = 569,
+		E = 605,
+		L = 540,
+		A = 610,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 131,
+	label = "Crds-OdCrsOrs",
+	group = 
+"""
+1 * CO  u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs  u0 r1 {1,S}
+4   O2s u0 r1 {1,S} {5,S}
+5   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.36542,
+		B = 0.05361,
+		E = -0.01988,
+		L = 0.81639,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 32,
+		B = 32,
+		E = 33,
+		L = 29,
+		A = 32,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 132,
+	label = "Cds-OdCrsOs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 r1 {1,S}
+4   O2s u0 {1,S} {5,S}
+5   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.03325,
+		B = -0.03120,
+		E = -0.06544,
+		L = 0.17235,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 23,
+		B = 23,
+		E = 23,
+		L = 23,
+		A = 23,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 133,
+	label = "Cds-OdCdsOs",
+	group = 
+"""
+1 * CO      u0 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   O2s      u0 {1,S} {5,S}
+5   R!H     u0 {4,S}
+""",
+	solute = u'Cds-O2d(Cds-Cd)O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 134,
+	label = "Crds-OdCrdsOrs",
+	group = 
+"""
+1 * CO      u0 r1 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   [Cd,CO] u0 r1 {1,S}
+4   O2s      u0 r1 {1,S} {5,S}
+5   R!H     u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.05757,
+		B = 0.07131,
+		E = 0.04521,
+		L = 0.09985,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 14,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 135,
+	label = "Cds-OdCrdsOs",
+	group = 
+"""
+1 * CO      u0 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   [Cd,CO] u0 r1 {1,S}
+4   O2s      u0 {1,S} {5,S}
+5   R!H     u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.05927,
+		B = -0.05930,
+		E = -0.02584,
+		L = 0.00516,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 50,
+		B = 50,
+		E = 51,
+		L = 32,
+		A = 51,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 136,
+	label = "Cds-O2d(Cds-O2d)O2s",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   O2d u0 {2,D}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.05886,
+		B = 0.00323,
+		E = -0.04972,
+		L = -0.30062,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 137,
+	label = "Cds-O2d(Cds-Cd)O2s",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   C  u0 {2,D}
+6   R!H u0 {4,S}
+""",
+	solute = u'Cds-O2d(Cds-Cds)O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 138,
+	label = "Cds-O2d(Cds-Cds)O2s",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   Cd u0 {2,D}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.09615,
+		B = -0.04351,
+		E = -0.08829,
+		L = -0.22780,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 78,
+		B = 77,
+		E = 81,
+		L = 70,
+		A = 77,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 139,
+	label = "Cds-OdCbOs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   O2s u0 {1,S} {5,S}
+5   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00034,
+		B = -0.00910,
+		E = -0.06551,
+		L = -0.06894,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 182,
+		B = 175,
+		E = 190,
+		L = 174,
+		A = 197,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 140,
+	label = "Cds-OdCC",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+""",
+	solute = u'Cds-OdCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 141,
+	label = "Cds-OdCsCs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03370,
+		B = 0.07988,
+		E = -0.03325,
+		L = 0.02304,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 122,
+		B = 119,
+		E = 127,
+		L = 116,
+		A = 128,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 142,
+	label = "Crds-OdCrsCrs",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02604,
+		B = 0.06312,
+		E = 0.05659,
+		L = 0.73746,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 63,
+		B = 65,
+		E = 66,
+		L = 57,
+		A = 67,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 143,
+	label = "Cds-OdCrsCrs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07717,
+		B = 0.00755,
+		E = -0.01202,
+		L = 0.16951,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 144,
+	label = "Cds-OdCrsCs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.15060,
+		B = -0.00263,
+		E = -0.00005,
+		L = 0.68732,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 73,
+		B = 73,
+		E = 73,
+		L = 54,
+		A = 73,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 145,
+	label = "Cds-OdCdsCs",
+	group = 
+"""
+1 * CO      u0 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+""",
+	solute = u'Cds-O2d(Cds-Cd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 146,
+	label = "Cds-O2d(Cds-O2d)Cs",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   Cs u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.05409,
+		B = 0.00062,
+		E = -0.05738,
+		L = -0.38313,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 147,
+	label = "Cds-O2d(Cds-Cd)Cs",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   Cs u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.06456,
+		B = 0.07691,
+		E = -0.01848,
+		L = 0.16970,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 15,
+		E = 17,
+		L = 16,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 148,
+	label = "Crds-O2d(Crds-Crd)Crs",
+	group = 
+"""
+1 * CO u0 r1 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   Cs u0 r1 {1,S}
+5   C  u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.15652,
+		B = 0.04417,
+		E = 0.15310,
+		L = 0.48548,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 93,
+		B = 93,
+		E = 93,
+		L = 79,
+		A = 93,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 149,
+	label = "Cds-O2d(Crds-Crd)Cs",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   Cs u0 {1,S}
+5   C  u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.05204,
+		B = 0.02571,
+		E = -0.00388,
+		L = 0.06904,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 10,
+		L = 8,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 150,
+	label = "Cds-O2d(Cds-N3d)Cs",
+	group = 
+"""
+1 * CO u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   O2d u0 {1,D}
+4   Cs u0 {1,S}
+5   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.06320,
+		B = -0.02449,
+		E = 0.01077,
+		L = -0.18425,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 151,
+	label = "Cds-OdCdsCds",
+	group = 
+"""
+1 * CO      u0 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+""",
+	solute = u'Cds-O2d(Cds-Cd)(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 152,
+	label = "Cds-O2d(Cds-Cd)(Cds-O2d)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cd u0 {1,S} {5,D}
+4   CO u0 {1,S} {6,D}
+5   C  u0 {3,D}
+6   O2d u0 {4,D}
+""",
+	solute = u'Crds-O2d(Crds-Cd)(Crds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 153,
+	label = "Crds-O2d(Crds-Cd)(Crds-O2d)",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cd u0 r1 {1,S} {5,D}
+4   CO u0 r1 {1,S} {6,D}
+5   C  u0 {3,D}
+6   O2d u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.07348,
+		B = 0.02029,
+		E = -0.03701,
+		L = -0.78239,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 154,
+	label = "Cds-O2d(Cds-Cd)(Cds-Cd)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cd u0 {1,S} {5,D}
+4   Cd u0 {1,S} {6,D}
+5   C  u0 {3,D}
+6   C  u0 {4,D}
+""",
+	solute = u'Crds-O2d(Crds-Cd)(Crds-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 155,
+	label = "Crds-O2d(Crds-Cd)(Crds-Cd)",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cd u0 r1 {1,S} {5,D}
+4   Cd u0 r1 {1,S} {6,D}
+5   C  u0 {3,D}
+6   C  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.04584,
+		B = 0.04096,
+		E = 0.07457,
+		L = 0.35646,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 63,
+		B = 63,
+		E = 63,
+		L = 36,
+		A = 66,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 156,
+	label = "Cds-O2d(Cds-Cd)(Cds-N3d)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cd u0 {1,S} {5,D}
+4   Cd u0 {1,S} {6,D}
+5   C  u0 {3,D}
+6   N3d u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.04970,
+		B = -0.08156,
+		E = -0.04558,
+		L = -0.08790,
+		A = -0.09185,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 157,
+	label = "Cds-OdCbCs",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03897,
+		B = -0.00319,
+		E = -0.00714,
+		L = -0.06151,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 104,
+		B = 104,
+		E = 106,
+		L = 79,
+		A = 105,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 158,
+	label = "Crds-OdCbCrs",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03648,
+		B = 0.01518,
+		E = -0.04339,
+		L = -0.21825,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 159,
+	label = "Cds-OdCbCds",
+	group = 
+"""
+1 * CO      u0 {2,D} {3,S} {4,S}
+2   O2d      u0 {1,D}
+3   Cb      u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+""",
+	solute = u'Cds-OdCb(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 160,
+	label = "Cds-OdCb(Cds-O2d)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   CO u0 {1,S} {5,D}
+5   O2d u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.02007,
+		B = -0.04944,
+		E = -0.02980,
+		L = -0.51710,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 161,
+	label = "Cds-OdCb(Cds-Cd)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cd u0 {1,S} {5,D}
+5   C  u0 {4,D}
+""",
+	solute = u'Crds-OdCb(Crds-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 162,
+	label = "Crds-OdCb(Crds-Cd)",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cd u0 r1 {1,S} {5,D}
+5   C  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.08793,
+		B = -0.10178,
+		E = -0.07680,
+		L = -0.14387,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 107,
+		B = 107,
+		E = 110,
+		L = 106,
+		A = 108,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 163,
+	label = "Cds-OdCb(Crds-Cd)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cd u0 r1 {1,S} {5,D}
+5   C  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.01450,
+		B = -0.05778,
+		E = 0.05717,
+		L = 0.27953,
+		A = 0.01107,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 164,
+	label = "Cds-OdCb(Cds-N3d)",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cd u0 {1,S} {5,D}
+5   N3d u0 {4,D}
+""",
+	solute = u'Crds-OdCb(Crds-N3rd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 165,
+	label = "Crds-OdCb(Crds-N3rd)",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cd u0 r1 {1,S} {5,D}
+5   N3d u0 r1 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.05307,
+		B = -0.01848,
+		E = -0.02205,
+		L = -0.28226,
+		A = -0.00122,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 166,
+	label = "Cds-OdCbCb",
+	group = 
+"""
+1 * CO u0 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00554,
+		B = -0.02378,
+		E = -0.00392,
+		L = -0.07243,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 23,
+		L = 15,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 167,
+	label = "Crds-OdCbCb",
+	group = 
+"""
+1 * CO u0 r1 {2,D} {3,S} {4,S}
+2   O2d u0 {1,D}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.13304,
+		B = -0.12511,
+		E = -0.09555,
+		L = -0.41324,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 22,
+		E = 23,
+		L = 21,
+		A = 22,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 168,
+	label = "Cds-Nd",
+	group = 
+"""
+1 * Cd u0 {2,D}
+2   N  u0 {1,D}
+""",
+	solute = u'Cds-N3dCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 169,
+	label = "Cds-N3dCC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'Cds-N3dCdCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 170,
+	label = "Cds-N3dCbCb",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cb  u0 {1,S}
+4   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03681,
+		B = 0.06652,
+		E = 0.00411,
+		L = -0.20092,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 29,
+		L = 11,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 171,
+	label = "Cds-N3dCbCs",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.09288,
+		B = -0.06035,
+		E = 0.04350,
+		L = 0.12467,
+		A = 0.04837,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 16,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 172,
+	label = "Crds-N3rdCbCrs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02797,
+		B = 0.06693,
+		E = 0.10481,
+		L = 0.28635,
+		A = 0.04930,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 5,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 173,
+	label = "Crds-N3rdCbCs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.07304,
+		B = 0.13635,
+		E = 0.01905,
+		L = -0.14087,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 2,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 174,
+	label = "Cds-N3dCbCd",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cb  u0 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.18202,
+		B = 0.12100,
+		E = 0.08612,
+		L = 0.23370,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 14,
+		E = 17,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 175,
+	label = "Cds-N3dCb(Cd-O2d)",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cb  u0 {1,S}
+4   CO  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.05465,
+		B = -0.02885,
+		E = -0.09320,
+		L = -0.10844,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 176,
+	label = "Cds-N3dCsCs",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11478,
+		B = 0.04618,
+		E = 0.06091,
+		L = 0.40369,
+		A = 0.00454,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 177,
+	label = "Crds-N3rdCrsCs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11569,
+		B = -0.01990,
+		E = -0.01764,
+		L = -0.14520,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 178,
+	label = "Crds-N3dCrsCrs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05706,
+		B = 0.03230,
+		E = 0.02313,
+		L = 0.23506,
+		A = 0.00129,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 179,
+	label = "Cds-N3dCdCs",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   [Cd,CO,CS] u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = u'Cds-N3d(Cd-N3d)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 180,
+	label = "Cds-N3d(Cd-N3d)Cs",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cd  u0 {1,S}, {5,D}
+4   Cs  u0 {1,S}
+5   N3d u0 {3,D}
+""",
+	solute = u'Crds-N3rd(Crd-N3rd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 181,
+	label = "Crds-N3rd(Crd-N3rd)Cs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cd  u0 r1 {1,S}, {5,D}
+4   Cs  u0 {1,S}
+5   N3d u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.00809,
+		B = 0.06584,
+		E = 0.02751,
+		L = 0.16423,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 29,
+		L = 13,
+		A = 29,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 182,
+	label = "Cds-N3d(Cd-Cd)Cs",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cd  u0 {1,S}, {5,D}
+4   Cs  u0 {1,S}
+5   Cd  u0 {3,D}
+""",
+	solute = u'Crds-N3rd(Crd-Crd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 183,
+	label = "Crds-N3rd(Crd-Crd)Cs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cd  u0 r1 {1,S}, {5,D}
+4   Cs  u0 {1,S}
+5   Cd  u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.00520,
+		B = 0.02661,
+		E = 0.04547,
+		L = 0.06160,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 84,
+		B = 48,
+		E = 90,
+		L = 78,
+		A = 89,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 184,
+	label = "Cds-N3dCdCd",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   [Cd,CO,CS] u0 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00568,
+		B = 0.04318,
+		E = 0.03287,
+		L = 0.33367,
+		A = 0.05831,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 185,
+	label = "Crds-N3rdCrdCrd",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   [Cd,CO,CS] u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01981,
+		B = -0.03783,
+		E = 0.10647,
+		L = 0.39653,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 44,
+		B = 38,
+		E = 49,
+		L = 46,
+		A = 46,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 186,
+	label = "Crds-N3rdCrdCd",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04783,
+		B = 0.02773,
+		E = 0.02226,
+		L = 0.13322,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 187,
+	label = "Cds-N3dCtC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Ct  u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11547,
+		B = -0.03873,
+		E = -0.08101,
+		L = -0.20247,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 188,
+	label = "Cds-N3dCO",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   C   u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'Crds-N3rdCrO',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 189,
+	label = "Crds-N3rdCrO",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   C   u0 r1 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01188,
+		B = -0.02839,
+		E = 0.01501,
+		L = 0.28115,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 25,
+		L = 18,
+		A = 25,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 190,
+	label = "Crds-N3rdCOr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   C   u0 {1,S}
+4   O   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07892,
+		B = 0.01192,
+		E = 0.02933,
+		L = 0.36501,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 191,
+	label = "Cds-N3dCS",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   C   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = u'Crds-N3rdCrS',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 192,
+	label = "Crds-N3rdCrS",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   C   u0 r1 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01918,
+		B = 0.03892,
+		E = 0.08096,
+		L = 0.26538,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 18,
+		L = 18,
+		A = 18,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 193,
+	label = "Crds-N3rdCSr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   C   u0 {1,S}
+4   S   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01139,
+		B = 0.00870,
+		E = -0.01161,
+		L = 0.06755,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 12,
+		L = 7,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 194,
+	label = "Cds-N3dCH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   C   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Cds-N3dCdH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 195,
+	label = "Cds-N3dCbH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00363,
+		B = 0.02291,
+		E = 0.02329,
+		L = 0.04069,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 10,
+		L = 8,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 196,
+	label = "Crds-N3rdCbH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.14776,
+		B = 0.07104,
+		E = 0.00797,
+		L = 0.11432,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 7,
+		E = 8,
+		L = 7,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 197,
+	label = "Cds-N3dCdH",
+	group = 
+"""
+1 * Cd          u0 {2,D} {3,S} {4,S}
+2   N3d         u0 {1,D}
+3   [Cd,CO,CS]  u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'Crds-N3rdCrdH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 198,
+	label = "Crds-N3rdCrdH",
+	group = 
+"""
+1 * Cd          u0 r1 {2,D} {3,S} {4,S}
+2   N3d         u0 r1 {1,D}
+3   [Cd,CO,CS]  u0 r1 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09529,
+		B = 0.08537,
+		E = 0.01173,
+		L = 0.15595,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 305,
+		B = 285,
+		E = 337,
+		L = 275,
+		A = 334,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 199,
+	label = "Cds-N3dCrdH",
+	group = 
+"""
+1 * Cd          u0 {2,D} {3,S} {4,S}
+2   N3d         u0 {1,D}
+3   [Cd,CO,CS]  u0 r1 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02339,
+		B = 0.04516,
+		E = 0.06866,
+		L = 0.07688,
+		A = -0.01875,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 200,
+	label = "Cds-N3dCsH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Cds-(N3d-(O-H))CsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 201,
+	label = "Crds-N3rdCrsH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   Cs  u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Crds-N3rdCrdH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 202,
+	label = "Cds-(N3d-(O-H))CsH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D} {5,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   O   u0 {2,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.06672,
+		B = 0.07557,
+		E = 0.05253,
+		L = 0.22243,
+		A = 0.00459,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 203,
+	label = "Cds-N3dNN",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   N   u0 {1,S}
+""",
+	solute = u'Cds-N3dN3sN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 204,
+	label = "Cds-N3dN3sN3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N3s u0 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.05762,
+		B = 0.11105,
+		E = 0.09599,
+		L = 0.24135,
+		A = 0.11162,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 30,
+		L = 19,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 205,
+	label = "Crds-N3rdN3rsN3s",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3s u0 r1 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13118,
+		B = 0.04032,
+		E = 0.27899,
+		L = 0.61708,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 25,
+		E = 28,
+		L = 21,
+		A = 28,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 206,
+	label = "Cds-N3dN3dN3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N3d u0 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02803,
+		B = 0.15814,
+		E = 0.12515,
+		L = 0.26599,
+		A = 0.01928,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 207,
+	label = "Crds-N3rdN3rdN3s",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3d u0 r1 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07647,
+		B = -0.08450,
+		E = 0.13324,
+		L = 0.63295,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 53,
+		B = 52,
+		E = 53,
+		L = 49,
+		A = 53,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 208,
+	label = "Cds-N3dN3sN5dc",
+	group = 
+"""
+1 * Cd   u0 {2,D} {3,S} {4,S}
+2   N3d  u0 {1,D}
+3   N3s  u0 {1,S}
+4   N5dc u0 {1,S}
+""",
+	solute = u'Crds-N3rdN3rsN5dc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 209,
+	label = "Crds-N3rdN3rsN5dc",
+	group = 
+"""
+1 * Cd   u0 r1 {2,D} {3,S} {4,S}
+2   N3d  u0 r1 {1,D}
+3   N3s  u0 r1 {1,S}
+4   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05294,
+		B = -0.00271,
+		E = -0.08480,
+		L = 0.06636,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 210,
+	label = "Cds-N3dN3dN5dc",
+	group = 
+"""
+1 * Cd   u0 {2,D} {3,S} {4,S}
+2   N3d  u0 {1,D}
+3   N3d  u0 {1,S}
+4   N5dc u0 {1,S}
+""",
+	solute = u'Crds-N3rdN3rdN5dc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 211,
+	label = "Crds-N3rdN3rdN5dc",
+	group = 
+"""
+1 * Cd   u0 r1 {2,D} {3,S} {4,S}
+2   N3d  u0 r1 {1,D}
+3   N3d  u0 r1 {1,S}
+4   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10822,
+		B = 0.00460,
+		E = 0.03565,
+		L = 0.12163,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 212,
+	label = "Cds-N3dNC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'Cds-N3dN3sC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 213,
+	label = "Cds-N3dN3sC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N3s u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.12638,
+		B = 0.16950,
+		E = 0.09143,
+		L = 0.24028,
+		A = 0.03016,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 214,
+	label = "Crds-N3rdN3rsCr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3s u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06492,
+		B = 0.05554,
+		E = 0.19152,
+		L = 0.51827,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 49,
+		B = 48,
+		E = 49,
+		L = 44,
+		A = 49,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 215,
+	label = "Crds-N3rdN3rsC",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3s u0 r1 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13198,
+		B = 0.06486,
+		E = 0.11619,
+		L = 0.39926,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 24,
+		E = 27,
+		L = 22,
+		A = 27,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 216,
+	label = "Crds-N3rdN3sCr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3s u0 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04740,
+		B = 0.00784,
+		E = 0.07931,
+		L = 0.37109,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 23,
+		B = 23,
+		E = 23,
+		L = 21,
+		A = 23,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 217,
+	label = "Cds-N3dN3dC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N3d u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'Crds-N3rdN3rdCr',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 218,
+	label = "Crds-N3rdN3rdCr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3d u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10377,
+		B = 0.11958,
+		E = 0.17103,
+		L = 0.41730,
+		A = 0.07499,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 12,
+		E = 14,
+		L = 10,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 219,
+	label = "Crds-N3rdN3rdC",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3d u0 r1 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01283,
+		B = 0.08480,
+		E = 0.04368,
+		L = 0.29691,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 15,
+		E = 15,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 220,
+	label = "Cds-N3dNO",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'Crds-N3rdNrO',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 221,
+	label = "Crds-N3rdNrO",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N   u0 r1 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01097,
+		B = 0.02374,
+		E = 0.01046,
+		L = 0.20396,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 222,
+	label = "Crds-N3rdNOr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N   u0 {1,S}
+4   O   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01777,
+		B = 0.08029,
+		E = 0.07612,
+		L = 0.03641,
+		A = -0.03456,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 223,
+	label = "Cds-N3dNS",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = u'Crds-N3rdNSr',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 224,
+	label = "Crds-N3rdNrS",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N   u0 r1 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09759,
+		B = 0.00037,
+		E = 0.17123,
+		L = 0.62525,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 23,
+		B = 23,
+		E = 23,
+		L = 23,
+		A = 23,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 225,
+	label = "Crds-N3rdNSr",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N   u0 {1,S}
+4   S   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13138,
+		B = 0.01960,
+		E = 0.16156,
+		L = 0.55053,
+		A = 0.07631,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 26,
+		E = 28,
+		L = 23,
+		A = 27,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 226,
+	label = "Cds-N3dNH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Cds-N3dN3sH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 227,
+	label = "Cds-N3dN3sH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N3s u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Crds-N3rdN3rsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 228,
+	label = "Crds-N3rdN3rsH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3s u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.26414,
+		B = 0.16023,
+		E = 0.06966,
+		L = 0.43991,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 100,
+		B = 97,
+		E = 101,
+		L = 92,
+		A = 100,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 229,
+	label = "Cds-N3dN3dH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   N3d u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Crds-N3rdN3rdH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 230,
+	label = "Crds-N3rdN3rdH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   N3d u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13060,
+		B = 0.03256,
+		E = 0.02325,
+		L = 0.32982,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 62,
+		B = 61,
+		E = 65,
+		L = 58,
+		A = 67,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 231,
+	label = "Cds-N3dOH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   O   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Crds-N3rdOrH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 232,
+	label = "Crds-N3rdOrH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   O   u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05264,
+		B = 0.04581,
+		E = -0.06632,
+		L = -0.09899,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 233,
+	label = "Cds-N3dSS",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   S   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = u'Crds-N3rdSrS',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 234,
+	label = "Crds-N3rdSrS",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   S   u0 r1 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02333,
+		B = 0.01858,
+		E = 0.08286,
+		L = 0.25509,
+		A = -0.01500,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 235,
+	label = "Cds-N3dSH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   N3d u0 {1,D}
+3   S   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Crds-N3rdSrH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 236,
+	label = "Crds-N3rdSrH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   N3d u0 r1 {1,D}
+3   S   u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07801,
+		B = 0.03393,
+		E = 0.02476,
+		L = 0.04437,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 8,
+		L = 4,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 237,
+	label = "Cds-N5dc",
+	group = 
+"""
+1 * Cd   u0 {2,D}
+2   N5dc u0 {1,D}
+""",
+	solute = u'Crds-N5rdc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 238,
+	label = "Crds-N5rdc",
+	group = 
+"""
+1 * Cd   u0 r1 {2,D}
+2   N5dc u0 r1 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.19908,
+		B = 0.14855,
+		E = 0.06814,
+		L = 0.48605,
+		A = 0.11753,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 19,
+		L = 18,
+		A = 18,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 239,
+	label = "Cds-Cd",
+	group = 
+"""
+1 * Cd u0 {2,D}
+2   C  u0 {1,D}
+""",
+	solute = u'Cds-CdCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 240,
+	label = "Cds-CdHH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 241,
+	label = "Cds-CdsHH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07968,
+		B = 0.01758,
+		E = 0.06146,
+		L = 0.33013,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 361,
+		B = 347,
+		E = 379,
+		L = 340,
+		A = 380,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 242,
+	label = "Cds-CrdsHH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03399,
+		B = 0.04100,
+		E = 0.07796,
+		L = 0.43327,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 40,
+		B = 37,
+		E = 40,
+		L = 39,
+		A = 42,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 243,
+	label = "Cds-CddHH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   Cdd u0 {1,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'Cds-(Cdd-Cd)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 244,
+	label = "Cds-(Cdd-Cd)HH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   Cdd u0 {1,D} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.05813,
+		B = 0.01946,
+		E = 0.07261,
+		L = 0.41198,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 245,
+	label = "Cds-CdOsH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdsOsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 246,
+	label = "Cds-CdsOsH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04765,
+		B = 0.08459,
+		E = 0.04788,
+		L = 0.43043,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 13,
+		E = 13,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 247,
+	label = "Crds-CrdsOrsH",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   O2s u0 r1 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08597,
+		B = 0.03952,
+		E = 0.02714,
+		L = 0.08372,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 83,
+		B = 83,
+		E = 87,
+		L = 64,
+		A = 93,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 248,
+	label = "Cds-CdOsOs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = u'Cds-CdsOsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 249,
+	label = "Cds-CdsOsOs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = u'Crds-CrdsOrsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 250,
+	label = "Crds-CrdsOrsOs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   O2s u0 r1 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13378,
+		B = 0.08774,
+		E = 0.01198,
+		L = 0.23277,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 11,
+		L = 9,
+		A = 11,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 251,
+	label = "Cds-CdPH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   P  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 252,
+	label = "Cds-CdP5dH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   P5d u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03841,
+		B = -0.00750,
+		E = 0.03615,
+		L = 0.22459,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 2,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 253,
+	label = "Cds-CdNH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   N  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdN3dH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 254,
+	label = "Cds-CdN3sH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   H   u0 {1,S}
+6   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06523,
+		B = 0.10680,
+		E = 0.24047,
+		L = 0.42503,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 255,
+	label = "Crds-CrdN3rsH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {5,S} {6,S}
+2   Cd  u0 r1 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   H   u0 {1,S}
+6   N3s u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.25006,
+		B = 0.14664,
+		E = 0.12921,
+		L = 0.65557,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 178,
+		B = 164,
+		E = 186,
+		L = 141,
+		A = 182,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 256,
+	label = "Cds-CdN3dH",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   H   u0 {1,S}
+6   N3d u0 {1,S}
+""",
+	solute = u'Crds-CrdN3rdH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 257,
+	label = "Crds-CrdN3rdH",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {5,S} {6,S}
+2   Cd  u0 r1 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   H   u0 {1,S}
+6   N3d u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12495,
+		B = 0.06331,
+		E = 0.00670,
+		L = 0.11994,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 297,
+		B = 259,
+		E = 322,
+		L = 248,
+		A = 321,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 258,
+	label = "Cds-CdN5dcH",
+	group = 
+"""
+1 * Cd   u0 {2,D} {5,S} {6,S}
+2   Cd   u0 {1,D} {3,S} {4,S}
+3   R    u0 {2,S}
+4   R    u0 {2,S}
+5   H    u0 {1,S}
+6   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05238,
+		B = 0.05110,
+		E = -0.02091,
+		L = 0.21000,
+		A = 0.00197,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 259,
+	label = "Crds-CrdN5rdcH",
+	group = 
+"""
+1 * Cd   u0 r1 {2,D} {5,S} {6,S}
+2   Cd   u0 r1 {1,D} {3,S} {4,S}
+3   R    u0 {2,S}
+4   R    u0 {2,S}
+5   H    u0 {1,S}
+6   N5dc u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08058,
+		B = 0.11574,
+		E = 0.01135,
+		L = 0.25513,
+		A = 0.10422,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 260,
+	label = "Cds-CdNN",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   N  u0 {1,S}
+4   N  u0 {1,S}
+""",
+	solute = u'Cds-CdN3sN3d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 261,
+	label = "Cds-CdN3sN3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3s u0 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09430,
+		B = 0.15315,
+		E = 0.12938,
+		L = 0.65504,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 13,
+		L = 6,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 262,
+	label = "Cds-CdN3sN3d",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3s u0 {1,S}
+4   N3d u0 {1,S}
+""",
+	solute = u'Crds-CrdN3rsN3rd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 263,
+	label = "Crds-CrdN3rsN3rd",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   C   u0 r1 {1,D}
+3   N3s u0 r1 {1,S}
+4   N3d u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06871,
+		B = 0.00064,
+		E = 0.14722,
+		L = 0.30053,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 47,
+		B = 47,
+		E = 48,
+		L = 46,
+		A = 47,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 264,
+	label = "Crds-CrdN3sN3rd",
+	group = 
+"""
+1 * Cd  u0 r1 {2,D} {3,S} {4,S}
+2   C   u0 r1 {1,D}
+3   N3s u0 {1,S}
+4   N3d u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03200,
+		B = -0.06231,
+		E = 0.10723,
+		L = 0.39227,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 24,
+		L = 21,
+		A = 23,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 265,
+	label = "Cds-CdN3dN3d",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3d u0 {1,S}
+4   N3d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01504,
+		B = 0.07196,
+		E = 0.09643,
+		L = 0.17970,
+		A = 0.06621,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 13,
+		L = 13,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 266,
+	label = "Cds-CdN3sN5dc",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3s u0 {1,S}
+4   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00369,
+		B = 0.00874,
+		E = 0.05214,
+		L = 0.12815,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 267,
+	label = "Cds-CdN3dN5dc",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3d u0 {1,S}
+4   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02306,
+		B = -0.03132,
+		E = -0.07222,
+		L = -0.14316,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 268,
+	label = "Cds-CdNO",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N   u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'Cds-CdN3dO',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 269,
+	label = "Cds-CdN3sO",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3s u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05150,
+		B = 0.10284,
+		E = -0.01548,
+		L = 0.42766,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 270,
+	label = "Cds-CdN3dO",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N3d u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03404,
+		B = -0.04538,
+		E = -0.00417,
+		L = 0.16282,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 10,
+		E = 11,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 271,
+	label = "Cds-CdN5dcO",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N5dc u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00581,
+		B = 0.03189,
+		E = 0.10957,
+		L = 0.03950,
+		A = -0.02945,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 272,
+	label = "Cds-CdNS",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   C   u0 {1,D}
+3   N   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02226,
+		B = -0.01506,
+		E = 0.07272,
+		L = 0.08631,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 273,
+	label = "Cds-CdSH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   S  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdsSH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 274,
+	label = "Cds-CdsSH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   S  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdsS2H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 275,
+	label = "Cds-CdsS2H",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   S2s  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Crds-CrdsS2rH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 276,
+	label = "Crds-CrdsS2rH",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   S2s  u0 r1 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09462,
+		B = 0.00309,
+		E = 0.10521,
+		L = 0.44391,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 77,
+		B = 76,
+		E = 81,
+		L = 69,
+		A = 79,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 277,
+	label = "Cds-CdCH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   C  u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 278,
+	label = "Cds-CdsCsH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02507,
+		B = 0.00376,
+		E = 0.03644,
+		L = 0.24129,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 443,
+		B = 437,
+		E = 457,
+		L = 410,
+		A = 458,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 279,
+	label = "Crds-CrdsCrsH",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 r1 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08511,
+		B = 0.03005,
+		E = 0.09702,
+		L = 0.54967,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 220,
+		B = 201,
+		E = 231,
+		L = 194,
+		A = 231,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 280,
+	label = "Cds-CrdsCsH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00706,
+		B = 0.03660,
+		E = 0.06762,
+		L = 0.45070,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 281,
+	label = "Cds-CdsCrsH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 r1 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00600,
+		B = 0.02316,
+		E = 0.12287,
+		L = 0.69995,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 23,
+		E = 24,
+		L = 23,
+		A = 24,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 282,
+	label = "Cds-CdsCdsH",
+	group = 
+"""
+1 * Cd      u0 {2,D} {3,S} {4,S}
+2   Cd      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   H       u0 {1,S}
+""",
+	solute = u'Cds-Cd(Cd-O2d)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 283,
+	label = "Cds-Cd(Cd-O2d)H",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   CO u0 {1,S} {5,D}
+3   H  u0 {1,S}
+4   Cd u0 {1,D}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.03600,
+		B = 0.07147,
+		E = 0.09085,
+		L = 0.30190,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 123,
+		B = 122,
+		E = 126,
+		L = 114,
+		A = 126,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 284,
+	label = "Crds-Crd(Crd-O2d)H",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,S} {4,D}
+2   CO u0 r1 {1,S} {5,D}
+3   H  u0 {1,S}
+4   Cd u0 r1 {1,D}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.12557,
+		B = 0.05233,
+		E = 0.03925,
+		L = 0.31276,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 270,
+		B = 268,
+		E = 276,
+		L = 218,
+		A = 275,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 285,
+	label = "Cds-Cd(Cd-N3d)H",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Cd u0 {1,S} {5,D}
+3   H  u0 {1,S}
+4   Cd u0 {1,D}
+5   N3d u0 {2,D}
+""",
+	solute = u'Crds-Crd(Crd-N3rd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 286,
+	label = "Crds-Crd(Crd-N3rd)H",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,S} {4,D}
+2   Cd u0 r1 {1,S} {5,D}
+3   H  u0 {1,S}
+4   Cd u0 r1 {1,D}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.18917,
+		B = 0.05309,
+		E = 0.07234,
+		L = 0.56724,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 344,
+		B = 303,
+		E = 374,
+		L = 320,
+		A = 367,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 287,
+	label = "Cds-Cd(Crd-N3rd)H",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Cd u0 r1 {1,S} {5,D}
+3   H  u0 {1,S}
+4   Cd u0 {1,D}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00344,
+		B = 0.04936,
+		E = 0.02238,
+		L = 0.17804,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 288,
+	label = "Cds-Cd(Cd-N5dc)H",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,S} {4,D}
+2   Cd  u0 {1,S} {5,D}
+3   H   u0 {1,S}
+4   Cd  u0 {1,D}
+5   N5dc u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.18364,
+		B = 0.13893,
+		E = 0.06493,
+		L = 0.53183,
+		A = 0.09687,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 18,
+		L = 17,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 289,
+	label = "Cds-Cds(Cds-Cd)H",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   H  u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = u'Cds-Cds(Cds-Cds)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 290,
+	label = "Cds-Cds(Cds-Cds)H",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   H  u0 {1,S}
+5   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04783,
+		B = 0.03620,
+		E = 0.11287,
+		L = 0.56372,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 38,
+		B = 38,
+		E = 43,
+		L = 36,
+		A = 44,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 291,
+	label = "Crds-Crds(Crds-Crds)H",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   H  u0 {1,S}
+5   Cd u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.10498,
+		B = 0.03593,
+		E = 0.12358,
+		L = 0.52628,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 424,
+		B = 374,
+		E = 477,
+		L = 387,
+		A = 472,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 292,
+	label = "Crds-Crds(Crds-Cds)H",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   H  u0 {1,S}
+5   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01586,
+		B = -0.00161,
+		E = 0.09037,
+		L = 0.38978,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 7,
+		L = 5,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 293,
+	label = "Cds-Cds(Crds-Crds)H",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   H  u0 {1,S}
+5   Cd u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.02247,
+		B = 0.07088,
+		E = 0.10137,
+		L = 0.65942,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 8,
+		A = 10,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 294,
+	label = "Cds-CdsCtH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Ct u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = u'Cds-CdsH(Ct-N3t)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 295,
+	label = "Cds-CdsH(Ct-N3t)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,D} {4,S}
+2   Ct  u0 {1,S} {5,T}
+3   Cd  u0 {1,D}
+4   H   u0 {1,S}
+5   N3t u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.11286,
+		B = 0.03471,
+		E = 0.12848,
+		L = 0.44452,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 19,
+		L = 19,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 296,
+	label = "Cds-CdsH(Ct-Ct)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,D} {4,S}
+2   Ct  u0 {1,S} {5,T}
+3   Cd  u0 {1,D}
+4   H   u0 {1,S}
+5   Ct  u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.03008,
+		B = 0.03313,
+		E = 0.04987,
+		L = 0.41557,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 297,
+	label = "Cds-CdsCbH",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00296,
+		B = -0.00815,
+		E = 0.15448,
+		L = 0.41715,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 72,
+		B = 68,
+		E = 96,
+		L = 86,
+		A = 80,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 298,
+	label = "Crds-CrdsCbH",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09331,
+		B = -0.01751,
+		E = 0.16906,
+		L = 0.43575,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 155,
+		B = 138,
+		E = 162,
+		L = 155,
+		A = 155,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 299,
+	label = "Cds-CddCH",
+	group = 
+"""
+1 * Cd u0  {2,D} {3,S} {4,S}
+2   Cdd u0 {1,D}
+3   C  u0  {1,S}
+4   H  u0  {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04061,
+		B = 0.02717,
+		E = 0.06992,
+		L = 0.49604,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 6,
+		L = 4,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 300,
+	label = "Cds-CdCO",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   C  u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = u'Cds-CdsCdsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 301,
+	label = "Cds-CdsCdsOs",
+	group = 
+"""
+1 * Cd      u0 {2,D} {3,S} {4,S}
+2   Cd      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   O2s      u0 {1,S}
+""",
+	solute = u'Cds-Cds(Cds-O2d)O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 302,
+	label = "Cds-Cds(Cds-O2d)O2s",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   O2s u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = u'Crds-Crds(Crds-O2d)O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 303,
+	label = "Crds-Crds(Crds-O2d)O2s",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   CO u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   O2s u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = u'Crds-Crds(Crds-O2d)(O2s-H)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 304,
+	label = "Crds-Crds(Crds-O2d)(O2s-H)",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   CO u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   O2d u0 {2,D}
+6   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.14557,
+		B = 0.04025,
+		E = 0.05041,
+		L = 0.36191,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 36,
+		B = 36,
+		E = 36,
+		L = 19,
+		A = 36,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 305,
+	label = "Crds-Crds(Crds-O2d)(O2s-R)",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   CO u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   O2d u0 {2,D}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.22671,
+		B = -0.00166,
+		E = 0.02106,
+		L = -0.28263,
+		A = -0.36787,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 306,
+	label = "Crds-Crds(Cds-O2d)O2rs",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   O2s u0 r1 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00849,
+		B = 0.05521,
+		E = 0.07059,
+		L = -0.02969,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 15,
+		L = 8,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 307,
+	label = "Cds-Cds(Cds-N3d)O2s",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   O2s u0 {1,S}
+5   N3d u0 {2,D}
+""",
+	solute = u'Cds-Cds(Cds-N3d)(O2s-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 308,
+	label = "Cds-Cds(Cds-N3d)(O2s-H)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   N3d u0 {2,D}
+6   H  u0 {4,S}
+""",
+	solute = u'Crds-Crds(Crds-Nr3d)(O2s-H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 309,
+	label = "Crds-Crds(Crds-Nr3d)(O2s-H)",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   N3d u0 r1 {2,D}
+6   H  u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.09273,
+		B = 0.03153,
+		E = 0.01827,
+		L = 0.23382,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 310,
+	label = "Cds-Cds(Cds-N3d)(O2s-R)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   O2s u0 {1,S} {6,S}
+5   N3d u0 {2,D}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.00526,
+		B = 0.00965,
+		E = 0.07260,
+		L = 0.20994,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 7,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 311,
+	label = "Cds-Cds(Cds-Cd)O2s",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   O2s u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = u'Cds-Cds(Cds-Cds)O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 312,
+	label = "Cds-Cds(Cds-Cds)O2s",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   O2s u0 {1,S}
+5   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.01017,
+		B = 0.00698,
+		E = 0.10567,
+		L = 0.68971,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 15,
+		L = 13,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 313,
+	label = "Cds-CdsCbOs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cb u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = u'Crds-CrdsCbOrs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 314,
+	label = "Crds-CrdsCbOrs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cb u0 {1,S}
+4   O2s u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.07990,
+		B = -0.03418,
+		E = 0.01291,
+		L = -0.39831,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 54,
+		B = 54,
+		E = 56,
+		L = 54,
+		A = 55,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 315,
+	label = "Crds-CrdsCbOs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cb u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11464,
+		B = -0.01740,
+		E = 0.00828,
+		L = 0.01425,
+		A = 0.04540,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 316,
+	label = "Cds-CdCsOs",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S}
+4   C  u0 {1,D}
+""",
+	solute = u'Cds-CdsCsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 317,
+	label = "Cds-CdsCsOs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06818,
+		B = -0.08846,
+		E = 0.01118,
+		L = 0.39983,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 318,
+	label = "Crds-CrdsCsOrs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 {1,S}
+4   O2s u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10630,
+		B = 0.01507,
+		E = 0.04087,
+		L = 0.29935,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 38,
+		B = 38,
+		E = 41,
+		L = 34,
+		A = 40,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 319,
+	label = "Cds-CdCtOs",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Ct u0 {1,S}
+3   O2s u0 {1,S}
+4   C  u0 {1,D}
+""",
+	solute = u'Crds-CrdCtOrs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 320,
+	label = "Crds-CrdCtOrs",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,S} {4,D}
+2   Ct u0 {1,S}
+3   O2s u0 r1 {1,S}
+4   C  u0 r1 {1,D}
+""",
+	solute = u'Crds-CrdsCsOrs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 321,
+	label = "Cds-CdCS",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   C  u0 {1,S}
+4   S  u0 {1,S}
+""",
+	solute = u'Cds-CdsCsSs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 322,
+	label = "Cds-CdsCsSs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4   S  u0 {1,S}
+""",
+	solute = u'Cds-CdsCsS2',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 323,
+	label = "Cds-CdsCsS2",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4   S2s  u0 {1,S}
+""",
+	solute = u'Crds-CrdsCsS2r',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 324,
+	label = "Crds-CrdsCsS2r",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 {1,S}
+4   S2s  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00736,
+		B = 0.02501,
+		E = 0.05474,
+		L = 0.40231,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 28,
+		L = 25,
+		A = 27,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 325,
+	label = "Cds-CdsCdsSs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   [Cd,CO,CS] u0 {1,S}
+4   S2s u0 {1,S}
+""",
+	solute = u'Cds-Cds(Cds-O2d)S2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 326,
+	label = "Cds-Cds(Cds-Cd)S2s",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   S2s u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.12369,
+		B = -0.04542,
+		E = 0.11429,
+		L = 0.60731,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 5,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 327,
+	label = "Cds-Cds(Cds-O2d)S2s",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   S2s u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00880,
+		B = 0.01827,
+		E = 0.04427,
+		L = 0.07171,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 328,
+	label = "Cds-CdsCS6dd",
+	group = 
+"""
+1 * Cd   u0 {2,D} {3,S} {4,S}
+2   Cd   u0 {1,D}
+3   C    u0 {1,S}
+4   S6dd u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03646,
+		B = -0.04074,
+		E = 0.03417,
+		L = 0.07442,
+		A = 0.03443,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 329,
+	label = "Cds-CdCC",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+""",
+	solute = u'Cds-CdsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 330,
+	label = "Cds-CdsCsCs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00326,
+		B = 0.04603,
+		E = -0.01615,
+		L = 0.04799,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 115,
+		B = 114,
+		E = 117,
+		L = 108,
+		A = 116,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 331,
+	label = "Crds-CrdsCrsCrs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.20933,
+		B = 0.12797,
+		E = 0.14719,
+		L = 0.79422,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 126,
+		B = 125,
+		E = 129,
+		L = 102,
+		A = 129,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 332,
+	label = "Crds-CrdsCrsCs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.09114,
+		B = 0.06344,
+		E = 0.06020,
+		L = 0.50316,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 102,
+		B = 98,
+		E = 106,
+		L = 101,
+		A = 106,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 333,
+	label = "Cds-CrdsCsCs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03246,
+		B = -0.00645,
+		E = 0.02374,
+		L = 0.14733,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 9,
+		E = 13,
+		L = 11,
+		A = 13,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 334,
+	label = "Cds-CdsCrsCs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.12058,
+		B = -0.00433,
+		E = 0.04365,
+		L = 0.40576,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 82,
+		B = 74,
+		E = 82,
+		L = 79,
+		A = 85,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 335,
+	label = "Cds-CdsCdsCs",
+	group = 
+"""
+1 * Cd      u0 {2,D} {3,S} {4,S}
+2   Cd      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+""",
+	solute = u'Cds-Cd(Cds-O2d)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 336,
+	label = "Cds-Cd(Cds-O2d)Cs",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   CO u0 {1,S} {5,D}
+3   Cs u0 {1,S}
+4   Cd u0 {1,D}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.13838,
+		B = 0.08384,
+		E = 0.03805,
+		L = 0.12893,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 45,
+		E = 48,
+		L = 45,
+		A = 47,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 337,
+	label = "Crds-Crd(Crds-O2d)Cs",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,S} {4,D}
+2   CO u0 r1 {1,S} {5,D}
+3   Cs u0 {1,S}
+4   Cd u0 r1 {1,D}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.05898,
+		B = 0.13315,
+		E = 0.00357,
+		L = 0.11483,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 31,
+		B = 31,
+		E = 31,
+		L = 27,
+		A = 33,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 338,
+	label = "Cds-Cd(Cds-N3d)Cs",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,S} {4,D}
+2   Cd  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cd  u0 {1,D}
+5   N3d u0 {2,D}
+""",
+	solute = u'Crds-Crd(Crds-N3rd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 339,
+	label = "Crds-Crd(Crds-N3rd)Cs",
+	group = 
+"""
+1 * Cd  u0 r1 {2,S} {3,S} {4,D}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cd  u0 r1 {1,D}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.10779,
+		B = 0.06981,
+		E = 0.05726,
+		L = 0.58502,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 55,
+		B = 34,
+		E = 63,
+		L = 50,
+		A = 65,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 340,
+	label = "Cds-Cds(Cds-Cd)Cs",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   Cs u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = u'Cds-Cds(Cds-Cds)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 341,
+	label = "Cds-Cds(Cds-Cds)Cs",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   Cs u0 {1,S}
+5   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00718,
+		B = 0.02570,
+		E = 0.04958,
+		L = 0.36551,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 24,
+		L = 19,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 342,
+	label = "Crds-Crds(Crds-Crds)Cs",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   Cs u0 {1,S}
+5   Cd u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09342,
+		B = 0.03768,
+		E = 0.09907,
+		L = 0.64588,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 145,
+		B = 98,
+		E = 171,
+		L = 138,
+		A = 172,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 343,
+	label = "Crds-Cds(Crds-Crds)Crs",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   Cd u0 r1 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   Cs u0 r1 {1,S}
+5   Cd u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01586,
+		B = -0.00161,
+		E = 0.09037,
+		L = 0.38978,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 7,
+		L = 5,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 344,
+	label = "Cds-CdsCdsCds",
+	group = 
+"""
+1 * Cd      u0 {2,D} {3,S} {4,S}
+2   Cd      u0 {1,D}
+3   [Cd,CO] u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+""",
+	solute = u'Cds-Cds(Cds-Cd)(Cds-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 345,
+	label = "Cds-Cds(Cds-O2d)(Cds-O2d)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   CO u0 {1,S} {5,D}
+3   CO u0 {1,S} {6,D}
+4   Cd u0 {1,D}
+5   O2d u0 {2,D}
+6   O2d u0 {3,D}
+""",
+	solute = u'Crds-Crds(Crds-O2d)(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 346,
+	label = "Crds-Crds(Crds-O2d)(Cds-O2d)",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,S} {4,D}
+2   CO u0 r1 {1,S} {5,D}
+3   CO u0 {1,S} {6,D}
+4   Cd u0 r1 {1,D}
+5   O2d u0 {2,D}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.02894,
+		B = -0.00926,
+		E = -0.01341,
+		L = 0.24078,
+		A = -0.14627,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 22,
+		L = 21,
+		A = 21,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 347,
+	label = "Cds-Cds(Cds-O2d)(Cds-Cd)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   CO u0 {1,S} {6,D}
+3   Cd u0 {1,S} {5,D}
+4   Cd u0 {1,D}
+5   C  u0 {3,D}
+6   O2d u0 {2,D}
+""",
+	solute = u'Cds-Cds(Cds-O2d)(Cds-Cds)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 348,
+	label = "Cds-Cds(Cds-O2d)(Cds-Cds)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   CO u0 {1,S} {6,D}
+3   Cd u0 {1,S} {5,D}
+4   Cd u0 {1,D}
+5   Cd u0 {3,D}
+6   O2d u0 {2,D}
+""",
+	solute = u'Crds-Crds(Cds-O2d)(Crds-Crds)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 349,
+	label = "Crds-Crds(Cds-O2d)(Crds-Crds)",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,S} {4,D}
+2   CO u0 {1,S} {6,D}
+3   Cd u0 r1 {1,S} {5,D}
+4   Cd u0 r1 {1,D}
+5   Cd u0 r1 {3,D}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.03800,
+		B = 0.01238,
+		E = 0.08541,
+		L = 0.29580,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 69,
+		B = 69,
+		E = 71,
+		L = 61,
+		A = 73,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 350,
+	label = "Cds-Cds(Cds-O2d)(Cds-N3d)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,S} {4,D}
+2   CO  u0 {1,S} {6,D}
+3   Cd  u0 {1,S} {5,D}
+4   Cd  u0 {1,D}
+5   N3d u0 {3,D}
+6   O2d u0 {2,D}
+""",
+	solute = u'Crds-Crds(Cds-O2d)(Crds-N3rd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 351,
+	label = "Crds-Crds(Crds-O2d)(Crds-N3rd)",
+	group = 
+"""
+1 * Cd  u0 r1 {2,S} {3,S} {4,D}
+2   CO  u0 r1 {1,S} {6,D}
+3   Cd  u0 r1 {1,S} {5,D}
+4   Cd  u0 r1 {1,D}
+5   N3d u0 r1 {3,D}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.02130,
+		B = 0.05204,
+		E = -0.00717,
+		L = 0.02242,
+		A = 0.06217,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 352,
+	label = "Crds-Crds(Cds-O2d)(Crds-N3rd)",
+	group = 
+"""
+1 * Cd  u0 r1 {2,S} {3,S} {4,D}
+2   CO  u0 {1,S} {6,D}
+3   Cd  u0 r1 {1,S} {5,D}
+4   Cd  u0 r1 {1,D}
+5   N3d u0 r1 {3,D}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.06487,
+		B = 0.01081,
+		E = 0.04249,
+		L = 0.18443,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 7,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 353,
+	label = "Cds-Cds(Cds-N3d)(Cds-N3d)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,S} {4,D}
+2   Cd  u0 {1,S} {6,D}
+3   Cd  u0 {1,S} {5,D}
+4   Cd  u0 {1,D}
+5   N3d u0 {3,D}
+6   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.06092,
+		B = -0.04807,
+		E = 0.24820,
+		L = 0.06570,
+		A = -0.02368,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 1,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 354,
+	label = "Cds-Cds(Cds-Cd)(Cds-N3d)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,S} {4,D}
+2   Cd  u0 {1,S} {6,D}
+3   Cd  u0 {1,S} {5,D}
+4   Cd  u0 {1,D}
+5   N3d u0 {3,D}
+6   C   u0 {2,D}
+""",
+	solute = u'Crds-Crds(Crds-Crd)(Crds-N3rd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 355,
+	label = "Crds-Crds(Crds-Crd)(Crds-N3rd)",
+	group = 
+"""
+1 * Cd  u0 r1 {2,S} {3,S} {4,D}
+2   Cd  u0 r1 {1,S} {6,D}
+3   Cd  u0 r1 {1,S} {5,D}
+4   Cd  u0 r1 {1,D}
+5   N3d u0 r1 {3,D}
+6   C   u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.02899,
+		B = 0.07090,
+		E = 0.17860,
+		L = 0.59976,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 36,
+		B = 30,
+		E = 38,
+		L = 37,
+		A = 34,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 356,
+	label = "Cds-Cds(Cds-Cd)(Cds-Cd)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,S} {6,D}
+4   Cd u0 {1,D}
+5   C  u0 {2,D}
+6   C  u0 {3,D}
+""",
+	solute = u'Cds-Cds(Cds-Cds)(Cds-Cds)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 357,
+	label = "Cds-Cds(Cds-Cds)(Cds-Cds)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,S} {4,D}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,S} {6,D}
+4   Cd u0 {1,D}
+5   Cd u0 {2,D}
+6   Cd u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.09611,
+		B = -0.00828,
+		E = 0.15894,
+		L = 0.61078,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 15,
+		L = 13,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 358,
+	label = "Cds-CdsCtCs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Ct u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = u'Cds-CdCs(CtN3t)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 359,
+	label = "Cds-CdCs(CtN3t)",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   Cd  u0 {1,D} {5,S} {6,S}
+3   Ct  u0 {1,S} {7,T}
+4   Cs  u0 {1,S}
+5   R   u0 {2,S}
+6   R   u0 {2,S}
+7   N3t u0 {3,T}
+""",
+	solute = SoluteData(
+		S = 0.00353,
+		B = 0.02517,
+		E = -0.01696,
+		L = 0.00197,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 360,
+	label = "Cds-CdsCtCds",
+	group = 
+"""
+1 * Cd      u0 {2,D} {3,S} {4,S}
+2   Cd      u0 {1,D}
+3   Ct      u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00074,
+		B = -0.00408,
+		E = 0.04319,
+		L = 0.16589,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 361,
+	label = "Cds-CdsCtCt",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Ct u0 {1,S}
+4   Ct u0 {1,S}
+""",
+	solute = u'Cds-Cd(CtN3t)(CtN3t)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 362,
+	label = "Cds-Cd(CtN3t)(CtN3t)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,S} {4,D}
+2   Ct  u0 {1,S} {5,T}
+3   Ct  u0 {1,S} {6,T}
+4   Cd  u0 {1,D}
+5   N3t u0 {2,T}
+6   N3t u0 {3,T}
+""",
+	solute = SoluteData(
+		S = 0.06003,
+		B = 0.05931,
+		E = -0.02248,
+		L = 0.09131,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 363,
+	label = "Cds-CdsCbCs",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01883,
+		B = 0.00344,
+		E = 0.01876,
+		L = 0.31010,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 364,
+	label = "Crds-CrdsCbCrs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cb u0 {1,S}
+4   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05957,
+		B = -0.03906,
+		E = 0.10209,
+		L = 0.50230,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 12,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 365,
+	label = "Crds-CrdsCbCs",
+	group = 
+"""
+1 * Cd u0 r1 {2,D} {3,S} {4,S}
+2   Cd u0 r1 {1,D}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00513,
+		B = 0.03195,
+		E = 0.13433,
+		L = 0.49814,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 33,
+		B = 31,
+		E = 37,
+		L = 34,
+		A = 35,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 366,
+	label = "Cds-CdsCbCds",
+	group = 
+"""
+1 * Cd      u0 {2,D} {3,S} {4,S}
+2   Cd      u0 {1,D}
+3   Cb      u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+""",
+	solute = u'Cds-CdsCb(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 367,
+	label = "Cds-CdsCb(Cds-O2d)",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   CO u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   Cb u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.01724,
+		B = -0.00834,
+		E = 0.10738,
+		L = 0.24795,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 368,
+	label = "Crds-CrdsCb(Crds-O2d)",
+	group = 
+"""
+1 * Cd u0 r1 {2,S} {3,D} {4,S}
+2   CO u0 r1 {1,S} {5,D}
+3   Cd u0 r1 {1,D}
+4   Cb u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.03975,
+		B = 0.05229,
+		E = 0.03889,
+		L = -0.13396,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 39,
+		E = 39,
+		L = 39,
+		A = 39,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 369,
+	label = "Cds-CdsCb(Cds-N3d)",
+	group = 
+"""
+1 * Cd  u0 {2,S} {3,D} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cd  u0 {1,D}
+4   Cb  u0 {1,S}
+5   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.08646,
+		B = -0.10783,
+		E = 0.08029,
+		L = 0.36628,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 3,
+		E = 10,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 370,
+	label = "Cds-Cds(Cds-Cd)Cb",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   Cb u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = u'Cds-Cds(Cds-Cds)Cb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 371,
+	label = "Cds-Cds(Cds-Cds)Cb",
+	group = 
+"""
+1 * Cd u0 {2,S} {3,D} {4,S}
+2   Cd u0 {1,S} {5,D}
+3   Cd u0 {1,D}
+4   Cb u0 {1,S}
+5   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.03073,
+		B = 0.03633,
+		E = 0.06458,
+		L = 0.63031,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 23,
+		L = 19,
+		A = 23,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 372,
+	label = "Cds-CdsCbCb",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06718,
+		B = -0.04433,
+		E = 0.08250,
+		L = 0.14928,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 13,
+		L = 12,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 373,
+	label = "Cds-CddCC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   Cdd u0 {1,D}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'Cds-(Cdd-Cd)CC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 374,
+	label = "Cds-(Cdd-Cd)CC",
+	group = 
+"""
+1 * Cd  u0 {2,D} {3,S} {4,S}
+2   Cdd u0 {1,D} {5,D}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01534,
+		B = 0.00892,
+		E = 0.01752,
+		L = 0.17511,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 1,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 375,
+	label = "Cds-CdCN",
+	group = 
+"""
+1 * Cd u0 {2,D} {3,S} {4,S}
+2   C  u0 {1,D}
+3   C  u0 {1,S}
+4   N  u0 {1,S}
+""",
+	solute = u'Cds-CdCsN3d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 376,
+	label = "Cds-CdCbN3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   Cb  u0 {1,S}
+6   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12008,
+		B = 0.07004,
+		E = 0.06553,
+		L = 0.62998,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 377,
+	label = "Cds-CdCsN3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   Cs  u0 {1,S}
+6   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06071,
+		B = 0.21262,
+		E = 0.12735,
+		L = 0.70798,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 66,
+		B = 61,
+		E = 69,
+		L = 46,
+		A = 65,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 378,
+	label = "Cds-CdCdsN3s",
+	group = 
+"""
+1 * Cd         u0 {2,D} {5,S} {6,S}
+2   Cd         u0 {1,D} {3,S} {4,S}
+3   R          u0 {2,S}
+4   R          u0 {2,S}
+5   [Cd,CO,Cs] u0 {1,S}
+6   N3s        u0 {1,S}
+""",
+	solute = u'Cds-Cd(Cds-O2d)N3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 379,
+	label = "Cds-Cd(Cds-O2d)N3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   CO  u0 {1,S} {7,D}
+6   N3s u0 {1,S}
+7   O2d u0 {5,D}
+""",
+	solute = SoluteData(
+		S = -0.01501,
+		B = 0.02492,
+		E = 0.08663,
+		L = 0.31055,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 53,
+		B = 53,
+		E = 55,
+		L = 50,
+		A = 53,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 380,
+	label = "Cds-Cd(Cds-N3d)N3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   Cd  u0 {1,S} {7,D}
+6   N3s u0 {1,S}
+7   N3d u0 {5,D}
+""",
+	solute = SoluteData(
+		S = 0.11330,
+		B = 0.04604,
+		E = 0.02887,
+		L = 0.58012,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 18,
+		E = 21,
+		L = 18,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 381,
+	label = "Cds-Cd(Cds-Cds)N3s",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   Cd  u0 {1,S} {7,D}
+6   N3s u0 {1,S}
+7   Cd  u0 {5,D}
+""",
+	solute = SoluteData(
+		S = 0.00753,
+		B = 0.08562,
+		E = 0.12813,
+		L = 0.57197,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 35,
+		L = 25,
+		A = 35,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 382,
+	label = "Cds-CdCbN3d",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   Cb  u0 {1,S}
+6   N3d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01947,
+		B = 0.02515,
+		E = 0.09000,
+		L = 0.20944,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 12,
+		L = 8,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 383,
+	label = "Cds-CdCsN3d",
+	group = 
+"""
+1 * Cd  u0 {2,D} {5,S} {6,S}
+2   Cd  u0 {1,D} {3,S} {4,S}
+3   R   u0 {2,S}
+4   R   u0 {2,S}
+5   Cs  u0 {1,S}
+6   N3d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03247,
+		B = 0.15030,
+		E = -0.00959,
+		L = 0.05341,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 105,
+		B = 77,
+		E = 125,
+		L = 96,
+		A = 124,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 384,
+	label = "Cds-CdCdsN3d",
+	group = 
+"""
+1 * Cd         u0 {2,D} {5,S} {6,S}
+2   Cd         u0 {1,D} {3,S} {4,S}
+3   R          u0 {2,S}
+4   R          u0 {2,S}
+5   [Cd,CO,Cs] u0 {1,S}
+6   N3d        u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05925,
+		B = -0.00538,
+		E = 0.01742,
+		L = 0.17340,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 46,
+		E = 51,
+		L = 40,
+		A = 51,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 385,
+	label = "Cds-CdCtN3d",
+	group = 
+"""
+1 * Cd   u0 {2,D} {5,S} {6,S}
+2   Cd   u0 {1,D} {3,S} {4,S}
+3   R    u0 {2,S}
+4   R    u0 {2,S}
+5   Ct   u0 {1,S}
+6   N3d  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00287,
+		B = -0.03744,
+		E = -0.04962,
+		L = -0.10150,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 386,
+	label = "Cds-CdCN5dc",
+	group = 
+"""
+1 * Cd   u0 {2,D} {5,S} {6,S}
+2   Cd   u0 {1,D} {3,S} {4,S}
+3   R    u0 {2,S}
+4   R    u0 {2,S}
+5   C    u0 {1,S}
+6   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08474,
+		B = -0.01509,
+		E = 0.04048,
+		L = 0.40020,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 19,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 387,
+	label = "Cds-Sd",
+	group = 
+"""
+1 * CS u0 {2,D}
+2   S  u0 {1,D}
+""",
+	solute = u'Cds-S2dNN',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 388,
+	label = "Cds-S2dNN",
+	group = 
+"""
+1 * CS u0 {2,D} {3,S} {4,S}
+2   S2d u0 {1,D}
+3   N   u0 {1,S}
+4   N   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08127,
+		B = 0.13686,
+		E = 0.17091,
+		L = 0.52156,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 19,
+		L = 14,
+		A = 19,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 389,
+	label = "Cds-S2dNC",
+	group = 
+"""
+1 * CS u0 {2,D} {3,S} {4,S}
+2   S2d u0 {1,D}
+3   N   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.25290,
+		B = 0.03884,
+		E = 0.12637,
+		L = 0.67317,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 9,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 390,
+	label = "Cds-S2dNS",
+	group = 
+"""
+1 * CS u0 {2,D} {3,S} {4,S}
+2   S2d u0 {1,D}
+3   N   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06140,
+		B = -0.00583,
+		E = 0.14690,
+		L = 0.31565,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 391,
+	label = "Cds-S2dOC",
+	group = 
+"""
+1 * CS u0 {2,D} {3,S} {4,S}
+2   S2d u0 {1,D}
+3   O  u0 {1,S}
+4   C  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00785,
+		B = 0.00141,
+		E = -0.04527,
+		L = 0.11173,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 2,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 392,
+	label = "Cs",
+	group = 
+"""
+1 * Cs u0
+""",
+	solute = u'Cs-CCCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 393,
+	label = "Cs-P3s",
+	group = 
+"""
+1 * Cs u0 {2,S}
+2   P3s u0 {1,S}
+""",
+	solute = u'Cs-P3sHHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 394,
+	label = "Cs-P3sHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P3s u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06356,
+		B = 0.12722,
+		E = 0.09695,
+		L = 0.60735,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 395,
+	label = "Cs-P3sRHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P3s u0 {1,S}
+3   R!H u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-P3sCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 396,
+	label = "Cs-P3sCsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P3s u0 {1,S}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-P3sHHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 397,
+	label = "Cs-P5d",
+	group = 
+"""
+1 * Cs u0 {2,S}
+2   P5d u0 {1,S}
+""",
+	solute = u'Cs-P5dRHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 398,
+	label = "Cs-P5dHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-(P5d-O2d)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 399,
+	label = "Cs-(P5d-O2d)HHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S} {6,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.12367,
+		B = 0.08738,
+		E = -0.02010,
+		L = 0.20421,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 12,
+		L = 5,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 400,
+	label = "Cs-P5dRHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   R!H u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-P5dCHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 401,
+	label = "Cs-P5dNHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   N  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-P5dN3sHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 402,
+	label = "Cs-P5dN3sHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   N3s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-P5dCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 403,
+	label = "Cs-P5dCHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   C  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-P5dCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 404,
+	label = "Cs-P5dCsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09328,
+		B = 0.29014,
+		E = 0.00630,
+		L = 0.57279,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 21,
+		L = 9,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 405,
+	label = "Cs-P5dOsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   P5d u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.05564,
+		B = 0.06896,
+		E = 0.06334,
+		L = 0.07604,
+		A = 0.05232,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 407,
+	label = "Cs-P5dOCH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   O  u0 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00845,
+		B = 0.07668,
+		E = 0.08441,
+		L = 0.19730,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 408,
+	label = "Cs-P5d(O-H)CH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   O  u0 {1,S} {6,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+6   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.06329,
+		B = -0.00847,
+		E = 0.04766,
+		L = 0.23122,
+		A = 0.03096,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 409,
+	label = "Cs-P5dOCC",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d  u0 {1,S}
+3   O   u0 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = u'Cs-P5dOCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 410,
+	label = "Cs-P5dOCC",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   O2s u0 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = u'Cs-P5dOCH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 411,
+	label = "Cs-P5d(O-H)CC",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+6   H   u0 {3,S}
+""",
+	solute = u'Cs-P5d(O-H)CH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 413,
+	label = "Cs-P5dCCC",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   C  u0 {1,S}
+""",
+	solute = u'Cs-P5dCsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 414,
+	label = "Cs-P5dCsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   P5d u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Cs-P5dCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 415,
+	label = "Cs-NHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-N3sHHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 416,
+	label = "Cs-N3sHHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = u'Cs-(N3s-RR)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 417,
+	label = "Cs-N3rsHHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 r1 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.21254,
+		B = 0.14235,
+		E = 0.03871,
+		L = 0.49095,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 165,
+		B = 165,
+		E = 169,
+		L = 142,
+		A = 165,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 418,
+	label = "Cs-(N3s-RH)HHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S} {6,S} {7,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   H   u0 {2,S}
+7   R!H u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.13514,
+		B = 0.17889,
+		E = 0.04890,
+		L = 0.53868,
+		A = 0.03602,
+	),
+	dataCount = DataCountGAV(
+		S = 92,
+		B = 88,
+		E = 99,
+		L = 71,
+		A = 95,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 419,
+	label = "Cs-(N3s-RR)HHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S} {6,S} {7,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   R!H u0 {2,S}
+7   R!H u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.13036,
+		B = 0.14475,
+		E = 0.07419,
+		L = 0.64399,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 228,
+		B = 229,
+		E = 248,
+		L = 190,
+		A = 257,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 420,
+	label = "Cs-N3dHHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = u'Cs-(N3dCd)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 421,
+	label = "Cs-(N3dCd)HHH",
+	group = 
+"""
+1 * Cs       u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d      u0 {1,S} {6,D}
+3   H        u0 {1,S}
+4   H        u0 {1,S}
+5   H        u0 {1,S}
+6   [Cd,Cdd] u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.12541,
+		B = 0.05892,
+		E = 0.05968,
+		L = 0.34286,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 3,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 422,
+	label = "Cs-N5cHHH",
+	group = 
+"""
+1 * Cs   u0 {2,S} {3,S} {4,S} {5,S}
+2   N    u0 c+1  {1,S}
+3   H    u0 {1,S}
+4   H    u0 {1,S}
+5   H    u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08297,
+		B = -0.00887,
+		E = -0.04654,
+		L = 0.32829,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 6,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 423,
+	label = "Cs-NNHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   N  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.16930,
+		B = 0.04448,
+		E = 0.15883,
+		L = 0.81401,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 13,
+		L = 13,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 424,
+	label = "Cs-NOHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   O  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-N3sOHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 425,
+	label = "Cs-N3sOHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S}
+3   O  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-N3rsOHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 426,
+	label = "Cs-N3rsOHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 r1 {1,S}
+3   O  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01595,
+		B = 0.08998,
+		E = 0.15129,
+		L = 0.57385,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 45,
+		E = 46,
+		L = 38,
+		A = 45,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 427,
+	label = "Cs-NSHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   S  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06086,
+		B = 0.03327,
+		E = 0.12442,
+		L = 0.10093,
+		A = -0.00272,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 428,
+	label = "Cs-NCHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   C  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-NCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 429,
+	label = "Cs-NCbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07724,
+		B = 0.06578,
+		E = 0.03677,
+		L = 0.41610,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 52,
+		B = 52,
+		E = 53,
+		L = 31,
+		A = 55,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 430,
+	label = "Crs-NrCbHH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 r1 {1,S}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12096,
+		B = 0.04510,
+		E = 0.09099,
+		L = 0.33701,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 431,
+	label = "Cs-NrCbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 r1 {1,S}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11405,
+		B = -0.01551,
+		E = 0.04266,
+		L = 0.37098,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 34,
+		B = 34,
+		E = 34,
+		L = 29,
+		A = 34,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 432,
+	label = "Cs-NCsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-N3sCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 433,
+	label = "Cs-N3sCsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09432,
+		B = 0.17831,
+		E = 0.05618,
+		L = 0.64379,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 401,
+		B = 396,
+		E = 420,
+		L = 349,
+		A = 421,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 434,
+	label = "Crs-N3rsCrsHH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 r1 {1,S}
+3   Cs  u0 r1 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13555,
+		B = 0.17421,
+		E = 0.08666,
+		L = 0.70570,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 257,
+		B = 258,
+		E = 269,
+		L = 237,
+		A = 264,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 435,
+	label = "Cs-N3rsCsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 r1 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06269,
+		B = 0.12307,
+		E = 0.04171,
+		L = 0.57835,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 144,
+		B = 144,
+		E = 151,
+		L = 121,
+		A = 146,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 436,
+	label = "Cs-N3dCHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d u0 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = u'Cs-(N3d-Cd)CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 437,
+	label = "Cs-(N3d-Nd)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d u0 {1,S} {6,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   N   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.16105,
+		B = 0.04298,
+		E = 0.06468,
+		L = 0.39388,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 438,
+	label = "Cs-(N3d-Cd)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d u0 {1,S} {6,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   Cd  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.08232,
+		B = 0.21370,
+		E = 0.01305,
+		L = 0.49914,
+		A = 0.11280,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 16,
+		E = 16,
+		L = 13,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 439,
+	label = "Cs-(N3d-Cdd)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d u0 {1,S} {6,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   Cdd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07643,
+		B = 0.08052,
+		E = 0.03855,
+		L = 0.37266,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 440,
+	label = "Cs-N5cCsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N   u0 c+1 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.29454,
+		B = 0.05443,
+		E = 0.01156,
+		L = 0.61309,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 16,
+		L = 8,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 441,
+	label = "Cs-NCdsHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   [Cd,CO,CS] u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-N(Cds-Cd)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 442,
+	label = "Cs-N(Cds-O2d)HH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   CO         u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.21646,
+		B = 0.02862,
+		E = 0.09309,
+		L = 0.76065,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 39,
+		E = 40,
+		L = 24,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 443,
+	label = "Cs-N(Cds-O2d(OsH))HH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   CO         u0 {1,S} {6,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   O2s        u0 {3,S} {7,S}
+7   H          u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.24685,
+		B = -0.02241,
+		E = 0.12665,
+		L = 0.58548,
+		A = -0.08198,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 30,
+		E = 30,
+		L = 29,
+		A = 30,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 444,
+	label = "Cs-N(Cds-Cd)HH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   Cd         u0 {1,S} {6,D}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   C          u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.03449,
+		B = 0.13209,
+		E = 0.05279,
+		L = 0.61179,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 36,
+		B = 36,
+		E = 40,
+		L = 31,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 445,
+	label = "Cs-N(Cds-N3d)HH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   Cd         u0 {1,S} {6,D}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   N3d        u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.21086,
+		B = 0.11833,
+		E = -0.03720,
+		L = 0.70966,
+		A = -0.00185,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 446,
+	label = "Cs-NCtHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N   u0 {1,S}
+3   Ct  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03381,
+		B = 0.04164,
+		E = 0.02801,
+		L = 0.18082,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 8,
+		L = 5,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 447,
+	label = "Cs-NNCH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   N  u0 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01005,
+		B = 0.10779,
+		E = 0.13837,
+		L = 0.61712,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 448,
+	label = "Cs-NOCH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   O  u0 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.24017,
+		B = 0.08511,
+		E = 0.12095,
+		L = 0.28252,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 30,
+		E = 30,
+		L = 26,
+		A = 30,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 449,
+	label = "Cs-NSCH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   S  u0 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11441,
+		B = -0.03339,
+		E = 0.14626,
+		L = 0.13370,
+		A = -0.13097,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 26,
+		L = 25,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 450,
+	label = "Cs-NCCH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09180,
+		B = 0.08140,
+		E = -0.00598,
+		L = 0.48297,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 22,
+		L = 19,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 451,
+	label = "Cs-NCsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-N3sCsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 452,
+	label = "Cs-N3sCsCsH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03117,
+		B = 0.18969,
+		E = 0.05167,
+		L = 0.62509,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 90,
+		B = 88,
+		E = 93,
+		L = 85,
+		A = 94,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 453,
+	label = "Crs-N3rsCrsCrsH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 r1 {1,S}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06273,
+		B = 0.18852,
+		E = 0.15623,
+		L = 0.62870,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 45,
+		E = 46,
+		L = 42,
+		A = 45,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 454,
+	label = "Crs-N3sCrsCrsH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00333,
+		B = 0.17505,
+		E = 0.05637,
+		L = 0.53423,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 56,
+		B = 55,
+		E = 61,
+		L = 50,
+		A = 57,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 455,
+	label = "Crs-N3rsCrsCsH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 r1 {1,S}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07907,
+		B = 0.15884,
+		E = 0.08263,
+		L = 0.72863,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 23,
+		E = 26,
+		L = 23,
+		A = 25,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 456,
+	label = "Cs-N3dCsCsH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3d u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.19109,
+		B = 0.14875,
+		E = 0.25485,
+		L = 0.49593,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 11,
+		E = 11,
+		L = 10,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 457,
+	label = "Cs-N5dcCsCsH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N5dc u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09035,
+		B = 0.03713,
+		E = 0.01712,
+		L = 0.42741,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 458,
+	label = "Cs-NCsCdsH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   Cs         u0 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-NCs(Cds-O2d)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 459,
+	label = "Cs-NCs(Cds-O2d)H",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   Cs         u0 {1,S}
+4   CO         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05416,
+		B = 0.20770,
+		E = 0.10886,
+		L = 0.74604,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 73,
+		B = 73,
+		E = 73,
+		L = 69,
+		A = 73,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 460,
+	label = "Cs-NCs(Cds-Cd)H",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   N          u0 {1,S}
+3   Cs         u0 {1,S}
+4   Cd         u0 {1,S} {6,D}
+5   H          u0 {1,S}
+6   C          u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.02779,
+		B = 0.03849,
+		E = 0.04723,
+		L = 0.17215,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 461,
+	label = "Cs-NOCR",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N   u0 {1,S}
+3   O   u0 {1,S}
+4   C   u0 {1,S}
+5   R!H u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00518,
+		B = -0.03614,
+		E = 0.14251,
+		L = 0.34035,
+		A = -0.00235,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 462,
+	label = "Cs-NCCC",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   C  u0 {1,S}
+""",
+	solute = u'Cs-NCsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 463,
+	label = "Cs-NCsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Cs-N3CsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 464,
+	label = "Cs-N3CsCsCs",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   [N3s,N3d] u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09535,
+		B = 0.20273,
+		E = 0.02178,
+		L = 0.61692,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 41,
+		B = 41,
+		E = 41,
+		L = 37,
+		A = 44,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 465,
+	label = "Cs-N5dcCsCsCs",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N5dc u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.16390,
+		B = 0.03806,
+		E = 0.02741,
+		L = 0.53216,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 466,
+	label = "Cs-NCdCbCb",
+	group = 
+"""
+1 * Cs          u0 {2,S} {3,S} {4,S} {5,S}
+2   N           u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   Cb          u0 {1,S}
+5   Cb          u0 {1,S}
+""",
+	solute = u'Cs-N3s(Cd-O2d)CbCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 467,
+	label = "Cs-N3s(Cd-O2d)CbCb",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   N3s u0 {1,S}
+3   CO  u0 {1,S}
+4   Cb  u0 {1,S}
+5   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01426,
+		B = 0.02508,
+		E = -0.21400,
+		L = -0.07816,
+		A = 0.05944,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 8,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 468,
+	label = "Cs-NNNN",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   N  u0 {1,S}
+3   N  u0 {1,S}
+4   N  u0 {1,S}
+5   N  u0 {1,S}
+""",
+	solute = u'Cs-N5dcN5dcN5dcN5dc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 469,
+	label = "Cs-N5dcN5dcN5dcN5dc",
+	group = 
+"""
+1 * Cs   u0 {2,S} {3,S} {4,S} {5,S}
+2   N5dc u0 {1,S}
+3   N5dc u0 {1,S}
+4   N5dc u0 {1,S}
+5   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.18222,
+		B = -0.02717,
+		E = -0.10655,
+		L = -0.53262,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 470,
+	label = "Cs-OsHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10606,
+		B = 0.06237,
+		E = 0.04228,
+		L = 0.42904,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 663,
+		B = 626,
+		E = 691,
+		L = 619,
+		A = 692,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 471,
+	label = "Cs-OsOsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03318,
+		B = -0.02621,
+		E = 0.00000,
+		L = 0.11764,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 6,
+		E = 31,
+		L = 17,
+		A = 36,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 472,
+	label = "Crs-OrsOrsHH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 r1 {1,S}
+3   O2s u0 r1 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13088,
+		B = 0.01101,
+		E = 0.08958,
+		L = -0.02162,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 23,
+		L = 21,
+		A = 22,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 473,
+	label = "Cs-OsSHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   S u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-OsS2HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 474,
+	label = "Cs-OsS2HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   S2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02108,
+		B = 0.12338,
+		E = 0.09977,
+		L = 0.47438,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 475,
+	label = "Cs-OsOsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-OsOsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 476,
+	label = "Cs-OsOsOsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Cs-CsCsOsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 477,
+	label = "Cs-CHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsHHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 478,
+	label = "Cs-CsHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.40084,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3619,
+		B = 3489,
+		E = 3855,
+		L = 3315,
+		A = 3882,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 479,
+	label = "Cs-CdsHHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   H          u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 480,
+	label = "Cs-(Cds-O2d)HHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.17391,
+		B = 0.05563,
+		E = 0.03381,
+		L = 0.30890,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 462,
+		B = 445,
+		E = 490,
+		L = 407,
+		A = 502,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 481,
+	label = "Cs-(Cds-Cd)HHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 482,
+	label = "Cs-(Cds-Cds)HHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.08299,
+		B = 0.00670,
+		E = 0.02660,
+		L = 0.46561,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 577,
+		B = 518,
+		E = 620,
+		L = 552,
+		A = 615,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 483,
+	label = "Cs-(Cds-Cdd)HHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd  u0 {1,S} {6,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   Cdd u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cdd-Cd)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 484,
+	label = "Cs-(Cds-Cdd-Cd)HHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {4,S} {5,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cdd u0 {2,D} {7,D}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   H   u0 {1,S}
+7   C   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.03345,
+		B = 0.01592,
+		E = 0.05347,
+		L = 0.37636,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 3,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 485,
+	label = "Cs-(Cd-Nd)HHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd  u0 {1,S} {6,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   N   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07608,
+		B = 0.09777,
+		E = -0.00141,
+		L = 0.44489,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 126,
+		B = 102,
+		E = 136,
+		L = 110,
+		A = 134,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 486,
+	label = "Cs-(Cd-S2d)SHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CS u0 {1,S} {6,D}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   S2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07306,
+		B = 0.07796,
+		E = 0.04554,
+		L = 0.10310,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 487,
+	label = "Cs-CtHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-(Ct-Ct)HHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 488,
+	label = "Cs-(Ct-Ct)HHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct  u0 {1,S} {6,T}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   Ct  u0 {2,T}
+""",
+	solute = SoluteData(
+		S = -0.03605,
+		B = -0.04365,
+		E = 0.04106,
+		L = -0.02686,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 21,
+		E = 23,
+		L = 15,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 489,
+	label = "Cs-CbHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03408,
+		B = -0.05849,
+		E = 0.01760,
+		L = 0.11622,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 774,
+		B = 720,
+		E = 824,
+		L = 736,
+		A = 808,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 490,
+	label = "Cs-CCHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsCsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 491,
+	label = "Crs-CrCrHH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   C  u0 r1 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Crs-CrsCrsHH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 492,
+	label = "Crs-CrsCrsHH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03683,
+		B = 0.00000,
+		E = 0.03901,
+		L = 0.49867,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 901,
+		B = 872,
+		E = 952,
+		L = 827,
+		A = 949,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 493,
+	label = "Crs-CrdsCrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Crs-(Crds-O2d)CrsHH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 494,
+	label = "Crs-(Crds-Cd)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   C          u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07413,
+		B = 0.04837,
+		E = 0.06595,
+		L = 0.54998,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 50,
+		B = 45,
+		E = 51,
+		L = 49,
+		A = 51,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 495,
+	label = "Crs-(Crds-Crd)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   C          u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00045,
+		B = 0.00690,
+		E = 0.04775,
+		L = 0.44018,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 253,
+		B = 242,
+		E = 260,
+		L = 222,
+		A = 260,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 496,
+	label = "Crs-(Crds-O2d)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   CO         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   O2d        u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.22154,
+		B = 0.08339,
+		E = -0.03379,
+		L = 0.24870,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 190,
+		B = 192,
+		E = 195,
+		L = 170,
+		A = 193,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 497,
+	label = "Crs-(Crds-Nd)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   N          u0 {2,D}
+""",
+	solute = u'Crs-(Crds-N3d)CrsHH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 498,
+	label = "Crs-(Crds-Nrd)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   N          u0 r1 {2,D}
+""",
+	solute = u'Crs-(Crds-N3rd)CrsHH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 499,
+	label = "Crs-(Crds-N3rd)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   N3d        u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04761,
+		B = 0.04624,
+		E = 0.03455,
+		L = 0.30997,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 500,
+	label = "Crs-(Crds-N3d)CrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+6   N3d        u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.11411,
+		B = 0.06461,
+		E = 0.04627,
+		L = 0.47012,
+		A = 0.00258,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 501,
+	label = "Crs-CrdsCrdsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04471,
+		B = -0.00313,
+		E = 0.02770,
+		L = 0.24533,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 23,
+		E = 26,
+		L = 24,
+		A = 26,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 502,
+	label = "Crs-CbCrsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01848,
+		B = 0.02290,
+		E = 0.01687,
+		L = 0.33855,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 93,
+		B = 88,
+		E = 101,
+		L = 93,
+		A = 99,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 503,
+	label = "Crs-CbCrdsHH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12606,
+		B = -0.00293,
+		E = 0.05426,
+		L = 0.18254,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 13,
+		L = 13,
+		A = 13,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 504,
+	label = "Crs-CbCbHH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   Cb u0 r1 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00861,
+		B = -0.05467,
+		E = 0.05842,
+		L = 0.14990,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 16,
+		E = 18,
+		L = 16,
+		A = 18,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 505,
+	label = "Cs-CsCsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.49258,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2202,
+		B = 2168,
+		E = 2317,
+		L = 2014,
+		A = 2319,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 506,
+	label = "Cs-CdsCsHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   Cs         u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 507,
+	label = "Cs-(Cds-O2d)CsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.08767,
+		B = 0.07422,
+		E = -0.00602,
+		L = 0.30058,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 591,
+		B = 587,
+		E = 610,
+		L = 537,
+		A = 614,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 508,
+	label = "Cs-(Cds-Cd)CsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 509,
+	label = "Cs-(Cds-Cds)CsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.03558,
+		B = 0.01742,
+		E = 0.01675,
+		L = 0.45596,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 421,
+		B = 389,
+		E = 446,
+		L = 376,
+		A = 446,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 510,
+	label = "Cs-(Cds-Cdd)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd  u0 {1,S} {6,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   Cdd u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cdd-Cd)CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 511,
+	label = "Cs-(Cds-Cdd-Cd)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {4,S} {5,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cdd u0 {2,D} {7,D}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+6   H   u0 {1,S}
+7   C   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.02480,
+		B = 0.01302,
+		E = 0.05149,
+		L = 0.46989,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 2,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 512,
+	label = "Cs-(Cd-N3d)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd  u0 {1,S} {6,D} {7,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   N3d u0 {2,D}
+7   R   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.02925,
+		B = 0.11261,
+		E = -0.01126,
+		L = 0.44492,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 49,
+		B = 35,
+		E = 58,
+		L = 42,
+		A = 57,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 513,
+	label = "Cs-(Cds-S2d)CsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CS u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   S2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 514,
+	label = "Cs-CdsCdsHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   [Cd,CO,CS] u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)(Cds-Cd)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 515,
+	label = "Cs-(Cds-O2d)(Cds-O2d)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   CO u0 {1,S} {7,D}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+7   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.13243,
+		B = -0.08551,
+		E = 0.05491,
+		L = 0.14352,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 29,
+		B = 29,
+		E = 32,
+		L = 28,
+		A = 30,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 516,
+	label = "Cs-(Cds-O2d)(Cds-Cd)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 {1,S} {6,D}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)(Cds-Cds)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 517,
+	label = "Cs-(Cds-O2d)(Cds-Cds)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 {1,S} {6,D}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00162,
+		B = 0.00705,
+		E = 0.01856,
+		L = 0.21083,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 26,
+		L = 25,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 518,
+	label = "Cs-(Cds-Cd)(Cds-Cd)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cd u0 {1,S} {7,D}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+7   C  u0 {3,D}
+""",
+	solute = u'Cs-(Cds-Cds)(Cds-Cds)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 519,
+	label = "Cs-(Cds-Cds)(Cds-Cds)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cd u0 {1,S} {7,D}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+7   Cd u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.03289,
+		B = 0.04253,
+		E = 0.06497,
+		L = 0.49390,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 19,
+		E = 20,
+		L = 16,
+		A = 20,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 520,
+	label = "Cs-CtCsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-(Ct-Ct)CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 521,
+	label = "Cs-(Ct-N3t)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct  u0 {1,S} {6,T}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   N3t u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.19063,
+		B = 0.05558,
+		E = -0.01313,
+		L = 0.29211,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 27,
+		L = 26,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 522,
+	label = "Cs-(Ct-Ct)CsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct  u0 {1,S} {6,T}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   Ct  u0 {2,T}
+""",
+	solute = SoluteData(
+		S = -0.01485,
+		B = -0.04339,
+		E = -0.02705,
+		L = -0.11775,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 49,
+		B = 49,
+		E = 52,
+		L = 27,
+		A = 49,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 523,
+	label = "Cs-CtCdsHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct         u0 {1,S}
+3   [Cd,CO,CS] u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04720,
+		B = -0.00097,
+		E = 0.00927,
+		L = 0.06229,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 524,
+	label = "Cs-CtCtHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   Ct u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-(Ct-N3t)(Ct-N3t)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 525,
+	label = "Cs-(Ct-N3t)(Ct-N3t)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S} {6,T}
+3   Ct u0 {1,S} {7,T}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   N3t u0 {2,T}
+7   N3t u0 {3,T}
+""",
+	solute = SoluteData(
+		S = 0.03748,
+		B = 0.00701,
+		E = -0.00951,
+		L = 0.01205,
+		A = 0.04000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 526,
+	label = "Cs-CbCsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cs u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00741,
+		B = -0.03620,
+		E = 0.01176,
+		L = 0.10327,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 392,
+		B = 372,
+		E = 407,
+		L = 348,
+		A = 409,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 527,
+	label = "Cs-CbCdsHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 {1,S}
+3   [Cd,CO,CS] u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)CbHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 528,
+	label = "Cs-(Cds-O2d)CbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.09416,
+		B = 0.04178,
+		E = -0.03802,
+		L = -0.07294,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 60,
+		B = 60,
+		E = 60,
+		L = 48,
+		A = 61,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 529,
+	label = "Cs-(Cds-Cd)CbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CbHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 530,
+	label = "Cs-(Cds-Cds)CbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.04585,
+		B = 0.00289,
+		E = 0.00802,
+		L = 0.13872,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 13,
+		E = 17,
+		L = 15,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 531,
+	label = "Cs-(Cds-N3d)CbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.05755,
+		B = -0.00094,
+		E = -0.01700,
+		L = 0.11419,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 532,
+	label = "Cs-CbCtHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Ct u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00531,
+		B = 0.00702,
+		E = -0.02654,
+		L = -0.06262,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 533,
+	label = "Cs-CbCbHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.17743,
+		B = -0.04295,
+		E = 0.02634,
+		L = 0.52945,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 534,
+	label = "Cs-CCCH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsCsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 535,
+	label = "Crs-CrCrCrH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   C  u0 r1 {1,S}
+4   C  u0 r1 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Crs-CrsCrsCrsH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 536,
+	label = "Crs-CrsCrsCrsH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12326,
+		B = 0.00000,
+		E = 0.10592,
+		L = 0.51296,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 277,
+		B = 279,
+		E = 283,
+		L = 244,
+		A = 287,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 537,
+	label = "Crs-CrdCrsCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Crs-(Crd-Cd)CrsCrsH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 538,
+	label = "Crs-(Crd-Cd)CrsCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+6   C          u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.03860,
+		B = 0.05885,
+		E = 0.12599,
+		L = 0.46837,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 32,
+		B = 32,
+		E = 32,
+		L = 31,
+		A = 34,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 539,
+	label = "Crs-(Crd-Crd)CrsCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+6   C          u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07837,
+		B = 0.10681,
+		E = 0.11230,
+		L = 0.46203,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 92,
+		B = 89,
+		E = 96,
+		L = 85,
+		A = 96,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 540,
+	label = "Crs-(Crd-O2d)CrsCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   CO         u0 r1 {1,S} {6,D}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+6   O2d        u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.11668,
+		B = 0.02766,
+		E = 0.04771,
+		L = 0.24275,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 21,
+		E = 22,
+		L = 17,
+		A = 22,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 541,
+	label = "Crs-CbCrsCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00432,
+		B = 0.10323,
+		E = 0.00755,
+		L = 0.53551,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 35,
+		B = 35,
+		E = 37,
+		L = 35,
+		A = 36,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 542,
+	label = "Crs-CrdCrdCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02159,
+		B = -0.00820,
+		E = 0.05286,
+		L = 0.22751,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 4,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 543,
+	label = "Crs-CbCrdCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05479,
+		B = -0.02349,
+		E = 0.00616,
+		L = 0.19062,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 544,
+	label = "Crs-CbCrdCrdH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   [Cd,CO,CS] u0 r1 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.12161,
+		B = 0.07275,
+		E = -0.00011,
+		L = 0.03151,
+		A = 0.09793,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 545,
+	label = "Crs-CbCbCrsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   Cb         u0 r1 {1,S}
+4   Cs         u0 r1 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02089,
+		B = -0.00129,
+		E = -0.08184,
+		L = 0.12228,
+		A = -0.00464,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 546,
+	label = "Crs-CrCrCH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   C  u0 r1 {1,S}
+4   C  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Crs-CrsCrsCsH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 547,
+	label = "Crs-CrsCrsCsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02889,
+		B = 0.00000,
+		E = 0.03737,
+		L = 0.55376,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 226,
+		B = 215,
+		E = 235,
+		L = 209,
+		A = 227,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 548,
+	label = "Crs-CrsCrsCdH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09954,
+		B = 0.09593,
+		E = 0.00762,
+		L = 0.29495,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 81,
+		B = 77,
+		E = 81,
+		L = 77,
+		A = 82,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 549,
+	label = "Crs-CrsCrsCtH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Ct         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Crs-CrsCrs(Ct-Ct)H',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 550,
+	label = "Crs-CrsCrs(Ct-N3t)H",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Ct         u0 {1,S} {6,T}
+5   H          u0 {1,S}
+6   N3t        u0 {4,T}
+""",
+	solute = u'Cs-(Ct-N3t)CsCsH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 551,
+	label = "Crs-CrsCrs(Ct-Ct)H",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Ct         u0 {1,S} {6,T}
+5   H          u0 {1,S}
+6   Ct         u0 {4,T}
+""",
+	solute = u'Cs-(Ct-Ct)CsCsH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 552,
+	label = "Crs-CrdCrsCsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02918,
+		B = 0.07227,
+		E = 0.03340,
+		L = 0.55472,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 41,
+		E = 48,
+		L = 41,
+		A = 47,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 553,
+	label = "Crs-CrdCrsCdH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04280,
+		B = -0.01491,
+		E = 0.02947,
+		L = 0.07906,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 554,
+	label = "Crs-CrdCrdCsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02322,
+		B = 0.02008,
+		E = 0.04747,
+		L = 0.09280,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 1,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 555,
+	label = "Crs-CrdCrdCdH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.21649,
+		B = -0.06013,
+		E = 0.00017,
+		L = -0.43697,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 556,
+	label = "Crs-CbCrsCsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   Cs         u0 r1 {1,S}
+4   Cs         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01107,
+		B = -0.01279,
+		E = 0.01278,
+		L = 0.23578,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 7,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 557,
+	label = "Crs-CbCbCsH",
+	group = 
+"""
+1 * Cs         u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb         u0 r1 {1,S}
+3   Cb         u0 r1 {1,S}
+4   Cs         u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03259,
+		B = -0.03075,
+		E = -0.00979,
+		L = 0.07824,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 558,
+	label = "Cs-CsCsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.40981,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 409,
+		B = 399,
+		E = 420,
+		L = 385,
+		A = 432,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 559,
+	label = "Cs-CdsCsCsH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   Cs      u0 {1,S}
+4   Cs      u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)CsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 560,
+	label = "Cs-(Cds-O2d)CsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.05454,
+		B = 0.07812,
+		E = -0.00341,
+		L = 0.22936,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 96,
+		B = 95,
+		E = 97,
+		L = 89,
+		A = 98,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 561,
+	label = "Cs-(Cds-Cd)CsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 562,
+	label = "Cs-(Cds-Cds)CsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01356,
+		B = 0.02637,
+		E = 0.01047,
+		L = 0.40066,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 35,
+		B = 31,
+		E = 36,
+		L = 33,
+		A = 36,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 563,
+	label = "Cs-(CdN3d)CsCsH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd  u0 {1,S} {6,D} {7,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+6   N3d u0 {2,D}
+7   R   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.08975,
+		B = 0.09000,
+		E = 0.02314,
+		L = 0.57919,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 4,
+		E = 5,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 564,
+	label = "Cs-CtCsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-(Ct-N3t)CsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 565,
+	label = "Cs-(Ct-N3t)CsCsH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct  u0 {1,S} {6,T}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+6   N3t u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.09873,
+		B = 0.03342,
+		E = -0.01514,
+		L = 0.24266,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 566,
+	label = "Cs-(Ct-Ct)CsCsH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct  u0 {1,S} {6,T}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   H   u0 {1,S}
+6   Ct  u0 {2,T}
+""",
+	solute = SoluteData(
+		S = -0.04622,
+		B = -0.03485,
+		E = -0.02959,
+		L = 0.10041,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 6,
+		E = 5,
+		L = 2,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 567,
+	label = "Cs-CbCsCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00189,
+		B = -0.02530,
+		E = 0.01285,
+		L = 0.03492,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 93,
+		B = 84,
+		E = 99,
+		L = 80,
+		A = 95,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 568,
+	label = "Cs-CdsCdsCsH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01719,
+		B = -0.03372,
+		E = -0.00478,
+		L = 0.14775,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 10,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 569,
+	label = "Cs-CbCdsCsH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)CbCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 570,
+	label = "Cs-(Cds-O2d)CbCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04058,
+		B = 0.03020,
+		E = -0.02145,
+		L = 0.14258,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 28,
+		L = 26,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 571,
+	label = "Cs-(Cds-Cd)CbCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CbCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 572,
+	label = "Cs-(Cds-Cds)CbCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00314,
+		B = 0.00286,
+		E = 0.01699,
+		L = 0.32322,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 573,
+	label = "Cs-CbCbCsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09615,
+		B = 0.00664,
+		E = 0.00891,
+		L = 0.31177,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 14,
+		L = 13,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 574,
+	label = "Cs-CbCdsCdsH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00657,
+		B = -0.08838,
+		E = 0.09805,
+		L = 0.33279,
+		A = -0.00081,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 575,
+	label = "Cs-CbCbCdsH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   Cb      u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = u'Cs-CbCb(Cds-O2d)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 576,
+	label = "Cs-CbCb(Cds-O2d)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.05200,
+		B = 0.06384,
+		E = -0.02226,
+		L = -0.07640,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 2,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 577,
+	label = "Cs-CbCbCbH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01432,
+		B = -0.00751,
+		E = 0.00442,
+		L = -0.46157,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 578,
+	label = "Cs-CCCC",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   C  u0 {1,S}
+""",
+	solute = u'Cs-CsCsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 579,
+	label = "Crs-CrCrCrCr",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   C  u0 r1 {1,S}
+4   C  u0 r1 {1,S}
+5   C  u0 r1 {1,S}
+""",
+	solute = u'Crs-CbCrsCrsCrs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 580,
+	label = "Crs-CrsCrsCrsCrs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02699,
+		B = -0.01232,
+		E = 0.19857,
+		L = 0.28691,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 14,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 581,
+	label = "Crs-CbCrsCrsCrs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03756,
+		B = 0.06899,
+		E = 0.13755,
+		L = 0.24554,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 19,
+		A = 20,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 582,
+	label = "Crs-CrdCrsCrsCrs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04708,
+		B = 0.01104,
+		E = 0.04619,
+		L = 0.17574,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 583,
+	label = "Crs-CbCrdCrsCrs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.30776,
+		B = -0.01410,
+		E = -0.01172,
+		L = 0.67499,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 584,
+	label = "Crs-CrCrCrC",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   C  u0 r1 {1,S}
+4   C  u0 r1 {1,S}
+5   C  u0 {1,S}
+""",
+	solute = u'Crs-CrsCrsCrsCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 585,
+	label = "Crs-CrsCrsCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.16315,
+		B = 0.00000,
+		E = 0.07252,
+		L = 0.75695,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 165,
+		B = 165,
+		E = 166,
+		L = 135,
+		A = 168,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 586,
+	label = "Crs-CbCrsCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02584,
+		B = 0.04822,
+		E = -0.00520,
+		L = 0.27127,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 587,
+	label = "Crs-CbCrsCrsCd",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11161,
+		B = 0.07181,
+		E = 0.00343,
+		L = -0.01939,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 588,
+	label = "Crs-CbCrdCrsCd",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03834,
+		B = -0.01704,
+		E = -0.00473,
+		L = 0.04905,
+		A = 0.01444,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 589,
+	label = "Crs-CbCbCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   Cb u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02627,
+		B = -0.00734,
+		E = 0.09727,
+		L = 0.24891,
+		A = -0.00496,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 590,
+	label = "Crs-CrsCrsCrsCd",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = u'Crs-CrsCrsCrs(Cd-O2d)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 591,
+	label = "Crs-CrsCrsCrs(Cd-O2d)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   CO u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09607,
+		B = 0.12605,
+		E = -0.00837,
+		L = 0.35399,
+		A = -0.11074,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 592,
+	label = "Crs-CrdCrsCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Crs-(Crd-O2d)CrsCrsCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 593,
+	label = "Crs-(Crd-O2d)CrsCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.14531,
+		B = 0.08905,
+		E = 0.06193,
+		L = 0.11160,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 5,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 594,
+	label = "Crs-(Crd-Cd)CrsCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 r1 {1,S} {6,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+6   C u0 {2,D}
+""",
+	solute = u'Crs-(Crd-Crd)CrsCrsCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 595,
+	label = "Crs-(Crd-Crd)CrsCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 r1 {1,S} {6,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+6   C u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.08072,
+		B = 0.12947,
+		E = 0.07131,
+		L = 0.35719,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 84,
+		B = 84,
+		E = 85,
+		L = 68,
+		A = 86,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 596,
+	label = "Crs-CrdCrdCrsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06956,
+		B = 0.10121,
+		E = 0.04074,
+		L = 0.27232,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 22,
+		L = 12,
+		A = 22,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 597,
+	label = "Crs-CrdCrdCbCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cb u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01873,
+		B = -0.04416,
+		E = -0.02351,
+		L = 0.03967,
+		A = 0.09159,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 598,
+	label = "Crs-CrdCrdCrdCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   [Cd,CO,CS] u0 r1 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04025,
+		B = 0.05351,
+		E = -0.00463,
+		L = 0.08487,
+		A = -0.00656,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 1,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 599,
+	label = "Crs-CrCrCC",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   C  u0 r1 {1,S}
+4   C  u0 {1,S}
+5   C  u0 {1,S}
+""",
+	solute = u'Crs-CrsCrsCsCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 600,
+	label = "Crs-CrsCrsCsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.08160,
+		B = 0.00000,
+		E = -0.00335,
+		L = 0.32778,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 81,
+		B = 81,
+		E = 84,
+		L = 79,
+		A = 84,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 601,
+	label = "Crs-CbCrsCsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04577,
+		B = 0.00936,
+		E = 0.05732,
+		L = 0.30959,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 602,
+	label = "Crs-CrdCrsCsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09783,
+		B = 0.02688,
+		E = 0.02528,
+		L = 0.42410,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 13,
+		E = 14,
+		L = 14,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 603,
+	label = "Crs-CrdCrdCsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Crs-(Crd-O2d)(Crd-O2d)CsCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 604,
+	label = "Crs-(Crd-O2d)(Crd-O2d)CsCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 r1 {1,S}
+3   CO u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01938,
+		B = 0.09211,
+		E = -0.00349,
+		L = 0.16422,
+		A = 0.02342,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 46,
+		E = 47,
+		L = 13,
+		A = 46,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 605,
+	label = "Crs-CrdCrdCdCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 r1 {1,S}
+3   [Cd,CO,CS] u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Crs-(Crd-O2d)(Crd-O2d)CdCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 606,
+	label = "Crs-(Crd-O2d)(Crd-O2d)CdCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 r1 {1,S}
+3   CO u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = u'Crs-(Crd-O2d)(Crd-O2d)CsCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 607,
+	label = "Crs-CrsCrsCdCs",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   [Cd,CO,CS] u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.10701,
+		B = 0.10766,
+		E = 0.00385,
+		L = 0.03898,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 7,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 608,
+	label = "Cs-CsCsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.38226,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 80,
+		B = 80,
+		E = 78,
+		L = 69,
+		A = 80,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 609,
+	label = "Cs-CdsCsCsCs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   Cs      u0 {1,S}
+4   Cs      u0 {1,S}
+5   Cs      u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)CsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 610,
+	label = "Cs-(Cds-O2d)CsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04973,
+		B = 0.12163,
+		E = 0.00915,
+		L = 0.32713,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 19,
+		L = 19,
+		A = 20,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 611,
+	label = "Cs-(Cds-Cd)CsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 612,
+	label = "Cs-(Cds-Cds)CsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04109,
+		B = 0.03573,
+		E = -0.02479,
+		L = 0.40494,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 11,
+		L = 9,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 613,
+	label = "Cs-CtCsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02249,
+		B = 0.02547,
+		E = 0.03254,
+		L = 0.18485,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 2,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 614,
+	label = "Cs-CbCsCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04410,
+		B = 0.01241,
+		E = 0.01341,
+		L = 0.25132,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 61,
+		B = 60,
+		E = 70,
+		L = 60,
+		A = 67,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 615,
+	label = "Cs-CdsCdsCsCs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+5   Cs      u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04578,
+		B = -0.03230,
+		E = -0.03788,
+		L = 0.07553,
+		A = -0.07754,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 616,
+	label = "Cs-CbCtCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Ct u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01011,
+		B = 0.12546,
+		E = -0.02589,
+		L = 0.18917,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 617,
+	label = "Cs-CbCbCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00378,
+		B = 0.05379,
+		E = -0.00364,
+		L = 0.21433,
+		A = 0.00860,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 618,
+	label = "Cs-CbCdsCdsCs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+5   Cs      u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)(Cds-Cd)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 619,
+	label = "Cs-(Cds-O2d)(Cds-Cd)CbCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 {1,S} {6,D}
+4   Cb u0 {1,S}
+5   Cs u0 {1,S}
+6   C  u0 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)(Cds-Cds)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 620,
+	label = "Cs-(Cds-O2d)(Cds-Cds)CbCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 {1,S} {6,D}
+4   Cb u0 {1,S}
+5   Cs u0 {1,S}
+6   Cd u0 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)(Crds-Crds)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 621,
+	label = "Cs-(Cds-O2d)(Crds-Crds)CbCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 r1 {1,S} {6,D}
+4   Cb u0 {1,S}
+5   Cs u0 {1,S}
+6   Cd u0 r1 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)CbCbCs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 622,
+	label = "Cs-CbCbCdsCs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   Cb      u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+5   Cs      u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)CbCbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 623,
+	label = "Cs-(Cds-O2d)CbCbCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+5   Cs u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.01303,
+		B = 0.09437,
+		E = -0.02483,
+		L = 0.25873,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 624,
+	label = "Cs-CbCbCbCb",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+5   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.08035,
+		B = -0.02584,
+		E = -0.01078,
+		L = -0.55987,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 625,
+	label = "Cs-CCCOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = u'Cs-CsCsCsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 626,
+	label = "Cs-CsCsCsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = u'Cs-CsCsCs(Os-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 627,
+	label = "Cs-CsCsCs(Os-H)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {6,S}
+6   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02326,
+		B = 0.21460,
+		E = -0.03469,
+		L = 0.14805,
+		A = 0.03541,
+	),
+	dataCount = DataCountGAV(
+		S = 31,
+		B = 30,
+		E = 31,
+		L = 27,
+		A = 31,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 628,
+	label = "Crs-CrsCrsCrs(Os-H)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   O2s u0 {1,S} {6,S}
+6   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.20452,
+		B = 0.05943,
+		E = 0.14762,
+		L = 0.21668,
+		A = -0.06699,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 15,
+		L = 12,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 629,
+	label = "Crs-CrsCrsCs(Os-H)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {6,S}
+6   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.05891,
+		B = 0.13191,
+		E = 0.02670,
+		L = 0.53451,
+		A = 0.05930,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 19,
+		E = 20,
+		L = 16,
+		A = 19,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 630,
+	label = "Cs-CsCsCs(Os-R)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {6,S}
+6   R!H u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.00873,
+		B = 0.09966,
+		E = 0.00000,
+		L = 0.16083,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 30,
+		E = 37,
+		L = 26,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 631,
+	label = "Crs-CrsCrsCrs(Ors-R)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   O2s u0 r1 {1,S} {6,S}
+6   R!H u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.11248,
+		B = 0.08850,
+		E = 0.13885,
+		L = 0.21807,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 11,
+		L = 8,
+		A = 10,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 632,
+	label = "Crs-CrsCrsCs(Ors-R)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 r1 {1,S} {6,S}
+6   R!H u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.01116,
+		B = 0.08272,
+		E = 0.08100,
+		L = 0.22238,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 633,
+	label = "Crs-CrsCrsCs(Os-R)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {6,S}
+6   R!H u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.04282,
+		B = 0.08296,
+		E = 0.02043,
+		L = -2.45597,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 634,
+	label = "Crs-CrsCsCs(Ors-R)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 r1 {1,S} {6,S}
+6   R!H u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.08079,
+		B = 0.07647,
+		E = 0.02620,
+		L = -0.25668,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 14,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 635,
+	label = "Cs-CdsCsCsOs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   Cs      u0 {1,S}
+4   Cs      u0 {1,S}
+5   O2s      u0 {1,S}
+""",
+	solute = u'Cs-CdsCsCs(Os-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 636,
+	label = "Cs-CdsCsCs(Os-H)",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   Cs      u0 {1,S}
+4   Cs      u0 {1,S}
+5   O2s     u0 {1,S} {6,S}
+6   H       u0 {5,S}
+""",
+	solute = u'Cs-(Cds-O2d)CsCs(Os-H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 637,
+	label = "Cs-(Cds-O2d)CsCs(Os-H)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {7,S}
+6   O2d u0 {2,D}
+7   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.06470,
+		B = -0.09491,
+		E = -0.02128,
+		L = 0.14711,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 638,
+	label = "Crs-(Cds-O2d)CrsCrs(Os-H)",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 r1 {1,S}
+4   Cs u0 r1 {1,S}
+5   O2s u0 {1,S} {7,S}
+6   O2d u0 {2,D}
+7   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = -0.06496,
+		B = -0.06032,
+		E = -0.05199,
+		L = -0.16933,
+		A = -0.04858,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 45,
+		E = 46,
+		L = 35,
+		A = 45,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 639,
+	label = "Cs-(Cds-Cd)CsCs(Os-H)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {7,S}
+6   C  u0 {2,D}
+7   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.07313,
+		B = 0.04923,
+		E = -0.02442,
+		L = -0.04615,
+		A = 0.01282,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 640,
+	label = "Cs-CdsCsCs(Os-R)",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   Cs      u0 {1,S}
+4   Cs      u0 {1,S}
+5   O2s     u0 {1,S} {6,S}
+6   R!H     u0 {5,S}
+""",
+	solute = u'Cs-(Cds-Cd)CsCs(Os-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 641,
+	label = "Cs-(Cds-O2d)CsCs(Os-R)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {7,S}
+6   O2d u0 {2,D}
+7   R!H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = -0.01248,
+		B = 0.12481,
+		E = 0.02917,
+		L = 0.41046,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 17,
+		L = 9,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 642,
+	label = "Cs-(Cds-Cd)CsCs(Os-R)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S} {7,S}
+6   C  u0 {2,D}
+7   R!H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02338,
+		B = 0.06858,
+		E = -0.01962,
+		L = 0.26749,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 5,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 643,
+	label = "Cs-OsCtCsCs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   Ct u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.14808,
+		B = 0.06781,
+		E = 0.03621,
+		L = 0.52765,
+		A = 0.07466,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 15,
+		L = 11,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 644,
+	label = "Cs-CbCsCsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.12786,
+		B = 0.08883,
+		E = 0.03865,
+		L = -0.09199,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 21,
+		E = 21,
+		L = 20,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 645,
+	label = "Cs-CdsCdsCsOs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+5   O2s      u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)(Cds-Cd)CsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 646,
+	label = "Cs-(Cds-O2d)(Cds-Cd)CsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 {1,S} {6,D}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+6   C  u0 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)(Cds-Cds)CsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 647,
+	label = "Cs-(Cds-O2d)(Cds-Cds)CsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {7,D}
+3   Cd u0 {1,S} {6,D}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+6   Cd u0 {3,D}
+7   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.11603,
+		B = -0.00499,
+		E = -0.00195,
+		L = 0.03671,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 648,
+	label = "Cs-CtCdsCsOs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+5   O2s      u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)CtCsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 649,
+	label = "Cs-(Cds-Cd)CtCsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Ct u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CtCsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 650,
+	label = "Cs-(Cds-Cds)CtCsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Ct u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.08360,
+		B = -0.02115,
+		E = 0.03874,
+		L = 0.24741,
+		A = 0.03067,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 651,
+	label = "Cs-CbCdsCsOs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   Cs      u0 {1,S}
+5   O2s      u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01618,
+		B = 0.00349,
+		E = 0.08979,
+		L = 0.13263,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 652,
+	label = "Cs-CbCbCsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   Cs u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.09011,
+		B = 0.15785,
+		E = 0.01180,
+		L = 0.19184,
+		A = 0.00278,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 5,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 653,
+	label = "Cs-CbCbCdsOs",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   Cb      u0 {1,S}
+4   [Cd,CO] u0 {1,S}
+5   O2s      u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)CbCbOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 654,
+	label = "Cs-(Cds-O2d)CbCbOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+5   O2s u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.03810,
+		B = -0.04808,
+		E = -0.01699,
+		L = -0.03847,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 655,
+	label = "Cs-CbCbCbOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   Cb u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12927,
+		B = 0.01084,
+		E = -0.02009,
+		L = 0.21807,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 656,
+	label = "Cs-CCOsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   O2s u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = u'Cs-CsCsOsOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 657,
+	label = "Crs-CCOsOs",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 {1,S}
+3   O2s u0 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = u'Crs-OrsOrsCC',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 658,
+	label = "Crs-OrsOrsCC",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 r1 {1,S}
+3   O2s u0 r1 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05514,
+		B = 0.09381,
+		E = 0.13941,
+		L = 0.19930,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 24,
+		E = 24,
+		L = 17,
+		A = 24,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 659,
+	label = "Crs-CrOrsOsC",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C   u0 r1 {1,S}
+3   O2s u0 r1 {1,S}
+4   O2s u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.10670,
+		B = -0.19367,
+		E = 0.06361,
+		L = -0.06337,
+		A = 0.21730,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 660,
+	label = "Cs-CsCsOsOs",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00185,
+		B = 0.04791,
+		E = -0.03075,
+		L = 0.14849,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 661,
+	label = "Cs-COsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsOsOsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 662,
+	label = "Crs-COsOsH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C   u0 {1,S}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = u'Crs-CrOrsOsH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 663,
+	label = "Crs-OrsOrsCH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   O2s u0 r1 {1,S}
+3   O2s u0 r1 {1,S}
+4   C   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11251,
+		B = -0.00061,
+		E = 0.08195,
+		L = 0.13344,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 15,
+		L = 14,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 664,
+	label = "Crs-CrOrsOsH",
+	group = 
+"""
+1 * Cs  u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C   u0 r1 {1,S}
+3   O2s u0 r1 {1,S}
+4   O2s u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05199,
+		B = -0.11038,
+		E = 0.03597,
+		L = -0.03215,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 41,
+		B = 41,
+		E = 43,
+		L = 38,
+		A = 42,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 665,
+	label = "Cs-CsOsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04896,
+		B = 0.08880,
+		E = -0.01032,
+		L = 0.22679,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 9,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 666,
+	label = "Cs-COsSH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   O2s u0 {1,S}
+4   S  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsOsSH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 667,
+	label = "Cs-CsOsSH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S}
+4   S  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsOsS2H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 668,
+	label = "Cs-CsOsS2H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S}
+4   S2s  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04584,
+		B = -0.08341,
+		E = 0.04626,
+		L = 0.04549,
+		A = 0.01124,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 669,
+	label = "Cs-CCOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsCsOsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 670,
+	label = "Cs-CsCsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsCs(Os-H)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 671,
+	label = "Cs-CsCs(Os-H)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {6,S}
+5   H  u0 {1,S}
+6   H  u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.02639,
+		B = 0.04048,
+		E = 0.00331,
+		L = 0.27872,
+		A = -0.03207,
+	),
+	dataCount = DataCountGAV(
+		S = 140,
+		B = 138,
+		E = 141,
+		L = 129,
+		A = 141,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 672,
+	label = "Crs-CrsCrs(Os-H)H",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   O2s u0 {1,S} {6,S}
+5   H  u0 {1,S}
+6   H  u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.06134,
+		B = 0.01098,
+		E = 0.05978,
+		L = 0.35925,
+		A = -0.01867,
+	),
+	dataCount = DataCountGAV(
+		S = 153,
+		B = 153,
+		E = 162,
+		L = 131,
+		A = 153,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 673,
+	label = "Cs-CsCs(Os-R)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {6,S}
+5   H  u0 {1,S}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.03766,
+		B = 0.08419,
+		E = 0.00000,
+		L = 0.33244,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 96,
+		B = 83,
+		E = 112,
+		L = 91,
+		A = 110,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 674,
+	label = "Crs-CrsCrs(Ors-R)H",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   O2s u0 r1 {1,S} {6,S}
+5   H  u0 {1,S}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.12656,
+		B = 0.03721,
+		E = 0.13974,
+		L = 0.37174,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 34,
+		B = 34,
+		E = 34,
+		L = 26,
+		A = 35,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 675,
+	label = "Crs-CrsCs(Ors-R)H",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 r1 {1,S} {6,S}
+5   H  u0 {1,S}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.22051,
+		B = -0.00409,
+		E = 0.08250,
+		L = 0.46345,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 96,
+		B = 96,
+		E = 99,
+		L = 93,
+		A = 98,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 676,
+	label = "Crs-CrsCrs(Os-R)H",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+4   O2s u0 {1,S} {6,S}
+5   H  u0 {1,S}
+6   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.05071,
+		B = 0.14573,
+		E = 0.06871,
+		L = 0.63723,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 75,
+		B = 75,
+		E = 76,
+		L = 70,
+		A = 76,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 677,
+	label = "Cs-CdsCsOsH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   Cs         u0 {1,S}
+4   O2s        u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)CsOsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 678,
+	label = "Cs-(Cds-O2d)CsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)Cs(Os-H)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 679,
+	label = "Cs-(Cds-O2d)Cs(Os-H)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {7,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+7   H  u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.06555,
+		B = -0.07916,
+		E = -0.01119,
+		L = -0.20619,
+		A = -0.05781,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 20,
+		L = 16,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 680,
+	label = "Cs-(Cds-O2d)Cs(Os-R)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {7,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+7   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.28451,
+		B = 0.18035,
+		E = 0.09668,
+		L = -0.28628,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 13,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 681,
+	label = "Cs-(Cds-Cd)CsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)CsOsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 682,
+	label = "Cs-(Cds-Cds)CsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)Cs(Os-H)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 683,
+	label = "Cs-(Cds-Cds)Cs(Os-H)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {7,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+7   H  u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.03875,
+		B = 0.15167,
+		E = 0.04011,
+		L = 0.12938,
+		A = 0.03244,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 27,
+		E = 28,
+		L = 24,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 684,
+	label = "Cs-(Cds-Cds)Cs(Os-R)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S} {7,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+7   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.12285,
+		B = 0.02076,
+		E = -0.01405,
+		L = 0.34251,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 18,
+		L = 17,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 685,
+	label = "Cs-CtCsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01351,
+		B = 0.02384,
+		E = -0.05187,
+		L = -0.07799,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 686,
+	label = "Cs-CbCsOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cs u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11575,
+		B = 0.07941,
+		E = 0.03257,
+		L = 0.14228,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 38,
+		B = 37,
+		E = 41,
+		L = 37,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 687,
+	label = "Cs-CbCdsOsH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+4   O2s      u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = u'Cs-(Cds-O2d)CbOsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 688,
+	label = "Cs-(Cds-O2d)CbOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   Cb u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00947,
+		B = 0.02578,
+		E = 0.00534,
+		L = 0.01230,
+		A = -0.02657,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 689,
+	label = "Cs-CbCbOsH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+4   O2s u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01550,
+		B = 0.01210,
+		E = 0.00780,
+		L = 0.10645,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 690,
+	label = "Cs-COsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsOsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 691,
+	label = "Cs-CsOsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-Cs(Os-R)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 692,
+	label = "Cs-Cs(Os-H)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.12262,
+		B = 0.02183,
+		E = -0.01428,
+		L = 0.24975,
+		A = 0.03295,
+	),
+	dataCount = DataCountGAV(
+		S = 281,
+		B = 271,
+		E = 292,
+		L = 254,
+		A = 283,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 693,
+	label = "Cs-Cs(Os-R)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   R!H u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.06941,
+		B = 0.08610,
+		E = 0.00000,
+		L = 0.43827,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 844,
+		B = 825,
+		E = 907,
+		L = 790,
+		A = 910,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 694,
+	label = "Crs-Crs(Ors-R)HH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 r1 {1,S}
+3   O2s u0 r1 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   R!H u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.11646,
+		B = 0.07056,
+		E = 0.03960,
+		L = 0.36313,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 106,
+		B = 106,
+		E = 115,
+		L = 105,
+		A = 115,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 695,
+	label = "Cs-CdsOsHH",
+	group = 
+"""
+1 * Cs      u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO] u0 {1,S}
+3   O2s      u0 {1,S}
+4   H       u0 {1,S}
+5   H       u0 {1,S}
+""",
+	solute = u'Cs-(Cds-Cd)OsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 696,
+	label = "Cs-(Cds-O2d)OsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = u'Cs-(Cds-O2d)(Os-R)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 697,
+	label = "Cs-(Cds-O2d)(Os-H)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   O2s u0 {1,S} {7,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+7   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.01335,
+		B = -0.07053,
+		E = 0.00707,
+		L = -0.10246,
+		A = -0.02235,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 27,
+		L = 16,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 698,
+	label = "Cs-(Cds-O2d)(Os-R)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   CO u0 {1,S} {6,D}
+3   O2s u0 {1,S} {7,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   O2d u0 {2,D}
+7   R!H u0 {3,S}
+""",
+	solute = SoluteData(
+		S = -0.28532,
+		B = 0.10197,
+		E = 0.01050,
+		L = 0.05128,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 66,
+		B = 66,
+		E = 67,
+		L = 62,
+		A = 66,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 699,
+	label = "Cs-(Cds-Cd)OsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)OsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 700,
+	label = "Cs-(Cds-Cds)OsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)(Os-R)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 701,
+	label = "Cs-(Cds-Cds)(Os-H)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   O2s u0 {1,S} {7,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+7   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.10814,
+		B = 0.04961,
+		E = 0.01276,
+		L = 0.23619,
+		A = 0.08638,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 23,
+		E = 25,
+		L = 23,
+		A = 24,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 702,
+	label = "Cs-(Cds-Cds)(Os-R)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   O2s u0 {1,S} {7,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+7   R!H u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.03348,
+		B = 0.05687,
+		E = 0.01458,
+		L = 0.42585,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 67,
+		B = 63,
+		E = 67,
+		L = 66,
+		A = 67,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 703,
+	label = "Cs-(Cds-Nd)OsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   N  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-N3d)OsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 704,
+	label = "Cs-(Cds-N3d)OsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.01504,
+		B = 0.05106,
+		E = -0.07988,
+		L = 0.00797,
+		A = 0.05917,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 705,
+	label = "Cs-CtOsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-Ct(Os-H)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 706,
+	label = "Cs-Ct(Os-H)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.02191,
+		B = 0.02064,
+		E = -0.02182,
+		L = -0.19580,
+		A = 0.05311,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 707,
+	label = "Cs-Ct(Os-R)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Ct u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   R!H u0 {3,S}
+""",
+	solute = SoluteData(
+		S = -0.05880,
+		B = 0.01227,
+		E = 0.00731,
+		L = -0.08402,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 708,
+	label = "Cs-CbOsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   O2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-Cb(Os-R)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 709,
+	label = "Cs-Cb(Os-H)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.06494,
+		B = 0.02146,
+		E = 0.00119,
+		L = -0.04258,
+		A = 0.14012,
+	),
+	dataCount = DataCountGAV(
+		S = 41,
+		B = 40,
+		E = 51,
+		L = 25,
+		A = 45,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 710,
+	label = "Cs-Cb(Os-R)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   O2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   R!H u0 {3,S}
+""",
+	solute = SoluteData(
+		S = -0.03773,
+		B = 0.02312,
+		E = 0.00095,
+		L = 0.02842,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 40,
+		E = 45,
+		L = 43,
+		A = 46,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 711,
+	label = "Cs-CCCS",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   S u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02898,
+		B = 0.16094,
+		E = 0.08614,
+		L = 0.39673,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 29,
+		B = 29,
+		E = 29,
+		L = 28,
+		A = 33,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 712,
+	label = "Cs-CCC(S-H)",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   C  u0 {1,S}
+5   S u0 {1,S} {6,S}
+6   H  u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02770,
+		B = 0.07080,
+		E = 0.04513,
+		L = 0.32328,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 713,
+	label = "Cs-CCSS",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   S  u0 {1,S}
+5   S  u0 {1,S}
+""",
+	solute = u'Cs-CsCsSS',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 714,
+	label = "Cs-CsCsSS",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   S  u0 {1,S}
+5   S  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.26901,
+		B = -0.00438,
+		E = -0.22663,
+		L = -0.23993,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 715,
+	label = "Cs-CCSH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+4   S  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01002,
+		B = -0.01272,
+		E = 0.02622,
+		L = 0.33580,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 716,
+	label = "Cs-CsCsSH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   S  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.17437,
+		B = 0.11405,
+		E = 0.08230,
+		L = 0.47917,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 17,
+		E = 20,
+		L = 16,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 717,
+	label = "Cs-CsCs(S-H)H",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+4   S  u0 {1,S} {6,S}
+5   H  u0 {1,S}
+6   H  u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.07289,
+		B = 0.05923,
+		E = 0.09058,
+		L = 0.49396,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 718,
+	label = "Cs-CSHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 {1,S}
+3   S  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02061,
+		B = 0.10080,
+		E = -0.00039,
+		L = 0.17217,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 719,
+	label = "Crs-CrSrHH",
+	group = 
+"""
+1 * Cs u0 r1 {2,S} {3,S} {4,S} {5,S}
+2   C  u0 r1 {1,S}
+3   S  u0 r1 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.21372,
+		B = 0.09377,
+		E = 0.11274,
+		L = 0.62238,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 21,
+		E = 23,
+		L = 20,
+		A = 24,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 720,
+	label = "Cs-CsSHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   S  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-CsS2HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 721,
+	label = "Cs-CsS2HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   S2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12784,
+		B = 0.07985,
+		E = 0.10616,
+		L = 0.64136,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 106,
+		B = 108,
+		E = 128,
+		L = 104,
+		A = 130,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 722,
+	label = "Cs-Cs(S2-H)HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   S2s u0 {1,S} {6,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.15263,
+		B = 0.05553,
+		E = 0.15386,
+		L = 0.84696,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 23,
+		B = 23,
+		E = 23,
+		L = 23,
+		A = 23,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 723,
+	label = "Cs-CsS4HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   [S4s,S4d,S4b,S4t] u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.36935,
+		B = 0.20182,
+		E = 0.05648,
+		L = 0.62285,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 7,
+		E = 10,
+		L = 7,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 724,
+	label = "Cs-CsS6HH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cs u0 {1,S}
+3   [S6s,S6d,S6dd,S6t,S6td] u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.17886,
+		B = 0.14814,
+		E = 0.09700,
+		L = 0.20515,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 13,
+		L = 5,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 725,
+	label = "Cs-CdsSsHH",
+	group = 
+"""
+1 * Cs         u0 {2,S} {3,S} {4,S} {5,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   S2s        u0 {1,S}
+4   H          u0 {1,S}
+5   H          u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02496,
+		B = 0.09717,
+		E = 0.12336,
+		L = 0.37926,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 3,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 726,
+	label = "Cs-(Cds-Cd)SsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   S2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   C  u0 {2,D}
+""",
+	solute = u'Cs-(Cds-Cds)SsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 727,
+	label = "Cs-(Cds-Cds)SsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cd u0 {1,S} {6,D}
+3   S2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+6   Cd u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.13330,
+		B = 0.02846,
+		E = 0.14249,
+		L = 0.79871,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 27,
+		L = 19,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 728,
+	label = "Cs-(Cds-Od)SsHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   CO  u0 {1,S} {6,D}
+3   S2s u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+6   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.16918,
+		B = 0.01527,
+		E = 0.10263,
+		L = 0.57606,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 729,
+	label = "Cs-CbSsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   Cb u0 {1,S}
+3   S2s u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01133,
+		B = -0.00966,
+		E = 0.11321,
+		L = 0.33966,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 730,
+	label = "Cs-CS4dHH",
+	group = 
+"""
+1 * Cs  u0 {2,S} {3,S} {4,S} {5,S}
+2   C   u0 {1,S}
+3   S4d u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08311,
+		B = 0.06174,
+		E = 0.07144,
+		L = 0.53261,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 731,
+	label = "Cs-SsHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   S  u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = u'Cs-S2sHHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 732,
+	label = "Cs-S2sHHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   S2s  u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.14259,
+		B = 0.03954,
+		E = 0.12254,
+		L = 0.60167,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 54,
+		B = 53,
+		E = 55,
+		L = 53,
+		A = 55,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 733,
+	label = "Cs-S4HHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   [S4s,S4d,S4b,S4t]  u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.30364,
+		B = 0.15869,
+		E = 0.11391,
+		L = 0.69181,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 734,
+	label = "Cs-S6HHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   [S6s,S6d,S6dd,S6t,S6td]  u0 {1,S}
+3   H  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.23884,
+		B = 0.06128,
+		E = 0.04970,
+		L = 0.41058,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 25,
+		E = 28,
+		L = 21,
+		A = 29,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 735,
+	label = "Cs-SsSsHH",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S} {4,S} {5,S}
+2   S  u0 {1,S}
+3   S  u0 {1,S}
+4   H  u0 {1,S}
+5   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12853,
+		B = 0.04914,
+		E = 0.10862,
+		L = 0.25645,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 1,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 736,
+	label = "O",
+	group = 
+"""
+1 * O u0
+""",
+	solute = u'O2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 737,
+	label = "O2d",
+	group = 
+"""
+1 * O2d u0
+""",
+	solute = u'O2d-Cd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 738,
+	label = "O2d-Cd",
+	group = 
+"""
+1 * O2d u0 {2,D}
+2   CO u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.42260,
+		B = 0.26426,
+		E = 0.16122,
+		L = 1.33788,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2468,
+		B = 2432,
+		E = 2569,
+		L = 2186,
+		A = 2577,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 739,
+	label = "O2d-Crd",
+	group = 
+"""
+1 * O2d u0    {2,D}
+2   CO  u0 r1 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.38858,
+		B = 0.25281,
+		E = 0.25209,
+		L = 1.17012,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 768,
+		B = 768,
+		E = 786,
+		L = 629,
+		A = 780,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 740,
+	label = "O2d-Cdd",
+	group = 
+"""
+1 * O2d u0 {2,D}
+2   Cdd u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.16925,
+		B = 0.04807,
+		E = 0.06879,
+		L = 0.50992,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 741,
+	label = "O2d-N3d",
+	group = 
+"""
+1 * O2d  u0 {2,D}
+2   N3d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.30062,
+		B = 0.11165,
+		E = 0.09620,
+		L = 0.66859,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 54,
+		B = 54,
+		E = 62,
+		L = 54,
+		A = 64,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 742,
+	label = "O2d-N5dc",
+	group = 
+"""
+1 * O2d  u0 {2,D}
+2   N5dc u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.15169,
+		B = 0.01884,
+		E = 0.15896,
+		L = 0.50229,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 370,
+		B = 369,
+		E = 384,
+		L = 322,
+		A = 384,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 743,
+	label = "O2d-Sd",
+	group = 
+"""
+1 * O2d   u0 {2,D}
+2   S     ux {1,D}
+""",
+	solute = u'O2d-S6dd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 744,
+	label = "O2d-S4d",
+	group = 
+"""
+1 * O2d   u0 {2,D}
+2   S4d   u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.43270,
+		B = 0.32003,
+		E = 0.25408,
+		L = 1.50388,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 23,
+		E = 30,
+		L = 23,
+		A = 43,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 745,
+	label = "O2d-S6dd",
+	group = 
+"""
+1 * O2d   u0 {2,D}
+2   S6dd  u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.42033,
+		B = 0.23748,
+		E = 0.13369,
+		L = 1.18320,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 185,
+		B = 183,
+		E = 199,
+		L = 164,
+		A = 194,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 746,
+	label = "O2d-P5d",
+	group = 
+"""
+1 * O2d  u0 {2,D}
+2   P5d  u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.31224,
+		B = 0.33431,
+		E = 0.01768,
+		L = 1.02636,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 63,
+		B = 62,
+		E = 87,
+		L = 62,
+		A = 88,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 747,
+	label = "O2s",
+	group = 
+"""
+1 * O2s u0
+""",
+	solute = u'O2s-CC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 748,
+	label = "O2s-PH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P  u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = u'O2s-P5dH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 749,
+	label = "O2s-P5dH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08424,
+		B = 0.23799,
+		E = 0.20451,
+		L = 0.75843,
+		A = 0.76359,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 30,
+		E = 33,
+		L = 30,
+		A = 33,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 750,
+	label = "O2s-PC",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P  u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'O2s-P5dC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 751,
+	label = "O2s-P3sC",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P3s u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'O2s-P3sCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 752,
+	label = "O2s-P3sCs",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P3s u0 {1,S}
+3   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11817,
+		B = 0.20538,
+		E = 0.01933,
+		L = 0.53571,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 753,
+	label = "O2s-P5dC",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'O2s-P5dCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 754,
+	label = "O2s-P5dCs",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08609,
+		B = 0.16265,
+		E = 0.04349,
+		L = 0.58522,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 43,
+		B = 42,
+		E = 55,
+		L = 42,
+		A = 54,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 755,
+	label = "O2s-P5dCd",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 756,
+	label = "O2s-P5d(Cd-Nd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   Cd  u0 {1,S} {4,D}
+4   N   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.07004,
+		B = 0.02526,
+		E = 0.10284,
+		L = 0.56260,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 757,
+	label = "O2s-P5dCb",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01893,
+		B = 0.04914,
+		E = 0.03414,
+		L = 0.33853,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 20,
+		A = 20,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 758,
+	label = "O2s-NH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   N  u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12364,
+		B = 0.18761,
+		E = 0.16199,
+		L = 0.56775,
+		A = 0.30096,
+	),
+	dataCount = DataCountGAV(
+		S = 29,
+		B = 29,
+		E = 30,
+		L = 28,
+		A = 30,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 759,
+	label = "O2s-NR",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   N  u0 {1,S}
+3   R!H u0 {1,S}
+""",
+	solute = u'O2s-CN',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 760,
+	label = "O2s-CN",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   C  u0 {1,S}
+3   N  u0 {1,S}
+""",
+	solute = u'O2s-CdN3d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 761,
+	label = "O2s-CbN3d",
+	group = 
+"""
+1 * O2s  u0 {2,S} {3,S}
+2   N3d u0 {1,S}
+3   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09013,
+		B = 0.02305,
+		E = 0.00484,
+		L = 0.23195,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 762,
+	label = "O2s-CsN3s",
+	group = 
+"""
+1 * O2s  u0 {2,S} {3,S}
+2   N3s u0 {1,S}
+3   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02377,
+		B = 0.09308,
+		E = 0.06653,
+		L = 0.33936,
+		A = -0.00146,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 763,
+	label = "O2s-CsN3d",
+	group = 
+"""
+1 * O2s  u0 {2,S} {3,S}
+2   Cs  u0 {1,S}
+3   N3d u0 {1,S}
+""",
+	solute = u'O2s-Cs(N3d-Od)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 764,
+	label = "O2s-Cs(N3d-Od)",
+	group = 
+"""
+1 * O2s  u0 {2,S} {4,S}
+2   N3d u0 {1,S} {3,D}
+3   O2d  u0 {2,D}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01340,
+		B = 0.04305,
+		E = -0.01741,
+		L = 0.03588,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 13,
+		L = 5,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 765,
+	label = "O2s-Cs(N3d-Cd)",
+	group = 
+"""
+1 * O2s  u0 {2,S} {4,S}
+2   N3d u0 {1,S} {3,D}
+3   Cd  u0 {2,D}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04544,
+		B = 0.07594,
+		E = 0.08985,
+		L = 0.59921,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 766,
+	label = "O2s-CdN3d",
+	group = 
+"""
+1 * O2s        u0 {2,S} {3,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   N3d        u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05602,
+		B = 0.08093,
+		E = 0.06540,
+		L = 0.30162,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 14,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 767,
+	label = "O2s-CsN5dc",
+	group = 
+"""
+1 * O2s  u0 {2,S} {3,S}
+2   Cs  u0 {1,S}
+3   N5dc u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09525,
+		B = -0.07354,
+		E = -0.06071,
+		L = 0.07396,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 8,
+		E = 12,
+		L = 8,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 768,
+	label = "O2s-OsH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   O2s u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.15824,
+		B = 0.05902,
+		E = 0.12734,
+		L = 0.46756,
+		A = 0.23700,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 769,
+	label = "O2s-CH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   C  u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = u'O2s-CsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 770,
+	label = "O2s-CdsH",
+	group = 
+"""
+1 * O2s      u0 {2,S} {3,S}
+2   [Cd,CO] u0 {1,S}
+3   H       u0 {1,S}
+""",
+	solute = u'O2s-(Cds-O2d)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 771,
+	label = "O2s-(Cds-O2d)H",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CO u0 {1,S} {4,D}
+3   H  u0 {1,S}
+4   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.15290,
+		B = 0.05529,
+		E = 0.06258,
+		L = 0.41728,
+		A = 0.48657,
+	),
+	dataCount = DataCountGAV(
+		S = 538,
+		B = 538,
+		E = 549,
+		L = 496,
+		A = 538,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 772,
+	label = "O2s-(Cds-Cd)H",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cd u0 {1,S} {4,D}
+3   H  u0 {1,S}
+4   C  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09007,
+		B = 0.18326,
+		E = 0.21389,
+		L = 0.64439,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 72,
+		B = 72,
+		E = 73,
+		L = 54,
+		A = 72,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 773,
+	label = "O2s-CsH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.28190,
+		B = 0.34836,
+		E = 0.21079,
+		L = 0.99143,
+		A = 0.25925,
+	),
+	dataCount = DataCountGAV(
+		S = 759,
+		B = 747,
+		E = 798,
+		L = 669,
+		A = 768,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 774,
+	label = "O2s-CbH",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cb u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.26135,
+		B = 0.08802,
+		E = 0.18865,
+		L = 0.57213,
+		A = 0.43104,
+	),
+	dataCount = DataCountGAV(
+		S = 634,
+		B = 617,
+		E = 669,
+		L = 625,
+		A = 644,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 775,
+	label = "O2s-OsC",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   O2s u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'O2s-OsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 776,
+	label = "O2s-OsCds",
+	group = 
+"""
+1 * O2s      u0 {2,S} {3,S}
+2   O2s      u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+""",
+	solute = u'O2s-O2s(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 777,
+	label = "O2s-O2s(Cds-O2d)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CO u0 {1,S} {4,D}
+3   O2s u0 {1,S}
+4   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.14030,
+		B = 0.01441,
+		E = 0.00425,
+		L = 0.24733,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 778,
+	label = "O2s-OsCs",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   O2s u0 {1,S}
+3   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06478,
+		B = 0.23841,
+		E = 0.03638,
+		L = 0.50419,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 779,
+	label = "O2s-CC",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'O2s-CsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 780,
+	label = "O2s-CtCb",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Ct u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = u'O2s-(Ct-N3t)Cb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 781,
+	label = "O2s-(Ct-N3t)Cb",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Ct u0 {1,S} {4,T}
+3   Cb u0 {1,S}
+4   N3t u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.02528,
+		B = 0.01601,
+		E = -0.00086,
+		L = -0.00928,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 782,
+	label = "O2s-CdsCds",
+	group = 
+"""
+1 * O2s      u0 {2,S} {3,S}
+2   [Cd,CO] u0 {1,S}
+3   [Cd,CO] u0 {1,S}
+""",
+	solute = u'O2s-(Cds-Cd)(Cds-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 783,
+	label = "O2s-(Cds-O2d)(Cds-O2d)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CO u0 {1,S} {4,D}
+3   CO u0 {1,S} {5,D}
+4   O2d u0 {2,D}
+5   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.04290,
+		B = -0.07575,
+		E = -0.03043,
+		L = -0.20861,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 7,
+		L = 3,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 784,
+	label = "O2s-(Cds-O2d)(Cds-Cd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CO u0 {1,S} {5,D}
+3   Cd u0 {1,S} {4,D}
+4   C  u0 {3,D}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.01328,
+		B = 0.01879,
+		E = 0.00060,
+		L = -0.00504,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 5,
+		E = 5,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 785,
+	label = "O2s-(Cds-Cd)(Cds-Cd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cd u0 {1,S}
+3   Cd u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04121,
+		B = 0.03783,
+		E = 0.05339,
+		L = 0.46124,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 61,
+		B = 61,
+		E = 67,
+		L = 43,
+		A = 72,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 786,
+	label = "O2s-CdsCs",
+	group = 
+"""
+1 * O2s        u0 {2,S} {3,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   Cs         u0 {1,S}
+""",
+	solute = u'O2s-Cs(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 787,
+	label = "O2s-Cs(Cds-N3d)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cd u0 {1,S} {4,D}
+3   Cs u0 {1,S}
+4   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.06125,
+		B = 0.03441,
+		E = 0.03006,
+		L = 0.31039,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 27,
+		E = 29,
+		L = 22,
+		A = 29,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 788,
+	label = "O2s-Cs(Cds-O2d)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CO u0 {1,S} {4,D}
+3   Cs u0 {1,S}
+4   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07252,
+		B = 0.03205,
+		E = -0.04931,
+		L = 0.14232,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 996,
+		B = 975,
+		E = 1028,
+		L = 916,
+		A = 1025,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 789,
+	label = "O2s-Cs(Cds-Cd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cd u0 {1,S} {4,D}
+3   Cs u0 {1,S}
+4   C  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09456,
+		B = 0.13261,
+		E = 0.05365,
+		L = 0.26657,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 37,
+		B = 38,
+		E = 43,
+		L = 34,
+		A = 44,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 790,
+	label = "O2s-Cs(Cds-Sd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CS u0 {1,S} {4,D}
+3   Cs u0 {1,S}
+4   S  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00785,
+		B = 0.00141,
+		E = -0.04527,
+		L = 0.11173,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 2,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 791,
+	label = "O2s-CdsCb",
+	group = 
+"""
+1 * O2s        u0 {2,S} {3,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   Cb         u0 {1,S}
+""",
+	solute = u'O2s-Cb(Cds-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 792,
+	label = "O2s-Cb(Cds-N3d)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cd  u0 {1,S} {4,D}
+3   Cb  u0 {1,S}
+4   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.03802,
+		B = 0.02363,
+		E = 0.00980,
+		L = 0.17607,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 793,
+	label = "O2s-Cb(Cds-O2d)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CO u0 {1,S} {4,D}
+3   Cb u0 {1,S}
+4   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.06482,
+		B = -0.03227,
+		E = -0.04910,
+		L = -0.00387,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 66,
+		B = 63,
+		E = 66,
+		L = 55,
+		A = 73,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 794,
+	label = "O2s-Cb(Cds-Cd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cd u0 {1,S} {4,D}
+3   Cb u0 {1,S}
+4   C  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.05921,
+		B = 0.07025,
+		E = 0.03402,
+		L = 0.27689,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 101,
+		B = 101,
+		E = 102,
+		L = 98,
+		A = 101,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 795,
+	label = "O2s-Cb(Cds-Sd)",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   CS u0 {1,S} {4,D}
+3   Cb u0 {1,S}
+4   S  u0 {2,D}
+""",
+	solute = u'O2s-Cb(Cds-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 796,
+	label = "O2s-CsCs",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03540,
+		B = 0.29928,
+		E = 0.00000,
+		L = 0.92651,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 307,
+		B = 284,
+		E = 329,
+		L = 293,
+		A = 335,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 797,
+	label = "O2rs-CrsCrs",
+	group = 
+"""
+1 * O2s u0 r1 {2,S} {3,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03592,
+		B = 0.19310,
+		E = 0.00139,
+		L = 0.61888,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 173,
+		B = 173,
+		E = 182,
+		L = 161,
+		A = 182,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 798,
+	label = "O2s-CsCb",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13149,
+		B = 0.04434,
+		E = 0.03978,
+		L = 0.32573,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 451,
+		B = 425,
+		E = 467,
+		L = 425,
+		A = 461,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 799,
+	label = "O2rs-CrsCb",
+	group = 
+"""
+1 * O2s u0 r1 {2,S} {3,S}
+2   Cs u0 r1 {1,S}
+3   Cb u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06190,
+		B = 0.10797,
+		E = 0.02966,
+		L = 0.42495,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 56,
+		B = 56,
+		E = 58,
+		L = 55,
+		A = 56,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 800,
+	label = "O2s-CbCb",
+	group = 
+"""
+1 * O2s u0 {2,S} {3,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04687,
+		B = -0.08139,
+		E = -0.01455,
+		L = -0.11860,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 27,
+		E = 27,
+		L = 25,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 801,
+	label = "O2rs-CbCb",
+	group = 
+"""
+1 * O2s u0 r1 {2,S} {3,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.10408,
+		B = -0.03940,
+		E = 0.00652,
+		L = -0.14347,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 21,
+		L = 18,
+		A = 21,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 802,
+	label = "O2s-CS",
+	group = 
+"""
+1 * O2s   u0 {2,S} {3,S}
+2   S     ux {1,S}
+3   C     ux {1,S}
+""",
+	solute = SoluteData(
+		S = -0.22144,
+		B = 0.00791,
+		E = -0.00817,
+		L = 0.04782,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 15,
+		L = 8,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 803,
+	label = "O2s-SH",
+	group = 
+"""
+1 * O2s   u0 {2,S} {3,S}
+2   S     ux {1,S}
+3   H     ux {1,S}
+""",
+	solute = u'O2s-S_DeH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 804,
+	label = "O2s-S_DeH",
+	group = 
+"""
+1 * O2s   u0 {2,S} {3,S}
+2   [S4d,S6d,S6dd]   ux {1,S}
+3   H     ux {1,S}
+""",
+	solute = SoluteData(
+		S = 0.24344,
+		B = 0.24590,
+		E = 0.02099,
+		L = 0.29051,
+		A = 0.16623,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 805,
+	label = "Oc",
+	group = 
+"""
+1 * O0sc u0 c-1
+""",
+	solute = u'Oc-N5c',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 806,
+	label = "Oc-N5c",
+	group = 
+"""
+1 * O0sc u0 c-1 {2,S}
+2   [N5sc,N5dc] u0 c+1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.35077,
+		B = 0.16739,
+		E = 0.14849,
+		L = 0.98834,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 386,
+		B = 385,
+		E = 405,
+		L = 338,
+		A = 400,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 807,
+	label = "S",
+	group = 
+"""
+1 * S ux
+""",
+	solute = u'S2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 808,
+	label = "S2d",
+	group = 
+"""
+1 * S2d u0
+""",
+	solute = u'S2d-C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 809,
+	label = "S2d-C",
+	group = 
+"""
+1 * S2d u0 {2,D}
+2   C u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.44085,
+		B = 0.14681,
+		E = 0.47907,
+		L = 1.86092,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 40,
+		B = 42,
+		E = 43,
+		L = 35,
+		A = 48,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 810,
+	label = "S2d-P",
+	group = 
+"""
+1 * S2d u0 {2,D}
+2   P u0 {1,D}
+""",
+	solute = u'S2d-P5d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 811,
+	label = "S2d-P5d",
+	group = 
+"""
+1 * S2d u0 {2,D}
+2   P5d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.00892,
+		B = 0.11892,
+		E = 0.28230,
+		L = 0.97685,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 18,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 812,
+	label = "S2s",
+	group = 
+"""
+1 * S2s u0
+""",
+	solute = u'S2s-CC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 813,
+	label = "S2s-CH",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   C  u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = u'S2s-CsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 814,
+	label = "S2s-CsH",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.20433,
+		B = 0.14840,
+		E = 0.22845,
+		L = 0.91094,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 37,
+		B = 37,
+		E = 38,
+		L = 37,
+		A = 38,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 815,
+	label = "S2s-CdH",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   [Cd,CO,CS] u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07884,
+		B = 0.04018,
+		E = 0.20570,
+		L = 0.63132,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 816,
+	label = "S2s-CbH",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cb u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.15673,
+		B = -0.01553,
+		E = 0.21099,
+		L = 0.65357,
+		A = 0.05171,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 14,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 817,
+	label = "S2s-PH",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   P   u0 {1,S}
+3   H   u0 {1,S}
+""",
+	solute = u'S2s-P5dH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 818,
+	label = "S2s-P5dH",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06826,
+		B = 0.11157,
+		E = 0.15133,
+		L = 0.50523,
+		A = 0.00400,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 819,
+	label = "S2s-PC",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   P   u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'S2s-P5dC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 820,
+	label = "S2s-P5dC",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   P5d u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.08248,
+		B = 0.04760,
+		E = 0.11772,
+		L = 0.46096,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 821,
+	label = "S2s-SS",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   S ux {1,S}
+3   S ux {1,S}
+""",
+	solute = u'S2s-SsSs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 822,
+	label = "S2s-SsSs",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   S2s u0 {1,S}
+3   S2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09209,
+		B = 0.00000,
+		E = 0.23549,
+		L = 0.86175,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 823,
+	label = "S2s-SC",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   S ux {1,S}
+3   C ux {1,S}
+""",
+	solute = u'S2s-S2sC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 824,
+	label = "S2s-S2sC",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   S2s u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13828,
+		B = 0.07058,
+		E = 0.22146,
+		L = 0.96626,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 26,
+		L = 22,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 825,
+	label = "S2s-S46C",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   [S4s,S4d,S4b,S4t,S6d,S6dd,S6t,S6td] u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07094,
+		B = 0.04064,
+		E = 0.09107,
+		L = 0.42457,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 826,
+	label = "S2s-NN",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   N  u0 {1,S}
+3   N  u0 {1,S}
+""",
+	solute = u'S2s-N3dN3d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 827,
+	label = "S2s-N3dN3d",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   N3d u0 {1,S}
+3   N3d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13479,
+		B = 0.00827,
+		E = 0.12936,
+		L = 0.55934,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 828,
+	label = "S2s-NC",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   N   u0 {1,S}
+3   C   u0 {1,S}
+""",
+	solute = u'S2s-N3dCd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 829,
+	label = "S2s-N3dCd",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   N3d u0 {1,S}
+3   Cd  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01319,
+		B = 0.04536,
+		E = 0.16479,
+		L = 0.43630,
+		A = 0.04705,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 830,
+	label = "S2s-CC",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   C  u0 {1,S}
+3   C  u0 {1,S}
+""",
+	solute = u'S2s-CsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 831,
+	label = "S2s-CsCs",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10492,
+		B = 0.20161,
+		E = 0.13510,
+		L = 0.98477,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 103,
+		B = 103,
+		E = 115,
+		L = 102,
+		A = 117,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 832,
+	label = "S2rs-CrsCrs",
+	group = 
+"""
+1 * S2s u0 r1 {2,S} {3,S}
+2   Cs u0 r1 {1,S}
+3   Cs u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03907,
+		B = 0.11774,
+		E = 0.28209,
+		L = 0.73745,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 34,
+		B = 33,
+		E = 37,
+		L = 33,
+		A = 38,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 833,
+	label = "S2s-CsCd",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   Cd u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12528,
+		B = 0.00405,
+		E = 0.17226,
+		L = 0.75873,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 37,
+		B = 37,
+		E = 37,
+		L = 37,
+		A = 37,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 834,
+	label = "S2s-Cs(C=O)",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   CO u0 {1,S} {4,D}
+4   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.00137,
+		B = 0.06030,
+		E = 0.10865,
+		L = 0.34031,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 7,
+		E = 10,
+		L = 6,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 835,
+	label = "S2s-CsCt",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   Ct u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03527,
+		B = 0.05057,
+		E = 0.03588,
+		L = 0.11695,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 6,
+		E = 6,
+		L = 2,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 836,
+	label = "S2s-CsCb",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cs u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03852,
+		B = 0.06047,
+		E = 0.14117,
+		L = 0.62914,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 8,
+		L = 6,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 837,
+	label = "S2s-CdCd",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cd u0 {1,S}
+3   Cd u0 {1,S}
+""",
+	solute = u'S2rs-CrdCrd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 838,
+	label = "S2rs-CrdCrd",
+	group = 
+"""
+1 * S2s u0 r1 {2,S} {3,S}
+2   Cd u0 r1 {1,S}
+3   Cd u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10206,
+		B = 0.09010,
+		E = 0.14351,
+		L = 0.76630,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 53,
+		B = 52,
+		E = 62,
+		L = 47,
+		A = 59,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 839,
+	label = "S2s-CdCb",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cd u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = u'S2rs-CrdCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 840,
+	label = "S2rs-CrdCb",
+	group = 
+"""
+1 * S2s u0 r1 {2,S} {3,S}
+2   Cd u0 r1 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06070,
+		B = 0.02407,
+		E = 0.08802,
+		L = 0.42914,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 52,
+		B = 52,
+		E = 55,
+		L = 53,
+		A = 55,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 841,
+	label = "S2s-CtCb",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Ct u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = u'S2s-(Ct-N3t)Cb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 842,
+	label = "S2s-(Ct-N3t)Cb",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Ct u0 {1,S} {4,T}
+3   Cb u0 {1,S}
+4   N3t u0 {2,T}
+""",
+	solute = SoluteData(
+		S = 0.00882,
+		B = -0.02539,
+		E = 0.03334,
+		L = 0.04878,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 843,
+	label = "S2s-CbCb",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01084,
+		B = 0.00402,
+		E = 0.03885,
+		L = 0.14034,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 844,
+	label = "S2rs-CbCb",
+	group = 
+"""
+1 * S2s u0 r1 {2,S} {3,S}
+2   Cb u0 {1,S}
+3   Cb u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01785,
+		B = -0.00037,
+		E = 0.02261,
+		L = 0.07159,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 74,
+		B = 74,
+		E = 74,
+		L = 72,
+		A = 74,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 845,
+	label = "S2s-(Cd-S2d)C",
+	group = 
+"""
+1 * S2s u0 {2,S} {3,S}
+2   C  u0 {1,S}
+3   CS u0 {1,S} {4,D}
+4   S2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.10426,
+		B = -0.03720,
+		E = 0.12059,
+		L = 0.60369,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 846,
+	label = "S4dd",
+	group = 
+"""
+1 * S4dd  u0
+""",
+	solute = u'S4dd-N3dN3d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 847,
+	label = "S4dd-N3dN3d",
+	group = 
+"""
+1 * S4dd  u0 {2,D} {3,D}
+2   N3d   u0 {1,D}
+3   N3d   u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.09129,
+		B = 0.01073,
+		E = 0.11589,
+		L = 0.42640,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 848,
+	label = "S4d",
+	group = 
+"""
+1 * S4d  u0
+""",
+	solute = u'S4d-Od',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 849,
+	label = "S4d-Od",
+	group = 
+"""
+1 * S4d u0 p1 {2,D}
+2   O2d ux    {1,D}
+""",
+	solute = u'S4d-OdCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 850,
+	label = "S4d-OdCC",
+	group = 
+"""
+1 * S4d  u0 p1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   C    ux (1,S)
+4   C    ux (1,S)
+""",
+	solute = u'S4d-OdCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 851,
+	label = "S4d-OdCsCs",
+	group = 
+"""
+1 * S4d  u0 p1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   Cs    ux (1,S)
+4   Cs    ux (1,S)
+""",
+	solute = SoluteData(
+		S = 0.26069,
+		B = 0.17376,
+		E = 0.07036,
+		L = 0.60651,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 11,
+		E = 17,
+		L = 11,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 852,
+	label = "S4d-OdCsCb",
+	group = 
+"""
+1 * S4d  u0 p1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   Cs    ux (1,S)
+4   Cb    ux (1,S)
+""",
+	solute = SoluteData(
+		S = 0.09387,
+		B = 0.07349,
+		E = 0.08040,
+		L = 0.40789,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 11,
+		L = 10,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 853,
+	label = "S4d-OdCbCb",
+	group = 
+"""
+1 * S4d  u0 p1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   Cb    ux (1,S)
+4   Cb    ux (1,S)
+""",
+	solute = SoluteData(
+		S = 0.00720,
+		B = 0.03214,
+		E = 0.01226,
+		L = 0.06491,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 854,
+	label = "S4d-OdCS",
+	group = 
+"""
+1 * S4d  u0 p1 {2,D} {3,S} {4,S}
+2   O2d  ux {1,D}
+3   C    ux (1,S)
+4   S    ux (1,S)
+""",
+	solute = SoluteData(
+		S = 0.07094,
+		B = 0.04064,
+		E = 0.09107,
+		L = 0.42457,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 855,
+	label = "S6dd",
+	group = 
+"""
+1 * S6dd   u0
+""",
+	solute = u'S6dd-OdOd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 856,
+	label = "S6dd-OdOd",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+""",
+	solute = u'S6dd-OdOdCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 857,
+	label = "S6dd-OdOdCC",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   C    ux {1,S}
+5   C    ux {1,S}
+""",
+	solute = u'S6dd-OdOdCbCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 858,
+	label = "S6dd-OdOdCbCb",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   Cb   ux {1,S}
+5   Cb   ux {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02950,
+		B = -0.05186,
+		E = 0.03957,
+		L = 0.11171,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 23,
+		L = 20,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 859,
+	label = "S6dd-OdOdCrCr",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   C    ux r1 {1,S}
+5   C    ux r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01709,
+		B = -0.05985,
+		E = -0.06581,
+		L = -0.15529,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 860,
+	label = "S6dd-OdOdCsCs",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   Cs   ux {1,S}
+5   Cs   ux {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00384,
+		B = 0.00127,
+		E = -0.01552,
+		L = 0.13681,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 10,
+		E = 11,
+		L = 3,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 861,
+	label = "S6dd-OdOdCsCb",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   Cs   ux {1,S}
+5   Cb   ux {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01274,
+		B = 0.01130,
+		E = -0.00722,
+		L = -0.01918,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 18,
+		E = 19,
+		L = 13,
+		A = 19,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 862,
+	label = "S6dd-OdOdCO",
+	group = 
+"""
+1 * S6dd    u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d     ux {1,D}
+3   O2d     ux {1,D}
+4   C       ux {1,S}
+5   O       ux {1,S}
+""",
+	solute = u'S6dd-OdOdCbOs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 863,
+	label = "S6dd-OdOdCsOs",
+	group = 
+"""
+1 * S6dd    u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d     ux {1,D}
+3   O2d     ux {1,D}
+4   Cs      ux {1,S}
+5   O       ux {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00703,
+		B = 0.17261,
+		E = -0.04891,
+		L = -0.07132,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 5,
+		L = 3,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 864,
+	label = "S6dd-OdOdCbOs",
+	group = 
+"""
+1 * S6dd    u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d     ux {1,D}
+3   O2d     ux {1,D}
+4   Cb      ux {1,S}
+5   O       ux {1,S}
+""",
+	solute = SoluteData(
+		S = 0.19517,
+		B = 0.03231,
+		E = -0.05921,
+		L = 0.10478,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 7,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 865,
+	label = "S6dd-OdOdNC",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   N    ux {1,S}
+5   C    ux {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01653,
+		B = -0.06708,
+		E = 0.13698,
+		L = 0.13786,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 15,
+		L = 11,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 866,
+	label = "S6dd-OdOdNCb",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   N    ux {1,S}
+5   Cb   ux {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03298,
+		B = 0.07459,
+		E = 0.10086,
+		L = 0.22322,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 110,
+		B = 110,
+		E = 112,
+		L = 104,
+		A = 111,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 867,
+	label = "S6dd-OdOdNN",
+	group = 
+"""
+1 * S6dd u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d  ux {1,D}
+3   O2d  ux {1,D}
+4   N    ux {1,S}
+5   N    ux {1,S}
+""",
+	solute = u'S6dd-OdOdNC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 868,
+	label = "S6dd-OdOdOO",
+	group = 
+"""
+1 * S6dd    u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d     ux {1,D}
+3   O2d     ux {1,D}
+4   O       ux {1,S}
+5   O       ux {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05247,
+		B = 0.02515,
+		E = -0.05111,
+		L = 0.09171,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 869,
+	label = "S6dd-OdOdON",
+	group = 
+"""
+1 * S6dd    u0 p0 {2,D} {3,D} {4,S} {5,S}
+2   O2d     ux {1,D}
+3   O2d     ux {1,D}
+4   O       ux {1,S}
+5   N       ux {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01816,
+		B = -0.01970,
+		E = 0.03722,
+		L = 0.03131,
+		A = 0.00413,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 870,
+	label = "N",
+	group = 
+"""
+1 * N u0
+""",
+	solute = u'N3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 871,
+	label = "N1dc",
+	group = 
+"""
+1 * N1dc u0 p2 {2,D}
+2   R!H ux px {1,D}
+""",
+	solute = u'N1dc-N5ddc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 872,
+	label = "N1dc-N5ddc",
+	group = 
+"""
+1 * N1dc u0 p2 {2,D}
+2   N5ddc u0 px {1,D}
+""",
+	solute = SoluteData(
+		S = 0.04468,
+		B = 0.00000,
+		E = 0.09588,
+		L = 0.39946,
+		A = 0.01261,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 873,
+	label = "N3s",
+	group = 
+"""
+1 * N3s u0
+""",
+	solute = u'N3s-CCH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 874,
+	label = "N3s-CHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-CsHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 875,
+	label = "N3s-CsHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.27024,
+		B = 0.38829,
+		E = 0.16260,
+		L = 0.62432,
+		A = 0.17304,
+	),
+	dataCount = DataCountGAV(
+		S = 91,
+		B = 91,
+		E = 96,
+		L = 80,
+		A = 92,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 876,
+	label = "N3s-CrsHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 r1 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.24468,
+		B = 0.12098,
+		E = 0.17885,
+		L = 0.57256,
+		A = 0.12840,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 17,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 877,
+	label = "N3s-CbHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.40793,
+		B = 0.16116,
+		E = 0.22723,
+		L = 0.66930,
+		A = 0.23902,
+	),
+	dataCount = DataCountGAV(
+		S = 247,
+		B = 229,
+		E = 257,
+		L = 204,
+		A = 248,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 878,
+	label = "N3s-CdHH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   H           u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 879,
+	label = "N3s-(Cd-Cd)HH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 {2,D}
+""",
+	solute = u'N3s-(Crd-Crd)HH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 880,
+	label = "N3s-(Crd-Crd)HH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.18972,
+		B = 0.14751,
+		E = 0.22157,
+		L = 0.66050,
+		A = 0.25898,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 14,
+		A = 18,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 881,
+	label = "N3s-(Cd-N3d)HH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.19084,
+		B = 0.22975,
+		E = 0.23095,
+		L = 0.95739,
+		A = 0.13806,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 27,
+		L = 23,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 882,
+	label = "N3s-(Crd-N3rd)HH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.23348,
+		B = 0.21851,
+		E = 0.27122,
+		L = 0.79503,
+		A = 0.20872,
+	),
+	dataCount = DataCountGAV(
+		S = 36,
+		B = 31,
+		E = 36,
+		L = 29,
+		A = 36,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 883,
+	label = "N3s-(Cd-O2d)HH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.41631,
+		B = 0.18885,
+		E = 0.15875,
+		L = 0.77742,
+		A = 0.39827,
+	),
+	dataCount = DataCountGAV(
+		S = 136,
+		B = 130,
+		E = 142,
+		L = 101,
+		A = 138,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 884,
+	label = "N3s-(Cd-Sd)HH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CS  u0 {1,S} {5,D}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+5   S   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.12045,
+		B = 0.20854,
+		E = 0.09545,
+		L = 0.34140,
+		A = 0.23923,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 885,
+	label = "N3s-NHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-N3sHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 886,
+	label = "N3s-N3sHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   H   u0 {1,S}
+3   H   u0 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11956,
+		B = 0.11078,
+		E = 0.18172,
+		L = 0.60495,
+		A = 0.08925,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 8,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 887,
+	label = "N3s-SHH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   S   u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-S6ddHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 888,
+	label = "N3s-S6ddHH",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   S6dd u0 {1,S}
+3   H    u0 {1,S}
+4   H    u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07498,
+		B = 0.14653,
+		E = 0.14577,
+		L = 0.33390,
+		A = 0.48818,
+	),
+	dataCount = DataCountGAV(
+		S = 61,
+		B = 61,
+		E = 63,
+		L = 60,
+		A = 61,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 889,
+	label = "N3s-NNH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   N   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3rs-N3rd(Crd-Nd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 890,
+	label = "N3s-PCH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   P   u0 {1,S}
+3   C   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-P5dCH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 891,
+	label = "N3s-P5dCH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   P5d u0 {1,S}
+3   C   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.15712,
+		B = 0.07240,
+		E = -0.00694,
+		L = 0.43741,
+		A = 0.13478,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 892,
+	label = "N3s-NCH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   C   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-N3dCdH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 893,
+	label = "N3s-N3sCsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   H   u0 {1,S}
+4   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01408,
+		B = 0.09226,
+		E = 0.08007,
+		L = 0.19320,
+		A = 0.03846,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 4,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 894,
+	label = "N3s-N3sCbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3s u0 {1,S}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04221,
+		B = 0.10686,
+		E = 0.11535,
+		L = 0.29088,
+		A = 0.08564,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 895,
+	label = "N3s-N3sCdH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   N3s         u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.27252,
+		B = 0.07462,
+		E = 0.11966,
+		L = 0.68556,
+		A = 0.17297,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 896,
+	label = "N3s-N3dCsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3rs-N3rd(Crd-Cd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 897,
+	label = "N3s-N3dCbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03080,
+		B = -0.09369,
+		E = 0.00180,
+		L = 0.01489,
+		A = 0.29556,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 898,
+	label = "N3s-N3dCdH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   N3d         u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3s-N3d(Cd-O2d)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 899,
+	label = "N3rs-N3rdCrdH",
+	group = 
+"""
+1 * N3s         u0 r1 {2,S} {3,S} {4,S}
+2   N3d         u0 r1 {1,S}
+3   [Cd,CO,CS]  u0 r1 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3rs-N3rd(Crd-O2d)H',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 900,
+	label = "N3rs-N3rd(Crd-O2d)H",
+	group = 
+"""
+1 * N3s         u0 r1 {2,S} {3,S} {4,S}
+2   N3d         u0 r1 {1,S}
+3   CO          u0 r1 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00530,
+		B = 0.02004,
+		E = -0.02931,
+		L = -0.06992,
+		A = 0.07756,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 901,
+	label = "N3rs-N3rd(Crd-Cd)H",
+	group = 
+"""
+1 * N3s         u0 r1 {2,S} {3,S} {4,S}
+2   N3d         u0 r1 {1,S}
+3   Cd          u0 r1 {1,S} {5,D}
+4   H           u0 {1,S}
+5   C           u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.14290,
+		B = -0.00247,
+		E = 0.05898,
+		L = 0.32090,
+		A = 0.33960,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 3,
+		E = 8,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 902,
+	label = "N3rs-N3rd(Crd-Nd)H",
+	group = 
+"""
+1 * N3s         u0 r1 {2,S} {3,S} {4,S}
+2   N3d         u0 r1 {1,S}
+3   Cd          u0 r1 {1,S} {5,D}
+4   H           u0 {1,S}
+5   N           u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.13665,
+		B = 0.09966,
+		E = 0.01480,
+		L = 0.30183,
+		A = 0.35445,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 903,
+	label = "N3s-N3d(Cd-O2d)H",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   N3d         u0 {1,S}
+3   CO          u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03639,
+		B = 0.03215,
+		E = -0.04736,
+		L = 0.34880,
+		A = 0.09983,
+	),
+	dataCount = DataCountGAV(
+		S = 32,
+		B = 32,
+		E = 32,
+		L = 32,
+		A = 32,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 904,
+	label = "N3s-PCC",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   P   u0 {1,S}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03784,
+		B = 0.05012,
+		E = -0.01946,
+		L = 0.11493,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 905,
+	label = "N3s-NCC",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'N3s-N3dCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 906,
+	label = "N3rs-NrCrCr",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 r1 {1,S}
+3   C   u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03717,
+		B = 0.08658,
+		E = 0.09925,
+		L = 0.23346,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 907,
+	label = "N3rs-NrCrCb",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 r1 {1,S}
+3   C   u0 r1 {1,S}
+4   Cb  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.08888,
+		B = 0.07249,
+		E = 0.07750,
+		L = 0.02129,
+		A = 0.04929,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 908,
+	label = "N3rs-Nr(Crd-O2d)Cb",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 r1 {1,S}
+3   CO  u0 r1 {1,S}
+4   Cb  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.08027,
+		B = 0.09826,
+		E = -0.00320,
+		L = 0.06777,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 19,
+		A = 20,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 909,
+	label = "N3rs-NrCrC",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 r1 {1,S}
+3   C   u0 r1 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08102,
+		B = -0.03932,
+		E = 0.10687,
+		L = 0.25252,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 44,
+		B = 44,
+		E = 45,
+		L = 37,
+		A = 45,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 910,
+	label = "N3rs-NCrCr",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   C   u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = u'N3rs-N3dCrCr',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 911,
+	label = "N3rs-N3dCrCr",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S}
+3   C   u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07205,
+		B = 0.15034,
+		E = 0.10428,
+		L = 0.33714,
+		A = 0.06027,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 912,
+	label = "N3rs-(N3d-O2d)CrCr",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S} {5,D}
+3   C   u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.04914,
+		B = 0.01674,
+		E = 0.00120,
+		L = 0.03106,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 913,
+	label = "N3rs-N5dcCrCr",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N5dc u0 {1,S}
+3   C   u0 r1 {1,S}
+4   C   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02675,
+		B = -0.01251,
+		E = -0.04143,
+		L = 0.21473,
+		A = 0.07466,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 914,
+	label = "N3s-N3dCC",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'N3s-(N3d-O2d)CC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 915,
+	label = "N3s-(N3d-O2d)CC",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S} {5,D}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00575,
+		B = -0.05818,
+		E = -0.01779,
+		L = 0.12028,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 7,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 916,
+	label = "N3s-(N3d-O2d)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.16578,
+		B = 0.12560,
+		E = -0.02665,
+		L = 0.18833,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 26,
+		L = 26,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 917,
+	label = "N3s-(N3d-O2d)CbCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01769,
+		B = -0.00720,
+		E = 0.03744,
+		L = 0.06381,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 918,
+	label = "N3s-(N3d-O2d)CbCb",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N3d u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cb  u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00886,
+		B = -0.00973,
+		E = 0.03658,
+		L = -0.05446,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 919,
+	label = "N3s-NNC",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   N   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'N3rs-NrNrC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 920,
+	label = "N3rs-NrNrC",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 r1 {1,S}
+3   N   u0 r1 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'N3rs-NrCrC',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 921,
+	label = "N3s-NNO",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   N   u0 {1,S}
+3   N   u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'N3rs-NrNrO',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 922,
+	label = "N3rs-NrNrO",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N   u0 r1 {1,S}
+3   N   u0 r1 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'N3rs-N3rdN3rdO',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 923,
+	label = "N3rs-N3rdN3rdO",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N3d  u0 r1 {1,S}
+3   N3d u0 r1 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'N3rs-N3rdN3rd(O2s-H)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 924,
+	label = "N3rs-N3rdN3rd(O2s-H)",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   N3d  u0 r1 {1,S}
+3   N3d u0 r1 {1,S}
+4   O2s  u0 {1,S} {5,S}
+5   H    u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.04824,
+		B = 0.02361,
+		E = 0.04882,
+		L = 0.06663,
+		A = 0.10381,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 925,
+	label = "N3s-CCH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-CsCsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 926,
+	label = "N3s-CsCsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01402,
+		B = 0.25997,
+		E = 0.03900,
+		L = 0.38134,
+		A = 0.07343,
+	),
+	dataCount = DataCountGAV(
+		S = 107,
+		B = 106,
+		E = 110,
+		L = 99,
+		A = 108,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 927,
+	label = "N3rs-CrsCrsH",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cs  u0 r1 {1,S}
+3   Cs  u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10419,
+		B = 0.22632,
+		E = 0.06021,
+		L = 0.17752,
+		A = 0.11482,
+	),
+	dataCount = DataCountGAV(
+		S = 38,
+		B = 38,
+		E = 39,
+		L = 36,
+		A = 38,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 928,
+	label = "N3s-CbCsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10569,
+		B = -0.01570,
+		E = 0.12734,
+		L = 0.29768,
+		A = 0.08713,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 15,
+		E = 29,
+		L = 24,
+		A = 30,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 929,
+	label = "N3rs-CbCrsH",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cs  u0 r1 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10132,
+		B = 0.03747,
+		E = 0.11831,
+		L = 0.09311,
+		A = 0.16283,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 7,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 930,
+	label = "N3s-CbCbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04530,
+		B = -0.09186,
+		E = 0.01997,
+		L = -0.02473,
+		A = 0.05885,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 931,
+	label = "N3rs-CbCbH",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11689,
+		B = -0.04208,
+		E = -0.01174,
+		L = 0.38988,
+		A = 0.18917,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 21,
+		L = 20,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 932,
+	label = "N3s-CdCsH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   Cs          u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)CsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 933,
+	label = "N3s-(Cd-Cd)CsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09907,
+		B = 0.11900,
+		E = 0.09033,
+		L = 0.63360,
+		A = 0.15854,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 11,
+		L = 6,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 934,
+	label = "N3s-(Cd-N3d)CsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.10242,
+		B = 0.09640,
+		E = 0.10359,
+		L = 0.45079,
+		A = 0.12706,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 39,
+		E = 40,
+		L = 28,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 935,
+	label = "N3rs-(Crd-N3rd)CrsH",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cs  u0 r1 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01547,
+		B = 0.08380,
+		E = 0.22463,
+		L = 0.44209,
+		A = 0.13765,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 936,
+	label = "N3s-(Cd-O2d)CsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.27531,
+		B = 0.07844,
+		E = 0.09529,
+		L = 0.62625,
+		A = 0.27168,
+	),
+	dataCount = DataCountGAV(
+		S = 236,
+		B = 235,
+		E = 240,
+		L = 196,
+		A = 236,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 937,
+	label = "N3s-(Cd-Sd)CsH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CS  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   H   u0 {1,S}
+5   S   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07694,
+		B = 0.09424,
+		E = 0.05702,
+		L = 0.25350,
+		A = 0.13490,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 938,
+	label = "N3s-CdCtH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   Ct          u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3s-(Cd-N3d)CtH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 939,
+	label = "N3s-(Cd-N3d)CtH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   Cd          u0 {1,S} {5,D}
+3   Ct          u0 {1,S}
+4   H           u0 {1,S}
+5   N3d         u0 {2,D}
+""",
+	solute = u'N3s-(Cd-N3d)(Ct-N3t)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 940,
+	label = "N3s-(Cd-N3d)(Ct-N3t)H",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   Cd          u0 {1,S} {5,D}
+3   Ct          u0 {1,S} {6,T}
+4   H           u0 {1,S}
+5   N3d         u0 {2,D}
+6   N3t         u0 {3,T}
+""",
+	solute = u'N3s-(Cd-N3d)CsH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 941,
+	label = "N3s-CdCbH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   Cb          u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)CbH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 942,
+	label = "N3s-(Cd-Cd)CbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Crd)CbH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 943,
+	label = "N3rs-(Crd-Crd)CbH",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.20364,
+		B = -0.00534,
+		E = 0.10404,
+		L = 0.60136,
+		A = 0.31193,
+	),
+	dataCount = DataCountGAV(
+		S = 41,
+		B = 33,
+		E = 43,
+		L = 41,
+		A = 40,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 944,
+	label = "N3s-(Crd-Crd)CbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   C   u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.05871,
+		B = 0.11981,
+		E = 0.04934,
+		L = 0.39603,
+		A = 0.15331,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 945,
+	label = "N3s-(Cd-N3d)CbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 {2,D}
+""",
+	solute = u'N3s-(Crd-N3rd)CbH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 946,
+	label = "N3rs-(Crd-N3rd)CbH",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09927,
+		B = -0.00303,
+		E = 0.17548,
+		L = 0.49401,
+		A = 0.34952,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 24,
+		E = 24,
+		L = 22,
+		A = 24,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 947,
+	label = "N3s-(Crd-N3rd)CbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00029,
+		B = 0.09407,
+		E = 0.09852,
+		L = 0.21290,
+		A = 0.08747,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 14,
+		L = 12,
+		A = 13,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 948,
+	label = "N3s-(Cd-O2d)CbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.02187,
+		B = -0.00688,
+		E = 0.00555,
+		L = 0.07867,
+		A = 0.35985,
+	),
+	dataCount = DataCountGAV(
+		S = 165,
+		B = 159,
+		E = 168,
+		L = 95,
+		A = 164,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 949,
+	label = "N3s-(Cd-Sd)CbH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CS  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   H   u0 {1,S}
+5   S   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.15610,
+		B = 0.09548,
+		E = 0.00942,
+		L = 0.31130,
+		A = 0.20437,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 950,
+	label = "N3s-CdCdH",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   H           u0 {1,S}
+""",
+	solute = u'N3s-(Cd-Cd)(Cd-Cd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 951,
+	label = "N3s-(Cd-Cd)(Cd-Cd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cd  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   C   u0 {2,D}
+6   C   u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-Crd)(Crd-Crd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 952,
+	label = "N3rs-(Crd-Crd)(Crd-Crd)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   C   u0 r1 {2,D}
+6   C   u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.04822,
+		B = -0.04175,
+		E = 0.08125,
+		L = 0.42451,
+		A = 0.10480,
+	),
+	dataCount = DataCountGAV(
+		S = 43,
+		B = 43,
+		E = 53,
+		L = 39,
+		A = 52,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 953,
+	label = "N3s-(Cd-N3d)(Cd-Cd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cd  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   N3d u0 {2,D}
+6   C   u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-N3rd)(Crd-Crd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 954,
+	label = "N3rs-(Crd-N3rd)(Crd-Crd)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   N3d u0 r1 {2,D}
+6   C   u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.11659,
+		B = 0.05591,
+		E = 0.09783,
+		L = 0.30336,
+		A = 0.36901,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 24,
+		E = 32,
+		L = 22,
+		A = 31,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 955,
+	label = "N3s-(Cd-O2d)(Cd-Cd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cd  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   C   u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-Crd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 956,
+	label = "N3rs-(Crd-O2d)(Crd-Crd)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   C   u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.02212,
+		B = 0.11893,
+		E = 0.13108,
+		L = 0.35857,
+		A = 0.21888,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 24,
+		E = 28,
+		L = 23,
+		A = 25,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 957,
+	label = "N3s-(Cd-O2d)(Crd-Crd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   C   u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.03658,
+		B = -0.01540,
+		E = 0.05058,
+		L = 0.31102,
+		A = 0.06093,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 5,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 958,
+	label = "N3s-(Cd-Sd)(Cd-Cd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CS  u0 {1,S} {5,D}
+3   Cd  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   S   u0 {2,D}
+6   C   u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-Sd)(Crd-Crd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 959,
+	label = "N3rs-(Crd-Sd)(Crd-Crd)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CS  u0 r1 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   S   u0 {2,D}
+6   C   u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.05724,
+		B = 0.07594,
+		E = 0.06116,
+		L = 0.15459,
+		A = 0.08231,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 960,
+	label = "N3s-(Cd-O2d)(Cd-O2d)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   CO  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   O2d u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-O2d)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 961,
+	label = "N3rs-(Crd-O2d)(Crd-O2d)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   CO  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.04081,
+		B = 0.00953,
+		E = 0.03972,
+		L = 0.01880,
+		A = 0.21470,
+	),
+	dataCount = DataCountGAV(
+		S = 125,
+		B = 125,
+		E = 126,
+		L = 78,
+		A = 125,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 962,
+	label = "N3s-(Cd-O2d)(Cd-N3d)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cd  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   N3d u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-N3rd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 963,
+	label = "N3rs-(Crd-O2d)(Crd-N3rd)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   N3d u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.05652,
+		B = 0.02663,
+		E = -0.01893,
+		L = -0.00494,
+		A = 0.19227,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 16,
+		E = 18,
+		L = 14,
+		A = 18,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 964,
+	label = "N3s-(Cd-O2d)(Crd-N3rd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cd  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   N3d u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.08759,
+		B = 0.01986,
+		E = 0.11096,
+		L = 0.19544,
+		A = 0.19228,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 13,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 965,
+	label = "N3s-(Cd-O2d)(Cd-Sd)H",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   CS  u0 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   S   u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-Sd)H',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 966,
+	label = "N3rs-(Crd-O2d)(Crd-Sd)H",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   CS  u0 r1 {1,S} {6,D}
+4   H   u0 {1,S}
+5   O2d u0 {2,D}
+6   S   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.03928,
+		B = -0.00824,
+		E = 0.05579,
+		L = 0.08980,
+		A = 0.19612,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 967,
+	label = "N3s-COH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   O   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08721,
+		B = 0.02674,
+		E = 0.01591,
+		L = 0.14396,
+		A = 0.13152,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 968,
+	label = "N3s-CSH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   S   u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-CS6ddH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 969,
+	label = "N3s-CS6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-CrS6ddH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 970,
+	label = "N3s-CbS6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05051,
+		B = 0.04229,
+		E = -0.02881,
+		L = 0.09517,
+		A = 0.21541,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 971,
+	label = "N3s-CrS6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 r1 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-CrdS6ddH',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 972,
+	label = "N3s-CrdS6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.07906,
+		B = 0.06637,
+		E = 0.05224,
+		L = 0.13183,
+		A = 0.26684,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 25,
+		E = 25,
+		L = 23,
+		A = 25,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 973,
+	label = "N3s-CdS6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)S6ddH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 974,
+	label = "N3s-(Cd-O2d)S6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.09830,
+		B = -0.05440,
+		E = 0.03221,
+		L = -0.07423,
+		A = 0.13635,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 7,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 975,
+	label = "N3s-CsS6ddH",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   S6dd u0 {1,S}
+4   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.07195,
+		B = -0.01825,
+		E = 0.03641,
+		L = 0.07666,
+		A = 0.18086,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 976,
+	label = "N3s-CCC",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'N3s-CsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 977,
+	label = "N3s-CsCsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.11941,
+		B = 0.14315,
+		E = -0.08614,
+		L = 0.12131,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 141,
+		B = 141,
+		E = 150,
+		L = 114,
+		A = 151,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 978,
+	label = "N3rs-CrsCrsCrs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cs  u0 r1 {1,S}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.07446,
+		B = -0.03097,
+		E = 0.07594,
+		L = 0.00705,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 15,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 979,
+	label = "N3rs-CrsCrsCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cs  u0 r1 {1,S}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.07680,
+		B = 0.09229,
+		E = 0.01676,
+		L = 0.18912,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 141,
+		B = 141,
+		E = 144,
+		L = 132,
+		A = 142,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 980,
+	label = "N3s-CbCsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01650,
+		B = -0.09642,
+		E = 0.06505,
+		L = -0.09044,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 64,
+		B = 61,
+		E = 69,
+		L = 56,
+		A = 71,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 981,
+	label = "N3s-CbCdCd",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   Cb          u0 {1,S}
+""",
+	solute = u'N3s-Cb(Cd-O2d)(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 982,
+	label = "N3s-Cb(Cd-O2d)(Cd-Cd)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   CO   u0 {1,S}
+3   Cd   u0 {1,S} {5,D}
+4   Cb   u0 {1,S}
+5   C    u0 {3,D}
+""",
+	solute = u'N3rs-Cb(Cd-O2d)(Crd-Crd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 983,
+	label = "N3rs-Cb(Cd-O2d)(Crd-Crd)",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   CO   u0 {1,S}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cb   u0 {1,S}
+5   C    u0 r1 {3,D}
+""",
+	solute = u'N3rs-(Cd-O2d)CbCrs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 984,
+	label = "N3s-CbCbCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = u'N3rs-CbCbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 985,
+	label = "N3rs-CbCbCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03392,
+		B = -0.09198,
+		E = -0.13215,
+		L = -0.10413,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 27,
+		L = 25,
+		A = 26,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 986,
+	label = "N3s-CbCbCd",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   Cb          u0 {1,S}
+3   Cb          u0 {1,S}
+4   [Cd,CO,CS]  u0 {1,S}
+""",
+	solute = u'N3s-CbCb(Cd-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 987,
+	label = "N3s-CbCb(Cd-O2d)",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   CO  u0 {1,S} {5,D}
+5   O2d u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.05187,
+		B = 0.05829,
+		E = -0.17407,
+		L = -0.26976,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 988,
+	label = "N3s-CbCbCb",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04475,
+		B = -0.02670,
+		E = -0.05483,
+		L = -0.00790,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 989,
+	label = "N3s-CdCsCs",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   Cs          u0 {1,S}
+4   Cs          u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)CsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 990,
+	label = "N3s-(Cd-N3d)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   N3d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.03844,
+		B = 0.10897,
+		E = -0.04845,
+		L = 0.09584,
+		A = -0.01157,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 991,
+	label = "N3rs-(Crd-N3rd)CrsCrs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+5   N3d  u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.08500,
+		B = -0.09428,
+		E = 0.01809,
+		L = 0.09527,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 19,
+		E = 19,
+		L = 17,
+		A = 19,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 992,
+	label = "N3s-(Crd-N3rd)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   N3d  u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.18622,
+		B = -0.00426,
+		E = 0.05385,
+		L = -0.03400,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 993,
+	label = "N3s-(Cd-O2d)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.21632,
+		B = 0.07780,
+		E = -0.01746,
+		L = 0.32263,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 80,
+		B = 84,
+		E = 85,
+		L = 65,
+		A = 101,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 994,
+	label = "N3rs-(Crd-O2d)CrsCrs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.12288,
+		B = -0.00880,
+		E = 0.20355,
+		L = 0.07046,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 19,
+		A = 20,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 995,
+	label = "N3rs-(Cd-O2d)CrsCrs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 r1 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09173,
+		B = 0.00490,
+		E = 0.03635,
+		L = 0.27497,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 29,
+		B = 29,
+		E = 32,
+		L = 25,
+		A = 34,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 996,
+	label = "N3rs-(Crd-O2d)CrsCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.25162,
+		B = -0.02681,
+		E = -0.16355,
+		L = 0.36541,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 19,
+		L = 17,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 997,
+	label = "N3s-(Cd-Cd)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   C   u0 {2,D}
+""",
+	solute = u'N3s-(Crd-Crd)CsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 998,
+	label = "N3rs-(Crd-Crd)CrsCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cs  u0 r1 {1,S}
+4   Cs  u0 {1,S}
+5   C   u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.11364,
+		B = 0.01832,
+		E = 0.01620,
+		L = 0.40492,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 999,
+	label = "N3s-(Crd-Crd)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   C   u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.02560,
+		B = 0.01183,
+		E = 0.13265,
+		L = 0.24870,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 7,
+		E = 8,
+		L = 7,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1000,
+	label = "N3s-(Cd-Sd)CsCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CS  u0 {1,S} {5,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   S   u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01374,
+		B = 0.02245,
+		E = 0.03518,
+		L = 0.40353,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 4,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1001,
+	label = "N3s-CdCbCs",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   Cb          u0 {1,S}
+4   Cs          u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1002,
+	label = "N3s-(Cd-O2d)CbCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.02816,
+		B = 0.07418,
+		E = -0.02420,
+		L = -0.01764,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 24,
+		E = 26,
+		L = 22,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1003,
+	label = "N3rs-(Crd-O2d)CbCrs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 r1 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.06341,
+		B = 0.00351,
+		E = -0.00129,
+		L = -0.01278,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1004,
+	label = "N3rs-(Crd-O2d)CbCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01992,
+		B = -0.09733,
+		E = -0.02426,
+		L = 0.19885,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 27,
+		E = 27,
+		L = 13,
+		A = 27,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1005,
+	label = "N3rs-(Cd-O2d)CbCrs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   CO  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 r1 {1,S}
+5   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.01709,
+		B = -0.08440,
+		E = 0.04331,
+		L = -0.05840,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 17,
+		L = 15,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1006,
+	label = "N3s-(Cd-Cd)CbCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   C  u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Crd)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1007,
+	label = "N3rs-(Crd-Crd)CbCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   C  u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07305,
+		B = 0.10823,
+		E = 0.04875,
+		L = 0.37072,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 15,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1008,
+	label = "N3s-(Cd-Nd)CbCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cd  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   N  u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Nrd)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1009,
+	label = "N3rs-(Crd-Nrd)CbCs",
+	group = 
+"""
+1 * N3s u0 r1 {2,S} {3,S} {4,S}
+2   Cd  u0 r1 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   N  u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00752,
+		B = -0.00118,
+		E = -0.00735,
+		L = 0.21412,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1010,
+	label = "N3s-(Cd-S2d)CbCs",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   CS  u0 {1,S} {5,D}
+3   Cb  u0 {1,S}
+4   Cs  u0 {1,S}
+5   S2d u0 {2,D}
+""",
+	solute = u'N3s-(Cd-O2d)CbCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1011,
+	label = "N3s-CdCdCs",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   Cs          u0 {1,S}
+""",
+	solute = u'N3s-(Cd-O2d)(Cd-Cd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1012,
+	label = "N3s-(Cd-O2d)(Cd-O2d)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   CO   u0 {1,S}
+3   CO   u0 {1,S}
+4   Cs   u0 {1,S}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-O2d)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1013,
+	label = "N3rs-(Crd-O2d)(Crd-O2d)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   CO   u0 r1 {1,S}
+3   CO   u0 r1 {1,S}
+4   Cs   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.10952,
+		B = -0.14275,
+		E = -0.02558,
+		L = -0.06096,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 56,
+		B = 56,
+		E = 59,
+		L = 44,
+		A = 56,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1014,
+	label = "N3rs-(Crd-O2d)(Cd-O2d)Crs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   CO   u0 r1 {1,S}
+3   CO   u0 {1,S}
+4   Cs   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06671,
+		B = -0.01783,
+		E = 0.05477,
+		L = -0.33967,
+		A = 0.00601,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1015,
+	label = "N3s-(Cd-O2d)(Cd-Cd)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   CO   u0 {1,S}
+3   Cd   u0 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-Crd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1016,
+	label = "N3rs-(Crd-O2d)(Crd-Crd)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   CO   u0 r1 {1,S}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.09800,
+		B = 0.04498,
+		E = 0.13039,
+		L = 0.53174,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 62,
+		B = 62,
+		E = 62,
+		L = 61,
+		A = 62,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1017,
+	label = "N3s-(Cd-O2d)(Cd-Nd)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   CO   u0 {1,S}
+3   Cd   u0 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   N    u0 {3,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-Nrd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1018,
+	label = "N3rs-(Crd-O2d)(Crd-Nrd)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   CO   u0 r1 {1,S}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   N    u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.00819,
+		B = 0.02527,
+		E = 0.04558,
+		L = 0.04612,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1019,
+	label = "N3s-(Cd-Cd)(Cd-Cd)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cd   u0 {1,S} {6,D}
+3   Cd   u0 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 {3,D}
+6   C    u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Crd)(Crd-Crd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1020,
+	label = "N3rs-(Crd-Crd)(Crd-Crd)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   Cd   u0 r1 {1,S} {6,D}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 r1 {3,D}
+6   C    u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.03892,
+		B = 0.02468,
+		E = -0.04150,
+		L = 0.00851,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 24,
+		E = 24,
+		L = 6,
+		A = 24,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1021,
+	label = "N3s-(Cd-Cd)(Cd-Nd)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cd   u0 {1,S} {6,D}
+3   Cd   u0 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 {3,D}
+6   N    u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Crd)(Crd-Nrd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1022,
+	label = "N3rs-(Crd-Crd)(Crd-Nrd)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   Cd   u0 r1 {1,S} {6,D}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 r1 {3,D}
+6   N    u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.06297,
+		B = 0.00249,
+		E = 0.07425,
+		L = 0.34422,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 45,
+		E = 47,
+		L = 45,
+		A = 46,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1023,
+	label = "N3s-(Cd-Cd)(Cd-S2d)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   CS   u0 {1,S} {6,D}
+3   Cd   u0 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 {3,D}
+6   S2d  u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Crd)(Crd-S2d)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1024,
+	label = "N3rs-(Crd-Crd)(Crd-S2d)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   CS   u0 r1 {1,S} {6,D}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   C    u0 r1 {3,D}
+6   S2d  u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-O2d)(Crd-Crd)Cs',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1025,
+	label = "N3s-(Cd-Nd)(Cd-Nd)Cs",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cd   u0 {1,S} {6,D}
+3   Cd   u0 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   N    u0 {3,D}
+6   N    u0 {2,D}
+""",
+	solute = u'N3rs-(Crd-Nrd)(Crd-Nrd)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1026,
+	label = "N3rs-(Crd-Nrd)(Crd-Nrd)Cs",
+	group = 
+"""
+1 * N3s  u0 r1 {2,S} {3,S} {4,S}
+2   Cd   u0 r1 {1,S} {6,D}
+3   Cd   u0 r1 {1,S} {5,D}
+4   Cs   u0 {1,S}
+5   N    u0 r1 {3,D}
+6   N    u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.11807,
+		B = -0.01637,
+		E = 0.04096,
+		L = 0.17913,
+		A = 0.04984,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1027,
+	label = "N3s-CdCdCd",
+	group = 
+"""
+1 * N3s         u0 {2,S} {3,S} {4,S}
+2   [Cd,CO,CS]  u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   [Cd,CO,CS]  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.09449,
+		B = -0.07978,
+		E = 0.07824,
+		L = -0.10496,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 29,
+		L = 24,
+		A = 29,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1028,
+	label = "N3s-(Cd-O2d)(Cd-Cd)(Cd-Nd)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   CO   u0 {1,S}
+3   Cd   u0 {1,S} {5,D}
+4   Cd   u0 {1,S} {6,D}
+5   C    u0 {3,D}
+6   N    u0 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.02732,
+		B = -0.07457,
+		E = -0.04320,
+		L = 0.05112,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 13,
+		L = 12,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1029,
+	label = "N3s-CCO",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   O   u0 {1,S}
+""",
+	solute = u'N3s-Cb(Cd-O2d)(O-H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1030,
+	label = "N3s-CbCd(O-H)",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   [Cd,CO,CS] u0 {1,S}
+4   O2s u0 {1,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = u'N3s-Cb(Cd-O2d)(O-H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1031,
+	label = "N3s-Cb(Cd-O2d)(O-H)",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   CO  u0 {1,S}
+4   O2s u0 {1,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.17235,
+		B = 0.10594,
+		E = 0.03362,
+		L = -0.04211,
+		A = 0.02431,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 22,
+		L = 21,
+		A = 23,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1032,
+	label = "N3s-CCS",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   S   u0 {1,S}
+""",
+	solute = u'N3s-CCS6dd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1033,
+	label = "N3s-CCS4d",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   S4d u0 {1,S}
+""",
+	solute = u'N3s-CC(S4d-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1034,
+	label = "N3s-CC(S4d-O2d)",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   S4d u0 {1,S} {5,D}
+5   O2d u0 {4,D}
+""",
+	solute = u'N3s-CsCs(S4d-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1035,
+	label = "N3s-CsCs(S4d-O2d)",
+	group = 
+"""
+1 * N3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   Cs  u0 {1,S}
+4   S4d u0 {1,S} {5,D}
+5   O2d u0 {4,D}
+""",
+	solute = u'N3s-CsCs(S6dd-O2dO2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1036,
+	label = "N3s-CCS6dd",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   C    u0 {1,S}
+3   C    u0 {1,S}
+4   S6dd u0 {1,S}
+""",
+	solute = u'N3s-CC(S6dd-O2dO2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1037,
+	label = "N3s-CC(S6dd-O2dO2d)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   C    u0 {1,S}
+3   C    u0 {1,S}
+4   S6dd u0 {1,S} {5,D} {6,D}
+5   O2d  u0 {4,D}
+6   O2d  u0 {4,D}
+""",
+	solute = u'N3s-CsCs(S6dd-O2dO2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1038,
+	label = "N3s-CsCs(S6dd-O2dO2d)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cs   u0 {1,S}
+3   Cs   u0 {1,S}
+4   S6dd u0 {1,S} {5,D} {6,D}
+5   O2d  u0 {4,D}
+6   O2d  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.00396,
+		B = -0.12692,
+		E = -0.01189,
+		L = -0.07670,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 18,
+		L = 17,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1039,
+	label = "N3s-CsCd(S6dd-O2dO2d)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cs   u0 {1,S}
+3   [Cd,CO,CS]  u0 {1,S}
+4   S6dd u0 {1,S} {5,D} {6,D}
+5   O2d  u0 {4,D}
+6   O2d  u0 {4,D}
+""",
+	solute = u'N3s-Cs(Cd-Cd)(S6dd-O2dO2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1040,
+	label = "N3s-Cs(Cd-Cd)(S6dd-O2dO2d)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cs   u0 {1,S}
+3   Cd  u0 {1,S} {7,D}
+4   S6dd u0 {1,S} {5,D} {6,D}
+5   O2d  u0 {4,D}
+6   O2d  u0 {4,D}
+7   C    u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.00510,
+		B = 0.02041,
+		E = 0.03085,
+		L = 0.09413,
+		A = -0.01875,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1041,
+	label = "N3s-CbCb(S6dd-O2dO2d)",
+	group = 
+"""
+1 * N3s  u0 {2,S} {3,S} {4,S}
+2   Cb   u0 {1,S}
+3   Cb   u0 {1,S}
+4   S6dd u0 {1,S} {5,D} {6,D}
+5   O2d  u0 {4,D}
+6   O2d  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.06415,
+		B = -0.05212,
+		E = -0.07815,
+		L = -0.31958,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1042,
+	label = "N3d",
+	group = 
+"""
+1 * N3d u0
+""",
+	solute = u'N3d-CdC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1043,
+	label = "N3d-N5ddc",
+	group = 
+"""
+1 * N3d   u0 {2,D}
+2   N5ddc u0 c+1 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.04468,
+		B = 0.00000,
+		E = 0.09588,
+		L = 0.39946,
+		A = 0.01261,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1044,
+	label = "N3d-CdH",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   H    u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.08189,
+		B = 0.20816,
+		E = 0.18543,
+		L = 0.43644,
+		A = 0.04616,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 8,
+		L = 3,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1045,
+	label = "N3d-CdN",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   N    u0 {1,S}
+""",
+	solute = u'N3d-CdN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1046,
+	label = "N3d-CdN3s",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   N3s  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.18191,
+		B = 0.15063,
+		E = 0.32247,
+		L = 1.14517,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 102,
+		B = 99,
+		E = 105,
+		L = 96,
+		A = 103,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1047,
+	label = "N3d-CdN3d",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   N3d  u0 {1,S}
+""",
+	solute = u'N3rd-CrdN3rd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1048,
+	label = "N3rd-CrdN3rd",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   N3d  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.24565,
+		B = 0.12774,
+		E = 0.22520,
+		L = 0.88458,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 22,
+		L = 20,
+		A = 22,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1049,
+	label = "N3d-CdO",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   O    u0 {1,S}
+""",
+	solute = u'N3d-Cd(O-H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1050,
+	label = "N3d-Cd(O-H)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   O    u0 {1,S} {4,S}
+4   H    u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.18430,
+		B = 0.12440,
+		E = 0.13017,
+		L = 0.73864,
+		A = 0.03986,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 11,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1051,
+	label = "N3d-Cd(O-R)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   O    u0 {1,S} {4,S}
+4   R!H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.00356,
+		B = 0.11268,
+		E = 0.03656,
+		L = 0.42541,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1052,
+	label = "N3rd-Crd(Or-R)",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   O    u0 r1 {1,S} {4,S}
+4   R!H  u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.13615,
+		B = 0.09126,
+		E = 0.20262,
+		L = 0.62299,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 17,
+		L = 16,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1053,
+	label = "N3d-CdS",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   S    u0 {1,S}
+""",
+	solute = u'N3d-CdS2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1054,
+	label = "N3d-CdS2s",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   S2s  u0 {1,S}
+""",
+	solute = u'N3rd-CrdS2rs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1055,
+	label = "N3rd-CrdS2rs",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   S2s  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10020,
+		B = 0.04043,
+		E = 0.19174,
+		L = 0.70217,
+		A = -0.00913,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1056,
+	label = "N3d-CdS6dd",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   S6dd u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03518,
+		B = 0.00807,
+		E = 0.07348,
+		L = 0.13719,
+		A = -0.01722,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1057,
+	label = "N3d-CdC",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   C    u0 {1,S}
+""",
+	solute = u'N3d-CdCd',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1058,
+	label = "N3d-CdCs",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Cs   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.16065,
+		B = 0.14780,
+		E = 0.01262,
+		L = 0.02561,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 13,
+		L = 8,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1059,
+	label = "N3rd-CrdCrs",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   Cs   u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06109,
+		B = 0.22653,
+		E = 0.18571,
+		L = 0.64033,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 41,
+		B = 41,
+		E = 42,
+		L = 21,
+		A = 42,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1060,
+	label = "N3d-CdCb",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Cb   u0 {1,S}
+""",
+	solute = u'N3rd-CrdCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1061,
+	label = "N3rd-CrdCb",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00262,
+		B = 0.06847,
+		E = 0.17967,
+		L = 0.49325,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 124,
+		B = 116,
+		E = 132,
+		L = 123,
+		A = 126,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1062,
+	label = "N3d-CdCd",
+	group = 
+"""
+1 * N3d         u0 {2,D} {3,S}
+2   Cd          u0 {1,D}
+3   [Cd,CO,CS]  u0 {1,S}
+""",
+	solute = u'N3d-Cd(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1063,
+	label = "N3d-Cd(Cd-O2d)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   CO   u0 {1,S} {4,D}
+4   O2d  u0 {3,D}
+""",
+	solute = u'N3rd-Crd(Crd-O2d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1064,
+	label = "N3rd-Crd(Crd-O2d)",
+	group = 
+"""
+1 * N3d   u0 r1 {2,D} {3,S}
+2   Cd    u0 r1 {1,D}
+3   CO    u0 r1 {1,S} {4,D}
+4   O2d   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.09142,
+		B = 0.08863,
+		E = 0.15317,
+		L = 0.50789,
+		A = 0.02231,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 11,
+		E = 12,
+		L = 10,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1065,
+	label = "N3d-Cd(Cd-N3d)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Cd   u0 {1,S} {4,D}
+4   N3d  u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.09106,
+		B = 0.18768,
+		E = 0.04579,
+		L = 0.59277,
+		A = -0.00225,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1066,
+	label = "N3rd-Crd(Crd-N3rd)",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   Cd   u0 r1 {1,S} {4,D}
+4   N3d  u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.12462,
+		B = 0.18226,
+		E = 0.16491,
+		L = 0.69020,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 132,
+		B = 131,
+		E = 136,
+		L = 124,
+		A = 138,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1067,
+	label = "N3d-Cd(Crd-N3rd)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Cd   u0 r1 {1,S} {4,D}
+4   N3d  u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.00508,
+		B = -0.00293,
+		E = 0.04022,
+		L = 0.20700,
+		A = 0.16512,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1068,
+	label = "N3d-Cd(Cd-Cd)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Cd   u0 {1,S} {4,D}
+4   C    u0 {3,D}
+""",
+	solute = u'N3rd-Crd(Crd-Crd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1069,
+	label = "N3rd-Crd(Crd-Crd)",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   Cd   u0 r1 {1,D}
+3   Cd   u0 r1 {1,S} {4,D}
+4   C    u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.20649,
+		B = 0.13895,
+		E = 0.34976,
+		L = 1.24580,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 506,
+		B = 442,
+		E = 556,
+		L = 446,
+		A = 550,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1070,
+	label = "N3d-CdCt",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Ct   u0 {1,S}
+""",
+	solute = u'N3d-Cd(Ct-N3t)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1071,
+	label = "N3d-Cd(Ct-N3t)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cd   u0 {1,D}
+3   Ct   u0 {1,S} {4,T}
+4   N3t  u0 {3,T}
+""",
+	solute = SoluteData(
+		S = 0.08061,
+		B = 0.02152,
+		E = -0.00632,
+		L = 0.24359,
+		A = 0.12173,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 5,
+		L = 2,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1072,
+	label = "N3d-CddC",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D}
+3   C    u0 {1,S}
+""",
+	solute = u'N3d-(Cdd-O2d)C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1073,
+	label = "N3d-(Cdd-O2d)C",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   C    u0 {1,S}
+4   O2d  u0 {2,D}
+""",
+	solute = u'N3d-(Cdd-O2d)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1074,
+	label = "N3d-(Cdd-O2d)Cs",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   Cs   u0 {1,S}
+4   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.07104,
+		B = 0.01930,
+		E = 0.01070,
+		L = 0.20647,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1075,
+	label = "N3d-(Cdd-O2d)Cb",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   Cb   u0 {1,S}
+4   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.09820,
+		B = 0.02877,
+		E = 0.05808,
+		L = 0.30346,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1076,
+	label = "N3d-(Cdd-Sd)C",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   C    u0 {1,S}
+4   S    u0 {2,D}
+""",
+	solute = u'N3d-(Cdd-S2d)C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1077,
+	label = "N3d-(Cdd-S2d)C",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   C    u0 {1,S}
+4   S2d  u0 {2,D}
+""",
+	solute = u'N3d-(Cdd-S2d)Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1078,
+	label = "N3d-(Cdd-S2d)Cs",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   Cs   u0 {1,S}
+4   S2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.03612,
+		B = 0.00163,
+		E = 0.01842,
+		L = 0.15609,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 9,
+		E = 8,
+		L = 6,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1079,
+	label = "N3d-(Cdd-S2d)Cb",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   Cdd  u0 {1,D} {4,D}
+3   Cb   u0 {1,S}
+4   S2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.00131,
+		B = -0.02611,
+		E = 0.06175,
+		L = 0.08273,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1080,
+	label = "N3d-N3dN",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   N    u0 {1,S}
+""",
+	solute = u'N3d-N3dN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1081,
+	label = "N3d-N3dN3s",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   N3s  u0 {1,S}
+""",
+	solute = u'N3rd-N3rdN3rs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1082,
+	label = "N3rd-N3rdN3rs",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   N3d  u0 r1 {1,D}
+3   N3s  u0 r1 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.12876,
+		B = 0.10683,
+		E = 0.20440,
+		L = 0.57559,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 15,
+		E = 16,
+		L = 13,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1083,
+	label = "N3d-N3dN3d",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   N3d  u0 {1,S}
+""",
+	solute = u'N3d-N3d(N3d-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1084,
+	label = "N3d-N3d(N3d-Cd)",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   N3d  u0 {1,S} {4,D}
+4   Cd   u0 {3,D}
+""",
+	solute = u'N3rd-N3rd(N3rd-Crd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1085,
+	label = "N3rd-N3rd(N3rd-Crd)",
+	group = 
+"""
+1 * N3d  u0 r1 {2,D} {3,S}
+2   N3d  u0 r1 {1,D}
+3   N3d  u0 r1 {1,S} {4,D}
+4   Cd   u0 r1 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.02691,
+		B = 0.03029,
+		E = 0.02081,
+		L = 0.14437,
+		A = 0.03053,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1086,
+	label = "N3d-N3dC",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   C    u0 {1,S}
+""",
+	solute = u'N3d-N3dCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1087,
+	label = "N3d-N3dCb",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00703,
+		B = 0.02136,
+		E = 0.06188,
+		L = 0.44470,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 19,
+		E = 20,
+		L = 16,
+		A = 19,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1088,
+	label = "N3d-N3dCs",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   Cs   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.13053,
+		B = 0.04972,
+		E = 0.05888,
+		L = 0.58952,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1089,
+	label = "N3d-N3dCd",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   N3d  u0 {1,D}
+3   Cd   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.25089,
+		B = 0.12557,
+		E = 0.12649,
+		L = 0.65242,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 8,
+		E = 9,
+		L = 7,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1090,
+	label = "N3d-O2dO",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   O2d  u0 {1,D}
+3   O    u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01340,
+		B = 0.04305,
+		E = -0.01741,
+		L = 0.03588,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 13,
+		L = 5,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1091,
+	label = "N3d-O2dN",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   O2d  u0 {1,D}
+3   N    u0 {1,S}
+""",
+	solute = u'N3d-O2dN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1092,
+	label = "N3d-O2dN3s",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   O2d  u0 {1,D}
+3   N3s  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.29469,
+		B = 0.01752,
+		E = 0.14053,
+		L = 0.65622,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 39,
+		E = 39,
+		L = 39,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1093,
+	label = "N3d-O2dC",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   O2d  u0 {1,D}
+3   C    u0 {1,S}
+""",
+	solute = u'N3d-O2dCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1094,
+	label = "N3d-O2dCb",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   O2d  u0 {1,D}
+3   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01932,
+		B = 0.05108,
+		E = -0.02692,
+		L = -0.02351,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1095,
+	label = "N3d-SdS",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   S    u0 {1,D}
+3   S    u0 {1,S}
+""",
+	solute = u'N3d-S4ddS2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1096,
+	label = "N3d-S4ddS2s",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   S4dd u0 {1,D}
+3   S2s   u0 {1,S}
+""",
+	solute = u'N3d-(S4dd-N3d)S2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1097,
+	label = "N3d-(S4dd-N3d)S2s",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   S4dd u0 {1,D} {4,D}
+3   S2s  u0 {1,S}
+4   N3d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = 0.18259,
+		B = 0.02147,
+		E = 0.23178,
+		L = 0.85280,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1098,
+	label = "N3d-PdP",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   P    u0 {1,D}
+3   P    u0 {1,S}
+""",
+	solute = u'N3d-P5dP5d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1099,
+	label = "N3d-P5dP5d",
+	group = 
+"""
+1 * N3d  u0 {2,D} {3,S}
+2   P5d  u0 {1,D}
+3   P5d  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03994,
+		B = 0.09164,
+		E = 0.06619,
+		L = 0.40872,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1100,
+	label = "N3t",
+	group = 
+"""
+1 * N3t  u0 p1 {2,T}
+2   R!H  u0 {1,T}
+""",
+	solute = u'N3t-Ct',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1101,
+	label = "N3t-Ct",
+	group = 
+"""
+1 * N3t  u0 p1 {2,T}
+2   Ct   u0 {1,T}
+""",
+	solute = SoluteData(
+		S = 0.43784,
+		B = 0.17326,
+		E = 0.18638,
+		L = 1.20727,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 141,
+		B = 139,
+		E = 162,
+		L = 131,
+		A = 153,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1102,
+	label = "N5sc",
+	group = 
+"""
+1 * N5sc u0 p0 c+1
+""",
+	solute = u'N5sc-O0sc',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1103,
+	label = "N5sc-O0sc",
+	group = 
+"""
+1 * N5sc u0 p0 c+1 {2,S}
+2   O0sc u0 c-1 {1,S} 
+""",
+	solute = u'N5dc-CdO0sc(Crd-Crd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1104,
+	label = "N5dc",
+	group = 
+"""
+1 * N5dc u0 c+1
+""",
+	solute = u'N5dc-OdO0scC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1105,
+	label = "N5dc-OdO0scC",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   C    u0 {1,S}
+""",
+	solute = u'N5dc-OdO0scCb',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1106,
+	label = "N5dc-OdO0scCb",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01052,
+		B = -0.02704,
+		E = -0.06471,
+		L = -0.00701,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 301,
+		B = 299,
+		E = 303,
+		L = 258,
+		A = 307,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1107,
+	label = "N5dc-OdO0scCs",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   Cs   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.07052,
+		B = 0.04093,
+		E = -0.11504,
+		L = -0.28616,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 15,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1108,
+	label = "N5dc-OdO0scCd",
+	group = 
+"""
+1 * N5dc        u0 c+1 {2,D} {3,S} {4,S}
+2   O2d         u0 {1,D}
+3   O0sc        u0 c-1 {1,S}
+4   [Cd,CO,CS]  u0 {1,S}
+""",
+	solute = u'N5dc-OdO0sc(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1109,
+	label = "N5dc-OdO0sc(Cd-Cd)",
+	group = 
+"""
+1 * N5dc        u0 c+1 {2,D} {3,S} {4,S}
+2   O2d         u0 {1,D}
+3   O0sc        u0 c-1 {1,S}
+4   Cd          u0 {1,S} {5,D}
+5   C           u0 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.05238,
+		B = 0.05110,
+		E = 0.02977,
+		L = 0.39693,
+		A = 0.03358,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1110,
+	label = "N5dc-OdO0sc(Crd-Crd)",
+	group = 
+"""
+1 * N5dc        u0 c+1 {2,D} {3,S} {4,S}
+2   O2d         u0 {1,D}
+3   O0sc        u0 c-1 {1,S}
+4   Cd          u0 r1 {1,S} {5,D}
+5   C           u0 r1 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.09024,
+		B = -0.01540,
+		E = 0.07609,
+		L = 0.28353,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 26,
+		L = 21,
+		A = 22,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1111,
+	label = "N5dc-OdO0sc(Cd-Nd)",
+	group = 
+"""
+1 * N5dc        u0 c+1 {2,D} {3,S} {4,S}
+2   O2d         u0 {1,D}
+3   O0sc        u0 c-1 {1,S}
+4   Cd          u0 {1,S} {5,D}
+5   N           u0 {4,D}
+""",
+	solute = u'N5dc-OdO0sc(Crd-N3rd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1112,
+	label = "N5dc-OdO0sc(Crd-N3rd)",
+	group = 
+"""
+1 * N5dc        u0 c+1 {2,D} {3,S} {4,S}
+2   O2d         u0 {1,D}
+3   O0sc        u0 c-1 {1,S}
+4   Cd          u0 r1 {1,S} {5,D}
+5   N3d         u0 r1 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.03927,
+		B = -0.00815,
+		E = 0.11728,
+		L = 0.01902,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 12,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1113,
+	label = "N5dc-OdO0scO2s",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   O2s  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09525,
+		B = -0.07354,
+		E = -0.06071,
+		L = 0.07396,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 8,
+		E = 12,
+		L = 8,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1114,
+	label = "N5dc-OdO0scN",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   O2d  u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   N    u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.05141,
+		B = 0.08585,
+		E = 0.03266,
+		L = -0.13313,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 8,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1115,
+	label = "N5dc-CdO0scC",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   Cd   u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   C    u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10305,
+		B = 0.02319,
+		E = 0.05358,
+		L = 0.27670,
+		A = -0.00735,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1116,
+	label = "N5dc-CdO0scCd",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   Cd   u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   Cd   u0 {1,S}
+""",
+	solute = u'N5dc-CdO0sc(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1117,
+	label = "N5dc-CdO0sc(Cd-Cd)",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   Cd   u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   Cd   u0 {1,S} {5,D}
+5   C    u0 {4,D}
+""",
+	solute = u'N5dc-CdO0sc(Crd-Crd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1118,
+	label = "N5dc-CdO0sc(Crd-Crd)",
+	group = 
+"""
+1 * N5dc u0 c+1 {2,D} {3,S} {4,S}
+2   Cd   u0 {1,D}
+3   O0sc u0 c-1 {1,S}
+4   Cd   u0 r1 {1,S} {5,D}
+5   C    u0 r1 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.08199,
+		B = 0.09045,
+		E = 0.07957,
+		L = 0.36450,
+		A = 0.06846,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 19,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1119,
+	label = "N5ddc",
+	group = 
+"""
+1 * N5ddc u0 p0 c+1
+""",
+	solute = u'N5ddc-N1dcN3d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1120,
+	label = "N5ddc-N1dcN3d",
+	group = 
+"""
+1 * N5ddc u0 p0 c+1 {2,D} {3,D}
+2   N1dc  u0 c-1 {1,D}
+3   N3d   u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.04468,
+		B = 0.00000,
+		E = 0.09588,
+		L = 0.39946,
+		A = 0.01261,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1121,
+	label = "N5tc",
+	group = 
+"""
+1 * N5tc u0 p0 c+1
+""",
+	solute = u'N5tc-C2tcC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1122,
+	label = "N5tc-C2tcC",
+	group = 
+"""
+1 * N5tc u0 p0 c+1 {2,T} {3,S}
+2   C2tc u0 c-1 {1,T}
+3   C    u0 {1,S}
+""",
+	solute = u'N5tc-C2tcCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1123,
+	label = "N5tc-C2tcCs",
+	group = 
+"""
+1 * N5tc u0 p0 c+1 {2,T} {3,S}
+2   C2tc u0 c-1 {1,T}
+3   Cs   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04195,
+		B = -0.00307,
+		E = 0.03744,
+		L = 0.13348,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1124,
+	label = "N5tc-C2tcCb",
+	group = 
+"""
+1 * N5tc u0 p0 c+1 {2,T} {3,S}
+2   C2tc u0 c-1 {1,T}
+3   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03915,
+		B = 0.02085,
+		E = 0.04258,
+		L = 0.24081,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1125,
+	label = "P",
+	group = 
+"""
+1 * P u0
+""",
+	solute = u'P3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1126,
+	label = "P3s",
+	group = 
+"""
+1 * P3s u0
+""",
+	solute = u'P3s-CCC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1127,
+	label = "P3s-O2sO2sO2s",
+	group = 
+"""
+1 * P3s u0 {2,S} {3,S} {4,S}
+2   O2s u0 {1,S}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03939,
+		B = 0.06846,
+		E = 0.00644,
+		L = 0.17857,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1128,
+	label = "P3s-CCC",
+	group = 
+"""
+1 * P3s u0 {2,S} {3,S} {4,S}
+2   C   u0 {1,S}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+""",
+	solute = u'P3s-CsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1129,
+	label = "P3s-CsCsCs",
+	group = 
+"""
+1 * P3s u0 {2,S} {3,S} {4,S}
+2   Cs  u0 {1,S}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02119,
+		B = 0.04241,
+		E = 0.03763,
+		L = 0.20245,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1130,
+	label = "P3s-CbCbCb",
+	group = 
+"""
+1 * P3s u0 {2,S} {3,S} {4,S}
+2   Cb  u0 {1,S}
+3   Cb  u0 {1,S}
+4   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01826,
+		B = 0.02522,
+		E = 0.04446,
+		L = 0.28633,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1131,
+	label = "P5d",
+	group = 
+"""
+1 * P5d u0
+""",
+	solute = u'P5d-O2d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1132,
+	label = "P5d-O2d",
+	group = 
+"""
+1 * P5d u0 {2,D}
+2   O2d u0 {1,D}
+""",
+	solute = u'P5d-O2dO2sO2sO2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1133,
+	label = "P5d-O2dO2sCH",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   C   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05910,
+		B = 0.02484,
+		E = 0.00977,
+		L = 0.20991,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 5,
+		L = 2,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1134,
+	label = "P5d-O2dO2sO2sH",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03548,
+		B = 0.02141,
+		E = -0.01617,
+		L = -0.05763,
+		A = 0.01667,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 1,
+		E = 5,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1135,
+	label = "P5d-O2dNNN",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   N   u0 {1,S}
+4   N   u0 {1,S}
+5   N   u0 {1,S}
+""",
+	solute = u'P5d-O2dN3sN3sN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1136,
+	label = "P5d-O2dN3sN3sN3s",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   N3s u0 {1,S}
+4   N3s u0 {1,S}
+5   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01261,
+		B = 0.01671,
+		E = -0.01180,
+		L = 0.03831,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1137,
+	label = "P5d-O2dCCC",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   C   u0 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = u'P5d-O2dCsCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1138,
+	label = "P5d-O2dCbCbCb",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   Cb  u0 {1,S}
+4   Cb  u0 {1,S}
+5   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03711,
+		B = 0.10339,
+		E = -0.05135,
+		L = 0.12497,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1139,
+	label = "P5d-O2dCsCsCs",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   Cs  u0 {1,S}
+4   Cs  u0 {1,S}
+5   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06224,
+		B = 0.11382,
+		E = 0.06389,
+		L = 0.23542,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 9,
+		L = 1,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1140,
+	label = "P5d-O2dO2sCC",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   C   u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = u'P5d-O2dO2sCsCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1141,
+	label = "P5d-O2dO2sCbCb",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   Cb  u0 {1,S}
+5   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04972,
+		B = -0.01787,
+		E = 0.07423,
+		L = 0.05448,
+		A = -0.02595,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1142,
+	label = "P5d-O2dO2sCbCs",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   Cb  u0 {1,S}
+5   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01258,
+		B = -0.05228,
+		E = 0.03358,
+		L = 0.12447,
+		A = -0.04373,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1143,
+	label = "P5d-O2dO2sCsCs",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   Cs  u0 {1,S}
+5   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04377,
+		B = 0.04838,
+		E = 0.00145,
+		L = -0.03121,
+		A = -0.04156,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 8,
+		L = 5,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1144,
+	label = "P5d-O2dO2sO2sN",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   N   u0 {1,S}
+""",
+	solute = u'P5d-O2dO2sO2sN3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1145,
+	label = "P5d-O2dO2sO2sN3s",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.14510,
+		B = -0.06299,
+		E = -0.05811,
+		L = 0.06398,
+		A = 0.10290,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1146,
+	label = "P5d-O2dO2sO2sC",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   C   u0 {1,S}
+""",
+	solute = u'P5d-O2dO2sO2sCs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1147,
+	label = "P5d-O2dO2sO2sCs",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   Cs  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.10011,
+		B = 0.08711,
+		E = 0.02767,
+		L = 0.41582,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 16,
+		L = 11,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1148,
+	label = "P5d-O2dO2sO2sCd",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   [Cd,CO,CS]  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03345,
+		B = 0.03803,
+		E = 0.05408,
+		L = 0.16385,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1149,
+	label = "P5d-O2dO2sO2sO2s",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   O2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00413,
+		B = 0.01377,
+		E = -0.10957,
+		L = -0.31601,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 30,
+		B = 30,
+		E = 31,
+		L = 30,
+		A = 33,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1150,
+	label = "P5d-N3d",
+	group = 
+"""
+1 * P5d u0 {2,D}
+2   N3d u0 {1,D}
+""",
+	solute = u'P5d-N3dNOO',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1151,
+	label = "P5d-N3dNHH",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = u'P5d-N3dN3dHH',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1152,
+	label = "P5d-N3dN3dHH",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   N3d u0 {1,D}
+3   N3d u0 {1,S}
+4   H   u0 {1,S}
+5   H   u0 {1,S}
+""",
+	solute = u'P5d-N3dN3dO2sO2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1153,
+	label = "P5d-N3dNOO",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   N3d u0 {1,D}
+3   N   u0 {1,S}
+4   O   u0 {1,S}
+5   O   u0 {1,S}
+""",
+	solute = u'P5d-N3dNOO',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1154,
+	label = "P5d-N3dN3dO2sO2s",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   N3d u0 {1,D}
+3   N3d u0 {1,S}
+4   O2s u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03994,
+		B = 0.09164,
+		E = 0.06619,
+		L = 0.40872,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1155,
+	label = "P5d-S2d",
+	group = 
+"""
+1 * P5d u0 {2,D}
+2   S2d u0 {1,D}
+""",
+	solute = u'P5d-S2dO2sO2sO2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1156,
+	label = "P5d-S2dO2sO2sS",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   S2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   S   u0 {1,S}
+""",
+	solute = u'P5d-S2dO2sO2sS2s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1157,
+	label = "P5d-S2dO2sO2sS2s",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   S2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   S2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.04395,
+		B = 0.07729,
+		E = 0.18675,
+		L = 0.74347,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1158,
+	label = "P5d-S2dO2sO2sO2s",
+	group = 
+"""
+1 * P5d u0 {2,D} {3,S} {4,S} {5,S}
+2   S2d u0 {1,D}
+3   O2s u0 {1,S}
+4   O2s u0 {1,S}
+5   O2s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.03503,
+		B = 0.04163,
+		E = 0.09555,
+		L = 0.23338,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+tree(
+"""
+L1: R
+	L2: C
+		L3: C2tc
+			L4: C2tc-N5tc
+		L3: Cbf
+			L4: Cbf-CbCbCbf
+			L4: Cbf-CbCbfCbf
+			L4: Cbf-CbfCbfCbf
+		L3: Cb
+			L4: Cb-H
+			L4: Cb-P
+				L5: Cb-P3s
+				L5: Cb-P5d
+			L4: Cb-O
+				L5: Cb-O2s
+					L6: Cb-O2rs
+			L4: Cb-S
+				L5: Cb-S2s
+					L6: Cb-S2rs
+				L5: Cb-S4d
+				L5: Cb-S6dd
+			L4: Cb-N
+				L5: Cb-N3s
+					L6: Cb-N3rs
+				L5: Cb-N3d
+					L6: Cb-N3rd
+				L5: Cb-N5dc
+				L5: Cb-N5tc
+			L4: Cb-C
+				L5: Cb-Cb
+				L5: Cb-Cr
+				L5: Cb-Cs
+					L6: Cb-(Cs-Cb)
+					L6: Cb-(Cs-Cr)
+				L5: Cb-Cds
+					L6: Cb-(Cds-O2d)
+						L7: Cb-(Cds-O2dOs)
+					L6: Cb-(Cds-Cd)
+					L6: Cb-(Cds-N3d)
+					L6: Cb-(Cds-S2d)
+				L5: Cb-Ct
+					L6: Cb-(CtCt)
+					L6: Cb-(CtN3t)
+		L3: Ct
+			L4: Ct-N3tN
+			L4: Ct-N3tS
+				L5: Ct-N3tS2s
+			L4: Ct-CtH
+			L4: Ct-N3tO
+				L5: Ct-N3tOs
+			L4: Ct-N3tC
+				L5: Ct-N3tCb
+				L5: Ct-N3tCs
+				L5: Ct-N3tCd
+				L5: Ct-N3tCt
+					L6: Ct-N3t(CtN3t)
+			L4: Ct-CtC
+				L5: Ct-CtCs
+				L5: Ct-CtCds
+					L6: Ct-Ct(Cds-O2d)
+					L6: Ct-Ct(Cds-Cd)
+						L7: Ct-Ct(Cds-Cds)
+				L5: Ct-CtCt
+					L6: Ct-Ct(CtCt)
+				L5: Ct-CtCb
+		L3: Cdd
+			L4: Cdd-CdCd
+				L5: Cdd-CdsCds
+			L4: Cdd-N3dO2d
+			L4: Cdd-N3dS
+				L5: Cdd-N3dS2d
+		L3: Cds
+			L4: Cds-Od
+				L5: Cds-OdNC
+					L6: Cds-OdN3sC
+						L7: Crds-OdN3rsCr
+						L7: Cds-OdN3sCb
+							L8: Cds-Od(N3s-HH)Cb
+							L8: Cds-Od(N3s-RH)Cb
+							L8: Cds-Od(N3s-RR)Cb
+						L7: Cds-OdN3sCs
+							L8: Cds-OdN3rsCs
+							L8: Cds-Od(N3s-HH)Cs
+							L8: Cds-Od(N3s-RH)Cs
+							L8: Cds-Od(N3s-RR)Cs
+						L7: Cds-OdN3sCd
+							L8: Cds-OdN3rsCd
+							L8: Cds-OdN3sCrd
+					L6: Cds-OdN3dC
+						L7: Crds-OdN3rdCr
+				L5: Cds-OdNH
+				L5: Cds-OdNN
+					L6: Cds-OdN3sN
+						L7: Cds-OdN3sN3s
+							L8: Crds-OdN3rsN3rs
+							L8: Cds-OdN3rsN3s
+						L7: Cds-OdN3sN3d
+							L8: Crds-OdN3rsN3rd
+				L5: Cds-OdNOs
+					L6: Cds-OdN3rsOs
+					L6: Cds-Od(N3sHH)Os
+					L6: Cds-Od(N3sCH)Os
+					L6: Cds-Od(N3sCC)Os
+				L5: Cds-OdNS
+				L5: Cds-OdOsH
+				L5: Cds-OdOsOs
+				L5: Cds-OdCS
+					L6: Cds-OdCsSs
+				L5: Cds-OdCH
+					L6: Cds-OdCsH
+					L6: Cds-OdCdsH
+						L7: Cds-O2d(Cds-O2d)H
+						L7: Cds-O2d(Cds-Cd)H
+							L8: Cds-O2d(Cds-Cds)H
+					L6: Cds-OdCtH
+						L7: Cds-Od(Ct-(Ct-H))H
+					L6: Cds-OdCbH
+				L5: Cds-OdPOs
+					L6: Cds-OdP5dOs
+						L7: Cds-OdP5d(OsH)
+				L5: Cds-OdCOs
+					L6: Cds-OdCtOs
+					L6: Cds-OdC(OsH)
+						L7: Cds-OdCs(OsH)
+						L7: Cds-OdCds(OsH)
+							L8: Cds-Od(Cds-O2d)(OsH)
+							L8: Cds-Od(Cds-Cd)(OsH)
+								L9: Cds-Od(Crds-Crd)(OsH)
+							L8: Cds-Od(Cds-N3d)(OsH)
+						L7: Cds-OdCb(OsH)
+					L6: Cds-OdCsOs
+						L7: Crds-OdCrsOrs
+						L7: Cds-OdCrsOs
+					L6: Cds-OdCdsOs
+						L7: Crds-OdCrdsOrs
+						L7: Cds-OdCrdsOs
+						L7: Cds-O2d(Cds-O2d)O2s
+						L7: Cds-O2d(Cds-Cd)O2s
+							L8: Cds-O2d(Cds-Cds)O2s
+					L6: Cds-OdCbOs
+				L5: Cds-OdCC
+					L6: Cds-OdCsCs
+						L7: Crds-OdCrsCrs
+						L7: Cds-OdCrsCrs
+						L7: Cds-OdCrsCs
+					L6: Cds-OdCdsCs
+						L7: Cds-O2d(Cds-O2d)Cs
+						L7: Cds-O2d(Cds-Cd)Cs
+							L8: Crds-O2d(Crds-Crd)Crs
+							L8: Cds-O2d(Crds-Crd)Cs
+						L7: Cds-O2d(Cds-N3d)Cs
+					L6: Cds-OdCdsCds
+						L7: Cds-O2d(Cds-Cd)(Cds-O2d)
+							L8: Crds-O2d(Crds-Cd)(Crds-O2d)
+						L7: Cds-O2d(Cds-Cd)(Cds-Cd)
+							L8: Crds-O2d(Crds-Cd)(Crds-Cd)
+						L7: Cds-O2d(Cds-Cd)(Cds-N3d)
+					L6: Cds-OdCbCs
+						L7: Crds-OdCbCrs
+					L6: Cds-OdCbCds
+						L7: Cds-OdCb(Cds-O2d)
+						L7: Cds-OdCb(Cds-Cd)
+							L8: Crds-OdCb(Crds-Cd)
+							L8: Cds-OdCb(Crds-Cd)
+						L7: Cds-OdCb(Cds-N3d)
+							L8: Crds-OdCb(Crds-N3rd)
+					L6: Cds-OdCbCb
+						L7: Crds-OdCbCb
+			L4: Cds-Nd
+				L5: Cds-N3dCC
+					L6: Cds-N3dCbCb
+					L6: Cds-N3dCbCs
+						L7: Crds-N3rdCbCrs
+						L7: Crds-N3rdCbCs
+					L6: Cds-N3dCbCd
+						L7: Cds-N3dCb(Cd-O2d)
+					L6: Cds-N3dCsCs
+						L7: Crds-N3rdCrsCs
+						L7: Crds-N3dCrsCrs
+					L6: Cds-N3dCdCs
+						L7: Cds-N3d(Cd-N3d)Cs
+							L8: Crds-N3rd(Crd-N3rd)Cs
+						L7: Cds-N3d(Cd-Cd)Cs
+							L8: Crds-N3rd(Crd-Crd)Cs
+					L6: Cds-N3dCdCd
+						L7: Crds-N3rdCrdCrd
+						L7: Crds-N3rdCrdCd
+					L6: Cds-N3dCtC
+				L5: Cds-N3dCO
+					L6: Crds-N3rdCrO
+					L6: Crds-N3rdCOr
+				L5: Cds-N3dCS
+					L6: Crds-N3rdCrS
+					L6: Crds-N3rdCSr
+				L5: Cds-N3dCH
+					L6: Cds-N3dCbH
+						L7: Crds-N3rdCbH
+					L6: Cds-N3dCdH
+						L7: Crds-N3rdCrdH
+						L7: Cds-N3dCrdH
+					L6: Cds-N3dCsH
+						L7: Crds-N3rdCrsH
+						L7: Cds-(N3d-(O-H))CsH
+				L5: Cds-N3dNN
+					L6: Cds-N3dN3sN3s
+						L7: Crds-N3rdN3rsN3s
+					L6: Cds-N3dN3dN3s
+						L7: Crds-N3rdN3rdN3s
+					L6: Cds-N3dN3sN5dc
+						L7: Crds-N3rdN3rsN5dc
+					L6: Cds-N3dN3dN5dc
+						L7: Crds-N3rdN3rdN5dc
+				L5: Cds-N3dNC
+					L6: Cds-N3dN3sC
+						L7: Crds-N3rdN3rsCr
+						L7: Crds-N3rdN3rsC
+						L7: Crds-N3rdN3sCr
+					L6: Cds-N3dN3dC
+						L7: Crds-N3rdN3rdCr
+						L7: Crds-N3rdN3rdC
+				L5: Cds-N3dNO
+					L6: Crds-N3rdNrO
+					L6: Crds-N3rdNOr
+				L5: Cds-N3dNS
+					L6: Crds-N3rdNrS
+					L6: Crds-N3rdNSr
+				L5: Cds-N3dNH
+					L6: Cds-N3dN3sH
+						L7: Crds-N3rdN3rsH
+					L6: Cds-N3dN3dH
+						L7: Crds-N3rdN3rdH
+				L5: Cds-N3dOH
+					L6: Crds-N3rdOrH
+				L5: Cds-N3dSS
+					L6: Crds-N3rdSrS
+				L5: Cds-N3dSH
+					L6: Crds-N3rdSrH
+				L5: Cds-N5dc
+					L6: Crds-N5rdc
+			L4: Cds-Cd
+				L5: Cds-CdHH
+					L6: Cds-CdsHH
+						L7: Cds-CrdsHH
+					L6: Cds-CddHH
+						L7: Cds-(Cdd-Cd)HH
+				L5: Cds-CdOsH
+					L6: Cds-CdsOsH
+						L7: Crds-CrdsOrsH
+				L5: Cds-CdOsOs
+					L6: Cds-CdsOsOs
+						L7: Crds-CrdsOrsOs
+				L5: Cds-CdPH
+					L6: Cds-CdP5dH
+				L5: Cds-CdNH
+					L6: Cds-CdN3sH
+						L7: Crds-CrdN3rsH
+					L6: Cds-CdN3dH
+						L7: Crds-CrdN3rdH
+					L6: Cds-CdN5dcH
+						L7: Crds-CrdN5rdcH
+				L5: Cds-CdNN
+					L6: Cds-CdN3sN3s
+					L6: Cds-CdN3sN3d
+						L7: Crds-CrdN3rsN3rd
+						L7: Crds-CrdN3sN3rd
+					L6: Cds-CdN3dN3d
+					L6: Cds-CdN3sN5dc
+					L6: Cds-CdN3dN5dc
+				L5: Cds-CdNO
+					L6: Cds-CdN3sO
+					L6: Cds-CdN3dO
+					L6: Cds-CdN5dcO
+				L5: Cds-CdNS
+				L5: Cds-CdSH
+					L6: Cds-CdsSH
+						L7: Cds-CdsS2H
+							L8: Crds-CrdsS2rH
+				L5: Cds-CdCH
+					L6: Cds-CdsCsH
+						L7: Crds-CrdsCrsH
+						L7: Cds-CrdsCsH
+						L7: Cds-CdsCrsH
+					L6: Cds-CdsCdsH
+						L7: Cds-Cd(Cd-O2d)H
+							L8: Crds-Crd(Crd-O2d)H
+						L7: Cds-Cd(Cd-N3d)H
+							L8: Crds-Crd(Crd-N3rd)H
+							L8: Cds-Cd(Crd-N3rd)H
+						L7: Cds-Cd(Cd-N5dc)H
+						L7: Cds-Cds(Cds-Cd)H
+							L8: Cds-Cds(Cds-Cds)H
+								L9: Crds-Crds(Crds-Crds)H
+								L9: Crds-Crds(Crds-Cds)H
+								L9: Cds-Cds(Crds-Crds)H
+					L6: Cds-CdsCtH
+						L7: Cds-CdsH(Ct-N3t)
+						L7: Cds-CdsH(Ct-Ct)
+					L6: Cds-CdsCbH
+						L7: Crds-CrdsCbH
+					L6: Cds-CddCH
+				L5: Cds-CdCO
+					L6: Cds-CdsCdsOs
+						L7: Cds-Cds(Cds-O2d)O2s
+							L8: Crds-Crds(Crds-O2d)O2s
+								L9: Crds-Crds(Crds-O2d)(O2s-H)
+								L9: Crds-Crds(Crds-O2d)(O2s-R)
+							L8: Crds-Crds(Cds-O2d)O2rs
+						L7: Cds-Cds(Cds-N3d)O2s
+							L8: Cds-Cds(Cds-N3d)(O2s-H)
+								L9: Crds-Crds(Crds-Nr3d)(O2s-H)
+							L8: Cds-Cds(Cds-N3d)(O2s-R)
+						L7: Cds-Cds(Cds-Cd)O2s
+							L8: Cds-Cds(Cds-Cds)O2s
+					L6: Cds-CdsCbOs
+						L7: Crds-CrdsCbOrs
+						L7: Crds-CrdsCbOs
+					L6: Cds-CdCsOs
+						L7: Cds-CdsCsOs
+							L8: Crds-CrdsCsOrs
+					L6: Cds-CdCtOs
+						L7: Crds-CrdCtOrs
+				L5: Cds-CdCS
+					L6: Cds-CdsCsSs
+						L7: Cds-CdsCsS2
+							L8: Crds-CrdsCsS2r
+					L6: Cds-CdsCdsSs
+						L7: Cds-Cds(Cds-Cd)S2s
+						L7: Cds-Cds(Cds-O2d)S2s
+					L6: Cds-CdsCS6dd
+				L5: Cds-CdCC
+					L6: Cds-CdsCsCs
+						L7: Crds-CrdsCrsCrs
+						L7: Crds-CrdsCrsCs
+						L7: Cds-CrdsCsCs
+						L7: Cds-CdsCrsCs
+					L6: Cds-CdsCdsCs
+						L7: Cds-Cd(Cds-O2d)Cs
+							L8: Crds-Crd(Crds-O2d)Cs
+						L7: Cds-Cd(Cds-N3d)Cs
+							L8: Crds-Crd(Crds-N3rd)Cs
+						L7: Cds-Cds(Cds-Cd)Cs
+							L8: Cds-Cds(Cds-Cds)Cs
+								L9: Crds-Crds(Crds-Crds)Cs
+								L9: Crds-Cds(Crds-Crds)Crs
+					L6: Cds-CdsCdsCds
+						L7: Cds-Cds(Cds-O2d)(Cds-O2d)
+							L8: Crds-Crds(Crds-O2d)(Cds-O2d)
+						L7: Cds-Cds(Cds-O2d)(Cds-Cd)
+							L8: Cds-Cds(Cds-O2d)(Cds-Cds)
+								L9: Crds-Crds(Cds-O2d)(Crds-Crds)
+						L7: Cds-Cds(Cds-O2d)(Cds-N3d)
+							L8: Crds-Crds(Crds-O2d)(Crds-N3rd)
+							L8: Crds-Crds(Cds-O2d)(Crds-N3rd)
+						L7: Cds-Cds(Cds-N3d)(Cds-N3d)
+						L7: Cds-Cds(Cds-Cd)(Cds-N3d)
+							L8: Crds-Crds(Crds-Crd)(Crds-N3rd)
+						L7: Cds-Cds(Cds-Cd)(Cds-Cd)
+							L8: Cds-Cds(Cds-Cds)(Cds-Cds)
+					L6: Cds-CdsCtCs
+						L7: Cds-CdCs(CtN3t)
+					L6: Cds-CdsCtCds
+					L6: Cds-CdsCtCt
+						L7: Cds-Cd(CtN3t)(CtN3t)
+					L6: Cds-CdsCbCs
+						L7: Crds-CrdsCbCrs
+						L7: Crds-CrdsCbCs
+					L6: Cds-CdsCbCds
+						L7: Cds-CdsCb(Cds-O2d)
+							L8: Crds-CrdsCb(Crds-O2d)
+						L7: Cds-CdsCb(Cds-N3d)
+						L7: Cds-Cds(Cds-Cd)Cb
+							L8: Cds-Cds(Cds-Cds)Cb
+					L6: Cds-CdsCbCb
+					L6: Cds-CddCC
+						L7: Cds-(Cdd-Cd)CC
+				L5: Cds-CdCN
+					L6: Cds-CdCbN3s
+					L6: Cds-CdCsN3s
+					L6: Cds-CdCdsN3s
+						L7: Cds-Cd(Cds-O2d)N3s
+						L7: Cds-Cd(Cds-N3d)N3s
+						L7: Cds-Cd(Cds-Cds)N3s
+					L6: Cds-CdCbN3d
+					L6: Cds-CdCsN3d
+					L6: Cds-CdCdsN3d
+					L6: Cds-CdCtN3d
+					L6: Cds-CdCN5dc
+			L4: Cds-Sd
+				L5: Cds-S2dNN
+				L5: Cds-S2dNC
+				L5: Cds-S2dNS
+				L5: Cds-S2dOC
+		L3: Cs
+			L4: Cs-P3s
+				L5: Cs-P3sHHH
+				L5: Cs-P3sRHH
+					L6: Cs-P3sCsHH
+			L4: Cs-P5d
+				L5: Cs-P5dHHH
+					L6: Cs-(P5d-O2d)HHH
+				L5: Cs-P5dRHH
+					L6: Cs-P5dNHH
+						L7: Cs-P5dN3sHH
+					L6: Cs-P5dCHH
+						L7: Cs-P5dCsHH
+					L6: Cs-P5dOsHH
+				L5: Cs-P5dOCH
+					L6: Cs-P5d(O-H)CH
+				L5: Cs-P5dOCC
+					L6: Cs-P5d(O-H)CC
+				L5: Cs-P5dCCC
+					L6: Cs-P5dCsCsCs
+			L4: Cs-NHHH
+				L5: Cs-N3sHHH
+					L6: Cs-N3rsHHH
+					L6: Cs-(N3s-RH)HHH
+					L6: Cs-(N3s-RR)HHH
+				L5: Cs-N3dHHH
+					L6: Cs-(N3dCd)HHH
+				L5: Cs-N5cHHH
+			L4: Cs-NNHH
+			L4: Cs-NOHH
+				L5: Cs-N3sOHH
+					L6: Cs-N3rsOHH
+			L4: Cs-NSHH
+			L4: Cs-NCHH
+				L5: Cs-NCbHH
+					L6: Crs-NrCbHH
+					L6: Cs-NrCbHH
+				L5: Cs-NCsHH
+					L6: Cs-N3sCsHH
+						L7: Crs-N3rsCrsHH
+						L7: Cs-N3rsCsHH
+					L6: Cs-N3dCHH
+						L7: Cs-(N3d-Nd)CsHH
+						L7: Cs-(N3d-Cd)CsHH
+						L7: Cs-(N3d-Cdd)CsHH
+					L6: Cs-N5cCsHH
+				L5: Cs-NCdsHH
+					L6: Cs-N(Cds-O2d)HH
+						L7: Cs-N(Cds-O2d(OsH))HH
+					L6: Cs-N(Cds-Cd)HH
+					L6: Cs-N(Cds-N3d)HH
+				L5: Cs-NCtHH
+			L4: Cs-NNCH
+			L4: Cs-NOCH
+			L4: Cs-NSCH
+			L4: Cs-NCCH
+				L5: Cs-NCsCsH
+					L6: Cs-N3sCsCsH
+						L7: Crs-N3rsCrsCrsH
+						L7: Crs-N3sCrsCrsH
+						L7: Crs-N3rsCrsCsH
+					L6: Cs-N3dCsCsH
+					L6: Cs-N5dcCsCsH
+				L5: Cs-NCsCdsH
+					L6: Cs-NCs(Cds-O2d)H
+					L6: Cs-NCs(Cds-Cd)H
+			L4: Cs-NOCR
+			L4: Cs-NCCC
+				L5: Cs-NCsCsCs
+					L6: Cs-N3CsCsCs
+					L6: Cs-N5dcCsCsCs
+				L5: Cs-NCdCbCb
+					L6: Cs-N3s(Cd-O2d)CbCb
+			L4: Cs-NNNN
+				L5: Cs-N5dcN5dcN5dcN5dc
+			L4: Cs-OsHHH
+			L4: Cs-OsOsHH
+				L5: Crs-OrsOrsHH
+			L4: Cs-OsSHH
+				L5: Cs-OsS2HH
+			L4: Cs-OsOsOsH
+			L4: Cs-OsOsOsCs
+			L4: Cs-CHHH
+				L5: Cs-CsHHH
+				L5: Cs-CdsHHH
+					L6: Cs-(Cds-O2d)HHH
+					L6: Cs-(Cds-Cd)HHH
+						L7: Cs-(Cds-Cds)HHH
+						L7: Cs-(Cds-Cdd)HHH
+							L8: Cs-(Cds-Cdd-Cd)HHH
+					L6: Cs-(Cd-Nd)HHH
+					L6: Cs-(Cd-S2d)SHHH
+				L5: Cs-CtHHH
+					L6: Cs-(Ct-Ct)HHH
+				L5: Cs-CbHHH
+			L4: Cs-CCHH
+				L5: Crs-CrCrHH
+					L6: Crs-CrsCrsHH
+					L6: Crs-CrdsCrsHH
+						L7: Crs-(Crds-Cd)CrsHH
+							L8: Crs-(Crds-Crd)CrsHH
+						L7: Crs-(Crds-O2d)CrsHH
+						L7: Crs-(Crds-Nd)CrsHH
+							L8: Crs-(Crds-Nrd)CrsHH
+								L9: Crs-(Crds-N3rd)CrsHH
+							L8: Crs-(Crds-N3d)CrsHH
+					L6: Crs-CrdsCrdsHH
+					L6: Crs-CbCrsHH
+					L6: Crs-CbCrdsHH
+					L6: Crs-CbCbHH
+				L5: Cs-CsCsHH
+				L5: Cs-CdsCsHH
+					L6: Cs-(Cds-O2d)CsHH
+					L6: Cs-(Cds-Cd)CsHH
+						L7: Cs-(Cds-Cds)CsHH
+						L7: Cs-(Cds-Cdd)CsHH
+							L8: Cs-(Cds-Cdd-Cd)CsHH
+					L6: Cs-(Cd-N3d)CsHH
+					L6: Cs-(Cds-S2d)CsHH
+				L5: Cs-CdsCdsHH
+					L6: Cs-(Cds-O2d)(Cds-O2d)HH
+					L6: Cs-(Cds-O2d)(Cds-Cd)HH
+						L7: Cs-(Cds-O2d)(Cds-Cds)HH
+					L6: Cs-(Cds-Cd)(Cds-Cd)HH
+						L7: Cs-(Cds-Cds)(Cds-Cds)HH
+				L5: Cs-CtCsHH
+					L6: Cs-(Ct-N3t)CsHH
+					L6: Cs-(Ct-Ct)CsHH
+				L5: Cs-CtCdsHH
+				L5: Cs-CtCtHH
+					L6: Cs-(Ct-N3t)(Ct-N3t)HH
+				L5: Cs-CbCsHH
+				L5: Cs-CbCdsHH
+					L6: Cs-(Cds-O2d)CbHH
+					L6: Cs-(Cds-Cd)CbHH
+						L7: Cs-(Cds-Cds)CbHH
+					L6: Cs-(Cds-N3d)CbHH
+				L5: Cs-CbCtHH
+				L5: Cs-CbCbHH
+			L4: Cs-CCCH
+				L5: Crs-CrCrCrH
+					L6: Crs-CrsCrsCrsH
+					L6: Crs-CrdCrsCrsH
+						L7: Crs-(Crd-Cd)CrsCrsH
+							L8: Crs-(Crd-Crd)CrsCrsH
+						L7: Crs-(Crd-O2d)CrsCrsH
+					L6: Crs-CbCrsCrsH
+					L6: Crs-CrdCrdCrsH
+					L6: Crs-CbCrdCrsH
+					L6: Crs-CbCrdCrdH
+					L6: Crs-CbCbCrsH
+				L5: Crs-CrCrCH
+					L6: Crs-CrsCrsCsH
+					L6: Crs-CrsCrsCdH
+					L6: Crs-CrsCrsCtH
+						L7: Crs-CrsCrs(Ct-N3t)H
+						L7: Crs-CrsCrs(Ct-Ct)H
+					L6: Crs-CrdCrsCsH
+					L6: Crs-CrdCrsCdH
+					L6: Crs-CrdCrdCsH
+					L6: Crs-CrdCrdCdH
+					L6: Crs-CbCrsCsH
+					L6: Crs-CbCbCsH
+				L5: Cs-CsCsCsH
+				L5: Cs-CdsCsCsH
+					L6: Cs-(Cds-O2d)CsCsH
+					L6: Cs-(Cds-Cd)CsCsH
+						L7: Cs-(Cds-Cds)CsCsH
+					L6: Cs-(CdN3d)CsCsH
+				L5: Cs-CtCsCsH
+					L6: Cs-(Ct-N3t)CsCsH
+					L6: Cs-(Ct-Ct)CsCsH
+				L5: Cs-CbCsCsH
+				L5: Cs-CdsCdsCsH
+				L5: Cs-CbCdsCsH
+					L6: Cs-(Cds-O2d)CbCsH
+					L6: Cs-(Cds-Cd)CbCsH
+						L7: Cs-(Cds-Cds)CbCsH
+				L5: Cs-CbCbCsH
+				L5: Cs-CbCdsCdsH
+				L5: Cs-CbCbCdsH
+					L6: Cs-CbCb(Cds-O2d)H
+				L5: Cs-CbCbCbH
+			L4: Cs-CCCC
+				L5: Crs-CrCrCrCr
+					L6: Crs-CrsCrsCrsCrs
+					L6: Crs-CbCrsCrsCrs
+					L6: Crs-CrdCrsCrsCrs
+					L6: Crs-CbCrdCrsCrs
+				L5: Crs-CrCrCrC
+					L6: Crs-CrsCrsCrsCs
+					L6: Crs-CbCrsCrsCs
+					L6: Crs-CbCrsCrsCd
+					L6: Crs-CbCrdCrsCd
+					L6: Crs-CbCbCrsCs
+					L6: Crs-CrsCrsCrsCd
+						L7: Crs-CrsCrsCrs(Cd-O2d)
+					L6: Crs-CrdCrsCrsCs
+						L7: Crs-(Crd-O2d)CrsCrsCs
+						L7: Crs-(Crd-Cd)CrsCrsCs
+							L8: Crs-(Crd-Crd)CrsCrsCs
+					L6: Crs-CrdCrdCrsCs
+					L6: Crs-CrdCrdCbCs
+					L6: Crs-CrdCrdCrdCs
+				L5: Crs-CrCrCC
+					L6: Crs-CrsCrsCsCs
+					L6: Crs-CbCrsCsCs
+					L6: Crs-CrdCrsCsCs
+					L6: Crs-CrdCrdCsCs
+						L7: Crs-(Crd-O2d)(Crd-O2d)CsCs
+					L6: Crs-CrdCrdCdCs
+						L7: Crs-(Crd-O2d)(Crd-O2d)CdCs
+					L6: Crs-CrsCrsCdCs
+				L5: Cs-CsCsCsCs
+				L5: Cs-CdsCsCsCs
+					L6: Cs-(Cds-O2d)CsCsCs
+					L6: Cs-(Cds-Cd)CsCsCs
+						L7: Cs-(Cds-Cds)CsCsCs
+				L5: Cs-CtCsCsCs
+				L5: Cs-CbCsCsCs
+				L5: Cs-CdsCdsCsCs
+				L5: Cs-CbCtCsCs
+				L5: Cs-CbCbCsCs
+				L5: Cs-CbCdsCdsCs
+					L6: Cs-(Cds-O2d)(Cds-Cd)CbCs
+						L7: Cs-(Cds-O2d)(Cds-Cds)CbCs
+							L8: Cs-(Cds-O2d)(Crds-Crds)CbCs
+				L5: Cs-CbCbCdsCs
+					L6: Cs-(Cds-O2d)CbCbCs
+				L5: Cs-CbCbCbCb
+			L4: Cs-CCCOs
+				L5: Cs-CsCsCsOs
+					L6: Cs-CsCsCs(Os-H)
+						L7: Crs-CrsCrsCrs(Os-H)
+						L7: Crs-CrsCrsCs(Os-H)
+					L6: Cs-CsCsCs(Os-R)
+						L7: Crs-CrsCrsCrs(Ors-R)
+						L7: Crs-CrsCrsCs(Ors-R)
+						L7: Crs-CrsCrsCs(Os-R)
+						L7: Crs-CrsCsCs(Ors-R)
+				L5: Cs-CdsCsCsOs
+					L6: Cs-CdsCsCs(Os-H)
+						L7: Cs-(Cds-O2d)CsCs(Os-H)
+							L8: Crs-(Cds-O2d)CrsCrs(Os-H)
+						L7: Cs-(Cds-Cd)CsCs(Os-H)
+					L6: Cs-CdsCsCs(Os-R)
+						L7: Cs-(Cds-O2d)CsCs(Os-R)
+						L7: Cs-(Cds-Cd)CsCs(Os-R)
+				L5: Cs-OsCtCsCs
+				L5: Cs-CbCsCsOs
+				L5: Cs-CdsCdsCsOs
+					L6: Cs-(Cds-O2d)(Cds-Cd)CsOs
+						L7: Cs-(Cds-O2d)(Cds-Cds)CsOs
+				L5: Cs-CtCdsCsOs
+					L6: Cs-(Cds-Cd)CtCsOs
+						L7: Cs-(Cds-Cds)CtCsOs
+				L5: Cs-CbCdsCsOs
+				L5: Cs-CbCbCsOs
+				L5: Cs-CbCbCdsOs
+					L6: Cs-(Cds-O2d)CbCbOs
+				L5: Cs-CbCbCbOs
+			L4: Cs-CCOsOs
+				L5: Crs-CCOsOs
+					L6: Crs-OrsOrsCC
+					L6: Crs-CrOrsOsC
+				L5: Cs-CsCsOsOs
+			L4: Cs-COsOsH
+				L5: Crs-COsOsH
+					L6: Crs-OrsOrsCH
+					L6: Crs-CrOrsOsH
+				L5: Cs-CsOsOsH
+			L4: Cs-COsSH
+				L5: Cs-CsOsSH
+					L6: Cs-CsOsS2H
+			L4: Cs-CCOsH
+				L5: Cs-CsCsOsH
+					L6: Cs-CsCs(Os-H)H
+						L7: Crs-CrsCrs(Os-H)H
+					L6: Cs-CsCs(Os-R)H
+						L7: Crs-CrsCrs(Ors-R)H
+						L7: Crs-CrsCs(Ors-R)H
+						L7: Crs-CrsCrs(Os-R)H
+				L5: Cs-CdsCsOsH
+					L6: Cs-(Cds-O2d)CsOsH
+						L7: Cs-(Cds-O2d)Cs(Os-H)H
+						L7: Cs-(Cds-O2d)Cs(Os-R)H
+					L6: Cs-(Cds-Cd)CsOsH
+						L7: Cs-(Cds-Cds)CsOsH
+							L8: Cs-(Cds-Cds)Cs(Os-H)H
+							L8: Cs-(Cds-Cds)Cs(Os-R)H
+				L5: Cs-CtCsOsH
+				L5: Cs-CbCsOsH
+				L5: Cs-CbCdsOsH
+					L6: Cs-(Cds-O2d)CbOsH
+				L5: Cs-CbCbOsH
+			L4: Cs-COsHH
+				L5: Cs-CsOsHH
+					L6: Cs-Cs(Os-H)HH
+					L6: Cs-Cs(Os-R)HH
+						L7: Crs-Crs(Ors-R)HH
+				L5: Cs-CdsOsHH
+					L6: Cs-(Cds-O2d)OsHH
+						L7: Cs-(Cds-O2d)(Os-H)HH
+						L7: Cs-(Cds-O2d)(Os-R)HH
+					L6: Cs-(Cds-Cd)OsHH
+						L7: Cs-(Cds-Cds)OsHH
+							L8: Cs-(Cds-Cds)(Os-H)HH
+							L8: Cs-(Cds-Cds)(Os-R)HH
+					L6: Cs-(Cds-Nd)OsHH
+						L7: Cs-(Cds-N3d)OsHH
+				L5: Cs-CtOsHH
+					L6: Cs-Ct(Os-H)HH
+					L6: Cs-Ct(Os-R)HH
+				L5: Cs-CbOsHH
+					L6: Cs-Cb(Os-H)HH
+					L6: Cs-Cb(Os-R)HH
+			L4: Cs-CCCS
+				L5: Cs-CCC(S-H)
+			L4: Cs-CCSS
+				L5: Cs-CsCsSS
+			L4: Cs-CCSH
+				L5: Cs-CsCsSH
+					L6: Cs-CsCs(S-H)H
+			L4: Cs-CSHH
+				L5: Crs-CrSrHH
+				L5: Cs-CsSHH
+					L6: Cs-CsS2HH
+						L7: Cs-Cs(S2-H)HH
+					L6: Cs-CsS4HH
+					L6: Cs-CsS6HH
+				L5: Cs-CdsSsHH
+					L6: Cs-(Cds-Cd)SsHH
+						L7: Cs-(Cds-Cds)SsHH
+					L6: Cs-(Cds-Od)SsHH
+				L5: Cs-CbSsHH
+				L5: Cs-CS4dHH
+			L4: Cs-SsHHH
+				L5: Cs-S2sHHH
+				L5: Cs-S4HHH
+				L5: Cs-S6HHH
+			L4: Cs-SsSsHH
+	L2: O
+		L3: O2d
+			L4: O2d-Cd
+				L5: O2d-Crd
+			L4: O2d-Cdd
+			L4: O2d-N3d
+			L4: O2d-N5dc
+			L4: O2d-Sd
+				L5: O2d-S4d
+				L5: O2d-S6dd
+			L4: O2d-P5d
+		L3: O2s
+			L4: O2s-PH
+				L5: O2s-P5dH
+			L4: O2s-PC
+				L5: O2s-P3sC
+					L6: O2s-P3sCs
+				L5: O2s-P5dC
+					L6: O2s-P5dCs
+					L6: O2s-P5dCd
+						L7: O2s-P5d(Cd-Nd)
+					L6: O2s-P5dCb
+			L4: O2s-NH
+			L4: O2s-NR
+				L5: O2s-CN
+					L6: O2s-CbN3d
+					L6: O2s-CsN3s
+					L6: O2s-CsN3d
+						L7: O2s-Cs(N3d-Od)
+						L7: O2s-Cs(N3d-Cd)
+					L6: O2s-CdN3d
+					L6: O2s-CsN5dc
+			L4: O2s-OsH
+			L4: O2s-CH
+				L5: O2s-CdsH
+					L6: O2s-(Cds-O2d)H
+					L6: O2s-(Cds-Cd)H
+				L5: O2s-CsH
+				L5: O2s-CbH
+			L4: O2s-OsC
+				L5: O2s-OsCds
+					L6: O2s-O2s(Cds-O2d)
+				L5: O2s-OsCs
+			L4: O2s-CC
+				L5: O2s-CtCb
+					L6: O2s-(Ct-N3t)Cb
+				L5: O2s-CdsCds
+					L6: O2s-(Cds-O2d)(Cds-O2d)
+					L6: O2s-(Cds-O2d)(Cds-Cd)
+					L6: O2s-(Cds-Cd)(Cds-Cd)
+				L5: O2s-CdsCs
+					L6: O2s-Cs(Cds-N3d)
+					L6: O2s-Cs(Cds-O2d)
+					L6: O2s-Cs(Cds-Cd)
+					L6: O2s-Cs(Cds-Sd)
+				L5: O2s-CdsCb
+					L6: O2s-Cb(Cds-N3d)
+					L6: O2s-Cb(Cds-O2d)
+					L6: O2s-Cb(Cds-Cd)
+					L6: O2s-Cb(Cds-Sd)
+				L5: O2s-CsCs
+					L6: O2rs-CrsCrs
+				L5: O2s-CsCb
+					L6: O2rs-CrsCb
+				L5: O2s-CbCb
+					L6: O2rs-CbCb
+			L4: O2s-CS
+			L4: O2s-SH
+				L5: O2s-S_DeH
+		L3: Oc
+			L4: Oc-N5c
+	L2: S
+		L3: S2d
+			L4: S2d-C
+			L4: S2d-P
+				L5: S2d-P5d
+		L3: S2s
+			L4: S2s-CH
+				L5: S2s-CsH
+				L5: S2s-CdH
+				L5: S2s-CbH
+			L4: S2s-PH
+				L5: S2s-P5dH
+			L4: S2s-PC
+				L5: S2s-P5dC
+			L4: S2s-SS
+				L5: S2s-SsSs
+			L4: S2s-SC
+				L5: S2s-S2sC
+				L5: S2s-S46C
+			L4: S2s-NN
+				L5: S2s-N3dN3d
+			L4: S2s-NC
+				L5: S2s-N3dCd
+			L4: S2s-CC
+				L5: S2s-CsCs
+					L6: S2rs-CrsCrs
+				L5: S2s-CsCd
+				L5: S2s-Cs(C=O)
+				L5: S2s-CsCt
+				L5: S2s-CsCb
+				L5: S2s-CdCd
+					L6: S2rs-CrdCrd
+				L5: S2s-CdCb
+					L6: S2rs-CrdCb
+				L5: S2s-CtCb
+					L6: S2s-(Ct-N3t)Cb
+				L5: S2s-CbCb
+					L6: S2rs-CbCb
+				L5: S2s-(Cd-S2d)C
+		L3: S4dd
+			L4: S4dd-N3dN3d
+		L3: S4d
+			L4: S4d-Od
+				L5: S4d-OdCC
+					L6: S4d-OdCsCs
+					L6: S4d-OdCsCb
+					L6: S4d-OdCbCb
+				L5: S4d-OdCS
+		L3: S6dd
+			L4: S6dd-OdOd
+				L5: S6dd-OdOdCC
+					L6: S6dd-OdOdCbCb
+					L6: S6dd-OdOdCrCr
+					L6: S6dd-OdOdCsCs
+					L6: S6dd-OdOdCsCb
+				L5: S6dd-OdOdCO
+					L6: S6dd-OdOdCsOs
+					L6: S6dd-OdOdCbOs
+				L5: S6dd-OdOdNC
+					L6: S6dd-OdOdNCb
+				L5: S6dd-OdOdNN
+				L5: S6dd-OdOdOO
+				L5: S6dd-OdOdON
+	L2: N
+		L3: N1dc
+			L4: N1dc-N5ddc
+		L3: N3s
+			L4: N3s-CHH
+				L5: N3s-CsHH
+					L6: N3s-CrsHH
+				L5: N3s-CbHH
+				L5: N3s-CdHH
+					L6: N3s-(Cd-Cd)HH
+						L7: N3s-(Crd-Crd)HH
+					L6: N3s-(Cd-N3d)HH
+						L7: N3s-(Crd-N3rd)HH
+					L6: N3s-(Cd-O2d)HH
+					L6: N3s-(Cd-Sd)HH
+			L4: N3s-NHH
+				L5: N3s-N3sHH
+			L4: N3s-SHH
+				L5: N3s-S6ddHH
+			L4: N3s-NNH
+			L4: N3s-PCH
+				L5: N3s-P5dCH
+			L4: N3s-NCH
+				L5: N3s-N3sCsH
+				L5: N3s-N3sCbH
+				L5: N3s-N3sCdH
+				L5: N3s-N3dCsH
+				L5: N3s-N3dCbH
+				L5: N3s-N3dCdH
+					L6: N3rs-N3rdCrdH
+						L7: N3rs-N3rd(Crd-O2d)H
+						L7: N3rs-N3rd(Crd-Cd)H
+						L7: N3rs-N3rd(Crd-Nd)H
+					L6: N3s-N3d(Cd-O2d)H
+			L4: N3s-PCC
+			L4: N3s-NCC
+				L5: N3rs-NrCrCr
+					L6: N3rs-NrCrCb
+						L7: N3rs-Nr(Crd-O2d)Cb
+				L5: N3rs-NrCrC
+				L5: N3rs-NCrCr
+					L6: N3rs-N3dCrCr
+						L7: N3rs-(N3d-O2d)CrCr
+					L6: N3rs-N5dcCrCr
+				L5: N3s-N3dCC
+					L6: N3s-(N3d-O2d)CC
+						L7: N3s-(N3d-O2d)CsCs
+						L7: N3s-(N3d-O2d)CbCs
+						L7: N3s-(N3d-O2d)CbCb
+			L4: N3s-NNC
+				L5: N3rs-NrNrC
+			L4: N3s-NNO
+				L5: N3rs-NrNrO
+					L6: N3rs-N3rdN3rdO
+						L7: N3rs-N3rdN3rd(O2s-H)
+			L4: N3s-CCH
+				L5: N3s-CsCsH
+					L6: N3rs-CrsCrsH
+				L5: N3s-CbCsH
+					L6: N3rs-CbCrsH
+				L5: N3s-CbCbH
+					L6: N3rs-CbCbH
+				L5: N3s-CdCsH
+					L6: N3s-(Cd-Cd)CsH
+					L6: N3s-(Cd-N3d)CsH
+						L7: N3rs-(Crd-N3rd)CrsH
+					L6: N3s-(Cd-O2d)CsH
+					L6: N3s-(Cd-Sd)CsH
+				L5: N3s-CdCtH
+					L6: N3s-(Cd-N3d)CtH
+						L7: N3s-(Cd-N3d)(Ct-N3t)H
+				L5: N3s-CdCbH
+					L6: N3s-(Cd-Cd)CbH
+						L7: N3rs-(Crd-Crd)CbH
+						L7: N3s-(Crd-Crd)CbH
+					L6: N3s-(Cd-N3d)CbH
+						L7: N3rs-(Crd-N3rd)CbH
+						L7: N3s-(Crd-N3rd)CbH
+					L6: N3s-(Cd-O2d)CbH
+					L6: N3s-(Cd-Sd)CbH
+				L5: N3s-CdCdH
+					L6: N3s-(Cd-Cd)(Cd-Cd)H
+						L7: N3rs-(Crd-Crd)(Crd-Crd)H
+					L6: N3s-(Cd-N3d)(Cd-Cd)H
+						L7: N3rs-(Crd-N3rd)(Crd-Crd)H
+					L6: N3s-(Cd-O2d)(Cd-Cd)H
+						L7: N3rs-(Crd-O2d)(Crd-Crd)H
+						L7: N3s-(Cd-O2d)(Crd-Crd)H
+					L6: N3s-(Cd-Sd)(Cd-Cd)H
+						L7: N3rs-(Crd-Sd)(Crd-Crd)H
+					L6: N3s-(Cd-O2d)(Cd-O2d)H
+						L7: N3rs-(Crd-O2d)(Crd-O2d)H
+					L6: N3s-(Cd-O2d)(Cd-N3d)H
+						L7: N3rs-(Crd-O2d)(Crd-N3rd)H
+						L7: N3s-(Cd-O2d)(Crd-N3rd)H
+					L6: N3s-(Cd-O2d)(Cd-Sd)H
+						L7: N3rs-(Crd-O2d)(Crd-Sd)H
+			L4: N3s-COH
+			L4: N3s-CSH
+				L5: N3s-CS6ddH
+					L6: N3s-CbS6ddH
+					L6: N3s-CrS6ddH
+						L7: N3s-CrdS6ddH
+					L6: N3s-CdS6ddH
+						L7: N3s-(Cd-O2d)S6ddH
+					L6: N3s-CsS6ddH
+			L4: N3s-CCC
+				L5: N3s-CsCsCs
+					L6: N3rs-CrsCrsCrs
+					L6: N3rs-CrsCrsCs
+				L5: N3s-CbCsCs
+				L5: N3s-CbCdCd
+					L6: N3s-Cb(Cd-O2d)(Cd-Cd)
+						L7: N3rs-Cb(Cd-O2d)(Crd-Crd)
+				L5: N3s-CbCbCs
+					L6: N3rs-CbCbCs
+				L5: N3s-CbCbCd
+					L6: N3s-CbCb(Cd-O2d)
+				L5: N3s-CbCbCb
+				L5: N3s-CdCsCs
+					L6: N3s-(Cd-N3d)CsCs
+						L7: N3rs-(Crd-N3rd)CrsCrs
+						L7: N3s-(Crd-N3rd)CsCs
+					L6: N3s-(Cd-O2d)CsCs
+						L7: N3rs-(Crd-O2d)CrsCrs
+						L7: N3rs-(Cd-O2d)CrsCrs
+						L7: N3rs-(Crd-O2d)CrsCs
+					L6: N3s-(Cd-Cd)CsCs
+						L7: N3rs-(Crd-Crd)CrsCs
+						L7: N3s-(Crd-Crd)CsCs
+					L6: N3s-(Cd-Sd)CsCs
+				L5: N3s-CdCbCs
+					L6: N3s-(Cd-O2d)CbCs
+						L7: N3rs-(Crd-O2d)CbCrs
+						L7: N3rs-(Crd-O2d)CbCs
+						L7: N3rs-(Cd-O2d)CbCrs
+					L6: N3s-(Cd-Cd)CbCs
+						L7: N3rs-(Crd-Crd)CbCs
+					L6: N3s-(Cd-Nd)CbCs
+						L7: N3rs-(Crd-Nrd)CbCs
+					L6: N3s-(Cd-S2d)CbCs
+				L5: N3s-CdCdCs
+					L6: N3s-(Cd-O2d)(Cd-O2d)Cs
+						L7: N3rs-(Crd-O2d)(Crd-O2d)Cs
+						L7: N3rs-(Crd-O2d)(Cd-O2d)Crs
+					L6: N3s-(Cd-O2d)(Cd-Cd)Cs
+						L7: N3rs-(Crd-O2d)(Crd-Crd)Cs
+					L6: N3s-(Cd-O2d)(Cd-Nd)Cs
+						L7: N3rs-(Crd-O2d)(Crd-Nrd)Cs
+					L6: N3s-(Cd-Cd)(Cd-Cd)Cs
+						L7: N3rs-(Crd-Crd)(Crd-Crd)Cs
+					L6: N3s-(Cd-Cd)(Cd-Nd)Cs
+						L7: N3rs-(Crd-Crd)(Crd-Nrd)Cs
+					L6: N3s-(Cd-Cd)(Cd-S2d)Cs
+						L7: N3rs-(Crd-Crd)(Crd-S2d)Cs
+					L6: N3s-(Cd-Nd)(Cd-Nd)Cs
+						L7: N3rs-(Crd-Nrd)(Crd-Nrd)Cs
+				L5: N3s-CdCdCd
+					L6: N3s-(Cd-O2d)(Cd-Cd)(Cd-Nd)
+			L4: N3s-CCO
+				L5: N3s-CbCd(O-H)
+					L6: N3s-Cb(Cd-O2d)(O-H)
+			L4: N3s-CCS
+				L5: N3s-CCS4d
+					L6: N3s-CC(S4d-O2d)
+						L7: N3s-CsCs(S4d-O2d)
+				L5: N3s-CCS6dd
+					L6: N3s-CC(S6dd-O2dO2d)
+						L7: N3s-CsCs(S6dd-O2dO2d)
+						L7: N3s-CsCd(S6dd-O2dO2d)
+							L8: N3s-Cs(Cd-Cd)(S6dd-O2dO2d)
+						L7: N3s-CbCb(S6dd-O2dO2d)
+		L3: N3d
+			L4: N3d-N5ddc
+			L4: N3d-CdH
+			L4: N3d-CdN
+				L5: N3d-CdN3s
+				L5: N3d-CdN3d
+					L6: N3rd-CrdN3rd
+			L4: N3d-CdO
+				L5: N3d-Cd(O-H)
+				L5: N3d-Cd(O-R)
+					L6: N3rd-Crd(Or-R)
+			L4: N3d-CdS
+				L5: N3d-CdS2s
+					L6: N3rd-CrdS2rs
+				L5: N3d-CdS6dd
+			L4: N3d-CdC
+				L5: N3d-CdCs
+					L6: N3rd-CrdCrs
+				L5: N3d-CdCb
+					L6: N3rd-CrdCb
+				L5: N3d-CdCd
+					L6: N3d-Cd(Cd-O2d)
+						L7: N3rd-Crd(Crd-O2d)
+					L6: N3d-Cd(Cd-N3d)
+						L7: N3rd-Crd(Crd-N3rd)
+						L7: N3d-Cd(Crd-N3rd)
+					L6: N3d-Cd(Cd-Cd)
+						L7: N3rd-Crd(Crd-Crd)
+				L5: N3d-CdCt
+					L6: N3d-Cd(Ct-N3t)
+			L4: N3d-CddC
+				L5: N3d-(Cdd-O2d)C
+					L6: N3d-(Cdd-O2d)Cs
+					L6: N3d-(Cdd-O2d)Cb
+				L5: N3d-(Cdd-Sd)C
+					L6: N3d-(Cdd-S2d)C
+						L7: N3d-(Cdd-S2d)Cs
+						L7: N3d-(Cdd-S2d)Cb
+			L4: N3d-N3dN
+				L5: N3d-N3dN3s
+					L6: N3rd-N3rdN3rs
+				L5: N3d-N3dN3d
+					L6: N3d-N3d(N3d-Cd)
+						L7: N3rd-N3rd(N3rd-Crd)
+			L4: N3d-N3dC
+				L5: N3d-N3dCb
+				L5: N3d-N3dCs
+				L5: N3d-N3dCd
+			L4: N3d-O2dO
+			L4: N3d-O2dN
+				L5: N3d-O2dN3s
+			L4: N3d-O2dC
+				L5: N3d-O2dCb
+			L4: N3d-SdS
+				L5: N3d-S4ddS2s
+					L6: N3d-(S4dd-N3d)S2s
+			L4: N3d-PdP
+				L5: N3d-P5dP5d
+		L3: N3t
+			L4: N3t-Ct
+		L3: N5sc
+			L4: N5sc-O0sc
+		L3: N5dc
+			L4: N5dc-OdO0scC
+				L5: N5dc-OdO0scCb
+				L5: N5dc-OdO0scCs
+				L5: N5dc-OdO0scCd
+					L6: N5dc-OdO0sc(Cd-Cd)
+						L7: N5dc-OdO0sc(Crd-Crd)
+					L6: N5dc-OdO0sc(Cd-Nd)
+						L7: N5dc-OdO0sc(Crd-N3rd)
+			L4: N5dc-OdO0scO2s
+			L4: N5dc-OdO0scN
+			L4: N5dc-CdO0scC
+				L5: N5dc-CdO0scCd
+					L6: N5dc-CdO0sc(Cd-Cd)
+						L7: N5dc-CdO0sc(Crd-Crd)
+		L3: N5ddc
+			L4: N5ddc-N1dcN3d
+		L3: N5tc
+			L4: N5tc-C2tcC
+				L5: N5tc-C2tcCs
+				L5: N5tc-C2tcCb
+	L2: P
+		L3: P3s
+			L4: P3s-O2sO2sO2s
+			L4: P3s-CCC
+				L5: P3s-CsCsCs
+				L5: P3s-CbCbCb
+		L3: P5d
+			L4: P5d-O2d
+				L5: P5d-O2dO2sCH
+				L5: P5d-O2dO2sO2sH
+				L5: P5d-O2dNNN
+					L6: P5d-O2dN3sN3sN3s
+				L5: P5d-O2dCCC
+					L6: P5d-O2dCbCbCb
+					L6: P5d-O2dCsCsCs
+				L5: P5d-O2dO2sCC
+					L6: P5d-O2dO2sCbCb
+					L6: P5d-O2dO2sCbCs
+					L6: P5d-O2dO2sCsCs
+				L5: P5d-O2dO2sO2sN
+					L6: P5d-O2dO2sO2sN3s
+				L5: P5d-O2dO2sO2sC
+					L6: P5d-O2dO2sO2sCs
+					L6: P5d-O2dO2sO2sCd
+				L5: P5d-O2dO2sO2sO2s
+			L4: P5d-N3d
+				L5: P5d-N3dNHH
+					L6: P5d-N3dN3dHH
+				L5: P5d-N3dNOO
+					L6: P5d-N3dN3dO2sO2s
+			L4: P5d-S2d
+				L5: P5d-S2dO2sO2sS
+					L6: P5d-S2dO2sO2sS2s
+				L5: P5d-S2dO2sO2sO2s
+"""
+)

--- a/input/solvation/groups/halogen.py
+++ b/input/solvation/groups/halogen.py
@@ -1,0 +1,10210 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "halogen"
+shortDesc = u""
+longDesc = u""" 
+All groups are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter data (manuscript in preparation)
+unless written otherwise.
+"""
+
+entry(
+	index = 1,
+	label = "X",
+	group = 
+"""
+1 * [F1s,Cl1s,Br1s,I1s] ux
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 2,
+	label = "F",
+	group = 
+"""
+1 * F1s u0
+""",
+	solute = u'F-C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 3,
+	label = "F-C",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   C   u0 {1,S}
+""",
+	solute = u'F-Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 4,
+	label = "F-Cb",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.02870,
+		B = -0.01608,
+		E = -0.10588,
+		L = -0.12204,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 135,
+		B = 131,
+		E = 146,
+		L = 104,
+		A = 150,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 5,
+	label = "F-Phenol",
+	group =  "OR{F-Phenol(ortho), F-Phenol(meta), F-Phenol(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 6,
+	label = "F-Phenol(ortho)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   O2s u0 {3,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.01903,
+		B = -0.03461,
+		E = -0.10427,
+		L = -0.12259,
+		A = 0.09756,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 8,
+		L = 5,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 7,
+	label = "F-Phenol(meta)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02174,
+		B = -0.03645,
+		E = -0.09013,
+		L = -0.02170,
+		A = 0.07464,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 5,
+		L = 3,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 8,
+	label = "F-Phenol(para)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = -0.00778,
+		B = -0.02958,
+		E = -0.09518,
+		L = -0.13622,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 6,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 9,
+	label = "F-BenzoicAcid",
+	group =  "OR{F-BenzoicAcid(ortho), F-BenzoicAcid(meta), F-BenzoicAcid(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 10,
+	label = "F-BenzoicAcid(ortho)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = -0.01126,
+		B = 0.00000,
+		E = -0.07247,
+		L = -0.04312,
+		A = 0.07852,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 11,
+	label = "F-BenzoicAcid(meta)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   CO  u0 {4,S} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = -0.05665,
+		B = 0.00000,
+		E = -0.07247,
+		L = -0.11925,
+		A = 0.05052,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 12,
+	label = "F-BenzoicAcid(para)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   CO  u0 {5,S} {7,S}
+7   O2s u0 {6,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.04977,
+		B = 0.01219,
+		E = -0.04977,
+		L = -0.11742,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 13,
+	label = "F-Aniline",
+	group =  "OR{F-Aniline(ortho), F-Aniline(meta), F-Aniline(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 14,
+	label = "F-Aniline(ortho)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   N3s u0 {3,S} {5,S} {6,S}
+5   H   u0 {4,S}
+6   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00377,
+		B = -0.00166,
+		E = -0.18386,
+		L = -0.20968,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 2,
+		E = 6,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 15,
+	label = "F-Aniline(meta)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   N3s u0 {4,S} {6,S} {7,S}
+6   H   u0 {5,S}
+7   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.03842,
+		B = -0.00651,
+		E = -0.17201,
+		L = -0.14335,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 1,
+		E = 4,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 16,
+	label = "F-Aniline(para)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   N3s u0 {5,S} {7,S} {8,S}
+7   H   u0 {6,S}
+8   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.02190,
+		B = -0.00166,
+		E = -0.14880,
+		L = -0.13381,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 2,
+		E = 6,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 17,
+	label = "F-Cs",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S}
+""",
+	solute = u'F-(Cs-CZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 18,
+	label = "F-(Cs-CZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 19,
+	label = "F-(Cs-CbZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CbHH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 20,
+	label = "F-(Cs-CbHH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00829,
+		B = 0.01872,
+		E = -0.01612,
+		L = 0.17940,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 21,
+	label = "F-(Cs-CbXX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'F-(Cs-CbFF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 22,
+	label = "F-(Cs-CbFF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.04570,
+		B = -0.02828,
+		E = -0.11707,
+		L = -0.13339,
+		A = 0.02420,
+	),
+	dataCount = DataCountGAV(
+		S = 49,
+		B = 48,
+		E = 54,
+		L = 41,
+		A = 54,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 23,
+	label = "F-(Cs-CsZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsHH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 24,
+	label = "F-(Cs-CsHH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.24834,
+		B = 0.07507,
+		E = -0.09938,
+		L = 0.13316,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 27,
+		L = 26,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 25,
+	label = "F-(Cs-(Cs-ZZZ)HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'F-(Cs-(Cs-HHH)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 26,
+	label = "F-(Cs-(Cs-HHH)HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.04250,
+		B = 0.01250,
+		E = 0.01733,
+		L = -0.18090,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 27,
+	label = "F-(Cs-(Cs-HHX)HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.06504,
+		B = 0.02047,
+		E = -0.01277,
+		L = 0.04968,
+		A = 0.01096,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 28,
+	label = "F-(Cs-(Cs-HXX)HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.00253,
+		B = 0.01809,
+		E = -0.04537,
+		L = -0.18993,
+		A = 0.01554,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 29,
+	label = "F-(Cs-(Cs-XXX)HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.00963,
+		B = 0.00000,
+		E = -0.09316,
+		L = -0.29943,
+		A = 0.00480,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 30,
+	label = "F-(Cs-(Cs-(OH))HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 31,
+	label = "F-(Cs-CsXH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = u'F-(Cs-CsFH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 32,
+	label = "F-(Cs-(Cs-ZZZ)XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'F-(Cs-(Cs-HHH)XH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 33,
+	label = "F-(Cs-(Cs-HHH)XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.08364,
+		B = 0.02000,
+		E = -0.06800,
+		L = -0.23276,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 34,
+	label = "F-(Cs-(Cs-HHX)XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.13987,
+		B = 0.02383,
+		E = -0.08194,
+		L = -0.10545,
+		A = 0.04114,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 35,
+	label = "F-(Cs-(Cs-HXX)XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.06123,
+		B = 0.02370,
+		E = -0.09350,
+		L = -0.18447,
+		A = 0.02543,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 36,
+	label = "F-(Cs-(Cs-XXX)XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.02803,
+		B = 0.00000,
+		E = -0.08484,
+		L = -0.19780,
+		A = 0.01288,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 37,
+	label = "F-(Cs-(Cs-(OH))XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   H   u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 38,
+	label = "F-(Cs-CsFH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.01502,
+		E = -0.12026,
+		L = -0.07584,
+		A = 0.02979,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 25,
+		E = 26,
+		L = 25,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 39,
+	label = "F-(Cs-CsClH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Cl1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.15129,
+		B = 0.01122,
+		E = 0.02979,
+		L = 0.31889,
+		A = 0.02231,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 40,
+	label = "F-(Cs-CsBrH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Br1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.07899,
+		B = -0.00121,
+		E = 0.01275,
+		L = 0.29461,
+		A = 0.01928,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 41,
+	label = "F-(Cs-CsIH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   I1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'F-(Cs-CsBrH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 42,
+	label = "F-(Cs-CsXX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.10378,
+		B = 0.02211,
+		E = 0.10567,
+		L = 0.61635,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 43,
+	label = "F-(Cs-(Cs-ZZZ)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'F-(Cs-(Cs-HHH)XX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 44,
+	label = "F-(Cs-(Cs-HHH)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.04332,
+		B = 0.02264,
+		E = -0.08635,
+		L = -0.25699,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 45,
+	label = "F-(Cs-(Cs-HHX)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.11899,
+		B = 0.00000,
+		E = -0.06618,
+		L = -0.07654,
+		A = 0.01824,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 46,
+	label = "F-(Cs-(Cs-HXX)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.05989,
+		B = 0.00000,
+		E = -0.05765,
+		L = -0.08983,
+		A = 0.02412,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 14,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 47,
+	label = "F-(Cs-(Cs-XXX)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = -0.04682,
+		B = 0.00000,
+		E = -0.08351,
+		L = -0.22240,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 48,
+	label = "F-(Cs-CsFX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'F-(Cs-CsFH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 49,
+	label = "F-(Cs-CsFF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = -0.04245,
+		B = 0.01028,
+		E = -0.09262,
+		L = -0.13333,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 57,
+		B = 54,
+		E = 64,
+		L = 53,
+		A = 60,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 50,
+	label = "F-(Cs-(Cs-(OH))FF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.00960,
+		B = -0.06363,
+		E = -0.06408,
+		L = -0.13003,
+		A = 0.05192,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 5,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 51,
+	label = "F-(Cs-(Cs-O)FF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   R!H u0 {6,S}
+""",
+	solute = SoluteData(
+		S = -0.01779,
+		B = 0.00000,
+		E = -0.08041,
+		L = -0.08676,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 35,
+		B = 34,
+		E = 35,
+		L = 33,
+		A = 34,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 52,
+	label = "F-(Cs-CsFCl)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   Cl1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.02719,
+		B = 0.00889,
+		E = -0.02778,
+		L = 0.15932,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 53,
+	label = "F-(Cs-CsFBr)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   Br1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.02893,
+		B = 0.00000,
+		E = -0.07133,
+		L = 0.00397,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 54,
+	label = "F-(Cs-CsFI)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   I1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'F-(Cs-CsFBr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 55,
+	label = "F-(Cs-CdZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   [Cd,CO,CS]   u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 56,
+	label = "F-(Cs-(Cd-Cd)ZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   C   u0 {3,D}
+""",
+	solute = u'F-(Cs-(Cd-Cd)FX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 57,
+	label = "F-(Cs-(Cd-Cd)FX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   F1s u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   C   u0 {3,D}
+""",
+	solute = u'F-(Cs-(Cd-Cd)FF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 58,
+	label = "F-(Cs-(Cd-Cd)FF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+6   C   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.09316,
+		B = 0.00562,
+		E = -0.11980,
+		L = -0.21486,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 59,
+	label = "F-(Cs-(Cd-Nd)ZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   N   u0 {3,D}
+""",
+	solute = u'F-(Cs-(Cd-Nd)XX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 60,
+	label = "F-(Cs-(Cd-Nd)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   N   u0 {3,D}
+""",
+	solute = u'F-(Cs-(Cd-Nd)FF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 61,
+	label = "F-(Cs-(Cd-Nd)FF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+6   N   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.00588,
+		B = -0.06859,
+		E = -0.13258,
+		L = -0.15040,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 9,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 62,
+	label = "F-(Cs-(Cd-O2d)ZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = u'F-(Cs-(Cd-O2d)XX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 63,
+	label = "F-(Cs-(Cd-O2d)HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.09225,
+		B = 0.00000,
+		E = 0.00179,
+		L = 0.11251,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 64,
+	label = "F-(Cs-(Cd-O2d(OH))HH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.05239,
+		B = -0.01337,
+		E = 0.01277,
+		L = 0.12359,
+		A = 0.04124,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 65,
+	label = "F-(Cs-(Cd-O2d)XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = u'F-(Cs-(Cd-O2d)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 66,
+	label = "F-(Cs-(Cd-O2d(OH))XH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   F1s u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.03075,
+		B = -0.03814,
+		E = -0.02290,
+		L = 0.05259,
+		A = 0.07655,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 67,
+	label = "F-(Cs-(Cd-O2d)XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.12822,
+		B = -0.01668,
+		E = -0.10019,
+		L = -0.22216,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 12,
+		E = 14,
+		L = 12,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 68,
+	label = "F-(Cs-(Cd-O2d(OH))XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00733,
+		B = -0.04837,
+		E = -0.08501,
+		L = -0.04070,
+		A = 0.08912,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 69,
+	label = "F-(Cs-(Cd-O2d(NH))XX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+7   N   u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.20640,
+		B = -0.09379,
+		E = -0.18216,
+		L = -0.37035,
+		A = 0.04150,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 70,
+	label = "F-(Cs-O2sZZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-O2sHZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 71,
+	label = "F-(Cs-O2sHZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   H   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-O2sHH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 72,
+	label = "F-(Cs-O2sHH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.11314,
+		B = -0.11150,
+		E = -0.02375,
+		L = 0.05805,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 73,
+	label = "F-(Cs-O2sHX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   H   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-O2sHF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 74,
+	label = "F-(Cs-O2sHF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   H   u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.04289,
+		B = -0.09603,
+		E = -0.05573,
+		L = -0.03596,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 75,
+	label = "F-(Cs-O2sXX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.08674,
+		B = -0.08006,
+		E = -0.03071,
+		L = -0.01907,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 76,
+	label = "F-(Cs-O2sFF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.10001,
+		B = -0.09097,
+		E = -0.13457,
+		L = -0.28153,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 77,
+	label = "F-(Cs-CCZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 78,
+	label = "F-(Cs-CsCsZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 79,
+	label = "F-(Cs-CsCsH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.14690,
+		B = 0.02914,
+		E = -0.04738,
+		L = 0.06577,
+		A = 0.05096,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 18,
+		L = 18,
+		A = 18,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 80,
+	label = "F-(Cs-CsCsX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 81,
+	label = "F-(Cs-CsCsF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.05069,
+		B = 0.01311,
+		E = -0.06259,
+		L = -0.08756,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 64,
+		B = 60,
+		E = 71,
+		L = 59,
+		A = 67,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 82,
+	label = "F-(Cs-(Cs-(OH))CsF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Cs  u0 {2,S}
+5   F1s u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.07503,
+		B = -0.16093,
+		E = -0.07162,
+		L = -0.01935,
+		A = 0.16197,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 83,
+	label = "F-(Cs-CsCsCl)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cl1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.00670,
+		B = 0.00000,
+		E = 0.03334,
+		L = 0.29750,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 84,
+	label = "F-(Cs-CsCsBr)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Br1s u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsCl)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 85,
+	label = "F-(Cs-CsCsI)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   I1s u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsCl)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 86,
+	label = "F-(Cs-CsCdZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [Cd,CO,CS]  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 87,
+	label = "F-(Cs-Cs(Cd-Cd)Z)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cd  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   C   u0 {4,D}
+""",
+	solute = u'F-(Cs-CsCsX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 88,
+	label = "F-(Cs-Cs(Cd-Nd)Z)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cd  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   N   u0 {4,D}
+""",
+	solute = u'F-(Cs-(Cd-Nd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 89,
+	label = "F-(Cs-Cs(Cd-O2d)Z)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {4,D}
+""",
+	solute = u'F-(Cs-(Cd-O2d)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 90,
+	label = "F-(Cs-CO2sZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   O2s u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsO2sZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 91,
+	label = "F-(Cs-CsO2sZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'F-(Cs-CsO2sH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 92,
+	label = "F-(Cs-CsO2sH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.04511,
+		B = -0.09196,
+		E = -0.08001,
+		L = -0.09593,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 93,
+	label = "F-(Cs-CsO2sX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.05247,
+		B = -0.02783,
+		E = -0.05463,
+		L = -0.18948,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 94,
+	label = "F-(Cs-CsO2sF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.13096,
+		B = -0.08618,
+		E = -0.07782,
+		L = -0.18447,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 20,
+		A = 20,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 95,
+	label = "F-(Cs-CCC)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   C   u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsCs)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 96,
+	label = "F-(Cs-CsCsCs)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cs  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.04446,
+		B = 0.01940,
+		E = -0.09103,
+		L = -0.19210,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 11,
+		E = 15,
+		L = 7,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 97,
+	label = "F-(Cs-CCO2s)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   O2s u0 {2,S}
+""",
+	solute = u'F-(Cs-CsCsO2s)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 98,
+	label = "F-(Cs-CsCsO2s)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   O2s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.12043,
+		B = -0.09214,
+		E = -0.10666,
+		L = -0.32313,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 99,
+	label = "F-Cd",
+	group = 
+"""
+1 * F1s        u0 {2,S}
+2   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = u'F-(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 100,
+	label = "F-(Cd-Cd)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D}
+3   C   u0 {2,D}
+""",
+	solute = u'F-(Cd-CdR)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 101,
+	label = "F-(Cd-CdR)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   [C,N,O,S]  u0 {2,S}
+""",
+	solute = u'F-(Cd-CdC)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 102,
+	label = "F-(Cd-CdC)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   C   u0 {2,S}
+""",
+	solute = u'F-(Crd-CrdCr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 103,
+	label = "F-(Crd-CrdCr)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 r1 {1,S} {3,D} {4,S}
+3   C   u0 r1 {2,D}
+4   C   u0 r1 {2,S}
+""",
+	solute = u'F-(Crd-CrdCrd)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 104,
+	label = "F-(Crd-CrdCrd)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 r1 {1,S} {3,D} {4,S}
+3   C   u0 r1 {2,D}
+4   [Cd,CO,CS] u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.01170,
+		B = -0.09174,
+		E = -0.10720,
+		L = -0.08695,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 48,
+		B = 48,
+		E = 51,
+		L = 43,
+		A = 52,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 105,
+	label = "F-(Cd-CdCs)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   Cs  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.01323,
+		B = 0.00079,
+		E = 0.01721,
+		L = 0.05175,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 106,
+	label = "F-(Cd-CdN)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   N   u0 {2,S}
+""",
+	solute = u'F-(Cd-CrdNr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 107,
+	label = "F-(Cd-CrdNr)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 r1 {1,S} {3,D} {4,S}
+3   C   u0 r1 {2,D}
+4   N   u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.01749,
+		B = -0.08261,
+		E = -0.09530,
+		L = -0.13030,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 108,
+	label = "F-(Cd-CdZ)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   [H,F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'F-(Cd-CdH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 109,
+	label = "F-(Cd-CdH)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = -0.01129,
+		E = -0.06664,
+		L = -0.13689,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 110,
+	label = "F-(Cd-CdX)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00952,
+		B = 0.00000,
+		E = -0.05465,
+		L = -0.00608,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 111,
+	label = "F-(Cd-CdF)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D} {4,S}
+3   C   u0 {2,D}
+4   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.07028,
+		B = 0.00000,
+		E = -0.12785,
+		L = -0.18943,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 112,
+	label = "F-(Cd-Nd)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D}
+3   N   u0 {2,D}
+""",
+	solute = u'F-(Cd-N3d)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 113,
+	label = "F-(Cd-N3d)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 {1,S} {3,D}
+3   N3d u0 {2,D}
+""",
+	solute = u'F-(Crd-N3rd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 114,
+	label = "F-(Crd-N3rd)",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   Cd  u0 r1 {1,S} {3,D}
+3   N3d u0 r1 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.02033,
+		B = -0.03384,
+		E = -0.08419,
+		L = -0.20990,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 115,
+	label = "F-N",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   N   u0 {1,S}
+""",
+	solute = u'F-N3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 116,
+	label = "F-N3s",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   N3s u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.27811,
+		B = -0.19612,
+		E = -0.18432,
+		L = -0.59242,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 117,
+	label = "F-P",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   P u0 {1,S}
+""",
+	solute = u'F-P5d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 118,
+	label = "F-P5d",
+	group = 
+"""
+1 * F1s u0 {2,S}
+2   P5d u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.04700,
+		B = 0.04165,
+		E = -0.12862,
+		L = 0.09741,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 1,
+		E = 5,
+		L = 1,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 119,
+	label = "Cl",
+	group = 
+"""
+1 * Cl1s u0
+""",
+	solute = u'Cl-C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 120,
+	label = "Cl-C",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   C    u0 {1,S}
+""",
+	solute = u'Cl-Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 121,
+	label = "Cl-Cb",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.09871,
+		B = -0.03125,
+		E = 0.13565,
+		L = 0.61878,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 625,
+		B = 609,
+		E = 639,
+		L = 574,
+		A = 642,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 122,
+	label = "Cl-Phenol",
+	group =  "OR{Cl-Phenol(ortho), Cl-Phenol(meta), Cl-Phenol(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 123,
+	label = "Cl-Phenol(ortho)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   O2s u0 {3,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00875,
+		B = -0.01197,
+		E = 0.06547,
+		L = 0.47353,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 35,
+		L = 35,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 124,
+	label = "Cl-Phenol(meta)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.12972,
+		B = -0.07300,
+		E = 0.10450,
+		L = 0.78011,
+		A = 0.14367,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 28,
+		L = 27,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 125,
+	label = "Cl-Phenol(para)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.01371,
+		B = -0.07460,
+		E = 0.08622,
+		L = 0.54024,
+		A = -0.01452,
+	),
+	dataCount = DataCountGAV(
+		S = 23,
+		B = 23,
+		E = 23,
+		L = 22,
+		A = 23,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 126,
+	label = "Cl-BenzoicAcid",
+	group =  "OR{Cl-BenzoicAcid(ortho), Cl-BenzoicAcid(meta), Cl-BenzoicAcid(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 127,
+	label = "Cl-BenzoicAcid(ortho)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.07761,
+		B = 0.00000,
+		E = 0.06262,
+		L = 0.47523,
+		A = 0.08274,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 128,
+	label = "Cl-BenzoicAcid(meta)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   CO  u0 {4,S} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.02261,
+		B = -0.02842,
+		E = 0.10484,
+		L = 0.50277,
+		A = 0.03911,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 129,
+	label = "Cl-BenzoicAcid(para)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   CO  u0 {5,S} {7,S}
+7   O2s u0 {6,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00052,
+		B = -0.03521,
+		E = 0.08251,
+		L = 0.44248,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 130,
+	label = "Cl-BenzylAlcohol",
+	group =  "OR{Cl-BenzylAlcohol(ortho), Cl-BenzylAlcohol(meta), Cl-BenzylAlcohol(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 131,
+	label = "Cl-BenzylAlcohol(ortho)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   C   u0 {3,S} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.03323,
+		B = -0.04378,
+		E = 0.08578,
+		L = 0.39463,
+		A = 0.01121,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 132,
+	label = "Cl-BenzylAlcohol(meta)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   C   u0 {4,S} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.00544,
+		B = -0.01836,
+		E = 0.07210,
+		L = 0.21519,
+		A = 0.00688,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 133,
+	label = "Cl-BenzylAlcohol(para)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   C   u0 {5,S} {7,S}
+7   O2s u0 {6,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.06224,
+		B = 0.00456,
+		E = 0.06827,
+		L = 0.34433,
+		A = 0.01051,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 134,
+	label = "Cl-Aniline",
+	group =  "OR{Cl-Aniline(ortho), Cl-Aniline(meta), Cl-Aniline(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 135,
+	label = "Cl-Aniline(ortho)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   N3s u0 {3,S} {5,S} {6,S}
+5   H   u0 {4,S}
+6   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.01752,
+		B = -0.08834,
+		E = 0.10899,
+		L = 0.57089,
+		A = 0.02114,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 21,
+		L = 16,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 136,
+	label = "Cl-Aniline(meta)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   N3s u0 {4,S} {6,S} {7,S}
+6   H   u0 {5,S}
+7   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.07620,
+		B = -0.05871,
+		E = 0.10018,
+		L = 0.59269,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 11,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 137,
+	label = "Cl-Aniline(para)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   N3s u0 {5,S} {7,S} {8,S}
+7   H   u0 {6,S}
+8   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.05315,
+		B = -0.08780,
+		E = 0.08998,
+		L = 0.47410,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 8,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 138,
+	label = "Cl-Cs",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs   u0 {1,S}
+""",
+	solute = u'Cl-(Cs-CZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 139,
+	label = "Cl-(Cs-CZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 140,
+	label = "Cl-(Cs-CbZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.14447,
+		B = 0.03849,
+		E = 0.14000,
+		L = 0.73475,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 10,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 141,
+	label = "Cl-(Cs-CsZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsHH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 142,
+	label = "Cl-(Cs-CsHH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.32335,
+		B = 0.05705,
+		E = 0.17805,
+		L = 0.86379,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 62,
+		B = 60,
+		E = 78,
+		L = 67,
+		A = 83,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 143,
+	label = "Cl-(Cs-(Cs-ZZZ)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-(Cs-HHH)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 144,
+	label = "Cl-(Cs-(Cs-HHH)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.05000,
+		B = 0.03000,
+		E = 0.07567,
+		L = 0.12344,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 145,
+	label = "Cl-(Cs-(Cs-HHX)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.15919,
+		B = 0.02649,
+		E = 0.16224,
+		L = 0.48838,
+		A = 0.02720,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 146,
+	label = "Cl-(Cs-(Cs-HXX)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.11845,
+		B = 0.01085,
+		E = 0.07506,
+		L = 0.40279,
+		A = 0.02283,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 147,
+	label = "Cl-(Cs-(Cs-XXX)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.05733,
+		B = 0.02324,
+		E = 0.05729,
+		L = 0.27932,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 148,
+	label = "Cl-(Cs-(Cs-(OH))HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.09056,
+		B = 0.02542,
+		E = 0.10384,
+		L = 0.34181,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 149,
+	label = "Cl-(Cs-CsXH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsClH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 150,
+	label = "Cl-(Cs-(Cs-ZZZ)XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-(Cs-HHH)XH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 151,
+	label = "Cl-(Cs-(Cs-HHH)XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.09636,
+		B = 0.02000,
+		E = 0.10733,
+		L = 0.27977,
+		A = 0.01750,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 152,
+	label = "Cl-(Cs-(Cs-HHX)XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.10210,
+		B = 0.03404,
+		E = 0.14131,
+		L = 0.53117,
+		A = 0.03560,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 153,
+	label = "Cl-(Cs-(Cs-HXX)XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.15167,
+		B = 0.02370,
+		E = 0.12627,
+		L = 0.57308,
+		A = 0.03743,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 154,
+	label = "Cl-(Cs-(Cs-XXX)XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   H   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.07166,
+		B = 0.01332,
+		E = 0.07136,
+		L = 0.38038,
+		A = 0.01465,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 155,
+	label = "Cl-(Cs-(Cs-(OH))XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   H   u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03118,
+		B = -0.01026,
+		E = 0.03847,
+		L = 0.08907,
+		A = 0.00177,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 1,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 156,
+	label = "Cl-(Cs-CsFH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.15129,
+		B = 0.01122,
+		E = 0.02979,
+		L = 0.31889,
+		A = 0.02231,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 157,
+	label = "Cl-(Cs-CsClH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Cl1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.19377,
+		B = -0.00037,
+		E = 0.14301,
+		L = 0.72356,
+		A = 0.03763,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 8,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 158,
+	label = "Cl-(Cs-CsBrH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Br1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.11026,
+		B = 0.01361,
+		E = 0.08308,
+		L = 0.48471,
+		A = 0.00068,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 159,
+	label = "Cl-(Cs-CsIH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   I1s u0 {2,S}
+5   H   u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-CsBrH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 160,
+	label = "Cl-(Cs-CsXX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsFX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 161,
+	label = "Cl-(Cs-(Cs-ZZZ)XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-(Cs-HHH)XX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 162,
+	label = "Cl-(Cs-(Cs-HHH)XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.11508,
+		B = 0.01879,
+		E = 0.10840,
+		L = 0.41693,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 163,
+	label = "Cl-(Cs-(Cs-HHX)XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.11838,
+		B = 0.02183,
+		E = 0.13553,
+		L = 0.59623,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 164,
+	label = "Cl-(Cs-(Cs-HXX)XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.10561,
+		B = 0.00764,
+		E = 0.12782,
+		L = 0.61185,
+		A = 0.03061,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 165,
+	label = "Cl-(Cs-(Cs-XXX)XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.10394,
+		B = 0.00000,
+		E = 0.10591,
+		L = 0.44403,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 166,
+	label = "Cl-(Cs-CsFX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-CsFF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 167,
+	label = "Cl-(Cs-CsFF)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.01359,
+		B = 0.00444,
+		E = -0.01389,
+		L = 0.07966,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 168,
+	label = "Cl-(Cs-CsFCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   Cl1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.04299,
+		B = 0.00958,
+		E = -0.00240,
+		L = 0.18687,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 169,
+	label = "Cl-(Cs-CsFBr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   Br1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.03522,
+		B = 0.00708,
+		E = 0.03587,
+		L = 0.24588,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 170,
+	label = "Cl-(Cs-CsFI)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   F1s u0 {2,S}
+5   I1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-CsFBr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 171,
+	label = "Cl-(Cs-CsClX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Cl1s u0 {2,S}
+5   [Cl1s,Br1s,I1s]  u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-CsClCl)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 172,
+	label = "Cl-(Cs-CsClCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Cl1s u0 {2,S}
+5   Cl1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.10763,
+		B = -0.02250,
+		E = 0.12668,
+		L = 0.53781,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 8,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 173,
+	label = "Cl-(Cs-(Cs-(OH))ClCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Cl1s u0 {2,S}
+5   Cl1s u0 {2,S}
+6   O2s  u0 {3,S} {7,S}
+7   H    u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.08101,
+		B = -0.04150,
+		E = 0.08764,
+		L = 0.47079,
+		A = 0.03836,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 174,
+	label = "Cl-(Cs-CsBrX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   Br1s u0 {2,S}
+5   [Br1s,I1s]  u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-CsFBr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 175,
+	label = "Cl-(Cs-CsII)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S}
+4   I1s u0 {2,S}
+5   I1s u0 {2,S}
+6   [C,N,O,S,P] u0 {3,S}
+""",
+	solute = u'Cl-(Cs-CsBrX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 176,
+	label = "Cl-(Cs-CdZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   [Cd,CO,CS]  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 177,
+	label = "Cl-(Cs-(Cd-Cd)ZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   Cd  u0 {3,D}
+""",
+	solute = u'Cl-(Cs-(Cd-Cd)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 178,
+	label = "Cl-(Cs-(Cd-Cd)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   Cd  u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.22974,
+		B = 0.02281,
+		E = 0.17909,
+		L = 0.77362,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 179,
+	label = "Cl-(Cs-(Cd-O2d)ZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = u'Cl-(Cs-(Cd-O2d)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 180,
+	label = "Cl-(Cs-(Cd-O2d)HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.08398,
+		B = -0.03047,
+		E = 0.12191,
+		L = 0.36586,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 14,
+		E = 15,
+		L = 12,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 181,
+	label = "Cl-(Cs-(Cd-O2d(OH))HH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,S} {8,D}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+8   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.03364,
+		B = -0.01587,
+		E = 0.06510,
+		L = 0.26159,
+		A = 0.03724,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 182,
+	label = "Cl-(Cs-(Cd-O2d)XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.00522,
+		B = -0.09571,
+		E = 0.14509,
+		L = 0.57205,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 3,
+		E = 7,
+		L = 4,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 183,
+	label = "Cl-(Cs-(Cd-O2d(OH))XH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,S} {8,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   H   u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+8   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.10385,
+		B = -0.05053,
+		E = 0.10045,
+		L = 0.59275,
+		A = 0.09486,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 184,
+	label = "Cl-(Cs-(Cd-O2d)XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+6   O2d  u0 {3,D}
+""",
+	solute = u'Cl-(Cs-(Cd-O2d)ClCl)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 185,
+	label = "Cl-(Cs-(Cd-O2d(OH))XX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,S} {8,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+6   O2s u0 {3,S} {7,S}
+7   H   u0 {6,S}
+8   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.08421,
+		B = -0.03837,
+		E = 0.07972,
+		L = 0.55221,
+		A = 0.09374,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 186,
+	label = "Cl-(Cs-(Cd-O2d)ClCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   Cl1s u0 {2,S}
+5   Cl1s u0 {2,S}
+6   O2d  u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.01373,
+		B = -0.04185,
+		E = 0.07079,
+		L = 0.52501,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 24,
+		L = 19,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 187,
+	label = "Cl-(Cs-CtZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Ct  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.11453,
+		B = -0.15203,
+		E = -0.01524,
+		L = 0.03024,
+		A = 0.02564,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 188,
+	label = "Cl-(Cs-O2sZZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-O2sHZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 189,
+	label = "Cl-(Cs-O2sHZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   H   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.03038,
+		B = -0.08138,
+		E = 0.09897,
+		L = 0.07602,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 190,
+	label = "Cl-(Cs-O2sXX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-O2sFF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 191,
+	label = "Cl-(Cs-O2sFF)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   O2s u0 {2,S}
+4   F1s u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.05420,
+		B = -0.04083,
+		E = 0.07111,
+		L = 0.27262,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 192,
+	label = "Cl-(Cs-CCZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsCsZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 193,
+	label = "Cl-(Cs-CsCsZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsCsH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 194,
+	label = "Cl-(Crs-CrsCrsZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 r1 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 r1 {2,S}
+4   Cs  u0 r1 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Crs-CrsCrsH)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 195,
+	label = "Cl-(Crs-CrsCrsH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 r1 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 r1 {2,S}
+4   Cs  u0 r1 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.10731,
+		B = 0.10686,
+		E = 0.20234,
+		L = 0.74509,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 13,
+		E = 17,
+		L = 14,
+		A = 17,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 196,
+	label = "Cl-(Crs-CrsCrsX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 r1 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 r1 {2,S}
+4   Cs  u0 r1 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Crs-CrsCrsF)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 197,
+	label = "Cl-(Crs-CrsCrsF)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 r1 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 r1 {2,S}
+4   Cs  u0 r1 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.04473,
+		B = 0.01903,
+		E = -0.01751,
+		L = -0.00507,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 198,
+	label = "Cl-(Crs-CrsCrsCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 r1 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 r1 {2,S}
+4   Cs  u0 r1 {2,S}
+5   Cl1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.08731,
+		B = 0.02678,
+		E = 0.13683,
+		L = 0.65129,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 199,
+	label = "Cl-(Cs-CsCsH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.11424,
+		B = 0.04608,
+		E = 0.12531,
+		L = 0.59153,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 14,
+		L = 10,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 200,
+	label = "Cl-(Cs-CsCsX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsCsF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 201,
+	label = "Cl-(Cs-CsCsF)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.03285,
+		B = 0.00000,
+		E = -0.00328,
+		L = 0.14682,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 202,
+	label = "Cl-(Cs-CsCsCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cl1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.11565,
+		B = 0.01803,
+		E = 0.10940,
+		L = 0.49549,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 203,
+	label = "Cl-(Cs-CsCdZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [Cd,CO,CS]  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-Cs(Cd-Cd)Z)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 204,
+	label = "Cl-(Cs-Cs(Cd-Cd)Z)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cd  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   Cd  u0 {4,D}
+""",
+	solute = u'Cl-(Cs-Cs(Cd-Cd)H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 205,
+	label = "Cl-(Cs-Cs(Cd-Cd)H)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cd  u0 {2,S} {6,D}
+5   H   u0 {2,S}
+6   Cd  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.07865,
+		B = 0.02077,
+		E = 0.11312,
+		L = 0.56330,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 206,
+	label = "Cl-(Cs-Cs(Cd-O2d)Z)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {4,D}
+""",
+	solute = u'Cl-(Cs-Cs(Cd-O2d)H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 207,
+	label = "Cl-(Cs-Cs(Cd-O2d)H)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D}
+5   H   u0 {2,S}
+6   O2d u0 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.06606,
+		B = -0.02040,
+		E = 0.09521,
+		L = 0.50264,
+		A = 0.03733,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 208,
+	label = "Cl-(Cs-CO2sZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   O2s u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsO2sZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 209,
+	label = "Cl-(Cs-CsO2sZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsO2sH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 210,
+	label = "Cl-(Cs-CsO2sH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.03993,
+		B = -0.03279,
+		E = 0.04192,
+		L = 0.27012,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 211,
+	label = "Cl-(Cs-CsO2sX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   O2s u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.07917,
+		B = -0.03240,
+		E = 0.09510,
+		L = 0.36421,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 212,
+	label = "Cl-(Cs-CCC)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   C   u0 {2,S}
+""",
+	solute = u'Cl-(Cs-CsCsCs)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 213,
+	label = "Cl-(Crs-CrCrCr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 r1 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 r1 {2,S}
+4   C   u0 r1 {2,S}
+5   C   u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.09055,
+		B = 0.11798,
+		E = 0.24303,
+		L = 0.77872,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 214,
+	label = "Cl-(Cs-CsCsCs)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cs  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.11021,
+		B = 0.04934,
+		E = 0.10790,
+		L = 0.53701,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 5,
+		E = 4,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 215,
+	label = "Cl-(Cs-N5dc)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cs   u0 {1,S} {3,S}
+3   N5dc u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.05314,
+		B = 0.00000,
+		E = 0.08697,
+		L = 0.45931,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 216,
+	label = "Cl-Cd",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = u'Cl-(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 217,
+	label = "Cl-(Cd-Cd)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   C    u0 {2,D}
+""",
+	solute = u'Cl-(Cd-CdC)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 218,
+	label = "Cl-(Cd-CdC)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   C    u0 {2,S}
+""",
+	solute = u'Cl-(Cd-CdCs)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 219,
+	label = "Cl-(Crd-CrdCr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   C    u0 r1 {2,S}
+""",
+	solute = u'Cl-(Crd-CrdCrs)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 220,
+	label = "Cl-(Crd-CrdCrs)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   Cs   u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.01559,
+		B = -0.04241,
+		E = 0.12255,
+		L = 0.30981,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 221,
+	label = "Cl-(Crd-CrdCrd)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   [Cd,CO,CS]   u0 r1 {2,S}
+""",
+	solute = u'Cl-(Crd-Crd(Crd-Crd))',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 222,
+	label = "Cl-(Crd-Crd(Crd-Crd))",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   Cd   u0 r1 {2,S} {5,D}
+5   C    u0 r1 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.11193,
+		B = -0.02295,
+		E = 0.12996,
+		L = 0.79760,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 223,
+	label = "Cl-(Crd-Crd(Crd-Nrd))",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   Cd   u0 r1 {2,S} {5,D}
+5   N    u0 r1 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.00481,
+		B = -0.05095,
+		E = 0.07807,
+		L = 0.20600,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 224,
+	label = "Cl-(Crd-Crd(Crd-O2d))",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   CO   u0 r1 {2,S} {5,D}
+5   O2d  u0 {4,D}
+""",
+	solute = SoluteData(
+		S = -0.02747,
+		B = 0.03784,
+		E = 0.18468,
+		L = 0.48334,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 225,
+	label = "Cl-(Cd-CdCs)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   Cs   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.06372,
+		B = 0.00746,
+		E = 0.13515,
+		L = 0.62671,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 226,
+	label = "Cl-(Cd-CdN)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   N    u0 {2,S}
+""",
+	solute = u'Cl-(Crd-CrdNr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 227,
+	label = "Cl-(Crd-CrdNr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   N    u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00459,
+		B = -0.06724,
+		E = 0.10540,
+		L = 0.57315,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 10,
+		L = 9,
+		A = 9,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 228,
+	label = "Cl-(Cd-CdS)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   S    u0 {2,S}
+""",
+	solute = u'Cl-(Crd-CrdSr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 229,
+	label = "Cl-(Crd-CrdSr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   S    u0 r1 {2,S}
+""",
+	solute = u'Cl-(Crd-CrdNr)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 230,
+	label = "Cl-(Cd-CdZ)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   [H,F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Cl-(Cd-CdH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 231,
+	label = "Cl-(Cd-CdH)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   H    u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.14002,
+		B = -0.02380,
+		E = 0.11119,
+		L = 0.68144,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 232,
+	label = "Cl-(Cd-CdX)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Cl-(Cd-CdCl)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 233,
+	label = "Cl-(Cd-CdCl)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   Cl1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00652,
+		B = 0.00000,
+		E = 0.08894,
+		L = 0.55869,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 16,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 234,
+	label = "Cl-(Cd-Nd)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   N    u0 {2,D}
+""",
+	solute = u'Cl-(Cd-NdN)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 235,
+	label = "Cl-(Cd-NdC)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   N    u0 {2,D}
+4   C    u0 {2,S}
+""",
+	solute = u'Cl-(Crd-NrdCr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 236,
+	label = "Cl-(Crd-NrdCr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   N    u0 r1 {2,D}
+4   C    u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.06871,
+		B = 0.00000,
+		E = 0.08195,
+		L = 0.38848,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 6,
+		E = 6,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 237,
+	label = "Cl-(Cd-NdN)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   N    u0 {2,D}
+4   N    u0 {2,S}
+""",
+	solute = u'Cl-(Crd-NrdNr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 238,
+	label = "Cl-(Crd-NrdNr)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   N    u0 r1 {2,D}
+4   N    u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.06360,
+		B = 0.00606,
+		E = 0.14775,
+		L = 0.46397,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 239,
+	label = "Cl-(Cd-O2d)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   CO   u0 {1,S} {3,D}
+3   O2d  u0 {2,D}
+""",
+	solute = SoluteData(
+		S = -0.00734,
+		B = -0.10685,
+		E = -0.05252,
+		L = -0.08603,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 5,
+		L = 1,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 240,
+	label = "Cl-N",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   N    u0 {1,S}
+""",
+	solute = u'Cl-N3s',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 241,
+	label = "Cl-N3s",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   N3s  u0 {1,S}
+""",
+	solute = u'Cl-(N3s-C)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 242,
+	label = "Cl-(N3s-C)",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   N3s  u0 {1,S} {3,S}
+3   C    u0 {2,S}
+""",
+	solute = u'Cl-(N3s-(Cd-O2d))',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 243,
+	label = "Cl-(N3s-(Cd-O2d))",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   N3s  u0 {1,S} {3,S}
+3   CO   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.15163,
+		B = -0.14953,
+		E = 0.04020,
+		L = 0.65885,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 244,
+	label = "Cl-P",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   P    u0 {1,S}
+""",
+	solute = u'Cl-P5d',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 245,
+	label = "Cl-P5d",
+	group = 
+"""
+1 * Cl1s u0 {2,S}
+2   P5d  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.20458,
+		B = -0.01805,
+		E = 0.07937,
+		L = 0.74524,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 246,
+	label = "Br",
+	group = 
+"""
+1 * Br1s u0
+""",
+	solute = u'Br-C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 247,
+	label = "Br-C",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   C    u0 {1,S}
+""",
+	solute = u'Br-Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 248,
+	label = "Br-Cb",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.16175,
+		B = -0.03229,
+		E = 0.30694,
+		L = 1.13072,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 112,
+		B = 112,
+		E = 119,
+		L = 84,
+		A = 120,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 249,
+	label = "Br-Phenol",
+	group =  "OR{Br-Phenol(ortho), Br-Phenol(meta), Br-Phenol(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 250,
+	label = "Br-Phenol(ortho)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   O2s u0 {3,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.17563,
+		B = -0.04015,
+		E = 0.27440,
+		L = 1.13285,
+		A = 0.00355,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 13,
+		L = 13,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 251,
+	label = "Br-Phenol(meta)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.23572,
+		B = -0.06201,
+		E = 0.30228,
+		L = 1.22823,
+		A = 0.15664,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 252,
+	label = "Br-Phenol(para)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.07998,
+		B = -0.04863,
+		E = 0.23943,
+		L = 0.79144,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 253,
+	label = "Br-BenzoicAcid",
+	group =  "OR{Br-BenzoicAcid(ortho), Br-BenzoicAcid(meta), Br-BenzoicAcid(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 254,
+	label = "Br-BenzoicAcid(ortho)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.11375,
+		B = 0.05300,
+		E = 0.19576,
+		L = 0.83805,
+		A = 0.07289,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 255,
+	label = "Br-BenzoicAcid(meta)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   CO  u0 {4,S} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.05818,
+		B = -0.04321,
+		E = 0.12389,
+		L = 0.61285,
+		A = 0.03086,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 256,
+	label = "Br-BenzoicAcid(para)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   CO  u0 {5,S} {7,S}
+7   O2s u0 {6,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.01354,
+		B = -0.02133,
+		E = 0.06559,
+		L = 0.28982,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 257,
+	label = "Br-Aniline",
+	group =  "OR{Br-Aniline(ortho), Br-Aniline(meta), Br-Aniline(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 258,
+	label = "Br-Aniline(ortho)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   N3s u0 {3,S} {5,S} {6,S}
+5   H   u0 {4,S}
+6   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00259,
+		B = -0.01901,
+		E = 0.04200,
+		L = 0.26830,
+		A = 0.01420,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 259,
+	label = "Br-Aniline(meta)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   N3s u0 {4,S} {6,S} {7,S}
+6   H   u0 {5,S}
+7   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02366,
+		B = -0.02401,
+		E = 0.06133,
+		L = 0.31164,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 260,
+	label = "Br-Aniline(para)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   N3s u0 {5,S} {7,S} {8,S}
+7   H   u0 {6,S}
+8   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03677,
+		B = -0.01786,
+		E = 0.12381,
+		L = 0.32564,
+		A = 0.01366,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 261,
+	label = "Br-Cs",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs   u0 {1,S}
+""",
+	solute = u'Br-(Cs-CZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 262,
+	label = "Br-(Cs-CZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 263,
+	label = "Br-(Cs-CbZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.14080,
+		B = 0.04528,
+		E = 0.29736,
+		L = 1.07189,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 264,
+	label = "Br-(Cs-CsZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsHH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 265,
+	label = "Br-(Cs-CsHH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.37495,
+		B = 0.10712,
+		E = 0.33350,
+		L = 1.23423,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 39,
+		E = 41,
+		L = 35,
+		A = 41,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 266,
+	label = "Br-(Cs-(Cs-ZZZ)HH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [H,F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'Br-(Cs-(Cs-HHH)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 267,
+	label = "Br-(Cs-(Cs-HHH)HH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   H   u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.05000,
+		B = 0.03000,
+		E = 0.12200,
+		L = 0.27544,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 268,
+	label = "Br-(Cs-(Cs-HHX)HH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   H   u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.20967,
+		B = 0.05812,
+		E = 0.26832,
+		L = 0.78227,
+		A = 0.03518,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 269,
+	label = "Br-(Cs-(Cs-HXX)HH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   H   u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = u'Br-(Cs-(Cs-HHX)HH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 270,
+	label = "Br-(Cs-(Cs-XXX)HH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S} {6,S} {7,S} {8,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+7   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+8   [F1s,Cl1s,Br1s,I1s] u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.01796,
+		B = 0.00954,
+		E = 0.07761,
+		L = 0.25105,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 271,
+	label = "Br-(Cs-CsXH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsFH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 272,
+	label = "Br-(Cs-CsFH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.10511,
+		B = 0.01812,
+		E = 0.15848,
+		L = 0.63214,
+		A = 0.00986,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 273,
+	label = "Br-(Cs-CsClH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   Cl1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.11927,
+		B = 0.01931,
+		E = 0.15647,
+		L = 0.59840,
+		A = 0.00703,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 274,
+	label = "Br-(Cs-CsBrH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   Br1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.18583,
+		B = 0.05037,
+		E = 0.29800,
+		L = 0.95060,
+		A = 0.03483,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 275,
+	label = "Br-(Cs-CsIH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   I1s u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsClH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 276,
+	label = "Br-(Cs-CsXX)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsFX)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 277,
+	label = "Br-(Cs-CsFX)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   F1s  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsFF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 278,
+	label = "Br-(Cs-CsFF)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   F1s  u0 {2,S}
+5   F1s  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.09289,
+		B = 0.00000,
+		E = 0.19934,
+		L = 0.77379,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 279,
+	label = "Br-(Cs-CsFCl)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   F1s  u0 {2,S}
+5   Cl1s  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.06749,
+		B = 0.00000,
+		E = 0.11328,
+		L = 0.51454,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 280,
+	label = "Br-(Cs-CsFBr)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   F1s  u0 {2,S}
+5   Br1s  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.09411,
+		B = 0.02047,
+		E = 0.14201,
+		L = 0.55406,
+		A = -0.00917,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 281,
+	label = "Br-(Cs-CsFI)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   F1s  u0 {2,S}
+5   I1s  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsClH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 282,
+	label = "Br-(Cs-CsClX)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cl1s  u0 {2,S}
+5   [Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsFCl)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 283,
+	label = "Br-(Cs-CsBrX)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Br1s  u0 {2,S}
+5   [Br1s,I1s]  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsFBr)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 284,
+	label = "Br-(Cs-CsII)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   I1s  u0 {2,S}
+5   I1s  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsFI)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 285,
+	label = "Br-(Cs-CdZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   [Cd,CO,CS]  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 286,
+	label = "Br-(Cs-(Cd-Cd)ZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   Cd  u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.04698,
+		B = 0.01251,
+		E = 0.12118,
+		L = 0.40588,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 287,
+	label = "Br-(Cs-(Cd-O2d)ZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.15375,
+		B = 0.01091,
+		E = 0.21845,
+		L = 0.91472,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 9,
+		L = 5,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 288,
+	label = "Br-(Cs-(Cd-O2d(OH))ZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 289,
+	label = "Br-(Cs-(Cd-O2d(OH))HH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.03739,
+		B = -0.00837,
+		E = 0.10810,
+		L = 0.40126,
+		A = 0.03324,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 290,
+	label = "Br-(Cs-(Cd-O2d(OH))XH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.11112,
+		B = -0.03625,
+		E = 0.20578,
+		L = 0.87408,
+		A = 0.09486,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 291,
+	label = "Br-(Cs-(Cd-O2d(OH))XX)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.09358,
+		B = -0.02587,
+		E = 0.23108,
+		L = 0.93757,
+		A = 0.08681,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 292,
+	label = "Br-(Cs-CtZZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Ct  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = -0.06813,
+		B = -0.07590,
+		E = 0.13418,
+		L = 0.26379,
+		A = 0.05856,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 293,
+	label = "Br-(Cs-CCZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsCsZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 294,
+	label = "Br-(Cs-CsCsZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsCsH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 295,
+	label = "Br-(Cs-CsCsH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.28618,
+		B = 0.11702,
+		E = 0.30404,
+		L = 1.22154,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 25,
+		B = 25,
+		E = 26,
+		L = 21,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 296,
+	label = "Br-(Cs-CsCsX)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsCsF)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 297,
+	label = "Br-(Cs-CsCsF)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   F1s u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00518,
+		B = -0.01293,
+		E = 0.05413,
+		L = 0.15575,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 298,
+	label = "Br-(Cs-CsCbZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cb  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-CbZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 299,
+	label = "Br-(Cs-CsCdZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [Cd,CO,CS]  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'Br-(Cs-Cs(Cd-Cd)Z)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 300,
+	label = "Br-(Cs-Cs(Cd-Cd)Z)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cd  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   Cd  u0 {4,D}
+""",
+	solute = u'Br-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 301,
+	label = "Br-(Cs-Cs(Cd-O2d)Z)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {4,D}
+""",
+	solute = u'Br-(Cs-Cs(Cd-O2d)H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 302,
+	label = "Br-(Cs-Cs(Cd-O2d)H)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D}
+5   H   u0 {2,S}
+6   O2d u0 {4,D}
+""",
+	solute = SoluteData(
+		S = 0.02293,
+		B = -0.00075,
+		E = 0.21061,
+		L = 0.62351,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 303,
+	label = "Br-(Cs-Cs(Cd-O2d(OH))H)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D} {7,S}
+5   H   u0 {2,S}
+6   O2d u0 {4,D}
+7   O2s u0 {4,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.13110,
+		B = -0.04723,
+		E = 0.18070,
+		L = 0.76259,
+		A = 0.06266,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 304,
+	label = "Br-(Cs-CO2sZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   O2s u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.00612,
+		B = -0.01410,
+		E = 0.14243,
+		L = 0.48767,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 305,
+	label = "Br-(Cs-CCC)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   C   u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsCsCs)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 306,
+	label = "Br-(Cs-CsCsCs)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cs  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.08195,
+		B = 0.05646,
+		E = 0.19966,
+		L = 0.65970,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 307,
+	label = "Br-(Cs-CsCsCb)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cb  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CbZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 308,
+	label = "Br-(Cs-CsCsCd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [Cd,CO,CS]  u0 {2,S}
+""",
+	solute = u'Br-(Cs-CsCs(Cd-Cd))',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 309,
+	label = "Br-(Cs-CsCs(Cd-Cd))",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   Cd  u0 {2,S} {6,D}
+6   Cd  u0 {5,D}
+""",
+	solute = u'Br-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 310,
+	label = "Br-(Cs-CsCs(Cd-O2d))",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   CO  u0 {2,S} {6,D}
+6   O2d u0 {5,D}
+""",
+	solute = u'Br-(Cs-Cs(Cd-O2d)H)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 311,
+	label = "Br-Cd",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   [Cd,CO,CS] u0 {1,S}
+""",
+	solute = u'Br-(Cd-Cd)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 312,
+	label = "Br-(Cd-Cd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   C    u0 {2,D}
+""",
+	solute = u'Br-(Cd-CdZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 313,
+	label = "Br-(Cd-CdZ)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   [H,F1s,Cl1s,Br1s,I1s]  u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.15019,
+		B = 0.00000,
+		E = 0.25124,
+		L = 0.95384,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 6,
+		E = 7,
+		L = 5,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 314,
+	label = "Br-(Cd-CdC)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   C    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 315,
+	label = "Br-(Cd-CdCd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   [Cd,CO,CS]   u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 316,
+	label = "Br-(Crd-CrdCrd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   [Cd,CO,CS]   u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.13580,
+		B = -0.05362,
+		E = 0.25784,
+		L = 0.85193,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 10,
+		A = 16,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 317,
+	label = "Br-(Cd-CdCs)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   Cs   u0 {2,S}
+""",
+	solute = u'Br-(Cd-CdZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 318,
+	label = "Br-(Cd-CdN)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   N    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 319,
+	label = "Br-(Cd-CdN3d)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   N3d  u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 320,
+	label = "Br-(Crd-CrdN3rd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   N3d  u0 r1 {2,S}
+""",
+	solute = u'Br-(Crd-CrdCrd)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 321,
+	label = "Br-(Cd-CdO2s)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   O2s  u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 322,
+	label = "Br-(Crd-CrdO2rs)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   O2s  u0 r1 {2,S}
+""",
+	solute = u'Br-(Crd-CrdCrd)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 323,
+	label = "Br-(Cd-Nd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   N    u0 {2,D}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 324,
+	label = "Br-(Cd-NdN)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   N    u0 {2,D}
+4   N    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 325,
+	label = "Br-(Cd-N3dN3d)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   N3d  u0 {2,D}
+4   N3d  u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 326,
+	label = "Br-(Crd-N3rdN3rd)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   N3d  u0 r1 {2,D}
+4   N3d  u0 r1 {2,S}
+""",
+	solute = u'Br-(Crd-CrdN3rd)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 327,
+	label = "Br-N",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   N    u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 328,
+	label = "Br-N3s",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   N3s  u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 329,
+	label = "Br-(N3s-CH)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   N3s  u0 {1,S} {3,S} {4,S}
+3   C    u0 {2,S}
+4   H    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 330,
+	label = "Br-(N3s-(Cd-O2d)H)",
+	group = 
+"""
+1 * Br1s u0 {2,S}
+2   N3s  u0 {1,S} {3,S} {4,S}
+3   CO   u0 {2,S}
+4   H    u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.04429,
+		B = -0.06935,
+		E = 0.06070,
+		L = 0.33856,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 331,
+	label = "I",
+	group = 
+"""
+1 * I1s u0
+""",
+	solute = u'I-C',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 332,
+	label = "I-C",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   C    u0 {1,S}
+""",
+	solute = u'I-Cs',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 333,
+	label = "I-Cb",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cb   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.19767,
+		B = -0.00107,
+		E = 0.57971,
+		L = 1.60540,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 47,
+		B = 40,
+		E = 46,
+		L = 28,
+		A = 47,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 334,
+	label = "I-Phenol",
+	group =  "OR{I-Phenol(ortho), I-Phenol(meta), I-Phenol(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 335,
+	label = "I-Phenol(ortho)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   O2s u0 {3,S} {5,S}
+5   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.12327,
+		B = 0.00000,
+		E = 0.56832,
+		L = 1.69175,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 336,
+	label = "I-Phenol(meta)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.04800,
+		B = -0.02617,
+		E = 0.18810,
+		L = 0.52734,
+		A = 0.05379,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 337,
+	label = "I-Phenol(para)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.12071,
+		B = 0.00000,
+		E = 0.45796,
+		L = 1.31024,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 338,
+	label = "I-BenzoicAcid",
+	group =  "OR{I-BenzoicAcid(ortho), I-BenzoicAcid(meta), I-BenzoicAcid(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 339,
+	label = "I-BenzoicAcid(ortho)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   O2s u0 {4,S} {6,S}
+6   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.16625,
+		B = 0.06425,
+		E = 0.41719,
+		L = 1.33662,
+		A = 0.08400,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 340,
+	label = "I-BenzoicAcid(meta)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   CO  u0 {4,S} {6,S}
+6   O2s u0 {5,S} {7,S}
+7   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.04479,
+		B = -0.02383,
+		E = 0.16893,
+		L = 0.60515,
+		A = 0.01173,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 341,
+	label = "I-BenzoicAcid(para)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   CO  u0 {5,S} {7,S}
+7   O2s u0 {6,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.04479,
+		B = -0.01383,
+		E = 0.16893,
+		L = 0.62815,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 342,
+	label = "I-Aniline",
+	group =  "OR{I-Aniline(ortho), I-Aniline(meta), I-Aniline(para)}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 343,
+	label = "I-Aniline(ortho)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,S}
+4   N3s u0 {3,S} {5,S} {6,S}
+5   H   u0 {4,S}
+6   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.08830,
+		B = 0.02814,
+		E = 0.41748,
+		L = 1.60331,
+		A = 0.03589,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 344,
+	label = "I-Aniline(meta)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,S}
+5   N3s u0 {4,S} {6,S} {7,S}
+6   H   u0 {5,S}
+7   H   u0 {5,S}
+""",
+	solute = SoluteData(
+		S = 0.03241,
+		B = -0.02151,
+		E = 0.15667,
+		L = 0.47997,
+		A = 0.01820,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 345,
+	label = "I-Aniline(para)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cb  u0 {1,S} {3,B}
+3   Cb  u0 {2,B} {4,B}
+4   Cb  u0 {3,B} {5,B}
+5   Cb  u0 {4,B} {6,S}
+6   N3s u0 {5,S} {7,S} {8,S}
+7   H   u0 {6,S}
+8   H   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.11050,
+		B = -0.00582,
+		E = 0.35221,
+		L = 1.05447,
+		A = 0.00440,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 346,
+	label = "I-Cs",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cs   u0 {1,S}
+""",
+	solute = u'I-(Cs-CZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 347,
+	label = "I-(Cs-CZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-CsZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 348,
+	label = "I-(Cs-CbZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cb  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.09157,
+		B = 0.03350,
+		E = 0.36377,
+		L = 1.06863,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 349,
+	label = "I-(Cs-CsZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-CsHH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 350,
+	label = "I-(Cs-CsHH)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.28905,
+		B = 0.12991,
+		E = 0.57766,
+		L = 1.81542,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 19,
+		E = 21,
+		L = 19,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 351,
+	label = "I-(Cs-CdZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   [Cd,CO,CS]   u0 {2,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 352,
+	label = "I-(Cs-(Cd-Cd)ZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cd  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   C   u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.05073,
+		B = 0.03501,
+		E = 0.22218,
+		L = 0.66254,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 353,
+	label = "I-(Cs-(Cd-O2d)ZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = 0.08634,
+		B = -0.00706,
+		E = 0.35642,
+		L = 0.93663,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 354,
+	label = "I-(Cs-(Cd-O2d(OH))ZZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 355,
+	label = "I-(Cs-(Cd-O2d(OH))HH)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   H   u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.04739,
+		B = -0.00837,
+		E = 0.19244,
+		L = 0.59092,
+		A = 0.03524,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 356,
+	label = "I-(Cs-(Cd-O2d(OH))XH)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   H   u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.09802,
+		B = -0.01814,
+		E = 0.37377,
+		L = 1.25459,
+		A = 0.07405,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 357,
+	label = "I-(Cs-(Cd-O2d(OH))XX)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   CO  u0 {2,S} {6,D} {7,S}
+4   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+5   [F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {3,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.10296,
+		B = -0.01587,
+		E = 0.45417,
+		L = 1.46503,
+		A = 0.08220,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 358,
+	label = "I-(Cs-CCZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-CsCsZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 359,
+	label = "I-(Cs-CsCsZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-CsCsH)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 360,
+	label = "I-(Cs-CsCsH)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cs  u0 {2,S}
+5   H   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.10502,
+		B = 0.07667,
+		E = 0.37866,
+		L = 1.00789,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 361,
+	label = "I-(Cs-CsCbZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cb  u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-CbZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 362,
+	label = "I-(Cs-CsCdZ)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   [Cd,CO,CS]   u0 {2,S}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+""",
+	solute = u'I-(Cs-Cs(Cd-Cd)Z)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 363,
+	label = "I-(Cs-Cs(Cd-Cd)Z)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   Cd  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   C   u0 {4,D}
+""",
+	solute = u'I-(Cs-(Cd-Cd)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 364,
+	label = "I-(Cs-Cs(Cd-O2d)Z)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   Cs  u0 {2,S}
+4   CO  u0 {2,S} {6,D}
+5   [H,F1s,Cl1s,Br1s,I1s] u0 {2,S}
+6   O2d u0 {4,D}
+""",
+	solute = u'I-(Cs-(Cd-O2d)ZZ)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 365,
+	label = "I-(Cs-CCC)",
+	group = 
+"""
+1 * I1s u0 {2,S}
+2   Cs  u0 {1,S} {3,S} {4,S} {5,S}
+3   C   u0 {2,S}
+4   C   u0 {2,S}
+5   C   u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.08359,
+		B = 0.05634,
+		E = 0.31160,
+		L = 1.00887,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 366,
+	label = "I-Cd",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   [Cd,CO,CS]   u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 367,
+	label = "I-(Cd-Cd)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   C    u0 {2,D}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 368,
+	label = "I-(Cd-CdC)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   C    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 369,
+	label = "I-(Crd-CrdCr)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   C    u0 r1 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.15654,
+		B = -0.05127,
+		E = 0.46471,
+		L = 1.24992,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 5,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 370,
+	label = "I-(Cd-CdN)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   C    u0 {2,D}
+4   N    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 371,
+	label = "I-(Crd-CrdNr)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   C    u0 r1 {2,D}
+4   N    u0 r1 {2,S}
+""",
+	solute = u'I-(Crd-CrdCr)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 372,
+	label = "I-(Cd-Nd)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 {1,S} {3,D}
+3   N    u0 {2,D}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 373,
+	label = "I-(Cd-NdN)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 {1,S} {3,D} {4,S}
+3   N    u0 {2,D}
+4   N    u0 {2,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 374,
+	label = "I-(Crd-NrdNr)",
+	group = 
+"""
+1 * I1s  u0 {2,S}
+2   Cd   u0 r1 {1,S} {3,D} {4,S}
+3   N    u0 r1 {2,D}
+4   N    u0 r1 {2,S}
+""",
+	solute = u'I-(Crd-CrdNr)',
+	dataCount = None,
+	shortDesc = u"""special solvation group with ring""",
+	longDesc = 
+u"""
+
+""",
+)
+
+tree(
+"""
+L1: X
+	L2: F
+		L3: F-C
+			L4: F-Cb
+				L5: F-Phenol
+					L6: F-Phenol(ortho)
+					L6: F-Phenol(meta)
+					L6: F-Phenol(para)
+				L5: F-BenzoicAcid
+					L6: F-BenzoicAcid(ortho)
+					L6: F-BenzoicAcid(meta)
+					L6: F-BenzoicAcid(para)
+				L5: F-Aniline
+					L6: F-Aniline(ortho)
+					L6: F-Aniline(meta)
+					L6: F-Aniline(para)
+			L4: F-Cs
+				L5: F-(Cs-CZZ)
+					L6: F-(Cs-CbZZ)
+						L7: F-(Cs-CbHH)
+						L7: F-(Cs-CbXX)
+							L8: F-(Cs-CbFF)
+					L6: F-(Cs-CsZZ)
+						L7: F-(Cs-CsHH)
+							L8: F-(Cs-(Cs-ZZZ)HH)
+								L9: F-(Cs-(Cs-HHH)HH)
+								L9: F-(Cs-(Cs-HHX)HH)
+								L9: F-(Cs-(Cs-HXX)HH)
+								L9: F-(Cs-(Cs-XXX)HH)
+							L8: F-(Cs-(Cs-(OH))HH)
+						L7: F-(Cs-CsXH)
+							L8: F-(Cs-(Cs-ZZZ)XH)
+								L9: F-(Cs-(Cs-HHH)XH)
+								L9: F-(Cs-(Cs-HHX)XH)
+								L9: F-(Cs-(Cs-HXX)XH)
+								L9: F-(Cs-(Cs-XXX)XH)
+							L8: F-(Cs-(Cs-(OH))XH)
+							L8: F-(Cs-CsFH)
+							L8: F-(Cs-CsClH)
+							L8: F-(Cs-CsBrH)
+							L8: F-(Cs-CsIH)
+						L7: F-(Cs-CsXX)
+							L8: F-(Cs-(Cs-ZZZ)XX)
+								L9: F-(Cs-(Cs-HHH)XX)
+								L9: F-(Cs-(Cs-HHX)XX)
+								L9: F-(Cs-(Cs-HXX)XX)
+								L9: F-(Cs-(Cs-XXX)XX)
+							L8: F-(Cs-CsFX)
+								L9: F-(Cs-CsFF)
+									L10: F-(Cs-(Cs-(OH))FF)
+									L10: F-(Cs-(Cs-O)FF)
+								L9: F-(Cs-CsFCl)
+								L9: F-(Cs-CsFBr)
+								L9: F-(Cs-CsFI)
+					L6: F-(Cs-CdZZ)
+						L7: F-(Cs-(Cd-Cd)ZZ)
+							L8: F-(Cs-(Cd-Cd)FX)
+								L9: F-(Cs-(Cd-Cd)FF)
+						L7: F-(Cs-(Cd-Nd)ZZ)
+							L8: F-(Cs-(Cd-Nd)XX)
+								L9: F-(Cs-(Cd-Nd)FF)
+						L7: F-(Cs-(Cd-O2d)ZZ)
+							L8: F-(Cs-(Cd-O2d)HH)
+								L9: F-(Cs-(Cd-O2d(OH))HH)
+							L8: F-(Cs-(Cd-O2d)XH)
+								L9: F-(Cs-(Cd-O2d(OH))XH)
+							L8: F-(Cs-(Cd-O2d)XX)
+								L9: F-(Cs-(Cd-O2d(OH))XX)
+								L9: F-(Cs-(Cd-O2d(NH))XX)
+				L5: F-(Cs-O2sZZ)
+					L6: F-(Cs-O2sHZ)
+						L7: F-(Cs-O2sHH)
+						L7: F-(Cs-O2sHX)
+							L8: F-(Cs-O2sHF)
+					L6: F-(Cs-O2sXX)
+						L7: F-(Cs-O2sFF)
+				L5: F-(Cs-CCZ)
+					L6: F-(Cs-CsCsZ)
+						L7: F-(Cs-CsCsH)
+						L7: F-(Cs-CsCsX)
+							L8: F-(Cs-CsCsF)
+								L9: F-(Cs-(Cs-(OH))CsF)
+							L8: F-(Cs-CsCsCl)
+							L8: F-(Cs-CsCsBr)
+							L8: F-(Cs-CsCsI)
+					L6: F-(Cs-CsCdZ)
+						L7: F-(Cs-Cs(Cd-Cd)Z)
+						L7: F-(Cs-Cs(Cd-Nd)Z)
+						L7: F-(Cs-Cs(Cd-O2d)Z)
+				L5: F-(Cs-CO2sZ)
+					L6: F-(Cs-CsO2sZ)
+						L7: F-(Cs-CsO2sH)
+						L7: F-(Cs-CsO2sX)
+							L8: F-(Cs-CsO2sF)
+				L5: F-(Cs-CCC)
+					L6: F-(Cs-CsCsCs)
+				L5: F-(Cs-CCO2s)
+					L6: F-(Cs-CsCsO2s)
+			L4: F-Cd
+				L5: F-(Cd-Cd)
+					L6: F-(Cd-CdR)
+						L7: F-(Cd-CdC)
+							L8: F-(Crd-CrdCr)
+								L9: F-(Crd-CrdCrd)
+							L8: F-(Cd-CdCs)
+						L7: F-(Cd-CdN)
+							L8: F-(Cd-CrdNr)
+					L6: F-(Cd-CdZ)
+						L7: F-(Cd-CdH)
+						L7: F-(Cd-CdX)
+							L8: F-(Cd-CdF)
+				L5: F-(Cd-Nd)
+					L6: F-(Cd-N3d)
+						L7: F-(Crd-N3rd)
+		L3: F-N
+			L4: F-N3s
+		L3: F-P
+			L4: F-P5d
+	L2: Cl
+		L3: Cl-C
+			L4: Cl-Cb
+				L5: Cl-Phenol
+					L6: Cl-Phenol(ortho)
+					L6: Cl-Phenol(meta)
+					L6: Cl-Phenol(para)
+				L5: Cl-BenzoicAcid
+					L6: Cl-BenzoicAcid(ortho)
+					L6: Cl-BenzoicAcid(meta)
+					L6: Cl-BenzoicAcid(para)
+				L5: Cl-BenzylAlcohol
+					L6: Cl-BenzylAlcohol(ortho)
+					L6: Cl-BenzylAlcohol(meta)
+					L6: Cl-BenzylAlcohol(para)
+				L5: Cl-Aniline
+					L6: Cl-Aniline(ortho)
+					L6: Cl-Aniline(meta)
+					L6: Cl-Aniline(para)
+			L4: Cl-Cs
+				L5: Cl-(Cs-CZZ)
+					L6: Cl-(Cs-CbZZ)
+					L6: Cl-(Cs-CsZZ)
+						L7: Cl-(Cs-CsHH)
+							L8: Cl-(Cs-(Cs-ZZZ)HH)
+								L9: Cl-(Cs-(Cs-HHH)HH)
+								L9: Cl-(Cs-(Cs-HHX)HH)
+								L9: Cl-(Cs-(Cs-HXX)HH)
+								L9: Cl-(Cs-(Cs-XXX)HH)
+							L8: Cl-(Cs-(Cs-(OH))HH)
+						L7: Cl-(Cs-CsXH)
+							L8: Cl-(Cs-(Cs-ZZZ)XH)
+								L9: Cl-(Cs-(Cs-HHH)XH)
+								L9: Cl-(Cs-(Cs-HHX)XH)
+								L9: Cl-(Cs-(Cs-HXX)XH)
+								L9: Cl-(Cs-(Cs-XXX)XH)
+							L8: Cl-(Cs-(Cs-(OH))XH)
+							L8: Cl-(Cs-CsFH)
+							L8: Cl-(Cs-CsClH)
+							L8: Cl-(Cs-CsBrH)
+							L8: Cl-(Cs-CsIH)
+						L7: Cl-(Cs-CsXX)
+							L8: Cl-(Cs-(Cs-ZZZ)XX)
+								L9: Cl-(Cs-(Cs-HHH)XX)
+								L9: Cl-(Cs-(Cs-HHX)XX)
+								L9: Cl-(Cs-(Cs-HXX)XX)
+								L9: Cl-(Cs-(Cs-XXX)XX)
+							L8: Cl-(Cs-CsFX)
+								L9: Cl-(Cs-CsFF)
+								L9: Cl-(Cs-CsFCl)
+								L9: Cl-(Cs-CsFBr)
+								L9: Cl-(Cs-CsFI)
+							L8: Cl-(Cs-CsClX)
+								L9: Cl-(Cs-CsClCl)
+									L10: Cl-(Cs-(Cs-(OH))ClCl)
+							L8: Cl-(Cs-CsBrX)
+							L8: Cl-(Cs-CsII)
+					L6: Cl-(Cs-CdZZ)
+						L7: Cl-(Cs-(Cd-Cd)ZZ)
+							L8: Cl-(Cs-(Cd-Cd)HH)
+						L7: Cl-(Cs-(Cd-O2d)ZZ)
+							L8: Cl-(Cs-(Cd-O2d)HH)
+								L9: Cl-(Cs-(Cd-O2d(OH))HH)
+							L8: Cl-(Cs-(Cd-O2d)XH)
+								L9: Cl-(Cs-(Cd-O2d(OH))XH)
+							L8: Cl-(Cs-(Cd-O2d)XX)
+								L9: Cl-(Cs-(Cd-O2d(OH))XX)
+								L9: Cl-(Cs-(Cd-O2d)ClCl)
+					L6: Cl-(Cs-CtZZ)
+				L5: Cl-(Cs-O2sZZ)
+					L6: Cl-(Cs-O2sHZ)
+					L6: Cl-(Cs-O2sXX)
+						L7: Cl-(Cs-O2sFF)
+				L5: Cl-(Cs-CCZ)
+					L6: Cl-(Cs-CsCsZ)
+						L7: Cl-(Crs-CrsCrsZ)
+							L8: Cl-(Crs-CrsCrsH)
+							L8: Cl-(Crs-CrsCrsX)
+								L9: Cl-(Crs-CrsCrsF)
+								L9: Cl-(Crs-CrsCrsCl)
+						L7: Cl-(Cs-CsCsH)
+						L7: Cl-(Cs-CsCsX)
+							L8: Cl-(Cs-CsCsF)
+							L8: Cl-(Cs-CsCsCl)
+					L6: Cl-(Cs-CsCdZ)
+						L7: Cl-(Cs-Cs(Cd-Cd)Z)
+							L8: Cl-(Cs-Cs(Cd-Cd)H)
+						L7: Cl-(Cs-Cs(Cd-O2d)Z)
+							L8: Cl-(Cs-Cs(Cd-O2d)H)
+				L5: Cl-(Cs-CO2sZ)
+					L6: Cl-(Cs-CsO2sZ)
+						L7: Cl-(Cs-CsO2sH)
+						L7: Cl-(Cs-CsO2sX)
+				L5: Cl-(Cs-CCC)
+					L6: Cl-(Crs-CrCrCr)
+					L6: Cl-(Cs-CsCsCs)
+				L5: Cl-(Cs-N5dc)
+			L4: Cl-Cd
+				L5: Cl-(Cd-Cd)
+					L6: Cl-(Cd-CdC)
+						L7: Cl-(Crd-CrdCr)
+							L8: Cl-(Crd-CrdCrs)
+							L8: Cl-(Crd-CrdCrd)
+								L9: Cl-(Crd-Crd(Crd-Crd))
+								L9: Cl-(Crd-Crd(Crd-Nrd))
+								L9: Cl-(Crd-Crd(Crd-O2d))
+						L7: Cl-(Cd-CdCs)
+					L6: Cl-(Cd-CdN)
+						L7: Cl-(Crd-CrdNr)
+					L6: Cl-(Cd-CdS)
+						L7: Cl-(Crd-CrdSr)
+					L6: Cl-(Cd-CdZ)
+						L7: Cl-(Cd-CdH)
+						L7: Cl-(Cd-CdX)
+							L8: Cl-(Cd-CdCl)
+				L5: Cl-(Cd-Nd)
+					L6: Cl-(Cd-NdC)
+						L7: Cl-(Crd-NrdCr)
+					L6: Cl-(Cd-NdN)
+						L7: Cl-(Crd-NrdNr)
+				L5: Cl-(Cd-O2d)
+		L3: Cl-N
+			L4: Cl-N3s
+				L5: Cl-(N3s-C)
+					L6: Cl-(N3s-(Cd-O2d))
+		L3: Cl-P
+			L4: Cl-P5d
+	L2: Br
+		L3: Br-C
+			L4: Br-Cb
+				L5: Br-Phenol
+					L6: Br-Phenol(ortho)
+					L6: Br-Phenol(meta)
+					L6: Br-Phenol(para)
+				L5: Br-BenzoicAcid
+					L6: Br-BenzoicAcid(ortho)
+					L6: Br-BenzoicAcid(meta)
+					L6: Br-BenzoicAcid(para)
+				L5: Br-Aniline
+					L6: Br-Aniline(ortho)
+					L6: Br-Aniline(meta)
+					L6: Br-Aniline(para)
+			L4: Br-Cs
+				L5: Br-(Cs-CZZ)
+					L6: Br-(Cs-CbZZ)
+					L6: Br-(Cs-CsZZ)
+						L7: Br-(Cs-CsHH)
+							L8: Br-(Cs-(Cs-ZZZ)HH)
+								L9: Br-(Cs-(Cs-HHH)HH)
+								L9: Br-(Cs-(Cs-HHX)HH)
+								L9: Br-(Cs-(Cs-HXX)HH)
+								L9: Br-(Cs-(Cs-XXX)HH)
+						L7: Br-(Cs-CsXH)
+							L8: Br-(Cs-CsFH)
+							L8: Br-(Cs-CsClH)
+							L8: Br-(Cs-CsBrH)
+							L8: Br-(Cs-CsIH)
+						L7: Br-(Cs-CsXX)
+							L8: Br-(Cs-CsFX)
+								L9: Br-(Cs-CsFF)
+								L9: Br-(Cs-CsFCl)
+								L9: Br-(Cs-CsFBr)
+								L9: Br-(Cs-CsFI)
+							L8: Br-(Cs-CsClX)
+							L8: Br-(Cs-CsBrX)
+							L8: Br-(Cs-CsII)
+					L6: Br-(Cs-CdZZ)
+						L7: Br-(Cs-(Cd-Cd)ZZ)
+						L7: Br-(Cs-(Cd-O2d)ZZ)
+							L8: Br-(Cs-(Cd-O2d(OH))ZZ)
+								L9: Br-(Cs-(Cd-O2d(OH))HH)
+								L9: Br-(Cs-(Cd-O2d(OH))XH)
+								L9: Br-(Cs-(Cd-O2d(OH))XX)
+					L6: Br-(Cs-CtZZ)
+				L5: Br-(Cs-CCZ)
+					L6: Br-(Cs-CsCsZ)
+						L7: Br-(Cs-CsCsH)
+						L7: Br-(Cs-CsCsX)
+							L8: Br-(Cs-CsCsF)
+					L6: Br-(Cs-CsCbZ)
+					L6: Br-(Cs-CsCdZ)
+						L7: Br-(Cs-Cs(Cd-Cd)Z)
+						L7: Br-(Cs-Cs(Cd-O2d)Z)
+							L8: Br-(Cs-Cs(Cd-O2d)H)
+								L9: Br-(Cs-Cs(Cd-O2d(OH))H)
+				L5: Br-(Cs-CO2sZ)
+				L5: Br-(Cs-CCC)
+					L6: Br-(Cs-CsCsCs)
+					L6: Br-(Cs-CsCsCb)
+					L6: Br-(Cs-CsCsCd)
+						L7: Br-(Cs-CsCs(Cd-Cd))
+						L7: Br-(Cs-CsCs(Cd-O2d))
+			L4: Br-Cd
+				L5: Br-(Cd-Cd)
+					L6: Br-(Cd-CdZ)
+					L6: Br-(Cd-CdC)
+						L7: Br-(Cd-CdCd)
+							L8: Br-(Crd-CrdCrd)
+						L7: Br-(Cd-CdCs)
+					L6: Br-(Cd-CdN)
+						L7: Br-(Cd-CdN3d)
+							L8: Br-(Crd-CrdN3rd)
+					L6: Br-(Cd-CdO2s)
+						L7: Br-(Crd-CrdO2rs)
+				L5: Br-(Cd-Nd)
+					L6: Br-(Cd-NdN)
+						L7: Br-(Cd-N3dN3d)
+							L8: Br-(Crd-N3rdN3rd)
+		L3: Br-N
+			L4: Br-N3s
+				L5: Br-(N3s-CH)
+					L6: Br-(N3s-(Cd-O2d)H)
+	L2: I
+		L3: I-C
+			L4: I-Cb
+				L5: I-Phenol
+					L6: I-Phenol(ortho)
+					L6: I-Phenol(meta)
+					L6: I-Phenol(para)
+				L5: I-BenzoicAcid
+					L6: I-BenzoicAcid(ortho)
+					L6: I-BenzoicAcid(meta)
+					L6: I-BenzoicAcid(para)
+				L5: I-Aniline
+					L6: I-Aniline(ortho)
+					L6: I-Aniline(meta)
+					L6: I-Aniline(para)
+			L4: I-Cs
+				L5: I-(Cs-CZZ)
+					L6: I-(Cs-CbZZ)
+					L6: I-(Cs-CsZZ)
+						L7: I-(Cs-CsHH)
+					L6: I-(Cs-CdZZ)
+						L7: I-(Cs-(Cd-Cd)ZZ)
+						L7: I-(Cs-(Cd-O2d)ZZ)
+							L8: I-(Cs-(Cd-O2d(OH))ZZ)
+								L9: I-(Cs-(Cd-O2d(OH))HH)
+								L9: I-(Cs-(Cd-O2d(OH))XH)
+								L9: I-(Cs-(Cd-O2d(OH))XX)
+				L5: I-(Cs-CCZ)
+					L6: I-(Cs-CsCsZ)
+						L7: I-(Cs-CsCsH)
+					L6: I-(Cs-CsCbZ)
+					L6: I-(Cs-CsCdZ)
+						L7: I-(Cs-Cs(Cd-Cd)Z)
+						L7: I-(Cs-Cs(Cd-O2d)Z)
+				L5: I-(Cs-CCC)
+			L4: I-Cd
+				L5: I-(Cd-Cd)
+					L6: I-(Cd-CdC)
+						L7: I-(Crd-CrdCr)
+					L6: I-(Cd-CdN)
+						L7: I-(Crd-CrdNr)
+				L5: I-(Cd-Nd)
+					L6: I-(Cd-NdN)
+						L7: I-(Crd-NrdNr)
+"""
+)

--- a/input/solvation/groups/longDistanceInteraction_cyclic.py
+++ b/input/solvation/groups/longDistanceInteraction_cyclic.py
@@ -1,0 +1,899 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "longDistanceInteraction_cyclic"
+shortDesc = u""
+longDesc = u""" 
+All groups are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter data (manuscript in preparation)
+unless written otherwise.
+"""
+
+entry(
+	index = -1,
+	label = "R",
+	group = 
+"""
+1 *1 R u0
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1,
+	label = "aromatic-ortho",
+	group = 
+"""
+1 *1 Cb u0 {2,B}
+2 *2 Cb u0 {1,B}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 2,
+	label = "o_OH",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B}
+3    O u0 {1,S} {4,S}
+4    H u0 {3,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 3,
+	label = "o_OH_OH",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {5,S}
+3    O u0 {1,S} {4,S}
+4    H u0 {3,S}
+5    O u0 {2,S} {6,S}
+6    H u0 {5,S}
+""",
+	solute = SoluteData(
+		S = -0.01250,
+		B = -0.01125,
+		E = -0.00857,
+		L = -0.04727,
+		A = -0.04812,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 45,
+		E = 46,
+		L = 45,
+		A = 45,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 4,
+	label = "o_OH_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {5,S}
+3    O u0 {1,S} {4,S}
+4    H u0 {3,S}
+5    O u0 {2,S} {6,S}
+6    C u0 {5,S} {7,S} {8,S} {9,S}
+7    H u0 {6,S}
+8    H u0 {6,S}
+9    H u0 {6,S}
+""",
+	solute = SoluteData(
+		S = -0.04689,
+		B = 0.03429,
+		E = -0.04782,
+		L = -0.08123,
+		A = -0.15375,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 26,
+		E = 30,
+		L = 30,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 5,
+	label = "o_OH_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {5,S}
+3    O u0 {1,S} {4,S}
+4    H u0 {3,S}
+5    C u0 {2,S} {6,S} {7,D}
+6    H u0 {5,S}
+7    O u0 {5,D}
+""",
+	solute = SoluteData(
+		S = -0.00219,
+		B = -0.08964,
+		E = -0.02234,
+		L = -0.12099,
+		A = -0.12705,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 6,
+	label = "o_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B}
+3    C u0 {1,S} {4,S} {5,D}
+4    H u0 {3,S}
+5    O u0 {3,D}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 7,
+	label = "o_CHO_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {5,S}
+3    C u0 {1,S} {4,S} {8,D}
+4    H u0 {3,S}
+5    C u0 {2,S} {6,S} {7,D}
+6    H u0 {5,S}
+7    O u0 {5,D}
+8    O u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.02599,
+		B = 0.02166,
+		E = -0.02119,
+		L = 0.05049,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 8,
+	label = "o_CHO_CH3",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {6,S}
+3    C u0 {1,S} {4,S} {5,D}
+4    H u0 {3,S}
+5    O u0 {3,D}
+6    C u0 {2,S} {7,S} {8,S} {9,S}
+7    H u0 {6,S}
+8    H u0 {6,S}
+9    H u0 {6,S}
+""",
+	solute = SoluteData(
+		S = -0.02032,
+		B = 0.01155,
+		E = 0.02170,
+		L = 0.05993,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 3,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 9,
+	label = "o_CHO_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {6,S}
+3    C u0 {1,S} {4,S} {5,D}
+4    H u0 {3,S}
+5    O u0 {3,D}
+6    O u0 {2,S} {7,S}
+7    C u0 {6,S} {8,S} {9,S} {10,S}
+8    H u0 {7,S}
+9    H u0 {7,S}
+10   H u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.00691,
+		B = -0.02058,
+		E = 0.03712,
+		L = 0.03491,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 10,
+	label = "o_vinyl",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B}
+3    C u0 {1,S} {4,S} {5,D}
+4    H u0 {3,S}
+5    C u0 {3,D} {6,S} {7,S}
+6   H u0 {5,S}
+7   H u0 {5,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 11,
+	label = "o_vinyl_CH3",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {8,S}
+3    C u0 {1,S} {4,S} {5,D}
+4    H u0 {3,S}
+5    C u0 {3,D} {6,S} {7,S}
+6    H u0 {5,S}
+7    H u0 {5,S}
+8    C u0 {2,S} {9,S} {10,S} {11,S}
+9    H u0 {8,S}
+10   H u0 {8,S}
+11   H u0 {8,S}
+""",
+	solute = SoluteData(
+		S = 0.00322,
+		B = -0.01187,
+		E = 0.01917,
+		L = -0.01980,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 12,
+	label = "o_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B}
+3    O u0 {1,S} {4,S}
+4    C u0 {3,S} {5,S} {6,S} {7,S}
+5    H u0 {4,S}
+6    H u0 {4,S}
+7    H u0 {4,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 13,
+	label = "o_MeO_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {8,S}
+3    O u0 {1,S} {4,S}
+4    C u0 {3,S} {5,S} {6,S} {7,S}
+5    H u0 {4,S}
+6    H u0 {4,S}
+7    H u0 {4,S}
+8    O u0 {2,S} {9,S}
+9    C u0 {8,S} {10,S} {11,S} {12,S}
+10   H u0 {9,S}
+11   H u0 {9,S}
+12   H u0 {9,S}
+""",
+	solute = SoluteData(
+		S = 0.00232,
+		B = 0.03528,
+		E = -0.00533,
+		L = 0.02199,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 37,
+		B = 27,
+		E = 38,
+		L = 35,
+		A = 37,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 14,
+	label = "o_CH3",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B}
+3    C u0 {1,S} {4,S} {5,S} {6,S}
+4    H u0 {3,S}
+5    H u0 {3,S}
+6    H u0 {3,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 15,
+	label = "o_CH3_CH3",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {7,S}
+3    C u0 {1,S} {4,S} {5,S} {6,S}
+4    H u0 {3,S}
+5    H u0 {3,S}
+6    H u0 {3,S}
+7    C u0 {2,S} {8,S} {9,S} {10,S}
+8    H u0 {7,S}
+9    H u0 {7,S}
+10    H u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00252,
+		B = 0.00305,
+		E = 0.01519,
+		L = 0.05823,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 78,
+		B = 72,
+		E = 83,
+		L = 73,
+		A = 83,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 16,
+	label = "o_CH3_C2H5",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {3,S}
+2 *2 Cb u0 {1,B} {7,S}
+3    C u0 {1,S} {4,S} {5,S} {6,S}
+4    H u0 {3,S}
+5    H u0 {3,S}
+6    H u0 {3,S}
+7    C u0 {2,S} {8,S} {9,S} {10,S}
+8    H u0 {7,S}
+9    H u0 {7,S}
+10   C u0 {7,S} {11,S} {12,S} {13,S}
+11   H u0 {10,S}
+12   H u0 {10,S}
+13   H u0 {10,S}
+""",
+	solute = SoluteData(
+		S = 0.02407,
+		B = -0.01130,
+		E = 0.04752,
+		L = 0.08493,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 12,
+		E = 14,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 17,
+	label = "aromatic-meta",
+	group = 
+"""
+1 *1 Cb u0 {2,B}
+2    Cb u0 {1,B} {3,B}
+3 *2 Cb u0 {2,B}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 18,
+	label = "m_CHO_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {4,S}
+2    Cb u0 {1,B} {3,B}
+3 *2 Cb u0 {2,B} {7,S}
+4    C  u0 {1,S} {5,D} {6,S}
+5    O  u0 {4,D}
+6    H  u0 {4,S}
+7    C  u0 {3,S} {8,D} {9,S}
+8    O  u0 {7,D}
+9    H  u0 {7,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 19,
+	label = "aromatic-para",
+	group = 
+"""
+1 *1 Cb u0 {2,B}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 20,
+	label = "p_OH",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B}
+5    O u0 {1,S} {6,S}
+6    H u0 {5,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 21,
+	label = "p_OH_OH",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B} {7,S}
+5    O u0 {1,S} {6,S}
+6    H u0 {5,S}
+7    O u0 {4,S} {8,S}
+8    H u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.01768,
+		B = -0.01463,
+		E = 0.00979,
+		L = -0.07210,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 20,
+		L = 20,
+		A = 20,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 22,
+	label = "p_OH_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B} {7,S}
+5    O u0 {1,S} {6,S}
+6    H u0 {5,S}
+7    O u0 {4,S} {8,S}
+8    C u0 {7,S} {9,S} {10,S} {11,S}
+9    H u0 {8,S}
+10   H u0 {8,S}
+11   H u0 {8,S}
+""",
+	solute = SoluteData(
+		S = 0.05626,
+		B = -0.02969,
+		E = -0.02441,
+		L = -0.06934,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 6,
+		L = 5,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 23,
+	label = "p_OH_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B} {7,S}
+5    O u0 {1,S} {6,S}
+6    H u0 {5,S}
+7    C u0 {4,S} {8,D} {9,S}
+8    O u0 {7,D}
+9    H u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.00084,
+		B = -0.02017,
+		E = -0.00036,
+		L = 0.17408,
+		A = 0.03002,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 14,
+		L = 14,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 24,
+	label = "p_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B}
+5    O u0 {1,S} {6,S}
+6    C u0 {5,S} {7,S} {8,S} {9,S}
+7    H u0 {6,S}
+8    H u0 {6,S}
+9    H u0 {6,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 25,
+	label = "p_MeO_MeO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B} {7,S}
+5    O u0 {1,S} {6,S}
+6    C u0 {5,S} {12,S} {13,S} {14,S}
+7    O u0 {4,S} {8,S}
+8    C u0 {7,S} {9,S} {10,S} {11,S}
+9    H u0 {8,S}
+10   H u0 {8,S}
+11   H u0 {8,S}
+12   H u0 {6,S}
+13   H u0 {6,S}
+14   H u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.01741,
+		B = -0.02377,
+		E = -0.01924,
+		L = -0.06033,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 26,
+	label = "p_MeO_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B} {7,S}
+5    O u0 {1,S} {6,S}
+6    C u0 {5,S} {10,S} {11,S} {12,S}
+7    C u0 {4,S} {8,D} {9,S}
+8    O u0 {7,D}
+9    H u0 {7,S}
+10   H u0 {6,S}
+11   H u0 {6,S}
+12   H u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03761,
+		B = -0.04243,
+		E = 0.01332,
+		L = -0.01369,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 27,
+	label = "p_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B}
+5    C u0 {1,S} {6,S} {7,D}
+6    H u0 {5,S}
+7    O u0 {5,D}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 28,
+	label = "p_CHO_CHO",
+	group = 
+"""
+1 *1 Cb u0 {2,B} {5,S}
+2    Cb u0 {1,B} {3,B}
+3    Cb u0 {2,B} {4,B}
+4 *2 Cb u0 {3,B} {7,S}
+5    C u0 {1,S} {6,S} {10,D}
+6    H u0 {5,S}
+7    C u0 {4,S} {8,D} {9,S}
+8    O u0 {7,D}
+9    H u0 {7,S}
+10   O u0 {5,D}
+""",
+	solute = SoluteData(
+		S = -0.03508,
+		B = -0.00120,
+		E = -0.00785,
+		L = -0.05185,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+tree(
+"""
+L1: R
+	L2: aromatic-ortho
+		L3: o_OH
+			L4: o_OH_OH
+			L4: o_OH_MeO
+			L4: o_OH_CHO
+		L3: o_CHO
+			L4: o_CHO_CHO
+			L4: o_CHO_CH3
+			L4: o_CHO_MeO
+		L3: o_vinyl
+			L4: o_vinyl_CH3
+		L3: o_MeO
+			L4: o_MeO_MeO
+		L3: o_CH3
+			L4: o_CH3_CH3
+			L4: o_CH3_C2H5
+	L2: aromatic-meta
+		L3: m_CHO_CHO
+	L2: aromatic-para
+		L3: p_OH
+			L4: p_OH_OH
+			L4: p_OH_MeO
+			L4: p_OH_CHO
+		L3: p_MeO
+			L4: p_MeO_MeO
+			L4: p_MeO_CHO
+		L3: p_CHO
+			L4: p_CHO_CHO
+"""
+)

--- a/input/solvation/groups/longDistanceInteraction_noncyclic.py
+++ b/input/solvation/groups/longDistanceInteraction_noncyclic.py
@@ -1,0 +1,1231 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "longDistanceInteraction_noncyclic"
+shortDesc = u""
+longDesc = u""" 
+All groups are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter data (manuscript in preparation)
+unless written otherwise.
+"""
+
+entry(
+	index = -1,
+	label = "R",
+	group = 
+"""
+1 *1 R u0
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 1,
+	label = "int14_gauche",
+	group = 
+"""
+1 *1 [Cs,O2s,Cd,S2s] u0 {2,S}
+2 *2 Cs u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 2,
+	label = "CsCs",
+	group = 
+"""
+1 *1 Cs u0 {2,S}
+2 *2 Cs u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 3,
+	label = "CsCs-P",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S}
+3   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+4   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3049,
+		B = 2937,
+		E = 3215,
+		L = 2767,
+		A = 3240,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 4,
+	label = "CsCs-S",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S}
+3   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+4   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+5   Cs u0 {1,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2073,
+		B = 2023,
+		E = 2170,
+		L = 1887,
+		A = 2169,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 5,
+	label = "CsCs-SS",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S}
+4   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+8   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1351,
+		B = 1338,
+		E = 1404,
+		L = 1226,
+		A = 1410,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 6,
+	label = "CsCs-ST",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S}
+4   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 262,
+		B = 260,
+		E = 263,
+		L = 245,
+		A = 268,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 7,
+	label = "CsCs-SQ",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S}
+4   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   Cs                         u0 {2,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 51,
+		B = 51,
+		E = 51,
+		L = 45,
+		A = 51,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 8,
+	label = "CsCs-T",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S}
+3   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 526,
+		B = 514,
+		E = 552,
+		L = 495,
+		A = 567,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 9,
+	label = "CsCs-TT",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S}
+4   Cs                         u0 {1,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 27,
+		E = 25,
+		L = 24,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 10,
+	label = "CsCs-T(TTP)",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S} {9,S} {10,S} {11,S}
+4   Cs                         u0 {1,S} {12,S} {13,S} {14,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+9   Cs                         u0 {3,S}
+10   Cs                         u0 {3,S}
+11   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {3,S}
+12   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+13   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+14   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 11,
+	label = "CsCs-T(TTS)",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S} {9,S} {10,S} {11,S}
+4   Cs                         u0 {1,S} {12,S} {13,S} {14,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+9   Cs                         u0 {3,S}
+10   Cs                         u0 {3,S}
+11   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {3,S}
+12   Cs u0 {4,S}
+13   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+14   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 1,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 12,
+	label = "CsCs-TQ",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S}
+4   Cs                         u0 {1,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   Cs                         u0 {2,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 12,
+		L = 12,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 13,
+	label = "CsCs-Q",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S}
+3   Cs u0 {1,S}
+4   Cs u0 {1,S}
+5   Cs u0 {1,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 75,
+		B = 75,
+		E = 73,
+		L = 64,
+		A = 75,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 14,
+	label = "CsCs-QQ",
+	group = 
+"""
+1 *1 Cs                         u0 {2,S} {3,S} {4,S} {5,S}
+2 *2 Cs                         u0 {1,S} {6,S} {7,S} {8,S}
+3   Cs                         u0 {1,S}
+4   Cs                         u0 {1,S}
+5   Cs                         u0 {1,S}
+6   Cs                         u0 {2,S}
+7   Cs                         u0 {2,S}
+8   Cs                         u0 {2,S}
+""",
+
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 15,
+	label = "OsCs",
+	group = 
+"""
+1 *1 O2s u0 {2,S}
+2 *2 Cs u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 16,
+	label = "OsCs-P",
+	group = 
+"""
+1 *1 O2s                         u0 {2,S} {3,S}
+2 *2 Cs                         u0 {1,S}
+3   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1592,
+		B = 1556,
+		E = 1645,
+		L = 1454,
+		A = 1622,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 17,
+	label = "OsCs-S",
+	group = 
+"""
+1 *1 O2s                         u0 {2,S} {3,S}
+2 *2 Cs                         u0 {1,S}
+3    Cs                         u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 18,
+	label = "OsCs-SP",
+	group = 
+"""
+1 *1 O2s                         u0 {2,S} {3,S}
+2 *2 Cs                         u0 {1,S} {4,S} {5,S} {6,S}
+3   Cs                         u0 {1,S}
+4   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+6   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.05053,
+		B = -0.03293,
+		E = 0.00000,
+		L = -0.20990,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 184,
+		B = 169,
+		E = 199,
+		L = 174,
+		A = 204,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 19,
+	label = "OsCs-SS",
+	group = 
+"""
+1 *1 O2s                         u0 {2,S} {3,S}
+2 *2 Cs                         u0 {1,S} {4,S} {5,S} {6,S}
+3   Cs                         u0 {1,S}
+4   Cs                         u0 {2,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+6   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.01821,
+		B = -0.05133,
+		E = 0.00000,
+		L = -0.26050,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 231,
+		B = 212,
+		E = 248,
+		L = 221,
+		A = 251,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 20,
+	label = "OsCs-ST",
+	group = 
+"""
+1 *1 O2s                         u0 {2,S} {3,S}
+2 *2 Cs                         u0 {1,S} {4,S} {5,S} {6,S}
+3   Cs                         u0 {1,S}
+4   Cs                         u0 {2,S}
+5   Cs                         u0 {2,S}
+6   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.03351,
+		B = 0.02734,
+		E = 0.00000,
+		L = -0.21073,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 34,
+		B = 23,
+		E = 40,
+		L = 33,
+		A = 39,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 21,
+	label = "OsCs-SQ",
+	group = 
+"""
+1 *1 O2s                         u0 {2,S} {3,S}
+2 *2 Cs                         u0 {1,S} {4,S} {5,S} {6,S}
+3   Cs                         u0 {1,S}
+4   Cs                         u0 {2,S}
+5   Cs                         u0 {2,S}
+6   Cs                         u0 {2,S}
+""",
+	solute = SoluteData(
+		S = 0.03210,
+		B = 0.04690,
+		E = 0.00000,
+		L = -0.09839,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 14,
+		L = 9,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 22,
+	label = "CdCs",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S}
+2   Cd u0 {1,D}
+3 *2 Cs u0 {1,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 23,
+	label = "CdCs-P",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+4 *2 Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.03660,
+		B = 0.03194,
+		E = 0.00896,
+		L = 0.25534,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 496,
+		B = 489,
+		E = 510,
+		L = 461,
+		A = 513,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 24,
+	label = "CdCs-S",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4 *2 Cs u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 0,
+		B = 0,
+		E = 0,
+		L = 0,
+		A = 0,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 25,
+	label = "CdCs-SP",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4 *2 Cs u0 {1,S} {5,S} {6,S} {7,S}
+5   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+6   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+7   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.06923,
+		B = 0.00629,
+		E = 0.03339,
+		L = 0.20427,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 151,
+		B = 145,
+		E = 155,
+		L = 142,
+		A = 155,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 26,
+	label = "CdCs-SS",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4 *2 Cs u0 {1,S} {5,S} {6,S} {7,S}
+5   Cs                         u0 {4,S}
+6   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+7   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.02028,
+		B = 0.00012,
+		E = 0.00999,
+		L = 0.22238,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 46,
+		E = 47,
+		L = 45,
+		A = 46,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 27,
+	label = "CdCs-ST",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4 *2 Cs u0 {1,S} {5,S} {6,S} {7,S}
+5   Cs                         u0 {4,S}
+6   Cs                         u0 {4,S}
+7   [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.02097,
+		B = -0.00294,
+		E = 0.01043,
+		L = 0.08786,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 28,
+	label = "CdCs-SQ",
+	group = 
+"""
+1 *1 Cd u0 {2,D} {3,S} {4,S}
+2   Cd u0 {1,D}
+3   Cs u0 {1,S}
+4 *2 Cs u0 {1,S} {5,S} {6,S} {7,S}
+5   Cs                         u0 {4,S}
+6   Cs                         u0 {4,S}
+7   Cs                         u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.00597,
+		B = 0.00942,
+		E = 0.01083,
+		L = 0.05317,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 29,
+	label = "int15",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S}
+2    [Cs,O2s,S2s] u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {3,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 30,
+	label = "CsCsCs",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S}
+2    Cs u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {3,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 31,
+	label = "CsCsCs-TQ",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S} {9,S}
+2    Cs u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {3,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+9    [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 16,
+		L = 13,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 32,
+	label = "CsCsCs-QQ",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S} {6,S}
+2    Cs u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {7,S} {8,S} {9,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {1,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+9    Cs u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 2,
+		L = 1,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 33,
+	label = "CsOsCs",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S}
+2    O2s u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {3,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 34,
+	label = "CsOsCs-TQ",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S} {9,S}
+2    O2s u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {3,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+9    [Cd,Cdd,Ct,Cb,Cbf,O2s,CO,H] u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.00592,
+		B = -0.00434,
+		E = -0.04000,
+		L = -0.05596,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 35,
+	label = "CsOsCs-QQ",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S} {6,S}
+2    O2s u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {7,S} {8,S} {9,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {1,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+9    Cs u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.00000,
+		B = 0.00000,
+		E = 0.00000,
+		L = 0.00000,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 0,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 36,
+	label = "CsSsCs",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S}
+2    S2s u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {6,S} {7,S} {8,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {3,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 37,
+	label = "CsSsCs-QQ",
+	group = 
+"""
+1 *1 Cs u0 {2,S} {4,S} {5,S} {6,S}
+2    S2s u0 {1,S} {3,S}
+3 *2 Cs u0 {2,S} {7,S} {8,S} {9,S}
+4    Cs u0 {1,S}
+5    Cs u0 {1,S}
+6    Cs u0 {1,S}
+7    Cs u0 {3,S}
+8    Cs u0 {3,S}
+9    Cs u0 {3,S}
+""",
+	solute = SoluteData(
+		S = 0.01584,
+		B = 0.01615,
+		E = 0.00654,
+		L = -0.01076,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+tree(
+"""
+L1: R
+	L2: int14_gauche
+		L3: CsCs
+			L4: CsCs-P
+			L4: CsCs-S
+				L5: CsCs-SS
+				L5: CsCs-ST
+				L5: CsCs-SQ
+			L4: CsCs-T
+				L5: CsCs-TT
+					L6: CsCs-T(TTP)
+					L6: CsCs-T(TTS)
+				L5: CsCs-TQ
+			L4: CsCs-Q
+				L5: CsCs-QQ
+		L3: OsCs
+			L4: OsCs-P
+			L4: OsCs-S
+				L5: OsCs-SP
+				L5: OsCs-SS
+				L5: OsCs-ST
+				L5: OsCs-SQ
+		L3: CdCs
+			L4: CdCs-P
+			L4: CdCs-S
+				L5: CdCs-SP
+				L5: CdCs-SS
+				L5: CdCs-ST
+				L5: CdCs-SQ
+	L2: int15
+		L3: CsCsCs
+			L4: CsCsCs-TQ
+			L4: CsCsCs-QQ
+		L3: CsOsCs
+			L4: CsOsCs-TQ
+			L4: CsOsCs-QQ
+		L3: CsSsCs
+			L4: CsSsCs-QQ
+"""
+)

--- a/input/solvation/groups/polycyclic.py
+++ b/input/solvation/groups/polycyclic.py
@@ -1,0 +1,10650 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "polycyclic"
+shortDesc = u""
+longDesc = u""" 
+All groups are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter data (manuscript in preparation)
+unless written otherwise.
+"""
+
+entry(
+	index = 1,
+	label = "PolycyclicRing",
+	group = 
+"""
+1 * R u0
+""",
+	solute = SoluteData(
+		S = 0.00086,
+		B = 0.04137,
+		E = -0.08617,
+		L = 0.16153,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 17,
+		L = 15,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 2,
+	label = "polycyclic_7fused",
+	group =  "OR{Strychnine_general}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 3,
+	label = "Strychnine_general",
+	group = 
+"""
+1  * R!H u0 {9,[S,D,B]} {16,[S,D,B]}
+2  R!H u0 {7,[S,D,B]} {13,[S,D,B]} {15,[S,D,B]}
+3  R!H u0 {6,[S,D,B]} {14,[S,D,B]} {19,[S,D,B]}
+4  R!H u0 {6,[S,D,B]} {7,[S,D,B]} {10,[S,D,B]} {18,[S,D,B]}
+5  R!H u0 {6,[S,D,B]} {8,[S,D,B]} {9,[S,D,B]}
+6  R!H u0 {3,[S,D,B]} {4,[S,D,B]} {5,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {11,[S,D,B]}
+8  R!H u0 {5,[S,D,B]} {11,[S,D,B]} {17,[S,D,B]}
+9  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {12,[S,D,B]}
+10 R!H u0 {4,[S,D,B]} {13,[S,D,B]}
+11 R!H u0 {7,[S,D,B]} {8,[S,D,B]}
+12 R!H u0 {9,[S,D,B]} {14,[S,D,B]}
+13 R!H u0 {2,[S,D,B]} {10,[S,D,B]}
+14 R!H u0 {3,[S,D,B]} {12,[S,D,B]}
+15 R!H u0 {2,[S,D,B]} {17,[S,D,B]}
+16 R!H u0 {1,[S,D,B]} {20,[S,D,B]}
+17 R!H u0 {8,[S,D,B]} {15,[S,D,B]} {20,[S,D,B]}
+18 R!H u0 {4,[S,D,B]} {19,[S,D,B]} {21,[S,D,B]}
+19 R!H u0 {3,[S,D,B]} {18,[S,D,B]} {22,[S,D,B]}
+20 R!H u0 {16,[S,D,B]} {17,[S,D,B]}
+21 R!H u0 {18,[S,D,B]} {23,[S,D,B]}
+22 R!H u0 {19,[S,D,B]} {24,[S,D,B]}
+23 R!H u0 {21,[S,D,B]} {24,[S,D,B]}
+24 R!H u0 {22,[S,D,B]} {23,[S,D,B]}
+""",
+	solute = u'Strychnine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 4,
+	label = "Strychnine",
+	group = 
+"""
+1  * O u0 {9,S} {16,S}
+2  N u0 {7,S} {13,S} {15,S}
+3  N u0 {6,S} {14,S} {19,S}
+4  C u0 {6,S} {7,S} {10,S} {18,S}
+5  C u0 {6,S} {8,S} {9,S}
+6  C u0 {3,S} {4,S} {5,S}
+7  C u0 {2,S} {4,S} {11,S}
+8  C u0 {5,S} {11,S} {17,S}
+9  C u0 {1,S} {5,S} {12,S}
+10 C u0 {4,S} {13,S}
+11 C u0 {7,S} {8,S}
+12 C u0 {9,S} {14,S}
+13 C u0 {2,S} {10,S}
+14 CO u0 {3,S} {12,S}
+15 C u0 {2,S} {17,S}
+16 C u0 {1,S} {20,S}
+17 C u0 {8,S} {15,S} {20,D}
+18 C u0 {4,S} {19,B} {21,B}
+19 C u0 {3,S} {18,B} {22,B}
+20 C u0 {16,S} {17,D}
+21 C u0 {18,B} {23,B}
+22 C u0 {19,B} {24,B}
+23 C u0 {21,B} {24,B}
+24 C u0 {22,B} {23,B}
+""",
+	solute = SoluteData(
+		S = -0.03901,
+		B = 0.04494,
+		E = 0.24179,
+		L = 0.19867,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 5,
+	label = "polycyclic_5fused",
+	group =  "OR{Porphyrin, Morphine_general, Benzo[e]pyrene_general, Benzo[a]pyrene_general, Fluoran_general, Picene_general,\
+1H-Cyclopenta[a]chrysene_general, Benzo[ghi]fluoranthene_general, Cholanthrene_general, \
+5fused_r6_r6_r6_r5_r5}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 6,
+	label = "Porphyrin",
+	group = 
+"""
+1  * N u0 {7,[S,D]} {8,[S,D]}
+2  N u0 {5,[S,D]} {6,[S,D]}
+3  N u0 {10,[S,D]} {11,[S,D]}
+4  N u0 {9,[S,D]} {12,[S,D]}
+5  C u0 {2,[S,D]} {13,[S,D]} {17,[S,D]}
+6  C u0 {2,[S,D]} {14,[S,D]} {18,[S,D]}
+7  C u0 {1,[S,D]} {15,[S,D]} {19,[S,D]}
+8  C u0 {1,[S,D]} {16,[S,D]} {20,[S,D]}
+9  C u0 {4,[S,D]} {13,[S,D]} {22,[S,D]}
+10 C u0 {3,[S,D]} {14,[S,D]} {24,[S,D]}
+11 C u0 {3,[S,D]} {15,[S,D]} {23,[S,D]}
+12 C u0 {4,[S,D]} {16,[S,D]} {21,[S,D]}
+13 C u0 {5,[S,D]} {9,[S,D]}
+14 C u0 {6,[S,D]} {10,[S,D]}
+15 C u0 {7,[S,D]} {11,[S,D]}
+16 C u0 {8,[S,D]} {12,[S,D]}
+17 C u0 {5,[S,D]} {18,[S,D]}
+18 C u0 {6,[S,D]} {17,[S,D]}
+19 C u0 {7,[S,D]} {20,[S,D]}
+20 C u0 {8,[S,D]} {19,[S,D]}
+21 C u0 {12,[S,D]} {22,[S,D]}
+22 C u0 {9,[S,D]} {21,[S,D]}
+23 C u0 {11,[S,D]} {24,[S,D]}
+24 C u0 {10,[S,D]} {23,[S,D]}
+""",
+	solute = SoluteData(
+		S = 0.00826,
+		B = -0.03271,
+		E = -0.10104,
+		L = 0.11850,
+		A = -0.06272,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 26,
+		L = 17,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 7,
+	label = "Morphine_general",
+	group = 
+"""
+1  * R!H u0 {6,[S,D,B]} {15,[S,D,B]}
+2  R!H u0 {5,[S,D,B]} {12,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]} {13,[S,D,B]}
+4  R!H u0 {3,[S,D,B]} {5,[S,D,B]} {8,[S,D,B]}
+5  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {11,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {9,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {12,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {10,[S,D,B]}
+9  R!H u0 {6,[S,D,B]} {10,[S,D,B]}
+10 R!H u0 {8,[S,D,B]} {9,[S,D,B]}
+11 R!H u0 {5,[S,D,B]} {14,[S,D,B]}
+12 R!H u0 {2,[S,D,B]} {7,[S,D,B]}
+13 R!H u0 {3,[S,D,B]} {14,[S,D,B]} {15,[S,D,B]}
+14 R!H u0 {11,[S,D,B]} {13,[S,D,B]} {16,[S,D,B]}
+15 R!H u0 {1,[S,D,B]} {13,[S,D,B]} {17,[S,D,B]}
+16 R!H u0 {14,[S,D,B]} {18,[S,D,B]}
+17 R!H u0 {15,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {16,[S,D,B]} {17,[S,D,B]}
+""",
+	solute = u'Dihydro-normorphine,3-desoxy-',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 8,
+	label = "Dihydro-normorphine,3-desoxy-",
+	group = 
+"""
+1  * O u0 {6,S} {15,S}
+2  N u0 {5,S} {12,S}
+3  C u0 {4,S} {6,S} {7,S} {13,S}
+4  C u0 {3,S} {5,S} {8,S}
+5  C u0 {2,S} {4,S} {11,S}
+6  C u0 {1,S} {3,S} {9,S}
+7  C u0 {3,S} {12,S}
+8  C u0 {4,S} {10,S}
+9  CO u0 {6,S} {10,S}
+10 C u0 {8,S} {9,S}
+11 C u0 {5,S} {14,S}
+12 C u0 {2,S} {7,S}
+13 C u0 {3,S} {14,B} {15,B}
+14 C u0 {11,S} {13,B} {16,B}
+15 C u0 {1,S} {13,B} {17,B}
+16 C u0 {14,B} {18,B}
+17 C u0 {15,B} {18,B}
+18 C u0 {16,B} {17,B}
+""",
+	solute = SoluteData(
+		S = 0.11119,
+		B = -0.08070,
+		E = 0.04218,
+		L = 0.12585,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 9,
+	label = "Morphine",
+	group = 
+"""
+1  * O u0 {6,S} {15,S}
+2  N u0 {5,S} {12,S}
+3  C u0 {4,S} {6,S} {7,S} {13,S}
+4  C u0 {3,S} {5,S} {8,S}
+5  C u0 {2,S} {4,S} {11,S}
+6  C u0 {1,S} {3,S} {9,S}
+7  C u0 {3,S} {12,S}
+8  C u0 {4,S} {10,D}
+9  C u0 {6,S} {10,S}
+10 C u0 {8,D} {9,S}
+11 C u0 {5,S} {14,S}
+12 C u0 {2,S} {7,S}
+13 C u0 {3,S} {14,B} {15,B}
+14 C u0 {11,S} {13,B} {16,B}
+15 C u0 {1,S} {13,B} {17,B}
+16 C u0 {14,B} {18,B}
+17 C u0 {15,B} {18,B}
+18 C u0 {16,B} {17,B}
+""",
+	solute = SoluteData(
+		S = 0.13666,
+		B = -0.08163,
+		E = -0.03679,
+		L = 0.24899,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 10,
+	label = "Dihydromorphine",
+	group = 
+"""
+1  * O u0 {6,S} {15,S}
+2  N u0 {5,S} {12,S}
+3  C u0 {4,S} {6,S} {7,S} {13,S}
+4  C u0 {3,S} {5,S} {8,S}
+5  C u0 {2,S} {4,S} {11,S}
+6  C u0 {1,S} {3,S} {9,S}
+7  C u0 {3,S} {12,S}
+8  C u0 {4,S} {10,S}
+9  C u0 {6,S} {10,S}
+10 C u0 {8,S} {9,S}
+11 C u0 {5,S} {14,S}
+12 C u0 {2,S} {7,S}
+13 C u0 {3,S} {14,B} {15,B}
+14 C u0 {11,S} {13,B} {16,B}
+15 C u0 {1,S} {13,B} {17,B}
+16 C u0 {14,B} {18,B}
+17 C u0 {15,B} {18,B}
+18 C u0 {16,B} {17,B}
+""",
+	solute = SoluteData(
+		S = 0.03415,
+		B = 0.13790,
+		E = 0.01346,
+		L = -0.10507,
+		A = -0.04230,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 11,
+	label = "Benzo[e]pyrene_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {6,[S,D,B]} {8,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {6,[S,D,B]} {9,[S,D,B]}
+4  R!H u0 {3,[S,D,B]} {5,[S,D,B]} {10,[S,D,B]}
+5  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {11,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {16,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {12,[S,D,B]} {13,[S,D,B]}
+8  R!H u0 {1,[S,D,B]} {14,[S,D,B]} {15,[S,D,B]}
+9  R!H u0 {3,[S,D,B]} {18,[S,D,B]}
+10 R!H u0 {4,[S,D,B]} {17,[S,D,B]}
+11 R!H u0 {5,[S,D,B]} {19,[S,D,B]}
+12 R!H u0 {7,[S,D,B]} {19,[S,D,B]}
+13 R!H u0 {7,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {8,[S,D,B]} {13,[S,D,B]}
+15 R!H u0 {8,[S,D,B]} {20,[S,D,B]}
+16 R!H u0 {6,[S,D,B]} {20,[S,D,B]}
+17 R!H u0 {10,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {9,[S,D,B]} {17,[S,D,B]}
+19 R!H u0 {11,[S,D,B]} {12,[S,D,B]}
+20 R!H u0 {15,[S,D,B]} {16,[S,D,B]}
+""",
+	solute = u'Benzo[e]pyrene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 12,
+	label = "Benzo[e]pyrene",
+	group = 
+"""
+1  * C u0 {2,B} {6,B} {8,B}
+2  C u0 {1,B} {5,B} {7,B}
+3  C u0 {4,B} {6,B} {9,B}
+4  C u0 {3,B} {5,B} {10,B}
+5  C u0 {2,B} {4,B} {11,B}
+6  C u0 {1,B} {3,B} {16,B}
+7  C u0 {2,B} {12,B} {13,B}
+8  C u0 {1,B} {14,B} {15,B}
+9  C u0 {3,B} {18,B}
+10 C u0 {4,B} {17,B}
+11 C u0 {5,B} {19,B}
+12 C u0 {7,B} {19,B}
+13 C u0 {7,B} {14,B}
+14 C u0 {8,B} {13,B}
+15 C u0 {8,B} {20,B}
+16 C u0 {6,B} {20,B}
+17 C u0 {10,B} {18,B}
+18 C u0 {9,B} {17,B}
+19 C u0 {11,B} {12,B}
+20 C u0 {15,B} {16,B}
+""",
+	solute = SoluteData(
+		S = 0.02831,
+		B = -0.04796,
+		E = 0.03844,
+		L = 0.39002,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 13,
+	label = "Benzo[a]pyrene_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {7,[S,D,B]} {8,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {5,[S,D,B]} {10,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {17,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {9,[S,D,B]} {11,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {9,[S,D,B]} {12,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {13,[S,D,B]} {14,[S,D,B]}
+8  R!H u0 {2,[S,D,B]} {15,[S,D,B]} {16,[S,D,B]}
+9  R!H u0 {5,[S,D,B]} {6,[S,D,B]}
+10 R!H u0 {3,[S,D,B]} {19,[S,D,B]}
+11 R!H u0 {5,[S,D,B]} {18,[S,D,B]}
+12 R!H u0 {6,[S,D,B]} {13,[S,D,B]}
+13 R!H u0 {7,[S,D,B]} {12,[S,D,B]}
+14 R!H u0 {7,[S,D,B]} {20,[S,D,B]}
+15 R!H u0 {8,[S,D,B]} {20,[S,D,B]}
+16 R!H u0 {8,[S,D,B]} {17,[S,D,B]}
+17 R!H u0 {4,[S,D,B]} {16,[S,D,B]}
+18 R!H u0 {11,[S,D,B]} {19,[S,D,B]}
+19 R!H u0 {10,[S,D,B]} {18,[S,D,B]}
+20 R!H u0 {14,[S,D,B]} {15,[S,D,B]}
+""",
+	solute = u'Benzo[a]pyrene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 14,
+	label = "Benzo[a]pyrene",
+	group = 
+"""
+1  * C u0 {2,B} {4,B} {6,B}
+2  C u0 {1,B} {7,B} {8,B}
+3  C u0 {4,B} {5,B} {10,B}
+4  C u0 {1,B} {3,B} {17,B}
+5  C u0 {3,B} {9,B} {11,B}
+6  C u0 {1,B} {9,B} {12,B}
+7  C u0 {2,B} {13,B} {14,B}
+8  C u0 {2,B} {15,B} {16,B}
+9  C u0 {5,B} {6,B}
+10 C u0 {3,B} {19,B}
+11 C u0 {5,B} {18,B}
+12 C u0 {6,B} {13,B}
+13 C u0 {7,B} {12,B}
+14 C u0 {7,B} {20,B}
+15 C u0 {8,B} {20,B}
+16 C u0 {8,B} {17,B}
+17 C u0 {4,B} {16,B}
+18 C u0 {11,B} {19,B}
+19 C u0 {10,B} {18,B}
+20 C u0 {14,B} {15,B}
+""",
+	solute = SoluteData(
+		S = 0.01349,
+		B = -0.01129,
+		E = 0.08825,
+		L = 0.18456,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 15,
+	label = "Fluoran_general",
+	group = 
+"""
+1  * R!H u0 {3,[S,D,B]} {4,[S,D,B]}
+2  R!H u0 {9,[S,D,B]} {10,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {8,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {8,[S,D,B]} {13,[S,D,B]}
+6  R!H u0 {3,[S,D,B]} {9,[S,D,B]} {11,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {10,[S,D,B]} {12,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {5,[S,D,B]} {14,[S,D,B]}
+9  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {15,[S,D,B]}
+10 R!H u0 {2,[S,D,B]} {7,[S,D,B]} {16,[S,D,B]}
+11 R!H u0 {6,[S,D,B]} {17,[S,D,B]}
+12 R!H u0 {7,[S,D,B]} {20,[S,D,B]}
+13 R!H u0 {5,[S,D,B]} {21,[S,D,B]}
+14 R!H u0 {8,[S,D,B]} {22,[S,D,B]}
+15 R!H u0 {9,[S,D,B]} {18,[S,D,B]}
+16 R!H u0 {10,[S,D,B]} {19,[S,D,B]}
+17 R!H u0 {11,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {15,[S,D,B]} {17,[S,D,B]}
+19 R!H u0 {16,[S,D,B]} {20,[S,D,B]}
+20 R!H u0 {12,[S,D,B]} {19,[S,D,B]}
+21 R!H u0 {13,[S,D,B]} {22,[S,D,B]}
+22 R!H u0 {14,[S,D,B]} {21,[S,D,B]}
+""",
+	solute = u'Fluoran',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 16,
+	label = "Fluoran",
+	group = 
+"""
+1  * O u0 {3,S} {4,S}
+2  O u0 {9,S} {10,S}
+3  C u0 {1,S} {5,S} {6,S} {7,S}
+4  CO u0 {1,S} {8,S}
+5  C u0 {3,S} {8,B} {13,B}
+6  C u0 {3,S} {9,B} {11,B}
+7  C u0 {3,S} {10,B} {12,B}
+8  C u0 {4,S} {5,B} {14,B}
+9  C u0 {2,S} {6,B} {15,B}
+10 C u0 {2,S} {7,B} {16,B}
+11 C u0 {6,B} {17,B}
+12 C u0 {7,B} {20,B}
+13 C u0 {5,B} {21,B}
+14 C u0 {8,B} {22,B}
+15 C u0 {9,B} {18,B}
+16 C u0 {10,B} {19,B}
+17 C u0 {11,B} {18,B}
+18 C u0 {15,B} {17,B}
+19 C u0 {16,B} {20,B}
+20 C u0 {12,B} {19,B}
+21 C u0 {13,B} {22,B}
+22 C u0 {14,B} {21,B}
+""",
+	solute = SoluteData(
+		S = 0.12438,
+		B = -0.00941,
+		E = -0.02436,
+		L = 0.13617,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 17,
+	label = "Picene_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {4,[S,D,B]} {9,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {20,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {7,[S,D,B]} {12,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {10,[S,D,B]} {11,[S,D,B]}
+5  R!H u0 {6,[S,D,B]} {8,[S,D,B]} {13,[S,D,B]}
+6  R!H u0 {5,[S,D,B]} {14,[S,D,B]} {21,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {15,[S,D,B]} {21,[S,D,B]}
+8  R!H u0 {5,[S,D,B]} {16,[S,D,B]}
+9  R!H u0 {1,[S,D,B]} {18,[S,D,B]}
+10 R!H u0 {4,[S,D,B]} {19,[S,D,B]}
+11 R!H u0 {4,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {3,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {5,[S,D,B]} {15,[S,D,B]}
+14 R!H u0 {6,[S,D,B]} {17,[S,D,B]}
+15 R!H u0 {7,[S,D,B]} {13,[S,D,B]}
+16 R!H u0 {8,[S,D,B]} {17,[S,D,B]}
+17 R!H u0 {14,[S,D,B]} {16,[S,D,B]}
+18 R!H u0 {9,[S,D,B]} {19,[S,D,B]}
+19 R!H u0 {10,[S,D,B]} {18,[S,D,B]}
+20 R!H u0 {2,[S,D,B]} {22,[S,D,B]}
+21 R!H u0 {6,[S,D,B]} {7,[S,D,B]} {22,[S,D,B]}
+22 R!H u0 {20,[S,D,B]} {21,[S,D,B]}
+""",
+	solute = u'Picene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 18,
+	label = "Picene",
+	group = 
+"""
+1  * C u0 {2,B} {4,B} {9,B}
+2  C u0 {1,B} {3,B} {20,B}
+3  C u0 {2,B} {7,B} {12,B}
+4  C u0 {1,B} {10,B} {11,B}
+5  C u0 {6,B} {8,B} {13,B}
+6  C u0 {5,B} {14,B} {21,B}
+7  C u0 {3,B} {15,B} {21,B}
+8  C u0 {5,B} {16,B}
+9  C u0 {1,B} {18,B}
+10 C u0 {4,B} {19,B}
+11 C u0 {4,B} {12,B}
+12 C u0 {3,B} {11,B}
+13 C u0 {5,B} {15,B}
+14 C u0 {6,B} {17,B}
+15 C u0 {7,B} {13,B}
+16 C u0 {8,B} {17,B}
+17 C u0 {14,B} {16,B}
+18 C u0 {9,B} {19,B}
+19 C u0 {10,B} {18,B}
+20 C u0 {2,B} {22,B}
+21 C u0 {6,B} {7,B} {22,B}
+22 C u0 {20,B} {21,B}
+""",
+	solute = SoluteData(
+		S = -0.00848,
+		B = 0.00482,
+		E = 0.01055,
+		L = 0.07780,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 19,
+	label = "Icosahydropicene",
+	group = 
+"""
+1  * C u0 {2,S} {4,S} {9,S}
+2  C u0 {1,S} {3,S} {20,S}
+3  C u0 {2,S} {7,S} {12,S}
+4  C u0 {1,S} {10,S} {11,S}
+5  C u0 {6,S} {8,S} {13,S}
+6  C u0 {5,S} {14,S} {21,S}
+7  C u0 {3,S} {15,S} {21,S}
+8  C u0 {5,S} {16,S}
+9  C u0 {1,S} {18,S}
+10 C u0 {4,S} {19,S}
+11 C u0 {4,S} {12,S}
+12 C u0 {3,S} {11,S}
+13 C u0 {5,S} {15,S}
+14 C u0 {6,S} {17,S}
+15 C u0 {7,S} {13,S}
+16 C u0 {8,S} {17,S}
+17 C u0 {14,S} {16,S}
+18 C u0 {9,S} {19,S}
+19 C u0 {10,S} {18,S}
+20 C u0 {2,S} {22,S}
+21 C u0 {6,S} {7,S} {22,D}
+22 C u0 {20,S} {21,D}
+""",
+	solute = SoluteData(
+		S = -0.04109,
+		B = 0.20873,
+		E = -0.14768,
+		L = 0.30673,
+		A = 0.59089,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 20,
+	label = "1H-Cyclopenta[a]chrysene_general",
+	group = 
+"""
+1  * R!H u0 {3,[S,D,B]} {7,[S,D,B]} {9,[S,D,B]}
+2  R!H u0 {3,[S,D,B]} {6,[S,D,B]} {12,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {2,[S,D,B]} {13,[S,D,B]}
+4  R!H u0 {5,[S,D,B]} {6,[S,D,B]} {14,[S,D,B]}
+5  R!H u0 {4,[S,D,B]} {8,[S,D,B]} {15,[S,D,B]}
+6  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {18,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {10,[S,D,B]} {11,[S,D,B]}
+8  R!H u0 {5,[S,D,B]} {16,[S,D,B]} {17,[S,D,B]}
+9  R!H u0 {1,[S,D,B]} {20,[S,D,B]}
+10 R!H u0 {7,[S,D,B]} {19,[S,D,B]}
+11 R!H u0 {7,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {2,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {3,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {4,[S,D,B]} {13,[S,D,B]}
+15 R!H u0 {5,[S,D,B]} {21,[S,D,B]}
+16 R!H u0 {8,[S,D,B]} {21,[S,D,B]}
+17 R!H u0 {8,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {6,[S,D,B]} {17,[S,D,B]}
+19 R!H u0 {10,[S,D,B]} {20,[S,D,B]}
+20 R!H u0 {9,[S,D,B]} {19,[S,D,B]}
+21 R!H u0 {15,[S,D,B]} {16,[S,D,B]}
+""",
+	solute = u'1H-Cyclopenta[a]chrysene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 21,
+	label = "1H-Cyclopenta[a]chrysene",
+	group = 
+"""
+1  * C u0 {3,S} {7,S} {9,S}
+2  C u0 {3,S} {6,S} {12,S}
+3  C u0 {1,S} {2,S} {13,S}
+4  C u0 {5,S} {6,S} {14,S}
+5  C u0 {4,S} {8,S} {15,S}
+6  C u0 {2,S} {4,S} {18,S}
+7  C u0 {1,S} {10,S} {11,S}
+8  C u0 {5,S} {16,S} {17,S}
+9  C u0 {1,S} {20,S}
+10 C u0 {7,S} {19,S}
+11 C u0 {7,S} {12,S}
+12 C u0 {2,S} {11,S}
+13 C u0 {3,S} {14,S}
+14 C u0 {4,S} {13,S}
+15 C u0 {5,S} {21,S}
+16 C u0 {8,S} {21,S}
+17 C u0 {8,S} {18,S}
+18 C u0 {6,S} {17,S}
+19 C u0 {10,S} {20,S}
+20 C u0 {9,S} {19,S}
+21 C u0 {15,S} {16,S}
+""",
+	solute = SoluteData(
+		S = -0.03500,
+		B = 0.14057,
+		E = -0.02027,
+		L = 0.27100,
+		A = 0.04393,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 22,
+	label = "Benzo[ghi]fluoranthene_general",
+	group = 
+"""
+1  * R!H u0 {3,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {3,[S,D,B]} {5,[S,D,B]} {8,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {2,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {9,[S,D,B]}
+5  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {16,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {10,[S,D,B]} {11,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {12,[S,D,B]} {13,[S,D,B]}
+8  R!H u0 {2,[S,D,B]} {14,[S,D,B]} {15,[S,D,B]}
+9  R!H u0 {4,[S,D,B]} {17,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {17,[S,D,B]}
+11 R!H u0 {6,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {7,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {7,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {8,[S,D,B]} {13,[S,D,B]}
+15 R!H u0 {8,[S,D,B]} {18,[S,D,B]}
+16 R!H u0 {5,[S,D,B]} {18,[S,D,B]}
+17 R!H u0 {9,[S,D,B]} {10,[S,D,B]}
+18 R!H u0 {15,[S,D,B]} {16,[S,D,B]}
+""",
+	solute = u'Benzo[ghi]fluoranthene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 23,
+	label = "Benzo[ghi]fluoranthene",
+	group = 
+"""
+1  * C u0 {3,B} {4,B} {6,B}
+2  C u0 {3,B} {5,B} {8,B}
+3  C u0 {1,B} {2,B} {7,B}
+4  C u0 {1,B} {5,S} {9,B}
+5  C u0 {2,B} {4,S} {16,B}
+6  C u0 {1,B} {10,B} {11,B}
+7  C u0 {3,B} {12,B} {13,B}
+8  C u0 {2,B} {14,B} {15,B}
+9  C u0 {4,B} {17,B}
+10 C u0 {6,B} {17,B}
+11 C u0 {6,B} {12,B}
+12 C u0 {7,B} {11,B}
+13 C u0 {7,B} {14,B}
+14 C u0 {8,B} {13,B}
+15 C u0 {8,B} {18,B}
+16 C u0 {5,B} {18,B}
+17 C u0 {9,B} {10,B}
+18 C u0 {15,B} {16,B}
+""",
+	solute = SoluteData(
+		S = 0.01965,
+		B = 0.01096,
+		E = 0.03205,
+		L = -0.08480,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 24,
+	label = "Cholanthrene_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {4,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {6,[S,D,B]}
+4  R!H u0 {2,[S,D,B]} {5,[S,D,B]} {12,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {4,[S,D,B]} {10,[S,D,B]}
+6  R!H u0 {3,[S,D,B]} {8,[S,D,B]} {13,[S,D,B]}
+7  R!H u0 {8,[S,D,B]} {9,[S,D,B]} {16,[S,D,B]}
+8  R!H u0 {6,[S,D,B]} {7,[S,D,B]} {11,[S,D,B]}
+9  R!H u0 {7,[S,D,B]} {14,[S,D,B]} {15,[S,D,B]}
+10 R!H u0 {5,[S,D,B]} {11,[S,D,B]} {17,[S,D,B]}
+11 R!H u0 {8,[S,D,B]} {10,[S,D,B]}
+12 R!H u0 {4,[S,D,B]} {18,[S,D,B]}
+13 R!H u0 {6,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {9,[S,D,B]} {13,[S,D,B]}
+15 R!H u0 {9,[S,D,B]} {19,[S,D,B]}
+16 R!H u0 {7,[S,D,B]} {20,[S,D,B]}
+17 R!H u0 {10,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {12,[S,D,B]} {17,[S,D,B]}
+19 R!H u0 {15,[S,D,B]} {20,[S,D,B]} 
+20 R!H u0 {16,[S,D,B]} {19,[S,D,B]}
+""",
+	solute = u'Cholanthrene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 25,
+	label = "Cholanthrene",
+	group = 
+"""
+1  * C u0 {2,S} {3,S}
+2  C u0 {1,S} {4,S}
+3  C u0 {1,S} {5,B} {6,B}
+4  C u0 {2,S} {5,B} {12,B}
+5  C u0 {3,B} {4,B} {10,B}
+6  C u0 {3,B} {8,B} {13,B}
+7  C u0 {8,B} {9,B} {16,B}
+8  C u0 {6,B} {7,B} {11,B}
+9  C u0 {7,B} {14,B} {15,B}
+10 C u0 {5,B} {11,B} {17,B}
+11 C u0 {8,B} {10,B}
+12 C u0 {4,B} {18,B}
+13 C u0 {6,B} {14,B}
+14 C u0 {9,B} {13,B}
+15 C u0 {9,B} {19,B}
+16 C u0 {7,B} {20,B}
+17 C u0 {10,B} {18,B}
+18 C u0 {12,B} {17,B}
+19 C u0 {15,B} {20,B} 
+20 C u0 {16,B} {19,B}
+""",
+	solute = SoluteData(
+		S = -0.03270,
+		B = 0.02006,
+		E = 0.08714,
+		L = 0.10280,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 26,
+	label = "5fused_r6_r6_r6_r5_r5",
+	group = 
+"""
+1  * R!H u0 {9,[S,D,B]} {16,[S,D,B]}
+2  R!H u0 {8,[S,D,B]} {16,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {5,[S,D,B]} {13,[S,D,B]}
+4  R!H u0 {3,[S,D,B]} {6,[S,D,B]} {10,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {7,[S,D,B]} {11,[S,D,B]}
+6  R!H u0 {4,[S,D,B]} {8,[S,D,B]} {12,[S,D,B]}
+7  R!H u0 {5,[S,D,B]} {17,[S,D,B]} {18,[S,D,B]}
+8  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {9,[S,D,B]}
+9  R!H u0 {1,[S,D,B]} {8,[S,D,B]} {10,[S,D,B]}
+10 R!H u0 {4,[S,D,B]} {9,[S,D,B]}
+11 R!H u0 {5,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {6,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {3,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {13,[S,D,B]} {17,[S,D,B]}
+15 R!H u0 {19,[S,D,B]} {20,[S,D,B]}
+16 R!H u0 {1,[S,D,B]} {2,[S,D,B]}
+17 R!H u0 {7,[S,D,B]} {14,[S,D,B]} {19,[S,D,B]}
+18 R!H u0 {7,[S,D,B]} {20,[S,D,B]}
+19 R!H u0 {15,[S,D,B]} {17,[S,D,B]}
+20 R!H u0 {15,[S,D,B]} {18,[S,D,B]}
+""",
+	solute = u'5fused_r6_diene_r6_r6_r5_r5_dioxo',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 27,
+	label = "5fused_r6_diene_r6_r6_r5_r5_dioxo",
+	group = 
+"""
+1  * O u0 {9,S} {16,S}
+2  O u0 {8,S} {16,S}
+3  C u0 {4,S} {5,S} {13,S}
+4  C u0 {3,S} {6,S} {10,S}
+5  C u0 {3,S} {7,S} {11,S}
+6  C u0 {4,S} {8,S} {12,S}
+7  C u0 {5,S} {17,S} {18,S}
+8  C u0 {2,S} {6,S} {9,S}
+9  C u0 {1,S} {8,S} {10,S}
+10 C u0 {4,S} {9,S}
+11 C u0 {5,S} {12,S}
+12 C u0 {6,S} {11,S}
+13 C u0 {3,S} {14,S}
+14 C u0 {13,S} {17,S}
+15 CO u0 {19,S} {20,S}
+16 C u0 {1,S} {2,S}
+17 C u0 {7,S} {14,S} {19,D}
+18 C u0 {7,S} {20,D}
+19 C u0 {15,S} {17,D}
+20 C u0 {15,S} {18,D}
+""",
+	solute = SoluteData(
+		S = -0.04129,
+		B = 0.00759,
+		E = 0.10643,
+		L = 0.08733,
+		A = 0.02091,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 3,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 28,
+	label = "polycyclic_4fused",
+	group =  "OR{Artemether_general, Fluoranthene_general, s3_6_6_s3_6_6_s3_6_6, s2_5_6_s2_6_6_s2_6_6, s2_6_6_s2_6_6_s2_6_6,\
+s2_6_6_s2_6_6_s2_6_6_A, s2_6_6_s2_6_6_s2_6_6_B, s2_6_5_s2_5_9_s3_9_6, s2_6_7_s2_7_6_s2_7_6, Quadricyclane_general}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 29,
+	label = "Artemether_general",
+	group = 
+"""
+1  * R!H u0 {14,[S,D,B]} {15,[S,D,B]}
+2  R!H u0 {14,[S,D,B]} {16,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {5,[S,D,B]}
+4  R!H u0 {3,[S,D,B]} {15,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]} {14,[S,D,B]}
+6  R!H u0 {5,[S,D,B]} {8,[S,D,B]} {11,[S,D,B]}
+7  R!H u0 {5,[S,D,B]} {9,[S,D,B]} {10,[S,D,B]}
+8  R!H u0 {6,[S,D,B]} {12,[S,D,B]}
+9  R!H u0 {7,[S,D,B]} {13,[S,D,B]}
+10 R!H u0 {7,[S,D,B]} {12,[S,D,B]}
+11 R!H u0 {6,[S,D,B]} {16,[S,D,B]}
+12 R!H u0 {8,[S,D,B]} {10,[S,D,B]}
+13 R!H u0 {9,[S,D,B]} {15,[S,D,B]}
+14 R!H u0 {1,[S,D,B]} {2,[S,D,B]} {5,[S,D,B]}
+15 R!H u0 {1,[S,D,B]} {4,[S,D,B]} {13,[S,D,B]}
+16 R!H u0 {2,[S,D,B]} {11,[S,D,B]}
+""",
+	solute = u'Artemether',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 30,
+	label = "Artemether",
+	group = 
+"""
+1  * O u0 {14,S} {15,S}
+2  O u0 {14,S} {16,S}
+3  O u0 {4,S} {5,S}
+4  O u0 {3,S} {15,S}
+5  C u0 {3,S} {6,S} {7,S} {14,S}
+6  C u0 {5,S} {8,S} {11,S}
+7  C u0 {5,S} {9,S} {10,S}
+8  C u0 {6,S} {12,S}
+9  C u0 {7,S} {13,S}
+10 C u0 {7,S} {12,S}
+11 C u0 {6,S} {16,S}
+12 C u0 {8,S} {10,S}
+13 C u0 {9,S} {15,S}
+14 C u0 {1,S} {2,S} {5,S}
+15 C u0 {1,S} {4,S} {13,S}
+16 C u0 {2,S} {11,S}
+""",
+	solute = SoluteData(
+		S = 0.03995,
+		B = 0.06911,
+		E = 0.08418,
+		L = 0.21893,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 31,
+	label = "Fluoranthene_general",
+	group = 
+"""
+1  * R!H u0 {4,[S,D,B]} {5,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {3,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {8,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {9,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {2,[S,D,B]} {12,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {10,[S,D,B]} {11,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {14,[S,D,B]}
+8  R!H u0 {3,[S,D,B]} {13,[S,D,B]}
+9  R!H u0 {4,[S,D,B]} {15,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {15,[S,D,B]}
+11 R!H u0 {6,[S,D,B]} {16,[S,D,B]}
+12 R!H u0 {5,[S,D,B]} {16,[S,D,B]}
+13 R!H u0 {8,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {7,[S,D,B]} {13,[S,D,B]} 
+15 R!H u0 {9,[S,D,B]} {10,[S,D,B]}
+16 R!H u0 {11,[S,D,B]} {12,[S,D,B]}
+""",
+	solute = u'Fluoranthene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 32,
+	label = "Fluoranthene",
+	group = 
+"""
+1  * C u0 {4,B} {5,B} {6,B}
+2  C u0 {3,B} {5,S} {7,B}
+3  C u0 {2,B} {4,S} {8,B}
+4  C u0 {1,B} {3,S} {9,B}
+5  C u0 {1,B} {2,S} {12,B}
+6  C u0 {1,B} {10,B} {11,B}
+7  C u0 {2,B} {14,B}
+8  C u0 {3,B} {13,B}
+9  C u0 {4,B} {15,B}
+10 C u0 {6,B} {15,B}
+11 C u0 {6,B} {16,B}
+12 C u0 {5,B} {16,B}
+13 C u0 {8,B} {14,B}
+14 C u0 {7,B} {13,B}
+15 C u0 {9,B} {10,B}
+16 C u0 {11,B} {12,B}
+""",
+	solute = SoluteData(
+		S = -0.00838,
+		B = -0.00639,
+		E = 0.00714,
+		L = 0.22045,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 33,
+	label = "s3_6_6_s3_6_6_s3_6_6",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {4,[S,D,B]} {5,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {7,[S,D,B]} {8,[S,D,B]}
+4  R!H u0 {2,[S,D,B]} {9,[S,D,B]} {10,[S,D,B]}
+5  R!H u0 {2,[S,D,B]} {11,[S,D,B]} {12,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {13,[S,D,B]} {14,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {15,[S,D,B]}
+8  R!H u0 {3,[S,D,B]} {9,[S,D,B]}
+9  R!H u0 {4,[S,D,B]} {8,[S,D,B]}
+10 R!H u0 {4,[S,D,B]} {16,[S,D,B]}
+11 R!H u0 {5,[S,D,B]} {16,[S,D,B]}
+12 R!H u0 {5,[S,D,B]} {13,[S,D,B]}
+13 R!H u0 {6,[S,D,B]} {12,[S,D,B]}
+14 * R!H u0 {6,[S,D,B]} {15,[S,D,B]}
+15 R!H u0 {7,[S,D,B]} {14,[S,D,B]}
+16 R!H u0 {10,[S,D,B]} {11,[S,D,B]}
+""",
+	solute = u's3_6_6_s3_6_6_s3_6_6_pyrene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 34,
+	label = "s3_6_6_s3_6_6_s3_6_6_pyrene",
+	group = 
+"""
+1  * C u0 {2,B} {3,B} {6,B}
+2  C u0 {1,B} {4,B} {5,B}
+3  C u0 {1,B} {7,B} {8,B}
+4  C u0 {2,B} {9,B} {10,B}
+5  C u0 {2,B} {11,B} {12,B}
+6  C u0 {1,B} {13,B} {14,B}
+7  C u0 {3,B} {15,B}
+8  C u0 {3,B} {9,B}
+9  C u0 {4,B} {8,B}
+10 C u0 {4,B} {16,B}
+11 C u0 {5,B} {16,B}
+12 C u0 {5,B} {13,B}
+13 C u0 {6,B} {12,B}
+14 * C u0 {6,B} {15,B}
+15 C u0 {7,B} {14,B}
+16 C u0 {10,B} {11,B}
+""",
+	solute = SoluteData(
+		S = 0.10088,
+		B = -0.01296,
+		E = 0.17247,
+		L = 0.12107,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 17,
+		L = 16,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 35,
+	label = "s2_5_6_s2_6_6_s2_6_6",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {17,[S,D,B]}
+2    R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+3    R!H u0 {2,[S,D,B]} {4,[S,D,B]} {15,[S,D,B]}
+4    R!H u0 {3,[S,D,B]} {5,[S,D,B]}
+5    R!H u0 {4,[S,D,B]} {6,[S,D,B]}
+6    R!H u0 {5,[S,D,B]} {7,[S,D,B]} {14,[S,D,B]}
+7    R!H u0 {6,[S,D,B]} {8,[S,D,B]} {11,[S,D,B]}
+8    R!H u0 {7,[S,D,B]} {9,[S,D,B]}
+9    R!H u0 {8,[S,D,B]} {10,[S,D,B]}
+10   R!H u0 {9,[S,D,B]} {11,[S,D,B]}
+11   R!H u0 {7,[S,D,B]} {10,[S,D,B]} {12,[S,D,B]}
+12   R!H u0 {11,[S,D,B]} {13,[S,D,B]}
+13   R!H u0 {12,[S,D,B]} {14,[S,D,B]}
+14   R!H u0 {6,[S,D,B]} {13,[S,D,B]} {15,[S,D,B]}
+15   R!H u0 {3,[S,D,B]} {14,[S,D,B]} {16,[S,D,B]}
+16   R!H u0 {15,[S,D,B]} {17,[S,D,B]}
+17   R!H u0 {1,[S,D,B]} {16,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.12106,
+		B = -0.00552,
+		E = -0.02452,
+		L = 0.38087,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 36,
+	label = "s2_5_6_s2_6_6_s2_6_6_ben",
+	group = 
+"""
+1  * Cb  u0 {2,B} {17,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,S} {15,B}
+4    R!H u0 {3,S} {5,S}
+5    R!H u0 {4,S} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {6,S} {13,S} {15,S}
+15   Cb  u0 {3,B} {14,S} {16,B}
+16   Cb  u0 {15,B} {17,B}
+17   Cb  u0 {1,B} {16,B}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_ben_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 37,
+	label = "s2_5_6_s2_6_6_s2_6_6_ben_onlyC",
+	group = 
+"""
+1  * Cb  u0 {2,B} {17,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,S} {15,B}
+4    C   u0 {3,S} {5,S}
+5    C   u0 {4,S} {6,S}
+6    C   u0 {5,S} {7,S} {14,S}
+7    C   u0 {6,S} {8,S} {11,S}
+8    C   u0 {7,S} {9,S}
+9    C   u0 {8,S} {10,S}
+10   C   u0 {9,S} {11,S}
+11   C   u0 {7,S} {10,S} {12,S}
+12   C   u0 {11,S} {13,S}
+13   C   u0 {12,S} {14,S}
+14   C   u0 {6,S} {13,S} {15,S}
+15   Cb  u0 {3,B} {14,S} {16,B}
+16   Cb  u0 {15,B} {17,B}
+17   Cb  u0 {1,B} {16,B}
+""",
+	solute = SoluteData(
+		S = 0.10685,
+		B = 0.19609,
+		E = 0.16013,
+		L = 0.04345,
+		A = 0.09970,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 38,
+	label = "s2_5_6_s2_6_6_s2_6_6_ane",
+	group = 
+"""
+1  * R!H u0 {2,S} {17,S}
+2    R!H u0 {1,S} {3,S}
+3    R!H u0 {2,S} {4,S} {15,S}
+4    R!H u0 {3,S} {5,S}
+5    R!H u0 {4,S} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {6,S} {13,S} {15,S}
+15   R!H u0 {3,S} {14,S} {16,S}
+16   R!H u0 {15,S} {17,S}
+17   R!H u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_ane_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 39,
+	label = "s2_5_6_s2_6_6_s2_6_6_ane_onlyC",
+	group = 
+"""
+1  * C  u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,S}
+3    C  u0 {2,S} {4,S} {15,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,S}
+17   C  u0 {1,S} {16,S}
+""",
+	solute = SoluteData(
+		S = 0.17040,
+		B = 0.00000,
+		E = -0.05725,
+		L = 0.25677,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 6,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 40,
+	label = "s2_5_6_s2_6_6_s2_6_6_ane_onlyC(=O)",
+	group = 
+"""
+1  * CO u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,S}
+3    C  u0 {2,S} {4,S} {15,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,S}
+17   C  u0 {1,S} {16,S}
+""",
+	solute = SoluteData(
+		S = 0.16022,
+		B = 0.06922,
+		E = 0.00919,
+		L = 0.29073,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 41,
+	label = "s2_5_6_s2_6_6_s2_6_6_ene_2",
+	group = 
+"""
+1  * R!H u0 {2,S} {17,S}
+2    R!H u0 {1,S} {3,D}
+3    R!H u0 {2,D} {4,S} {15,S}
+4    R!H u0 {3,S} {5,S}
+5    R!H u0 {4,S} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {6,S} {13,S} {15,S}
+15   R!H u0 {3,S} {14,S} {16,S}
+16   R!H u0 {15,S} {17,S}
+17   R!H u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_ene_2_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 42,
+	label = "s2_5_6_s2_6_6_s2_6_6_ene_2_onlyC",
+	group = 
+"""
+1  * C  u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,D}
+3    C  u0 {2,D} {4,S} {15,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,S}
+17   C  u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_ene_2_onlyC(=O)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 43,
+	label = "s2_5_6_s2_6_6_s2_6_6_ene_2_onlyC(=O)",
+	group = 
+"""
+1  * CO u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,D}
+3    C  u0 {2,D} {4,S} {15,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,S}
+17   C  u0 {1,S} {16,S}
+""",
+	solute = SoluteData(
+		S = 0.04818,
+		B = 0.03208,
+		E = -0.00754,
+		L = 0.04223,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 63,
+		B = 63,
+		E = 63,
+		L = 53,
+		A = 63,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 44,
+	label = "s2_5_6_s2_6_6_s2_6_6_ene_3",
+	group = 
+"""
+1  * R!H u0 {2,S} {17,S}
+2    R!H u0 {1,S} {3,S}
+3    R!H u0 {2,S} {4,D} {15,S}
+4    R!H u0 {3,D} {5,S}
+5    R!H u0 {4,S} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {6,S} {13,S} {15,S}
+15   R!H u0 {3,S} {14,S} {16,S}
+16   R!H u0 {15,S} {17,S}
+17   R!H u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_ene_3_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 45,
+	label = "s2_5_6_s2_6_6_s2_6_6_ene_3_onlyC",
+	group = 
+"""
+1  * C  u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,S}
+3    C  u0 {2,S} {4,D} {15,S}
+4    C  u0 {3,D} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,S}
+17   C  u0 {1,S} {16,S}
+""",
+	solute = SoluteData(
+		S = 0.10513,
+		B = 0.02489,
+		E = -0.02957,
+		L = 0.43057,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 46,
+	label = "s2_5_6_s2_6_6_s2_6_6_diene_2_16",
+	group = 
+"""
+1  * R!H u0 {2,S} {17,S}
+2    R!H u0 {1,S} {3,D}
+3    R!H u0 {2,D} {4,S} {15,S}
+4    R!H u0 {3,S} {5,S}
+5    R!H u0 {4,S} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {6,S} {13,S} {15,S}
+15   R!H u0 {3,S} {14,S} {16,S}
+16   R!H u0 {15,S} {17,D}
+17   R!H u0 {1,S} {16,D}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_diene_2_16_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 47,
+	label = "s2_5_6_s2_6_6_s2_6_6_diene_2_16_onlyC",
+	group = 
+"""
+1  * C  u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,D}
+3    C  u0 {2,D} {4,S} {15,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,D}
+17   C  u0 {1,S} {16,D}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_diene_2_16_onlyC(=O)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 48,
+	label = "s2_5_6_s2_6_6_s2_6_6_diene_2_16_onlyC(=O)",
+	group = 
+"""
+1  * CO u0 {2,S} {17,S}
+2    C  u0 {1,S} {3,D}
+3    C  u0 {2,D} {4,S} {15,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S} {14,S}
+7    C  u0 {6,S} {8,S} {11,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {9,S} {11,S}
+11   C  u0 {7,S} {10,S} {12,S}
+12   C  u0 {11,S} {13,S}
+13   C  u0 {12,S} {14,S}
+14   C  u0 {6,S} {13,S} {15,S}
+15   C  u0 {3,S} {14,S} {16,S}
+16   C  u0 {15,S} {17,D}
+17   C  u0 {1,S} {16,D}
+""",
+	solute = SoluteData(
+		S = 0.19379,
+		B = 0.05248,
+		E = 0.05417,
+		L = 0.24345,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 8,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 49,
+	label = "s2_5_6_s2_6_6_s2_6_6_diene_2_4",
+	group = 
+"""
+1  * R!H u0 {2,S} {17,S}
+2    R!H u0 {1,S} {3,D}
+3    R!H u0 {2,D} {4,S} {15,S}
+4    R!H u0 {3,S} {5,D}
+5    R!H u0 {4,D} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {6,S} {13,S} {15,S}
+15   R!H u0 {3,S} {14,S} {16,S}
+16   R!H u0 {15,S} {17,S}
+17   R!H u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_diene_2_4_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 50,
+	label = "s2_5_6_s2_6_6_s2_6_6_diene_2_4_onlyC",
+	group = 
+"""
+1  * C u0 {2,S} {17,S}
+2    C u0 {1,S} {3,D}
+3    C u0 {2,D} {4,S} {15,S}
+4    C u0 {3,S} {5,D}
+5    C u0 {4,D} {6,S}
+6    C u0 {5,S} {7,S} {14,S}
+7    C u0 {6,S} {8,S} {11,S}
+8    C u0 {7,S} {9,S}
+9    C u0 {8,S} {10,S}
+10   C u0 {9,S} {11,S}
+11   C u0 {7,S} {10,S} {12,S}
+12   C u0 {11,S} {13,S}
+13   C u0 {12,S} {14,S}
+14   C u0 {6,S} {13,S} {15,S}
+15   C u0 {3,S} {14,S} {16,S}
+16   C u0 {15,S} {17,S}
+17   C u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_diene_2_4_onlyC(=O)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 51,
+	label = "s2_5_6_s2_6_6_s2_6_6_diene_2_4_onlyC(=O)",
+	group = 
+"""
+1  * CO u0 {2,S} {17,S}
+2    C u0 {1,S} {3,D}
+3    C u0 {2,D} {4,S} {15,S}
+4    C u0 {3,S} {5,D}
+5    C u0 {4,D} {6,S}
+6    C u0 {5,S} {7,S} {14,S}
+7    C u0 {6,S} {8,S} {11,S}
+8    C u0 {7,S} {9,S}
+9    C u0 {8,S} {10,S}
+10   C u0 {9,S} {11,S}
+11   C u0 {7,S} {10,S} {12,S}
+12   C u0 {11,S} {13,S}
+13   C u0 {12,S} {14,S}
+14   C u0 {6,S} {13,S} {15,S}
+15   C u0 {3,S} {14,S} {16,S}
+16   C u0 {15,S} {17,S}
+17   C u0 {1,S} {16,S}
+""",
+	solute = SoluteData(
+		S = 0.04583,
+		B = 0.02142,
+		E = 0.04648,
+		L = 0.34717,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 52,
+	label = "s2_5_6_s2_6_6_s2_6_6_triene_2_12_14",
+	group = 
+"""
+1  * R!H u0 {2,S} {17,S}
+2    R!H u0 {1,S} {3,D}
+3    R!H u0 {2,D} {4,S} {15,S}
+4    R!H u0 {3,S} {5,S}
+5    R!H u0 {4,S} {6,S}
+6    R!H u0 {5,S} {7,S} {14,S}
+7    R!H u0 {6,S} {8,S} {11,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {7,S} {10,S} {12,S}
+12   R!H u0 {11,S} {13,D}
+13   R!H u0 {12,D} {14,S}
+14   R!H u0 {6,S} {13,S} {15,D}
+15   R!H u0 {3,S} {14,D} {16,S}
+16   R!H u0 {15,S} {17,S}
+17   R!H u0 {1,S} {16,S}
+""",
+	solute = u's2_5_6_s2_6_6_s2_6_6_triene_2_12_14_onlyC',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 53,
+	label = "s2_5_6_s2_6_6_s2_6_6_triene_2_12_14_onlyC",
+	group = 
+"""
+1  * C u0 {2,S} {17,S}
+2    C u0 {1,S} {3,D}
+3    C u0 {2,D} {4,S} {15,S}
+4    C u0 {3,S} {5,S}
+5    C u0 {4,S} {6,S}
+6    C u0 {5,S} {7,S} {14,S}
+7    C u0 {6,S} {8,S} {11,S}
+8    C u0 {7,S} {9,S}
+9    C u0 {8,S} {10,S}
+10   C u0 {9,S} {11,S}
+11   C u0 {7,S} {10,S} {12,S}
+12   C u0 {11,S} {13,D}
+13   C u0 {12,D} {14,S}
+14   C u0 {6,S} {13,S} {15,D}
+15   C u0 {3,S} {14,D} {16,S}
+16   C u0 {15,S} {17,S}
+17   C u0 {1,S} {16,S}
+""",
+	solute = SoluteData(
+		S = 0.06874,
+		B = 0.03920,
+		E = -0.03672,
+		L = 0.08413,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 54,
+	label = "s2_6_6_s2_6_6_s2_6_6",
+	group = 
+"""
+1  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {7,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {6,[S,D,B]} {14,[S,D,B]}
+3  R!H u0 {5,[S,D,B]} {7,[S,D,B]} {9,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {8,[S,D,B]} {11,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {8,[S,D,B]} {10,[S,D,B]}
+6  R!H u0 {2,[S,D,B]} {12,[S,D,B]} {13,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {5,[S,D,B]}
+9  R!H u0 {3,[S,D,B]} {16,[S,D,B]}
+10 R!H u0 {5,[S,D,B]} {15,[S,D,B]}
+11 R!H u0 {4,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {6,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {6,[S,D,B]} {17,[S,D,B]}
+14 R!H u0 {2,[S,D,B]} {18,[S,D,B]}
+15 R!H u0 {10,[S,D,B]} {16,[S,D,B]}
+16 R!H u0 {9,[S,D,B]} {15,[S,D,B]}
+17 R!H u0 {13,[S,D,B]} {18,[S,D,B]}
+18 * R!H u0 {14,[S,D,B]} {17,[S,D,B]}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_aromatic',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 55,
+	label = "s2_6_6_s2_6_6_s2_6_6_aromatic",
+	group =  "OR{s2_6_6_s2_6_6_s2_6_6_benz[a]anthracene, s2_6_6_s2_6_6_s2_6_6_benzacridine1, \
+s2_6_6_s2_6_6_s2_6_6_benzacridine2, s2_6_6_s2_6_6_s2_6_6_benzacridine3, s2_6_6_s2_6_6_s2_6_6_benzacridine4, \
+s2_6_6_s2_6_6_s2_6_6_benzacridine5}",
+	solute = u's2_6_6_s2_6_6_s2_6_6_benz[a]anthracene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 56,
+	label = "s2_6_6_s2_6_6_s2_6_6_benzacridine1",
+	group = 
+"""
+1  N u0 {6,D} {7,S}
+2  C u0 {3,S} {4,B} {9,B}
+3  C u0 {2,S} {6,S} {8,D}
+4  C u0 {2,B} {10,B} {11,S}
+5  C u0 {7,B} {8,S} {12,B}
+6  C u0 {1,D} {3,S} {13,S}
+7  C u0 {1,S} {5,B} {14,B}
+8  C u0 {3,D} {5,S}
+9  C u0 {2,B} {16,B}
+10 C u0 {4,B} {15,B}
+11 C u0 {4,S} {13,D}
+12 C u0 {5,B} {18,B}
+13 C u0 {6,S} {11,D}
+14 C u0 {7,B} {17,B}
+15 C u0 {10,B} {16,B}
+16 * C u0 {9,B} {15,B}
+17 C u0 {14,B} {18,B}
+18 C u0 {12,B} {17,B}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_benzacridine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_s2_6_6_s2_6_6_benzacridine
+""",
+)
+
+entry(
+	index = 57,
+	label = "s2_6_6_s2_6_6_s2_6_6_benzacridine2",
+	group = 
+"""
+1  N u0 {6,S} {7,D}
+2  C u0 {3,B} {4,B} {12,B}
+3  C u0 {2,B} {6,B} {8,S}
+4  C u0 {2,B} {10,B} {11,B}
+5  C u0 {7,S} {8,D} {9,S}
+6  C u0 {1,S} {3,B} {13,B}
+7  C u0 {1,D} {5,S} {14,S}
+8  C u0 {3,S} {5,D}
+9  C u0 {5,S} {15,D}
+10 C u0 {4,B} {13,B}
+11 C u0 {4,B} {16,B}
+12 C u0 {2,B} {17,B}
+13 C u0 {6,B} {10,B}
+14 C u0 {7,S} {18,D}
+15 C u0 {9,D} {18,S}
+16 C u0 {11,B} {17,B}
+17 * C u0 {12,B} {16,B}
+18 C u0 {14,D} {15,S}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_benzacridine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_s2_6_6_s2_6_6_benzacridine
+""",
+)
+
+entry(
+	index = 58,
+	label = "s2_6_6_s2_6_6_s2_6_6_benzacridine3",
+	group = 
+"""
+1  N u0 {6,D} {7,S}
+2  C u0 {3,B} {6,S} {12,B}
+3  C u0 {2,B} {11,S} {13,B}
+4  C u0 {7,B} {8,S} {9,B}
+5  C u0 {6,S} {8,D} {10,S}
+6  C u0 {1,D} {2,S} {5,S}
+7  C u0 {1,S} {4,B} {14,B}
+8  C u0 {4,S} {5,D}
+9  C u0 {4,B} {16,B}
+10 C u0 {5,S} {11,D}
+11 C u0 {3,S} {10,D}
+12 C u0 {2,B} {17,B}
+13 C u0 {3,B} {18,B}
+14 C u0 {7,B} {15,B}
+15 C u0 {14,B} {16,B} 
+16 C u0 {9,B} {15,B}
+17 * C u0 {12,B} {18,B}
+18 C u0 {13,B} {17,B}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_benzacridine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_s2_6_6_s2_6_6_benzacridine
+""",
+)
+
+entry(
+	index = 59,
+	label = "s2_6_6_s2_6_6_s2_6_6_benzacridine4",
+	group = 
+"""
+1  N u0 {6,D} {7,S}
+2  C u0 {3,B} {6,S} {9,B}
+3  C u0 {2,B} {10,B} {11,S}
+4  C u0 {6,S} {8,D} {12,S}
+5  C u0 {7,B} {8,S} {13,B}
+6  C u0 {1,D} {2,S} {4,S}
+7  C u0 {1,S} {5,B} {14,B}
+8  C u0 {4,D} {5,S}
+9  C u0 {2,B} {16,B}
+10 C u0 {3,B} {15,B}
+11 C u0 {3,S} {12,D}
+12 C u0 {4,S} {11,D}
+13 C u0 {5,B} {17,B}
+14 C u0 {7,B} {18,B}
+15 C u0 {10,B} {16,B}
+16 * C u0 {9,B} {15,B}
+17 C u0 {13,B} {18,B}
+18 C u0 {14,B} {17,B}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_benzacridine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_s2_6_6_s2_6_6_benzacridine
+""",
+)
+
+entry(
+	index = 60,
+	label = "s2_6_6_s2_6_6_s2_6_6_benzacridine5",
+	group = 
+"""
+1  N u0 {6,S} {7,D}
+2  C u0 {3,B} {6,B} {12,B}
+3  C u0 {2,B} {10,B} {11,B}
+4  C u0 {6,B} {8,S} {9,B}
+5  C u0 {7,S} {8,D} {13,S}
+6  C u0 {1,S} {2,B} {4,B}
+7  C u0 {1,D} {5,S} {14,S}
+8  C u0 {4,S} {5,D}
+9  C u0 {4,B} {10,B}
+10 C u0 {3,B} {9,B}
+11 C u0 {3,B} {16,B}
+12 C u0 {2,B} {17,B}
+13 C u0 {5,S} {18,D}
+14 C u0 {7,S} {15,D}
+15 C u0 {14,D} {18,S}
+16 C u0 {11,B} {17,B}
+17 * C u0 {12,B} {16,B}
+18 C u0 {13,D} {15,S}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_benzacridine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_s2_6_6_s2_6_6_benzacridine
+""",
+)
+
+entry(
+	index = 61,
+	label = "s2_6_6_s2_6_6_s2_6_6_benz[a]anthracene",
+	group = 
+"""
+1  C u0 {2,B} {4,B} {7,B}
+2  C u0 {1,B} {6,B} {14,B}
+3  C u0 {5,B} {7,B} {9,B}
+4  C u0 {1,B} {8,B} {11,B}
+5  C u0 {3,B} {8,B} {10,B}
+6  C u0 {2,B} {12,B} {13,B}
+7  C u0 {1,B} {3,B}
+8  C u0 {4,B} {5,B}
+9  C u0 {3,B} {16,B}
+10 C u0 {5,B} {15,B}
+11 C u0 {4,B} {12,B}
+12 C u0 {6,B} {11,B}
+13 C u0 {6,B} {17,B}
+14 C u0 {2,B} {18,B}
+15 C u0 {10,B} {16,B}
+16 C u0 {9,B} {15,B}
+17 C u0 {13,B} {18,B}
+18 * C u0 {14,B} {17,B}
+""",
+	solute = SoluteData(
+		S = -0.03349,
+		B = 0.02413,
+		E = -0.02557,
+		L = -0.18099,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 18,
+		L = 16,
+		A = 18,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 62,
+	label = "s2_6_6_s2_6_6_s2_6_6_benzacridine",
+	group = 
+"""
+1  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {7,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {6,[S,D,B]} {14,[S,D,B]}
+3  R!H u0 {5,[S,D,B]} {7,[S,D,B]} {9,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {8,[S,D,B]} {11,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {8,[S,D,B]} {10,[S,D,B]}
+6  R!H u0 {2,[S,D,B]} {12,[S,D,B]} {13,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {5,[S,D,B]}
+9  R!H u0 {3,[S,D,B]} {16,[S,D,B]}
+10 R!H u0 {5,[S,D,B]} {15,[S,D,B]}
+11 R!H u0 {4,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {6,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {6,[S,D,B]} {17,[S,D,B]}
+14 R!H u0 {2,[S,D,B]} {18,[S,D,B]}
+15 R!H u0 {10,[S,D,B]} {16,[S,D,B]}
+16 R!H u0 {9,[S,D,B]} {15,[S,D,B]}
+17 R!H u0 {13,[S,D,B]} {18,[S,D,B]}
+18 * R!H u0 {14,[S,D,B]} {17,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.02388,
+		B = -0.01301,
+		E = 0.36148,
+		L = 0.20888,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 1,
+		E = 9,
+		L = 9,
+		A = 3,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_6_6_s2_6_6_s2_6_6_benzacridine groups (s2_6_6_s2_6_6_s2_6_6_benzacridine1-5) together
+""",
+)
+
+entry(
+	index = 63,
+	label = "s2_6_6_s2_6_6_s2_6_6_A",
+	group = 
+"""
+1  * R!H u0 {4,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+2  R!H u0 {3,[S,D,B]} {4,[S,D,B]} {10,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {11,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {2,[S,D,B]} {14,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {8,[S,D,B]} {9,[S,D,B]}
+6  R!H u0 {3,[S,D,B]} {12,[S,D,B]} {13,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {16,[S,D,B]}
+8  R!H u0 {5,[S,D,B]} {15,[S,D,B]}
+9  R!H u0 {5,[S,D,B]} {10,[S,D,B]}
+10 R!H u0 {2,[S,D,B]} {9,[S,D,B]}
+11 R!H u0 {3,[S,D,B]} {17,[S,D,B]}
+12 R!H u0 {6,[S,D,B]} {18,[S,D,B]}
+13 R!H u0 {6,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {4,[S,D,B]} {13,[S,D,B]}
+15 R!H u0 {8,[S,D,B]} {16,[S,D,B]}
+16 R!H u0 {7,[S,D,B]} {15,[S,D,B]}
+17 R!H u0 {11,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {12,[S,D,B]} {17,[S,D,B]}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_A_chrysene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 64,
+	label = "s2_6_6_s2_6_6_s2_6_6_A_chrysene",
+	group = 
+"""
+1  * C u0 {4,B} {5,B} {7,B}
+2  C u0 {3,B} {4,B} {10,B}
+3  C u0 {2,B} {6,B} {11,B}
+4  C u0 {1,B} {2,B} {14,B}
+5  C u0 {1,B} {8,B} {9,B}
+6  C u0 {3,B} {12,B} {13,B}
+7  C u0 {1,B} {16,B}
+8  C u0 {5,B} {15,B}
+9  C u0 {5,B} {10,B}
+10 C u0 {2,B} {9,B}
+11 C u0 {3,B} {17,B}
+12 C u0 {6,B} {18,B}
+13 C u0 {6,B} {14,B}
+14 C u0 {4,B} {13,B}
+15 C u0 {8,B} {16,B}
+16 C u0 {7,B} {15,B}
+17 C u0 {11,B} {18,B}
+18 C u0 {12,B} {17,B}
+""",
+	solute = SoluteData(
+		S = -0.01431,
+		B = 0.01003,
+		E = -0.08884,
+		L = 0.02838,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 65,
+	label = "s2_6_6_s2_6_6_s2_6_6_B",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {4,[S,D,B]} {5,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {6,[S,D,B]} {12,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {7,[S,D,B]} {9,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {8,[S,D,B]}
+6  R!H u0 {2,[S,D,B]} {9,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {10,[S,D,B]}
+8  R!H u0 {5,[S,D,B]} {13,[S,D,B]}
+9  R!H u0 {3,[S,D,B]} {6,[S,D,B]} {14,[S,D,B]}
+10 R!H u0 {7,[S,D,B]} {11,[S,D,B]} {15,[S,D,B]}
+11 R!H u0 {10,[S,D,B]} {14,[S,D,B]} {16,[S,D,B]}
+12 R!H u0 {2,[S,D,B]} {13,[S,D,B]}
+13 R!H u0 {8,[S,D,B]} {12,[S,D,B]}
+14 R!H u0 {9,[S,D,B]} {11,[S,D,B]}
+15 R!H u0 {10,[S,D,B]} {18,[S,D,B]}
+16 R!H u0 {11,[S,D,B]} {17,[S,D,B]}
+17 R!H u0 {16,[S,D,B]} {18,[S,D,B]}
+18 R!H u0 {15,[S,D,B]} {17,[S,D,B]}
+""",
+	solute = u's2_6_6_s2_6_6_s2_6_6_B_ben_diene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 66,
+	label = "s2_6_6_s2_6_6_s2_6_6_B_tetracene",
+	group = 
+"""
+1  * C u0 {2,B} {4,B} {5,B}
+2  C u0 {1,B} {6,B} {12,B}
+3  C u0 {4,B} {7,B} {9,B}
+4  C u0 {1,B} {3,B}
+5  C u0 {1,B} {8,B}
+6  C u0 {2,B} {9,B}
+7  C u0 {3,B} {10,B}
+8  C u0 {5,B} {13,B}
+9  C u0 {3,B} {6,B} {14,B}
+10 C u0 {7,B} {11,B} {15,B}
+11 C u0 {10,B} {14,B} {16,B}
+12 C u0 {2,B} {13,B}
+13 C u0 {8,B} {12,B}
+14 C u0 {9,B} {11,B}
+15 C u0 {10,B} {18,B}
+16 C u0 {11,B} {17,B}
+17 C u0 {16,B} {18,B}
+18 C u0 {15,B} {17,B}
+""",
+	solute = SoluteData(
+		S = -0.01103,
+		B = 0.01066,
+		E = -0.01482,
+		L = -0.06004,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 67,
+	label = "s2_6_6_s2_6_6_s2_6_6_B_1,2,3,4,6,11-hexahydrotetracene",
+	group = 
+"""
+1  C u0 {2,S} {3,S}
+2  C u0 {1,S} {4,S}
+3  C u0 {1,S} {8,S}
+4  C u0 {2,S} {7,S}
+5  C u0 {10,S} {11,S}
+6  C u0 {9,S} {12,S}
+7  C u0 {4,S} {8,B} {13,B}
+8  * C u0 {3,S} {7,B} {14,B}
+9  C u0 {6,S} {10,B} {16,B}
+10 C u0 {5,S} {9,B} {15,B}
+11 C u0 {5,S} {12,B} {14,B}
+12 C u0 {6,S} {11,B} {13,B}
+13 C u0 {7,B} {12,B}
+14 C u0 {8,B} {11,B}
+15 C u0 {10,B} {17,B}
+16 C u0 {9,B} {18,B}
+17 C u0 {15,B} {18,B}
+18 C u0 {16,B} {17,B}
+""",
+	solute = SoluteData(
+		S = 0.05984,
+		B = 0.14753,
+		E = -0.00157,
+		L = -0.19294,
+		A = -0.26192,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 68,
+	label = "s2_6_6_s2_6_6_s2_6_6_B_ben_diene",
+	group = 
+"""
+1  * C u0 {2,S} {4,S} {5,S}
+2  C u0 {1,S} {6,S} {12,S}
+3  C u0 {4,S} {7,S} {9,S}
+4  C u0 {1,S} {3,S}
+5  C u0 {1,S} {8,S}
+6  C u0 {2,S} {9,S}
+7  C u0 {3,S} {10,S}
+8  C u0 {5,S} {13,S}
+9  C u0 {3,S} {6,S} {14,D}
+10 C u0 {7,S} {11,B} {15,B}
+11 C u0 {10,B} {14,S} {16,B}
+12 C u0 {2,S} {13,D}
+13 C u0 {8,S} {12,D}
+14 C u0 {9,D} {11,S}
+15 C u0 {10,B} {18,B}
+16 C u0 {11,B} {17,B}
+17 C u0 {16,B} {18,B}
+18 C u0 {15,B} {17,B}
+""",
+	solute = SoluteData(
+		S = -0.09062,
+		B = -0.05727,
+		E = -0.01586,
+		L = -0.16117,
+		A = 0.02541,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 69,
+	label = "s2_6_5_s2_5_9_s3_9_6",
+	group = 
+"""
+1  * R!H u0 {7,[S,D,B]} {8,[S,D,B]} {9,[S,D,B]}
+2  R!H u0 {13,[S,D,B]} {15,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {3,[S,D,B]} {6,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {10,[S,D,B]}
+6  R!H u0 {4,[S,D,B]} {8,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+8  R!H u0 {1,[S,D,B]} {6,[S,D,B]}
+9  R!H u0 {1,[S,D,B]} {11,[S,D,B]}
+10 R!H u0 {5,[S,D,B]} {13,[S,D,B]}
+11 R!H u0 {9,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {11,[S,D,B]} {13,[S,D,B]} {14,[S,D,B]}
+13 R!H u0 {2,[S,D,B]} {10,[S,D,B]} {12,[S,D,B]}
+14 R!H u0 {12,[S,D,B]} {15,[S,D,B]} {17,[S,D,B]}
+15 R!H u0 {2,[S,D,B]} {14,[S,D,B]} {16,[S,D,B]}
+16 R!H u0 {15,[S,D,B]} {18,[S,D,B]}
+17 R!H u0 {14,[S,D,B]} {19,[S,D,B]}
+18 R!H u0 {16,[S,D,B]} {19,[S,D,B]}
+19 R!H u0 {17,[S,D,B]} {18,[S,D,B]}
+""",
+	solute = u's2_6_5_ben_ene_s2_5_9_s3_9_6_hetero',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 70,
+	label = "s2_6_5_ben_ene_s2_5_9_s3_9_6_hetero",
+	group = 
+"""
+1  * N u0 {7,S} {8,S} {9,S}
+2  N u0 {13,S} {15,S}
+3  C u0 {4,S} {5,S} {7,S}
+4  C u0 {3,S} {6,S}
+5  C u0 {3,S} {10,S}
+6  C u0 {4,S} {8,S}
+7  C u0 {1,S} {3,S}
+8  C u0 {1,S} {6,S}
+9  C u0 {1,S} {11,S}
+10 C u0 {5,S} {13,S}
+11 C u0 {9,S} {12,S}
+12 C u0 {11,S} {13,D} {14,S}
+13 C u0 {2,S} {10,S} {12,D}
+14 C u0 {12,S} {15,B} {17,B}
+15 C u0 {2,S} {14,B} {16,B}
+16 C u0 {15,B} {18,B}
+17 C u0 {14,B} {19,B}
+18 C u0 {16,B} {19,B}
+19 C u0 {17,B} {18,B}
+""",
+	solute = SoluteData(
+		S = 0.03834,
+		B = -0.01704,
+		E = -0.00473,
+		L = 0.04905,
+		A = 0.01444,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 71,
+	label = "s2_6_7_s2_7_6_s2_7_6",
+	group = 
+"""
+1  * R!H u0 {10,[S,D,B]} {11,[S,D,B]}
+2  R!H u0 {6,[S,D,B]} {7,[S,D,B]}
+3  R!H u0 {4,[S,D,B]} {5,[S,D,B]} {8,[S,D,B]}
+4  R!H u0 {3,[S,D,B]} {6,[S,D,B]} {9,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {7,[S,D,B]}
+6  R!H u0 {2,[S,D,B]} {4,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {5,[S,D,B]}
+8  R!H u0 {3,[S,D,B]} {10,[S,D,B]} {12,[S,D,B]}
+9  R!H u0 {4,[S,D,B]} {11,[S,D,B]} {13,[S,D,B]}
+10 R!H u0 {1,[S,D,B]} {8,[S,D,B]} {14,[S,D,B]}
+11 R!H u0 {1,[S,D,B]} {9,[S,D,B]} {15,[S,D,B]}
+12 R!H u0 {8,[S,D,B]} {17,[S,D,B]}
+13 R!H u0 {9,[S,D,B]} {19,[S,D,B]}
+14 R!H u0 {10,[S,D,B]} {16,[S,D,B]}
+15 R!H u0 {11,[S,D,B]} {18,[S,D,B]}
+16 R!H u0 {14,[S,D,B]} {17,[S,D,B]}
+17 R!H u0 {12,[S,D,B]} {16,[S,D,B]}
+18 R!H u0 {15,[S,D,B]} {19,[S,D,B]}
+19 R!H u0 {13,[S,D,B]} {18,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = -0.07266,
+		B = -0.01224,
+		E = 0.04993,
+		L = 0.05495,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 72,
+	label = "s2_6_7_ben_s2_7_6_ben_s2_7_6_piperidine",
+	group = 
+"""
+1  * O u0 {10,S} {11,S}
+2  N u0 {6,S} {7,S}
+3  C u0 {4,S} {5,S} {8,S}
+4  C u0 {3,S} {6,S} {9,S}
+5  C u0 {3,S} {7,S}
+6  C u0 {2,S} {4,S}
+7  C u0 {2,S} {5,S}
+8  C u0 {3,S} {10,B} {12,B}
+9  C u0 {4,S} {11,B} {13,B}
+10 C u0 {1,S} {8,B} {14,B}
+11 C u0 {1,S} {9,B} {15,B}
+12 C u0 {8,B} {17,B}
+13 C u0 {9,B} {19,B}
+14 C u0 {10,B} {16,B}
+15 C u0 {11,B} {18,B}
+16 C u0 {14,B} {17,B}
+17 C u0 {12,B} {16,B}
+18 C u0 {15,B} {19,B}
+19 C u0 {13,B} {18,B}
+""",
+	solute = SoluteData(
+		S = -0.01105,
+		B = -0.02492,
+		E = 0.02815,
+		L = 0.01544,
+		A = -0.01389,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 73,
+	label = "Quadricyclane_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {4,[S,D,B]} {5,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {6,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {2,[S,D,B]} {7,[S,D,B]}
+6  R!H u0 {3,[S,D,B]} {4,[S,D,B]} {7,[S,D,B]}
+7  R!H u0 {5,[S,D,B]} {6,[S,D,B]}
+""",
+	solute = u'Quadricyclane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 74,
+	label = "Quadricyclane",
+	group = 
+"""
+1  * C u0 {2,S} {4,S} {5,S}
+2  C u0 {1,S} {3,S} {5,S}
+3  C u0 {2,S} {4,S} {6,S}
+4  C u0 {1,S} {3,S} {6,S}
+5  C u0 {1,S} {2,S} {7,S}
+6  C u0 {3,S} {4,S} {7,S}
+7  C u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.09580,
+		B = 0.00000,
+		E = -0.04218,
+		L = -0.47881,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 75,
+	label = "polycyclic_3fused",
+	group =  "OR{Adamantane_general, s2_6_7_s2_7_6, s2_6_6_s2_6_5, s2_6_6_s2_6_6, s2_6_6_s2_6_6_A, s2_6_5_s2_5_6, s2_5_6_s2_6_6,\
+s2_5_7_s2_7_3, Nortricyclene_general, s3_6_3_s3_3_6, Acenaphthene_general, s2_5_5_s2_5_5_ane}",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 76,
+	label = "Adamantane_general",
+	group = 
+"""
+1  * R!H u0 {5,[S,D,B]} {6,[S,D,B]} {9,[S,D,B]}
+2  R!H u0 {6,[S,D,B]} {7,[S,D,B]} {10,[S,D,B]}
+3  R!H u0 {5,[S,D,B]} {7,[S,D,B]} {8,[S,D,B]}
+4  R!H u0 {8,[S,D,B]} {9,[S,D,B]} {10,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {2,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {3,[S,D,B]}
+8  R!H u0 {3,[S,D,B]} {4,[S,D,B]}
+9  R!H u0 {1,[S,D,B]} {4,[S,D,B]}
+10 R!H u0 {2,[S,D,B]} {4,[S,D,B]}
+""",
+	solute = u'Adamantane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 77,
+	label = "Adamantane",
+	group = 
+"""
+1  * C u0 {5,S} {6,S} {9,S}
+2  C u0 {6,S} {7,S} {10,S}
+3  C u0 {5,S} {7,S} {8,S}
+4  C u0 {8,S} {9,S} {10,S}
+5  C u0 {1,S} {3,S}
+6  C u0 {1,S} {2,S}
+7  C u0 {2,S} {3,S}
+8  C u0 {3,S} {4,S}
+9  C u0 {1,S} {4,S}
+10 C u0 {2,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.06655,
+		B = 0.08122,
+		E = 0.06194,
+		L = 0.07941,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 78,
+	label = "s2_6_7_s2_7_6",
+	group = 
+"""
+1  * R!H u0 {6,[S,D,B]} {7,[S,D,B]}
+2  R!H u0 {3,[S,D,B]} {4,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {5,[S,D,B]}
+4  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {8,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {7,[S,D,B]} {9,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {4,[S,D,B]} {10,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {11,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {12,[S,D,B]}
+9  R!H u0 {5,[S,D,B]} {14,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {13,[S,D,B]}
+11 R!H u0 {7,[S,D,B]} {15,[S,D,B]}
+12 R!H u0 {8,[S,D,B]} {13,[S,D,B]}
+13 R!H u0 {10,[S,D,B]} {12,[S,D,B]}
+14 R!H u0 {9,[S,D,B]} {15,[S,D,B]}
+15 R!H u0 {11,[S,D,B]} {14,[S,D,B]}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_ene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 79,
+	label = "s2_6_7_ben_s2_7_6_ben_general",
+	group =  "OR{s2_6_7_ben_s2_7_6_ben, s2_6_7_ben_s2_7_6_ben_iminodibenzyl_general}",
+	solute = u's2_6_7_ben_s2_7_6_ben',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 80,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl_general",
+	group =  "OR{s2_6_7_ben_s2_7_6_ben_iminodibenzyl1, s2_6_7_ben_s2_7_6_ben_iminodibenzyl2, s2_6_7_ben_s2_7_6_ben_iminodibenzyl3, \
+s2_6_7_ben_s2_7_6_ben_iminodibenzyl4, s2_6_7_ben_s2_7_6_ben_iminodibenzyl5, s2_6_7_ben_s2_7_6_ben_iminodibenzyl6}",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 81,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl1",
+	group = 
+"""
+1  N u0 {6,S} {7,S}
+2  C u0 {3,S} {4,S}
+3  C u0 {2,S} {5,S}
+4  C u0 {2,S} {6,B} {8,B}
+5  C u0 {3,S} {7,B} {9,B}
+6  C u0 {1,S} {4,B} {10,B}
+7  C u0 {1,S} {5,B} {11,B}
+8  C u0 {4,B} {12,B}
+9  C u0 {5,B} {14,B}
+10 C u0 {6,B} {13,B}
+11 C u0 {7,B} {15,B}
+12 C u0 {8,B} {13,B}
+13 C u0 {10,B} {12,B}
+14 C u0 {9,B} {15,B}
+15 C u0 {11,B} {14,B}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+""",
+)
+
+entry(
+	index = 82,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl2",
+	group = 
+"""
+1  [C,N] u0 {4,S} {7,S}
+2  N     u0 {6,S} {8,S}
+3  [C,N] u0 {8,S} {15,D}
+4  [C,N] u0 {1,S} {5,S}
+5  [C,N] u0 {4,S} {6,B} {9,B}
+6  [C,N] u0 {2,S} {5,B} {10,B}
+7  [C,N] u0 {1,S} {8,D} {11,S}
+8  [C,N] u0 {2,S} {3,S} {7,D}
+9  [C,N] u0 {5,B} {13,B}
+10 [C,N] u0 {6,B} {12,B}
+11 [C,N] u0 {7,S} {14,D}
+12 [C,N] u0 {10,B} {13,B}
+13 [C,N] u0 {9,B} {12,B}
+14 [C,N] u0 {11,D} {15,S}
+15 [C,N] u0 {3,D} {14,S}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+""",
+)
+
+entry(
+	index = 83,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl3",
+	group = 
+"""
+1  [C,N] u0 {5,S} {7,S}
+2  N     u0 {8,S} {9,S}
+3  [C,N] u0 {9,D} {14,S}
+4  [C,N] u0 {8,S} {15,D}
+5  [C,N] u0 {1,S} {6,S}
+6  [C,N] u0 {5,S} {8,D} {10,S}
+7  [C,N] u0 {1,S} {9,S} {11,D}
+8  [C,N] u0 {2,S} {4,S} {6,D}
+9  [C,N] u0 {2,S} {3,D} {7,S}
+10 [C,N] u0 {6,S} {13,D}
+11 [C,N] u0 {7,D} {12,S}
+12 [C,N] u0 {11,S} {14,D}
+13 [C,N] u0 {10,D} {15,S}
+14 [C,N] u0 {3,S} {12,D}
+15 [C,N] u0 {4,D} {13,S}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+""",
+)
+
+entry(
+	index = 84,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl4",
+	group = 
+"""
+1  [C,N] u0 {5,S} {7,S}
+2  N     u0 {8,S} {9,S}
+3  [C,N] u0 {9,S} {14,D}
+4  [C,N] u0 {8,S} {15,D}
+5  [C,N] u0 {1,S} {6,S}
+6  [C,N] u0 {5,S} {8,D} {10,S}
+7  [C,N] u0 {1,S} {9,D} {11,S}
+8  [C,N] u0 {2,S} {4,S} {6,D}
+9  [C,N] u0 {2,S} {3,S} {7,D}
+10 [C,N] u0 {6,S} {13,D}
+11 [C,N] u0 {7,S} {12,D}
+12 [C,N] u0 {11,D} {14,S}
+13 [C,N] u0 {10,D} {15,S}
+14 [C,N] u0 {3,D} {12,S}
+15 [C,N] u0 {4,D} {13,S}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+""",
+)
+
+entry(
+	index = 85,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl5",
+	group = 
+"""
+1  [C,N] u0 {5,S} {7,S}
+2  N     u0 {8,S} {9,S}
+3  [C,N] u0 {9,D} {14,S}
+4  [C,N] u0 {8,D} {15,S}
+5  [C,N] u0 {1,S} {6,S}
+6  [C,N] u0 {5,S} {8,S} {10,D}
+7  [C,N] u0 {1,S} {9,S} {11,D}
+8  [C,N] u0 {2,S} {4,D} {6,S}
+9  [C,N] u0 {2,S} {3,D} {7,S}
+10 [C,N] u0 {6,D} {13,S}
+11 [C,N] u0 {7,D} {12,S}
+12 [C,N] u0 {11,S} {14,D}
+13 [C,N] u0 {10,S} {15,D}
+14 [C,N] u0 {3,S} {12,D}
+15 [C,N] u0 {4,S} {13,D}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+""",
+)
+
+entry(
+	index = 86,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl6",
+	group = 
+"""
+1  [C,N] u0 {4,S} {7,S}
+2  N     u0 {6,S} {8,S}
+3  [C,N] u0 {8,D} {15,S}
+4  [C,N] u0 {1,S} {5,S}
+5  [C,N] u0 {4,S} {6,B} {9,B}
+6  [C,N] u0 {2,S} {5,B} {10,B}
+7  [C,N] u0 {1,S} {8,S} {11,D}
+8  [C,N] u0 {2,S} {3,D} {7,S}
+9  [C,N] u0 {5,B} {13,B}
+10 [C,N] u0 {6,B} {12,B}
+11 [C,N] u0 {7,D} {14,S}
+12 [C,N] u0 {10,B} {13,B}
+13 [C,N] u0 {9,B} {12,B}
+14 [C,N] u0 {11,S} {15,D}
+15 [C,N] u0 {3,S} {14,D}
+""",
+	solute = u's2_6_7_ben_s2_7_6_ben_iminodibenzyl',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+""",
+)
+
+entry(
+	index = 87,
+	label = "s2_6_7_ben_s2_7_6_ben_iminodibenzyl",
+	group = 
+"""
+1  R!H u0 {6,[S,D,B]} {7,[S,D,B]}
+2  R!H u0 {3,[S,D,B]} {4,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {5,[S,D,B]}
+4  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {8,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {7,[S,D,B]} {9,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {4,[S,D,B]} {10,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {11,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {12,[S,D,B]}
+9  R!H u0 {5,[S,D,B]} {14,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {13,[S,D,B]}
+11 R!H u0 {7,[S,D,B]} {15,[S,D,B]}
+12 R!H u0 {8,[S,D,B]} {13,[S,D,B]}
+13 R!H u0 {10,[S,D,B]} {12,[S,D,B]}
+14 R!H u0 {9,[S,D,B]} {15,[S,D,B]}
+15 R!H u0 {11,[S,D,B]} {14,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.02338,
+		B = -0.05327,
+		E = -0.10435,
+		L = -0.15494,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy groups to put all s2_6_7_ben_s2_7_6_ben_iminodibenzyl groups (s2_6_7_ben_s2_7_6_ben_iminodibenzyl1-6) together
+""",
+)
+
+entry(
+	index = 88,
+	label = "s2_6_7_ben_s2_7_6_ben",
+	group = 
+"""
+1  * R!H u0 {6,S} {7,S}
+2  R!H u0 {3,S} {4,S}
+3  R!H u0 {2,S} {5,S}
+4  R!H u0 {2,S} {6,B} {8,B}
+5  R!H u0 {3,S} {7,B} {9,B}
+6  R!H u0 {1,S} {4,B} {10,B}
+7  R!H u0 {1,S} {5,B} {11,B}
+8  R!H u0 {4,B} {12,B}
+9  R!H u0 {5,B} {14,B}
+10 R!H u0 {6,B} {13,B}
+11 R!H u0 {7,B} {15,B}
+12 R!H u0 {8,B} {13,B}
+13 R!H u0 {10,B} {12,B}
+14 R!H u0 {9,B} {15,B}
+15 R!H u0 {11,B} {14,B}
+""",
+	solute = SoluteData(
+		S = 0.00696,
+		B = 0.00011,
+		E = -0.00973,
+		L = 0.07011,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 89,
+	label = "s2_6_7_ben_s2_7_6_ben_ene",
+	group = 
+"""
+1  * R!H u0 {6,S} {7,S}
+2  R!H u0 {3,D} {4,S}
+3  R!H u0 {2,D} {5,S}
+4  R!H u0 {2,S} {6,B} {8,B}
+5  R!H u0 {3,S} {7,B} {9,B}
+6  R!H u0 {1,S} {4,B} {10,B}
+7  R!H u0 {1,S} {5,B} {11,B}
+8  R!H u0 {4,B} {12,B}
+9  R!H u0 {5,B} {14,B}
+10 R!H u0 {6,B} {13,B}
+11 R!H u0 {7,B} {15,B}
+12 R!H u0 {8,B} {13,B}
+13 R!H u0 {10,B} {12,B}
+14 R!H u0 {9,B} {15,B}
+15 R!H u0 {11,B} {14,B}
+""",
+	solute = SoluteData(
+		S = -0.10938,
+		B = 0.09353,
+		E = -0.11225,
+		L = -0.19892,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 90,
+	label = "s2_6_6_s2_6_5",
+	group = 
+"""
+1  * R!H u0 {3,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {7,[S,D,B]} {13,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {8,[S,D,B]}
+4  R!H u0 {7,[S,D,B]} {9,[S,D,B]} {12,[S,D,B]}
+5  R!H u0 {6,[S,D,B]} {9,[S,D,B]} {10,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {11,[S,D,B]}
+7  R!H u0 {2,[S,D,B]} {4,[S,D,B]} {11,[S,D,B]}
+8  R!H u0 {3,[S,D,B]} {10,[S,D,B]}
+9  R!H u0 {4,[S,D,B]} {5,[S,D,B]}
+10 R!H u0 {5,[S,D,B]} {8,[S,D,B]}
+11 R!H u0 {6,[S,D,B]} {7,[S,D,B]}
+12 R!H u0 {4,[S,D,B]} {13,[S,D,B]}
+13 R!H u0 {2,[S,D,B]} {12,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.04715,
+		B = -0.02702,
+		E = 0.02078,
+		L = 0.14645,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 91,
+	label = "s2_6_6_s2_6_5_ben_ene",
+	group = 
+"""
+1  * R!H u0 {3,S} {6,S}
+2  R!H u0 {7,S} {13,S}
+3  R!H u0 {1,S} {8,D}
+4  R!H u0 {7,B} {9,B} {12,S}
+5  R!H u0 {6,B} {9,B} {10,S}
+6  R!H u0 {1,S} {5,B} {11,B}
+7  R!H u0 {2,S} {4,B} {11,B}
+8  R!H u0 {3,D} {10,S}
+9  R!H u0 {4,B} {5,B}
+10 R!H u0 {5,S} {8,S}
+11 R!H u0 {6,B} {7,B}
+12 R!H u0 {4,S} {13,S}
+13 R!H u0 {2,S} {12,S}
+""",
+	solute = SoluteData(
+		S = -0.08473,
+		B = 0.01327,
+		E = 0.10047,
+		L = -0.26149,
+		A = 0.00866,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 92,
+	label = "s2_6_6_s2_6_5_ben_diene",
+	group = 
+"""
+1  * R!H u0 {3,S} {6,S}
+2  R!H u0 {7,S} {13,S}
+3  R!H u0 {1,S} {8,S}
+4  R!H u0 {7,B} {9,B} {12,S}
+5  R!H u0 {6,B} {9,B} {10,S}
+6  R!H u0 {1,S} {5,B} {11,B}
+7  R!H u0 {2,S} {4,B} {11,B}
+8  R!H u0 {3,S} {10,D}
+9  R!H u0 {4,B} {5,B}
+10 R!H u0 {5,S} {8,D}
+11 R!H u0 {6,B} {7,B}
+12 R!H u0 {4,S} {13,D}
+13 R!H u0 {2,S} {12,D}
+""",
+	solute = u's2_6_6_s2_6_5_ben_diene_psoralen',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 93,
+	label = "s2_6_6_s2_6_5_ben_diene_psoralen",
+	group = 
+"""
+1  * O u0 {3,S} {6,S}
+2  O u0 {7,S} {13,S}
+3  CO u0 {1,S} {8,S}
+4  C u0 {7,B} {9,B} {12,S}
+5  C u0 {6,B} {9,B} {10,S}
+6  C u0 {1,S} {5,B} {11,B}
+7  C u0 {2,S} {4,B} {11,B}
+8  C u0 {3,S} {10,D}
+9  C u0 {4,B} {5,B}
+10 C u0 {5,S} {8,D}
+11 C u0 {6,B} {7,B}
+12 C u0 {4,S} {13,D}
+13 C u0 {2,S} {12,D}
+""",
+	solute = SoluteData(
+		S = -0.02531,
+		B = 0.02067,
+		E = 0.01404,
+		L = -0.09039,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 94,
+	label = "s2_6_6_s2_6_6",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]}
+2    R!H u0 {1,[S,D,B]} {4,[S,D,B]} {10,[S,D,B]}
+3    R!H u0 {1,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]}
+4    R!H u0 {2,[S,D,B]} {8,[S,D,B]} {9,[S,D,B]}
+5    R!H u0 {1,[S,D,B]} {12,[S,D,B]}
+6    R!H u0 {3,[S,D,B]} {11,[S,D,B]}
+7    R!H u0 {3,[S,D,B]} {8,[S,D,B]}
+8    R!H u0 {4,[S,D,B]} {7,[S,D,B]}
+9    R!H u0 {4,[S,D,B]} {13,[S,D,B]}
+10   R!H u0 {2,[S,D,B]} {14,[S,D,B]}
+11   R!H u0 {6,[S,D,B]} {12,[S,D,B]}
+12   R!H u0 {5,[S,D,B]} {11,[S,D,B]}
+13   R!H u0 {9,[S,D,B]} {14,[S,D,B]}
+14   R!H u0 {10,[S,D,B]} {13,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.10072,
+		B = -0.03236,
+		E = 0.09049,
+		L = -0.55079,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 95,
+	label = "s2_6_6_s2_6_6_aromatic",
+	group =  "OR{s2_6_6_s2_6_6_aromatic1, s2_6_6_s2_6_6_aromatic2, s2_6_6_s2_6_6_aromatic3, s2_6_6_s2_6_6_aromatic4}",
+	solute = u's2_6_6_s2_6_6_all_ben',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 96,
+	label = "s2_6_6_s2_6_6_aromatic1",
+	group = 
+"""
+1  * [C,N]  u0 {2,[S,B]} {3,B} {5,B}
+2    [C,N]  u0 {1,[S,B]} {4,B} {10,B}
+3    [C,N]  u0 {1,B} {6,B} {7,[S,B]}
+4    [C,N]  u0 {2,B} {8,[S,B]} {9,B}
+5    [C,N]  u0 {1,B} {12,B}
+6    [C,N]  u0 {3,B} {11,B}
+7    [C,N]  u0 {3,[S,B]} {8,[D,B]}
+8    [C,N]  u0 {4,[S,B]} {7,[D,B]}
+9    [C,N]  u0 {4,B} {13,B}
+10   [C,N]  u0 {2,B} {14,B}
+11   [C,N]  u0 {6,B} {12,B}
+12   [C,N]  u0 {5,B} {11,B}
+13   [C,N]  u0 {9,B} {14,B}
+14   [C,N]  u0 {10,B} {13,B}
+""",
+	solute = u's2_6_6_s2_6_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+the heterocyclic form belongs to s2_6_6_s2_6_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 97,
+	label = "s2_6_6_s2_6_6_aromatic2",
+	group = 
+"""
+1  * [C,N]  u0 {2,[S,B]} {3,[D,B]} {5,[S,B]}
+2    [C,N]  u0 {1,[S,B]} {4,[D,B]} {10,[S,B]}
+3    [C,N]  u0 {1,[D,B]} {6,[S,B]} {7,[S,B]}
+4    [C,N]  u0 {2,[D,B]} {8,[S,B]} {9,[S,B]}
+5    [C,N]  u0 {1,[S,B]} {12,[D,B]}
+6    [C,N]  u0 {3,[S,B]} {11,[D,B]}
+7    [C,N]  u0 {3,[S,B]} {8,[D,B]}
+8    [C,N]  u0 {4,[S,B]} {7,[D,B]}
+9    [C,N]  u0 {4,[S,B]} {13,[D,B]}
+10   [C,N]  u0 {2,[S,B]} {14,[D,B]}
+11   [C,N]  u0 {6,[D,B]} {12,[S,B]}
+12   [C,N]  u0 {5,[D,B]} {11,[S,B]}
+13   [C,N]  u0 {9,[D,B]} {14,[S,B]}
+14   [C,N]  u0 {10,[D,B]} {13,[S,B]}
+""",
+	solute = u's2_6_6_s2_6_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+the heterocyclic form belongs to s2_6_6_s2_6_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 98,
+	label = "s2_6_6_s2_6_6_aromatic3",
+	group = 
+"""
+1  * [C,N]  u0 {2,[S,B]} {3,[D,B]} {5,[S,B]}
+2    [C,N]  u0 {1,[S,B]} {4,[S,B]} {10,[D,B]}
+3    [C,N]  u0 {1,[D,B]} {6,[S,B]} {7,[S,B]}
+4    [C,N]  u0 {2,[S,B]} {8,[S,B]} {9,[D,B]}
+5    [C,N]  u0 {1,[S,B]} {12,[D,B]}
+6    [C,N]  u0 {3,[S,B]} {11,[D,B]}
+7    [C,N]  u0 {3,[S,B]} {8,[D,B]}
+8    [C,N]  u0 {4,[S,B]} {7,[D,B]}
+9    [C,N]  u0 {4,[D,B]} {13,[S,B]}
+10   [C,N]  u0 {2,[D,B]} {14,[S,B]}
+11   [C,N]  u0 {6,[D,B]} {12,[S,B]}
+12   [C,N]  u0 {5,[D,B]} {11,[S,B]}
+13   [C,N]  u0 {9,[S,B]} {14,[D,B]}
+14   [C,N]  u0 {10,[S,B]} {13,[D,B]}
+""",
+	solute = u's2_6_6_s2_6_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+the heterocyclic form belongs to s2_6_6_s2_6_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 99,
+	label = "s2_6_6_s2_6_6_aromatic4",
+	group = 
+"""
+1  * [C,N]  u0 {2,[S,B]} {3,[S,B]} {5,[D,B]}
+2    [C,N]  u0 {1,[S,B]} {4,[S,B]} {10,[D,B]}
+3    [C,N]  u0 {1,[S,B]} {6,[D,B]} {7,[S,B]}
+4    [C,N]  u0 {2,[S,B]} {8,[S,B]} {9,[D,B]}
+5    [C,N]  u0 {1,[D,B]} {12,[S,B]}
+6    [C,N]  u0 {3,[D,B]} {11,[S,B]}
+7    [C,N]  u0 {3,[S,B]} {8,[D,B]}
+8    [C,N]  u0 {4,[S,B]} {7,[D,B]}
+9    [C,N]  u0 {4,[D,B]} {13,[S,B]}
+10   [C,N]  u0 {2,[D,B]} {14,[S,B]}
+11   [C,N]  u0 {6,[S,B]} {12,[D,B]}
+12   [C,N]  u0 {5,[S,B]} {11,[D,B]}
+13   [C,N]  u0 {9,[S,B]} {14,[D,B]}
+14   [C,N]  u0 {10,[S,B]} {13,[D,B]}
+""",
+	solute = u's2_6_6_s2_6_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+the heterocyclic form belongs to s2_6_6_s2_6_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 100,
+	label = "s2_6_6_s2_6_6_all_ben",
+	group = 
+"""
+1  * C  u0 {2,B} {3,B} {5,B}
+2    C  u0 {1,B} {4,B} {10,B}
+3    C  u0 {1,B} {6,B} {7,B}
+4    C  u0 {2,B} {8,B} {9,B}
+5    C  u0 {1,B} {12,B}
+6    C  u0 {3,B} {11,B}
+7    C  u0 {3,B} {8,B}
+8    C  u0 {4,B} {7,B}
+9    C  u0 {4,B} {13,B}
+10   C  u0 {2,B} {14,B}
+11   C  u0 {6,B} {12,B}
+12   C  u0 {5,B} {11,B}
+13   C  u0 {9,B} {14,B}
+14   C  u0 {10,B} {13,B}
+""",
+	solute = SoluteData(
+		S = -0.07986,
+		B = 0.03301,
+		E = -0.21229,
+		L = -0.06221,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 23,
+		L = 22,
+		A = 25,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all aromatic s2_6_6_s2_6_6_aromatic groups (s2_6_6_s2_6_6_aromatic1-4) together
+""",
+)
+
+entry(
+	index = 101,
+	label = "s2_6_6_s2_6_6_heteroaromatic",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]}
+2    R!H u0 {1,[S,D,B]} {4,[S,D,B]} {10,[S,D,B]}
+3    R!H u0 {1,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]}
+4    R!H u0 {2,[S,D,B]} {8,[S,D,B]} {9,[S,D,B]}
+5    R!H u0 {1,[S,D,B]} {12,[S,D,B]}
+6    R!H u0 {3,[S,D,B]} {11,[S,D,B]}
+7    R!H u0 {3,[S,D,B]} {8,[S,D,B]}
+8    R!H u0 {4,[S,D,B]} {7,[S,D,B]}
+9    R!H u0 {4,[S,D,B]} {13,[S,D,B]}
+10   R!H u0 {2,[S,D,B]} {14,[S,D,B]}
+11   R!H u0 {6,[S,D,B]} {12,[S,D,B]}
+12   R!H u0 {5,[S,D,B]} {11,[S,D,B]}
+13   R!H u0 {9,[S,D,B]} {14,[S,D,B]}
+14   R!H u0 {10,[S,D,B]} {13,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = -0.03696,
+		B = -0.01071,
+		E = -0.02164,
+		L = 0.16883,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 3,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all heterocyclic s2_6_6_s2_6_6_aromatic groups (s2_6_6_s2_6_6_aromatic1-4) together
+""",
+)
+
+entry(
+	index = 102,
+	label = "s2_6_6_ben_s2_6_6_ben",
+	group = 
+"""
+1  * C   u0 {2,S} {3,B} {5,B}
+2    C   u0 {1,S} {4,B} {10,B}
+3    C   u0 {1,B} {6,B} {7,S}
+4    C   u0 {2,B} {8,S} {9,B}
+5    C   u0 {1,B} {12,B}
+6    C   u0 {3,B} {11,B}
+7    R!H u0 {3,S} {8,S}
+8    R!H u0 {4,S} {7,S}
+9    C   u0 {4,B} {13,B}
+10   C   u0 {2,B} {14,B}
+11   C   u0 {6,B} {12,B}
+12   C   u0 {5,B} {11,B}
+13   C   u0 {9,B} {14,B}
+14   C   u0 {10,B} {13,B}
+""",
+	solute = SoluteData(
+		S = 0.00726,
+		B = -0.00624,
+		E = -0.01118,
+		L = 0.34616,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 103,
+	label = "s2_6_6_ene_s2_6_6_ene",
+	group = 
+"""
+1    R!H u0 {2,S} {14,S}
+2    R!H u0 {1,S} {3,S}
+3    R!H u0 {2,S} {4,S}
+4    R!H u0 {3,S} {5,S}
+5    R!H u0 {4,S} {6,S} {14,S}
+6  * R!H u0 {5,S} {7,S} {11,S}
+7    R!H u0 {6,S} {8,S}
+8    R!H u0 {7,S} {9,S}
+9    R!H u0 {8,S} {10,D}
+10   R!H u0 {9,D} {11,S}
+11   R!H u0 {6,S} {10,S} {12,D}
+12   R!H u0 {11,D} {13,S}
+13   R!H u0 {12,S} {14,S}
+14   R!H u0 {1,S} {5,S} {13,S}
+""",
+	solute = SoluteData(
+		S = -0.04326,
+		B = 0.03785,
+		E = 0.01024,
+		L = 0.14346,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 104,
+	label = "s2_6_6_ben_s2_6_6_ane",
+	group = 
+"""
+1   R!H u0 {2,B} {6,B}
+2   R!H u0 {1,B} {3,B}
+3   R!H u0 {2,B} {4,B}
+4   R!H u0 {3,B} {5,B}
+5 * R!H u0 {4,B} {6,B} {14,S}
+6   R!H u0 {1,B} {5,B} {7,S}
+7   R!H u0 {6,S} {8,S}
+8   R!H u0 {7,S} {9,S}
+9   R!H u0 {8,S} {10,S} {14,S}
+10  R!H u0 {9,S} {11,S}
+11  R!H u0 {10,S} {12,S}
+12  R!H u0 {11,S} {13,S}
+13  R!H u0 {12,S} {14,S}
+14  R!H u0 {5,S} {9,S} {13,S}
+""",
+	solute = SoluteData(
+		S = 0.05601,
+		B = 0.01036,
+		E = -0.02585,
+		L = 0.24897,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 105,
+	label = "s2_6_6_s2_6_6_A",
+	group = 
+"""
+1  R!H u0 {4,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+2  * R!H u0 {3,[S,D,B]} {5,[S,D,B]} {8,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {9,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {6,[S,D,B]} {10,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {2,[S,D,B]}
+6  R!H u0 {3,[S,D,B]} {4,[S,D,B]}
+7  R!H u0 {1,[S,D,B]} {12,[S,D,B]}
+8  R!H u0 {2,[S,D,B]} {13,[S,D,B]}
+9  R!H u0 {3,[S,D,B]} {14,[S,D,B]}
+10 R!H u0 {4,[S,D,B]} {11,[S,D,B]}
+11 R!H u0 {10,[S,D,B]} {12,[S,D,B]}
+12 R!H u0 {7,[S,D,B]} {11,[S,D,B]}
+13 R!H u0 {8,[S,D,B]} {14,[S,D,B]}
+14 R!H u0 {9,[S,D,B]} {13,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.20220,
+		B = -0.03172,
+		E = 0.15349,
+		L = 0.33084,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 9,
+		L = 7,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 106,
+	label = "s2_6_6_s2_6_6_A_aromatic",
+	group =  "OR{s2_6_6_s2_6_6_A_anthracene, s2_6_6_s2_6_6_A_acridine}",
+	solute = u's2_6_6_s2_6_6_A_anthracene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 107,
+	label = "s2_6_6_s2_6_6_A_anthracene",
+	group = 
+"""
+1 * C u0 {4,B} {5,B} {7,B}
+2   C u0 {3,B} {5,B} {8,B}
+3   C u0 {2,B} {6,B} {9,B}
+4   C u0 {1,B} {6,B} {10,B}
+5   C u0 {1,B} {2,B}
+6   C u0 {3,B} {4,B}
+7   C u0 {1,B} {12,B}
+8   C u0 {2,B} {13,B}
+9   C u0 {3,B} {14,B}
+10  C u0 {4,B} {11,B}
+11  C u0 {10,B} {12,B}
+12  C u0 {7,B} {11,B}
+13  C u0 {8,B} {14,B}
+14  C u0 {9,B} {13,B}
+""",
+	solute = SoluteData(
+		S = -0.06710,
+		B = 0.07043,
+		E = 0.05360,
+		L = -0.24912,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 26,
+		L = 16,
+		A = 26,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 108,
+	label = "s2_6_6_s2_6_6_A_acridine",
+	group = 
+"""
+1  N u0 {4,S} {5,D}
+2  * C u0 {4,B} {6,S} {7,B}
+3  C u0 {5,S} {6,D} {8,S}
+4  C u0 {1,S} {2,B} {9,B}
+5  C u0 {1,D} {3,S} {10,S}
+6  C u0 {2,S} {3,D}
+7  C u0 {2,B} {12,B}
+8  C u0 {3,S} {13,D}
+9  C u0 {4,B} {11,B}
+10 C u0 {5,S} {14,D}
+11 C u0 {9,B} {12,B}
+12 C u0 {7,B} {11,B}
+13 C u0 {8,D} {14,S}
+14 C u0 {10,D} {13,S}
+""",
+	solute = SoluteData(
+		S = -0.07191,
+		B = 0.02070,
+		E = 0.27246,
+		L = -0.05036,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 1,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 109,
+	label = "s2_6_6_ben_s2_6_6_ben_A",
+	group = 
+"""
+1    R!H u0 {5,S} {6,S}
+2    R!H u0 {3,S} {4,S}
+3  * C   u0 {2,S} {5,B} {7,B}
+4    C   u0 {2,S} {6,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {1,S} {4,B} {10,B}
+7    C   u0 {3,B} {11,B}
+8    C   u0 {4,B} {14,B}
+9    C   u0 {5,B} {12,B}
+10   C   u0 {6,B} {13,B}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {9,B} {11,B}
+13   C   u0 {10,B} {14,B}
+14   C   u0 {8,B} {13,B}
+""",
+	solute = SoluteData(
+		S = -0.02275,
+		B = 0.05088,
+		E = -0.07847,
+		L = 0.05140,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 110,
+	label = "s2_6_6_ben_s2_6_6_ben_A_anthraquinone",
+	group = 
+"""
+1    CO  u0 {5,S} {6,S}
+2    CO  u0 {3,S} {4,S}
+3  * C   u0 {2,S} {5,B} {7,B}
+4    C   u0 {2,S} {6,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {1,S} {4,B} {10,B}
+7    C   u0 {3,B} {11,B}
+8    C   u0 {4,B} {14,B}
+9    C   u0 {5,B} {12,B}
+10   C   u0 {6,B} {13,B}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {9,B} {11,B}
+13   C   u0 {10,B} {14,B}
+14   C   u0 {8,B} {13,B}
+""",
+	solute = SoluteData(
+		S = -0.11753,
+		B = -0.22439,
+		E = -0.05683,
+		L = -0.37362,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 11,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 111,
+	label = "s2_6_6_ben_s2_6_6_ben_A_phenothiazine",
+	group = 
+"""
+1    N   u0 {5,S} {6,S}
+2    S   u0 {3,S} {4,S}
+3  * C   u0 {2,S} {5,B} {7,B}
+4    C   u0 {2,S} {6,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {1,S} {4,B} {10,B}
+7    C   u0 {3,B} {11,B}
+8    C   u0 {4,B} {14,B}
+9    C   u0 {5,B} {12,B}
+10   C   u0 {6,B} {13,B}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {9,B} {11,B}
+13   C   u0 {10,B} {14,B}
+14   C   u0 {8,B} {13,B}
+""",
+	solute = SoluteData(
+		S = 0.05546,
+		B = -0.03258,
+		E = -0.00404,
+		L = 0.05519,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 21,
+		L = 20,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 112,
+	label = "s2_6_6_ben_s2_6_6_ben_A_9H-xanthene",
+	group = 
+"""
+1    O   u0 {5,S} {6,S}
+2    C   u0 {3,S} {4,S}
+3  * C   u0 {2,S} {5,B} {7,B}
+4    C   u0 {2,S} {6,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {1,S} {4,B} {10,B}
+7    C   u0 {3,B} {11,B}
+8    C   u0 {4,B} {14,B}
+9    C   u0 {5,B} {12,B}
+10   C   u0 {6,B} {13,B}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {9,B} {11,B}
+13   C   u0 {10,B} {14,B}
+14   C   u0 {8,B} {13,B}
+""",
+	solute = SoluteData(
+		S = -0.08633,
+		B = 0.06984,
+		E = -0.03276,
+		L = -0.17675,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 113,
+	label = "s2_6_5_s2_5_6",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {6,[S,D,B]}
+2    R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+3    R!H u0 {2,[S,D,B]} {4,[S,D,B]}
+4    R!H u0 {3,[S,D,B]} {5,[S,D,B]} {13,[S,D,B]}
+5    R!H u0 {4,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]}
+6    R!H u0 {1,[S,D,B]} {5,[S,D,B]}
+7    R!H u0 {5,[S,D,B]} {8,[S,D,B]}
+8    R!H u0 {7,[S,D,B]} {9,[S,D,B]} {13,[S,D,B]}
+9    R!H u0 {8,[S,D,B]} {10,[S,D,B]}
+10   R!H u0 {9,[S,D,B]} {11,[S,D,B]}
+11   R!H u0 {10,[S,D,B]} {12,[S,D,B]}
+12   R!H u0 {11,[S,D,B]} {13,[S,D,B]}
+13   R!H u0 {4,[S,D,B]} {8,[S,D,B]} {12,[S,D,B]}
+""",
+	solute = SoluteData(
+		S = 0.02272,
+		B = -0.06517,
+		E = 0.14311,
+		L = 0.25278,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 6,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 114,
+	label = "s2_6_5_ben_s2_5_6_ben",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    R!H u0 {5,S} {8,S}
+8    Cb  u0 {7,S} {9,B} {13,B}
+9    Cb  u0 {8,B} {10,B}
+10   Cb  u0 {9,B} {11,B}
+11   Cb  u0 {10,B} {12,B}
+12   Cb  u0 {11,B} {13,B}
+13   Cb  u0 {4,S} {8,B} {12,B}
+""",
+	solute = u's2_6_5_s2_5_6_dibenzothiophene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 115,
+	label = "s2_6_5_s2_5_6_fluorene",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    C   u0 {5,S} {8,S}
+8    Cb  u0 {7,S} {9,B} {13,B}
+9    Cb  u0 {8,B} {10,B}
+10   Cb  u0 {9,B} {11,B}
+11   Cb  u0 {10,B} {12,B}
+12   Cb  u0 {11,B} {13,B}
+13   Cb  u0 {4,S} {8,B} {12,B}
+""",
+	solute = SoluteData(
+		S = -0.03670,
+		B = 0.00056,
+		E = 0.00353,
+		L = 0.20194,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 13,
+		L = 11,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 116,
+	label = "s2_6_5_s2_5_6_carbazole",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    N   u0 {5,S} {8,S}
+8    Cb  u0 {7,S} {9,B} {13,B}
+9    Cb  u0 {8,B} {10,B}
+10   Cb  u0 {9,B} {11,B}
+11   Cb  u0 {10,B} {12,B}
+12   Cb  u0 {11,B} {13,B}
+13   Cb  u0 {4,S} {8,B} {12,B}
+""",
+	solute = SoluteData(
+		S = 0.15219,
+		B = -0.15318,
+		E = 0.05875,
+		L = 0.36105,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 14,
+		L = 14,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 117,
+	label = "s2_6_5_s2_5_6_dibenzofuran",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    O   u0 {5,S} {8,S}
+8    Cb  u0 {7,S} {9,B} {13,B}
+9    Cb  u0 {8,B} {10,B}
+10   Cb  u0 {9,B} {11,B}
+11   Cb  u0 {10,B} {12,B}
+12   Cb  u0 {11,B} {13,B}
+13   Cb  u0 {4,S} {8,B} {12,B}
+""",
+	solute = SoluteData(
+		S = -0.08351,
+		B = 0.01747,
+		E = 0.00764,
+		L = 0.13563,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 2,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 118,
+	label = "s2_6_5_s2_5_6_dibenzothiophene",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    S   u0 {5,S} {8,S}
+8    Cb  u0 {7,S} {9,B} {13,B}
+9    Cb  u0 {8,B} {10,B}
+10   Cb  u0 {9,B} {11,B}
+11   Cb  u0 {10,B} {12,B}
+12   Cb  u0 {11,B} {13,B}
+13   Cb  u0 {4,S} {8,B} {12,B}
+""",
+	solute = SoluteData(
+		S = -0.00808,
+		B = -0.08225,
+		E = 0.01591,
+		L = 0.25147,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 45,
+		E = 46,
+		L = 44,
+		A = 46,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 119,
+	label = "s2_6_5_ben_s2_5_6",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    R!H u0 {5,S} {8,S}
+8    R!H u0 {7,S} {9,S} {13,S}
+9    R!H u0 {8,S} {10,S}
+10   R!H u0 {9,S} {11,S}
+11   R!H u0 {10,S} {12,S}
+12   R!H u0 {11,S} {13,S}
+13   R!H u0 {4,S} {8,S} {12,S}
+""",
+	solute = u's2_6_5_ben_s2_5_6_hetero',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 120,
+	label = "s2_6_5_ben_s2_5_6_hetero",
+	group = 
+"""
+1  * Cb  u0 {2,B} {6,B}
+2    Cb  u0 {1,B} {3,B}
+3    Cb  u0 {2,B} {4,B}
+4    Cb  u0 {3,B} {5,B} {13,S}
+5    Cb  u0 {4,B} {6,B} {7,S}
+6    Cb  u0 {1,B} {5,B}
+7    N   u0 {5,S} {8,S}
+8    C   u0 {7,S} {9,S} {13,S}
+9    C   u0 {8,S} {10,S}
+10   C   u0 {9,S} {11,S}
+11   N   u0 {10,S} {12,S}
+12   C   u0 {11,S} {13,S}
+13   C   u0 {4,S} {8,S} {12,S}
+""",
+	solute = SoluteData(
+		S = -0.05001,
+		B = -0.04688,
+		E = 0.05438,
+		L = 0.10199,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 121,
+	label = "s2_5_6_s2_6_6",
+	group = 
+"""
+1  * R!H u0 {5,[S,D,B]} {13,[S,D,B]}
+2    R!H u0 {3,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+3    R!H u0 {2,[S,D,B]} {5,[S,D,B]} {10,[S,D,B]}
+4    R!H u0 {2,[S,D,B]} {7,[S,D,B]} {8,[S,D,B]}
+5    R!H u0 {1,[S,D,B]} {3,[S,D,B]} {9,[S,D,B]}
+6    R!H u0 {2,[S,D,B]} {12,[S,D,B]}
+7    R!H u0 {4,[S,D,B]} {11,[S,D,B]}
+8    R!H u0 {4,[S,D,B]} {9,[S,D,B]}
+9    R!H u0 {5,[S,D,B]} {8,[S,D,B]}
+10   R!H u0 {3,[S,D,B]} {13,[S,D,B]}
+11   R!H u0 {7,[S,D,B]} {12,[S,D,B]}
+12   R!H u0 {6,[S,D,B]} {11,[S,D,B]}
+13   R!H u0 {1,[S,D,B]} {10,[S,D,B]}
+""",
+	solute = u's2_5_6_ben_s2_6_6_ben',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 122,
+	label = "s2_5_6_ben_s2_6_6_ben",
+	group = 
+"""
+1  * R!H u0 {5,S} {13,[S,D]}
+2    C   u0 {3,B} {4,B} {6,B}
+3    C   u0 {2,B} {5,B} {10,S}
+4    C   u0 {2,B} {7,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {2,B} {12,B}
+7    C   u0 {4,B} {11,B}
+8    C   u0 {4,B} {9,B}
+9    C   u0 {5,B} {8,B}
+10   R!H u0 {3,S} {13,[S,D]}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {6,B} {11,B}
+13   R!H u0 {1,[S,D]} {10,[S,D]}
+""",
+	solute = u's2_5_6_s2_6_6_naphtho[2,1-b]thiophene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 123,
+	label = "s2_5_6_s2_6_6_naphtho[2,1-b]thiophene",
+	group = 
+"""
+1  * S   u0 {5,S} {13,S}
+2    C   u0 {3,B} {4,B} {6,B}
+3    C   u0 {2,B} {5,B} {10,S}
+4    C   u0 {2,B} {7,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {2,B} {12,B}
+7    C   u0 {4,B} {11,B}
+8    C   u0 {4,B} {9,B}
+9    C   u0 {5,B} {8,B}
+10   C   u0 {3,S} {13,D}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {6,B} {11,B}
+13   C   u0 {1,S} {10,D}
+""",
+	solute = SoluteData(
+		S = 0.00101,
+		B = 0.01675,
+		E = 0.01663,
+		L = -0.06958,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 124,
+	label = "s2_5_6_s2_6_6_benzo[g][1]benzothiole",
+	group = 
+"""
+1  * C   u0 {5,S} {13,D}
+2    C   u0 {3,B} {4,B} {6,B}
+3    C   u0 {2,B} {5,B} {10,S}
+4    C   u0 {2,B} {7,B} {8,B}
+5    C   u0 {1,S} {3,B} {9,B}
+6    C   u0 {2,B} {12,B}
+7    C   u0 {4,B} {11,B}
+8    C   u0 {4,B} {9,B}
+9    C   u0 {5,B} {8,B}
+10   S   u0 {3,S} {13,S}
+11   C   u0 {7,B} {12,B}
+12   C   u0 {6,B} {11,B}
+13   C   u0 {1,D} {10,S}
+""",
+	solute = SoluteData(
+		S = 0.00561,
+		B = 0.00367,
+		E = 0.01878,
+		L = -0.14187,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 125,
+	label = "s2_5_7_s2_7_3",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]} 
+2  R!H u0 {1,[S,D,B]} {4,[S,D,B]} {8,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {2,[S,D,B]} {6,[S,D,B]} {9,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+6  R!H u0 {4,[S,D,B]} {10,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {10,[S,D,B]}
+8  R!H u0 {2,[S,D,B]} {11,[S,D,B]}
+9  R!H u0 {4,[S,D,B]} {11,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {7,[S,D,B]}
+11 R!H u0 {8,[S,D,B]} {9,[S,D,B]}
+""",
+	solute = u's2_5_7_s2_7_3_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 126,
+	label = "s2_5_7_s2_7_3_ane",
+	group = 
+"""
+1  * R!H u0 {2,S} {3,S} {5,S} 
+2  R!H u0 {1,S} {4,S} {8,S}
+3  R!H u0 {1,S} {5,S} {7,S}
+4  R!H u0 {2,S} {6,S} {9,S}
+5  R!H u0 {1,S} {3,S}
+6  R!H u0 {4,S} {10,S}
+7  R!H u0 {3,S} {10,S}
+8  R!H u0 {2,S} {11,S}
+9  R!H u0 {4,S} {11,S}
+10 R!H u0 {6,S} {7,S}
+11 R!H u0 {8,S} {9,S}
+""",
+	solute = u's2_5_7_s2_7_3_ane_side_ene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 127,
+	label = "s2_5_7_s2_7_3_ane_side_ene",
+	group = 
+"""
+1  * R!H u0 {2,S} {3,S} {5,S} 
+2  R!H u0 {1,S} {4,S} {8,S}
+3  R!H u0 {1,S} {5,S} {7,S}
+4  R!H u0 {2,S} {6,S} {9,S}
+5  R!H u0 {1,S} {3,S}
+6  R!H u0 {4,S} {10,S} {12,D}
+7  R!H u0 {3,S} {10,S}
+8  R!H u0 {2,S} {11,S}
+9  R!H u0 {4,S} {11,S}
+10 R!H u0 {6,S} {7,S}
+11 R!H u0 {8,S} {9,S}
+12 R!H u0 {6,D}
+""",
+	solute = SoluteData(
+		S = -0.04971,
+		B = 0.05845,
+		E = -0.03569,
+		L = -0.03516,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 128,
+	label = "s2_5_7_s2_7_3_ene",
+	group = 
+"""
+1  * R!H u0 {2,S} {3,S} {5,S} 
+2  R!H u0 {1,S} {4,S} {8,D}
+3  R!H u0 {1,S} {5,S} {7,S}
+4  R!H u0 {2,S} {6,S} {9,S}
+5  R!H u0 {1,S} {3,S}
+6  R!H u0 {4,S} {10,S}
+7  R!H u0 {3,S} {10,S}
+8  R!H u0 {2,D} {11,S}
+9  R!H u0 {4,S} {11,S}
+10 R!H u0 {6,S} {7,S}
+11 R!H u0 {8,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.04118,
+		B = -0.03465,
+		E = -0.00877,
+		L = -0.18708,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 129,
+	label = "Nortricyclene_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {2,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {5,[S,D,B]} {6,[S,D,B]} {7,[S,D,B]}
+5  R!H u0 {2,[S,D,B]} {4,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {4,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {4,[S,D,B]}
+""",
+	solute = u'Nortricyclene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 130,
+	label = "Nortricyclene",
+	group = 
+"""
+1  * C u0 {2,S} {3,S} {6,S}
+2  C u0 {1,S} {3,S} {5,S}
+3  C u0 {1,S} {2,S} {7,S}
+4  C u0 {5,S} {6,S} {7,S}
+5  C u0 {2,S} {4,S}
+6  C u0 {1,S} {4,S}
+7  C u0 {3,S} {4,S}
+""",
+	solute = SoluteData(
+		S = -0.09421,
+		B = 0.06698,
+		E = 0.00977,
+		L = -0.24951,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 131,
+	label = "s3_6_3_s3_3_6",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+3  R!H u0 {1,[S,D,B]} {4,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {2,[S,D,B]} {3,[S,D,B]} {8,[S,D,B]}
+5  R!H u0 {1,[S,D,B]} {9,[S,D,B]}
+6  R!H u0 {2,[S,D,B]} {10,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {10,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {9,[S,D,B]}
+9  R!H u0 {5,[S,D,B]} {8,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {7,[S,D,B]}
+""",
+	solute = u's3_6_3_s3_3_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 132,
+	label = "s3_6_3_s3_3_6_ane",
+	group = 
+"""
+1  * C u0 {2,S} {3,S} {5,S}
+2  C u0 {1,S} {4,S} {6,S}
+3  C u0 {1,S} {4,S} {7,S}
+4  C u0 {2,S} {3,S} {8,S}
+5  C u0 {1,S} {9,S}
+6  C u0 {2,S} {10,S}
+7  C u0 {3,S} {10,S}
+8  C u0 {4,S} {9,S}
+9  C u0 {5,S} {8,S}
+10 C u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.09448,
+		B = 0.06445,
+		E = -0.06016,
+		L = -0.23017,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 133,
+	label = "s3_6_3_s3_3_6_ene",
+	group = 
+"""
+1  * C u0 {2,S} {3,S} {5,S}
+2  C u0 {1,S} {4,S} {6,S}
+3  C u0 {1,S} {4,S} {7,S}
+4  C u0 {2,S} {3,S} {8,S}
+5  C u0 {1,S} {9,S}
+6  C u0 {2,S} {10,S}
+7  C u0 {3,S} {10,D}
+8  C u0 {4,S} {9,S}
+9  C u0 {5,S} {8,S}
+10 C u0 {6,S} {7,D}
+""",
+	solute = SoluteData(
+		S = -0.11844,
+		B = 0.04445,
+		E = -0.05581,
+		L = -0.40248,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 134,
+	label = "Acenaphthene_general",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {4,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {3,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {5,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {5,[S,D,B]} {8,[S,D,B]}
+5  R!H u0 {3,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+6  R!H u0 {5,[S,D,B]} {9,[S,D,B]} {10,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {11,[S,D,B]}
+8  R!H u0 {4,[S,D,B]} {12,[S,D,B]}
+9  R!H u0 {6,[S,D,B]} {12,[S,D,B]}
+10 R!H u0 {6,[S,D,B]} {11,[S,D,B]}
+11 R!H u0 {7,[S,D,B]} {10,[S,D,B]}
+12 R!H u0 {8,[S,D,B]} {9,[S,D,B]}
+""",
+	solute = u'Acenaphthene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 135,
+	label = "Acenaphthene",
+	group = 
+"""
+1  * C u0 {2,S} {4,S}
+2  C u0 {1,S} {3,S}
+3  C u0 {2,S} {5,B} {7,B}
+4  C u0 {1,S} {5,B} {8,B}
+5  C u0 {3,B} {4,B} {6,B}
+6  C u0 {5,B} {9,B} {10,B}
+7  C u0 {3,B} {11,B}
+8  C u0 {4,B} {12,B}
+9  C u0 {6,B} {12,B}
+10 C u0 {6,B} {11,B}
+11 C u0 {7,B} {10,B}
+12 C u0 {8,B} {9,B}
+""",
+	solute = SoluteData(
+		S = 0.01537,
+		B = -0.01647,
+		E = 0.06220,
+		L = -0.06515,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 136,
+	label = "Acenaphthylene",
+	group = 
+"""
+1  * C u0 {2,D} {4,S}
+2  C u0 {1,D} {3,S}
+3  C u0 {2,S} {5,B} {7,B}
+4  C u0 {1,S} {5,B} {8,B}
+5  C u0 {3,B} {4,B} {6,B}
+6  C u0 {5,B} {9,B} {10,B}
+7  C u0 {3,B} {11,B}
+8  C u0 {4,B} {12,B}
+9  C u0 {6,B} {12,B}
+10 C u0 {6,B} {11,B}
+11 C u0 {7,B} {10,B}
+12 C u0 {8,B} {9,B}
+""",
+	solute = SoluteData(
+		S = -0.00029,
+		B = 0.01016,
+		E = -0.03186,
+		L = -0.39261,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 137,
+	label = "s2_5_5_s2_5_5_ane",
+	group = 
+"""
+1    R!H u0 {2,S} {4,S} {9,S}
+2    R!H u0 {1,S} {3,S} {8,S}
+3  * R!H u0 {2,S} {5,S} {6,S}
+4    R!H u0 {1,S} {5,S} {7,S}
+5    R!H u0 {3,S} {4,S}
+6    R!H u0 {3,S} {7,S}
+7    R!H u0 {4,S} {6,S}
+8    R!H u0 {2,S} {10,S}
+9    R!H u0 {1,S} {10,S}
+10   R!H u0 {8,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.00425,
+		B = 0.01500,
+		E = -0.02258,
+		L = -0.13095,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 138,
+	label = "s1_3_6",
+	group = 
+"""
+1   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {6,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {4,[S,D,T,B]} {8,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {8,[S,D,T,B]}
+8 * R!H u0 {6,[S,D,T,B]} {7,[S,D,T,B]}
+""",
+	solute = u's1_3_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 139,
+	label = "s1_3_6_ane",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {4,S} {5,S}
+2   R!H u0 {1,S} {3,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {6,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {4,S} {8,S}
+7   R!H u0 {5,S} {8,S}
+8 * R!H u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.00921,
+		B = 0.02340,
+		E = -0.03777,
+		L = -0.03540,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 140,
+	label = "s1_5_5",
+	group = 
+"""
+1   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2 * R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {6,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+6   R!H u0 {4,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {3,[S,D,T,B]} {6,[S,D,T,B]}
+8   R!H u0 {5,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = u's1_5_5_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 141,
+	label = "s1_5_5_ane",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {4,S} {5,S}
+2 * R!H u0 {1,S} {9,S}
+3   R!H u0 {1,S} {7,S}
+4   R!H u0 {1,S} {6,S}
+5   R!H u0 {1,S} {8,S}
+6   R!H u0 {4,S} {7,S}
+7   R!H u0 {3,S} {6,S}
+8   R!H u0 {5,S} {9,S}
+9   R!H u0 {2,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.12322,
+		B = 0.03064,
+		E = 0.05470,
+		L = 0.04819,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 3,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 142,
+	label = "s1_5_6",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {6,[S,D,T,B]}
+4    R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+5    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+6  * R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+7    R!H u0 {2,[S,D,T,B]} {6,[S,D,T,B]}
+8    R!H u0 {4,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+10   R!H u0 {8,[S,D,T,B]} {9,[S,D,T,B]}
+""",
+	solute = u's1_5_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 143,
+	label = "s1_5_6_ane",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S} {5,S}
+2    R!H u0 {1,S} {7,S}
+3    R!H u0 {1,S} {6,S}
+4    R!H u0 {1,S} {8,S}
+5    R!H u0 {1,S} {9,S}
+6  * R!H u0 {3,S} {7,S}
+7    R!H u0 {2,S} {6,S}
+8    R!H u0 {4,S} {10,S}
+9    R!H u0 {5,S} {10,S}
+10   R!H u0 {8,S} {9,S}
+""",
+	solute = SoluteData(
+		S = 0.06245,
+		B = 0.12433,
+		E = 0.02612,
+		L = 0.10273,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 144,
+	label = "s1_5_6_ene",
+	group =  "OR{s1_5_6_ene_1, s1_5_6_ene_2, s1_5_6_ene_7, s1_5_6_ene_8}",
+	solute = u's1_5_6_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 145,
+	label = "s1_5_6_ene_1",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S} {5,S}
+2    R!H u0 {1,S} {6,S}
+3    R!H u0 {1,S} {7,D}
+4    R!H u0 {1,S} {8,S}
+5    R!H u0 {1,S} {9,S}
+6  * R!H u0 {2,S} {9,S}
+7    R!H u0 {3,D} {10,S}
+8    R!H u0 {4,S} {10,S}
+9    R!H u0 {5,S} {6,S}
+10   R!H u0 {7,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.01266,
+		B = 0.04906,
+		E = 0.06681,
+		L = 0.19447,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 146,
+	label = "s1_5_6_ene_2",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S} {5,S}
+2    R!H u0 {1,S} {6,S}
+3    R!H u0 {1,S} {8,S}
+4    R!H u0 {1,S} {7,S}
+5    R!H u0 {1,S} {9,S}
+6    R!H u0 {2,S} {10,S}
+7  * R!H u0 {4,S} {9,S}
+8    R!H u0 {3,S} {10,D}
+9    R!H u0 {5,S} {7,S}
+10   R!H u0 {6,S} {8,D}
+""",
+	solute = SoluteData(
+		S = -0.01143,
+		B = 0.02849,
+		E = -0.01609,
+		L = 0.05583,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 147,
+	label = "s1_5_6_ene_7",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S} {5,S}
+2    R!H u0 {1,S} {7,S}
+3    R!H u0 {1,S} {8,D}
+4    R!H u0 {1,S} {6,S}
+5    R!H u0 {1,S} {9,S}
+6    R!H u0 {4,S} {10,S}
+7    R!H u0 {2,S} {10,S}
+8  * R!H u0 {3,D} {9,S}
+9    R!H u0 {5,S} {8,S}
+10   R!H u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00048,
+		B = -0.00723,
+		E = 0.03829,
+		L = -0.03837,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 148,
+	label = "s1_5_6_ene_8",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S} {5,S}
+2    R!H u0 {1,S} {7,S}
+3    R!H u0 {1,S} {6,S}
+4    R!H u0 {1,S} {9,S}
+5    R!H u0 {1,S} {8,S}
+6  * R!H u0 {3,S} {8,D}
+7    R!H u0 {2,S} {10,S}
+8    R!H u0 {5,S} {6,D}
+9    R!H u0 {4,S} {10,S}
+10   R!H u0 {7,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.00962,
+		B = 0.02498,
+		E = -0.00381,
+		L = -0.09931,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 149,
+	label = "s1_6_6",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {1,[S,D,T,B]} {6,[S,D,T,B]}
+6    R!H u0 {5,[S,D,T,B]} {11,[S,D,T,B]}
+7    R!H u0 {4,[S,D,T,B]} {10,[S,D,T,B]}
+8    R!H u0 {2,[S,D,T,B]} {11,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {10,[S,D,T,B]}
+10 * R!H u0 {7,[S,D,T,B]} {9,[S,D,T,B]}
+11   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = u's1_6_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 150,
+	label = "s1_6_6_ane",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S} {5,S}
+2    R!H u0 {1,S} {8,S}
+3    R!H u0 {1,S} {9,S}
+4    R!H u0 {1,S} {7,S}
+5    R!H u0 {1,S} {6,S}
+6    R!H u0 {5,S} {11,S}
+7    R!H u0 {4,S} {10,S}
+8    R!H u0 {2,S} {11,S}
+9    R!H u0 {3,S} {10,S}
+10 * R!H u0 {7,S} {9,S}
+11   R!H u0 {6,S} {8,S}
+""",
+	solute = u's1_6_6_ane_2,4,8,10-Tetraoxa-3,9-diphosphaspiro-3,9-dioxide',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 151,
+	label = "s1_6_6_ane_2,4,8,10-Tetraoxa-3,9-diphosphaspiro-3,9-dioxide",
+	group = 
+"""
+1    C   u0 {2,S} {3,S} {4,S} {5,S}
+2    C   u0 {1,S} {8,S}
+3    C   u0 {1,S} {9,S}
+4    C   u0 {1,S} {7,S}
+5    C   u0 {1,S} {6,S}
+6    O2s u0 {5,S} {11,S}
+7    O2s u0 {4,S} {10,S}
+8    O2s u0 {2,S} {11,S}
+9    O2s u0 {3,S} {10,S}
+10 * P5d u0 {7,S} {9,S} {12,D}
+11   P5d u0 {6,S} {8,S} {13,D}
+12   O2d u0 {10,D}
+13   O2d u0 {11,D}
+""",
+	solute = SoluteData(
+		S = -0.05123,
+		B = -0.11390,
+		E = 0.03470,
+		L = 0.11015,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 152,
+	label = "s2_3_5",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {6,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {6,[S,D,T,B]}
+6   R!H u0 {4,[S,D,T,B]} {5,[S,D,T,B]}
+""",
+	solute = u's2_3_5_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 153,
+	label = "s2_3_5_ene",
+	group =  "OR{s2_3_5_ene_1, s2_3_5_ene_side}",
+	solute = u's2_3_5_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 154,
+	label = "s2_3_5_ene_1",
+	group = 
+"""
+1 * R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {3,S} {4,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {2,S} {6,D}
+5   R!H u0 {1,S} {6,S}
+6   R!H u0 {4,D} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.04519,
+		B = -0.00282,
+		E = -0.02174,
+		L = -0.19696,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 155,
+	label = "s2_3_5_ene_side",
+	group = 
+"""
+1 * R!H u0 {2,S} {4,S} {6,S}
+2   R!H u0 {1,S} {4,S} {5,S}
+3   R!H u0 {5,S} {6,S} {7,D}
+4   R!H u0 {1,S} {2,S}
+5   R!H u0 {2,S} {3,S}
+6   R!H u0 {1,S} {3,S}
+7   R!H ux {3,D}
+""",
+	solute = SoluteData(
+		S = -0.02003,
+		B = 0.01210,
+		E = 0.04142,
+		L = -0.35397,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 156,
+	label = "s2_3_5_ane",
+	group = 
+"""
+1 * R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {3,S} {4,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {2,S} {6,S}
+5   R!H u0 {1,S} {6,S}
+6   R!H u0 {4,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.11358,
+		B = 0.00000,
+		E = 0.01834,
+		L = -0.32737,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 13,
+		E = 12,
+		L = 12,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 157,
+	label = "s2_3_6",
+	group = 
+"""
+1   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {6,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6 * R!H u0 {4,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+""",
+	solute = u's2_3_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 158,
+	label = "s2_3_6_ane",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {3,S} {4,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {2,S} {6,S}
+5   R!H u0 {1,S} {7,S}
+6 * R!H u0 {4,S} {7,S}
+7   R!H u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03346,
+		B = 0.00000,
+		E = -0.02132,
+		L = -0.10768,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 6,
+		E = 4,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 159,
+	label = "s2_3_6_ene",
+	group =  "OR{s2_3_6_ene_1, s2_3_6_ene_2}",
+	solute = u's2_3_6_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 160,
+	label = "s2_3_6_ene_1",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S} {3,S} {5,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {6,D}
+5   R!H u0 {2,S} {7,S}
+6 * R!H u0 {4,D} {7,S}
+7   R!H u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.00984,
+		B = -0.00092,
+		E = -0.02400,
+		L = 0.00882,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 161,
+	label = "s2_3_6_ene_2",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S} {3,S} {5,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {7,S}
+5   R!H u0 {2,S} {6,S}
+6 * R!H u0 {5,S} {7,D}
+7   R!H u0 {4,S} {6,D}
+""",
+	solute = SoluteData(
+		S = 0.13834,
+		B = 0.00926,
+		E = 0.11867,
+		L = 0.40853,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 162,
+	label = "s2_3_8",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {4,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {6,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {4,[S,D,T,B]} {8,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {9,[S,D,T,B]}
+8   R!H u0 {6,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {7,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = u's2_3_8_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 163,
+	label = "s2_3_8_ane",
+	group = 
+"""
+1 * R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {3,S} {4,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {2,S} {6,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {4,S} {8,S}
+7   R!H u0 {5,S} {9,S}
+8   R!H u0 {6,S} {9,S}
+9   R!H u0 {7,S} {8,S}
+""",
+	solute = u's2_3_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 164,
+	label = "s2_4_5",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+""",
+	solute = u's2_4_5_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 165,
+	label = "s2_4_5_ane",
+	group = 
+"""
+1 * R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {4,S} {6,S}
+3   R!H u0 {1,S} {4,S}
+4   R!H u0 {2,S} {3,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {2,S} {7,S}
+7   R!H u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.00818,
+		B = 0.00000,
+		E = -0.02020,
+		L = -0.17704,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 166,
+	label = "s2_4_5_ane_hetero_N_S",
+	group = 
+"""
+1 * C   u0 {2,S} {3,S} {5,S}
+2   N   u0 {1,S} {4,S} {6,S}
+3   C   u0 {1,S} {4,S}
+4   C   u0 {2,S} {3,S}
+5   S   u0 {1,S} {7,S}
+6   C   u0 {2,S} {7,S}
+7   C   u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.14051,
+		B = -0.00345,
+		E = 0.11392,
+		L = -0.20032,
+		A = -0.17693,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 167,
+	label = "s2_4_6",
+	group = 
+"""
+1   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]}
+5   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+7 * R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+8   R!H u0 {5,[S,D,T,B]} {7,[S,D,T,B]}
+""",
+	solute = u's2_4_6_ene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 168,
+	label = "s2_4_6_ene",
+	group =  "OR{s2_4_6_ene_1}",
+	solute = u's2_4_6_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 169,
+	label = "s2_4_6_ene_1",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {4,S} {6,S}
+3   R!H u0 {1,S} {4,S}
+4   R!H u0 {2,S} {3,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {2,S} {8,D}
+7 * R!H u0 {5,S} {8,S}
+8   R!H u0 {6,D} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00319,
+		B = 0.00594,
+		E = 0.06447,
+		L = -0.04443,
+		A = 0.02298,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 170,
+	label = "s2_5_5",
+	group = 
+"""
+1   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {6,[S,D,T,B]}
+3 * R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+7   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]}
+8   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+""",
+	solute = u's2_5_5_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 171,
+	label = "s2_5_5_ane",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {4,S} {6,S}
+3 * R!H u0 {1,S} {7,S}
+4   R!H u0 {2,S} {7,S}
+5   R!H u0 {1,S} {8,S}
+6   R!H u0 {2,S} {8,S}
+7   R!H u0 {3,S} {4,S}
+8   R!H u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.01758,
+		B = -0.02628,
+		E = 0.01724,
+		L = -0.11722,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 23,
+		L = 21,
+		A = 23,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 172,
+	label = "s2_5_5_ene",
+	group =  "OR{s2_5_5_ene_0, s2_5_5_ene_1}",
+	solute = u's2_5_5_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 173,
+	label = "s2_5_5_ene_0",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S} {5,D} {6,S}
+3 * R!H u0 {1,S} {8,S}
+4   R!H u0 {1,S} {7,S}
+5   R!H u0 {2,D} {7,S}
+6   R!H u0 {2,S} {8,S}
+7   R!H u0 {4,S} {5,S}
+8   R!H u0 {3,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.00048,
+		B = -0.00723,
+		E = 0.03829,
+		L = -0.03837,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 174,
+	label = "s2_5_5_ene_1",
+	group = 
+"""
+1   R!H u0 {2,S} {4,S} {5,S}
+2   R!H u0 {1,S} {3,S} {6,S}
+3 * R!H u0 {2,S} {7,D}
+4   R!H u0 {1,S} {8,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {2,S} {8,S}
+7   R!H u0 {3,D} {5,S}
+8   R!H u0 {4,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.03907,
+		B = -0.02500,
+		E = -0.04708,
+		L = 0.05704,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 2,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 175,
+	label = "s2_5_5_diene",
+	group =  "OR{s2_5_5_diene_0_2, s2_5_5_diene_0_4}",
+	solute = u's2_5_5_diene_0_4',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 176,
+	label = "s2_5_5_diene_0_2",
+	group = 
+"""
+1   R!H u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S} {5,S} {6,D}
+3 * R!H u0 {1,S} {8,S}
+4   R!H u0 {1,S} {7,D}
+5   R!H u0 {2,S} {8,S}
+6   R!H u0 {2,D} {7,S}
+7   R!H u0 {4,D} {6,S}
+8   R!H u0 {3,S} {5,S}
+""",
+	solute = u's2_5_5_diene_0_4',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 177,
+	label = "s2_5_5_diene_0_4",
+	group = 
+"""
+1   R!H u0 {2,S} {3,D} {4,S}
+2   R!H u0 {1,S} {5,D} {6,S}
+3 * R!H u0 {1,D} {7,S}
+4   R!H u0 {1,S} {8,S}
+5   R!H u0 {2,D} {8,S}
+6   R!H u0 {2,S} {7,S}
+7   R!H u0 {3,S} {6,S}
+8   R!H u0 {4,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.03897,
+		B = -0.02929,
+		E = 0.00915,
+		L = 0.02292,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 178,
+	label = "s2_5_6",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H u0 {2,[S,D,T,B]} {9,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+8   R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {3,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = u's2_5_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 179,
+	label = "s2_5_6_ane",
+	group = 
+"""
+1 * R!H u0 {2,S} {4,S} {5,S}
+2   R!H u0 {1,S} {3,S} {6,S}
+3   R!H u0 {2,S} {9,S}
+4   R!H u0 {1,S} {8,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {2,S} {7,S}
+7   R!H u0 {5,S} {6,S}
+8   R!H u0 {4,S} {9,S}
+9   R!H u0 {3,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.06297,
+		B = 0.00000,
+		E = 0.04766,
+		L = 0.10993,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 28,
+		B = 28,
+		E = 29,
+		L = 24,
+		A = 28,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 180,
+	label = "s2_5_6_ene",
+	group =  "OR{s2_5_6_ene_0, s2_5_6_ene_1, s2_5_6_ene_m, s2_5_6_ene_2, s2_5_6_ene_5}",
+	solute = u's2_5_6_ene_m',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 181,
+	label = "s2_5_6_ene_0",
+	group = 
+"""
+1 * R!H u0 {2,S} {3,S} {5,S}
+2   R!H u0 {1,S} {4,D} {6,S}
+3   R!H u0 {1,S} {7,S}
+4   R!H u0 {2,D} {8,S}
+5   R!H u0 {1,S} {9,S}
+6   R!H u0 {2,S} {7,S}
+7   R!H u0 {3,S} {6,S}
+8   R!H u0 {4,S} {9,S}
+9   R!H u0 {5,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.01105,
+		B = -0.02032,
+		E = -0.07840,
+		L = 0.02487,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 182,
+	label = "s2_5_6_ene_1",
+	group = 
+"""
+1 * R!H u0 {2,S} {4,S} {6,S}
+2   R!H u0 {1,S} {3,S} {5,S}
+3   R!H u0 {2,S} {8,D}
+4   R!H u0 {1,S} {7,S}
+5   R!H u0 {2,S} {7,S}
+6   R!H u0 {1,S} {9,S}
+7   R!H u0 {4,S} {5,S}
+8   R!H u0 {3,D} {9,S}
+9   R!H u0 {6,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.07429,
+		B = 0.04486,
+		E = 0.14050,
+		L = 0.12520,
+		A = -0.00999,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 183,
+	label = "s2_5_6_ene_m",
+	group = 
+"""
+1 * R!H u0 {2,D} {5,S} {6,S}
+2   R!H u0 {1,D} {3,S} {4,S}
+3   R!H u0 {2,S} {8,S}
+4   R!H u0 {2,S} {7,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {1,S} {9,S}
+7   R!H u0 {4,S} {5,S}
+8   R!H u0 {3,S} {9,S}
+9   R!H u0 {6,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.08669,
+		B = 0.00540,
+		E = 0.02064,
+		L = -0.30851,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 184,
+	label = "s2_5_6_ene_2",
+	group = 
+"""
+1 * R!H u0 {2,S} {5,S} {6,S}
+2   R!H u0 {1,S} {3,S} {4,S}
+3   R!H u0 {2,S} {7,S}
+4   R!H u0 {2,S} {8,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {1,S} {9,S}
+7   R!H u0 {3,S} {5,S}
+8   R!H u0 {4,S} {9,D}
+9   R!H u0 {6,S} {8,D}
+""",
+	solute = u's2_5_6_ene_0',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 185,
+	label = "s2_5_6_ene_5",
+	group = 
+"""
+1 * R!H u0 {2,S} {3,D} {6,S}
+2   R!H u0 {1,S} {4,S} {5,S}
+3   R!H u0 {1,D} {7,S}
+4   R!H u0 {2,S} {9,S}
+5   R!H u0 {2,S} {7,S}
+6   R!H u0 {1,S} {8,S}
+7   R!H u0 {3,S} {5,S}
+8   R!H u0 {6,S} {9,S}
+9   R!H u0 {4,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.01693,
+		B = -0.03572,
+		E = 0.08585,
+		L = 0.09047,
+		A = -0.00992,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 186,
+	label = "s2_5_6_diene",
+	group =  "OR{s2_5_6_diene_m_2, s2_5_6_diene_m_7}",
+	solute = u's2_5_6_diene_m_7',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 187,
+	label = "s2_5_6_diene_m_2",
+	group = 
+"""
+1 * R!H u0 {2,D} {3,S} {6,S}
+2   R!H u0 {1,D} {4,S} {5,S}
+3   R!H u0 {1,S} {9,S}
+4   R!H u0 {2,S} {8,S}
+5   R!H u0 {2,S} {7,S}
+6   R!H u0 {1,S} {7,S}
+7   R!H u0 {5,S} {6,S}
+8   R!H u0 {4,S} {9,D}
+9   R!H u0 {3,S} {8,D}
+""",
+	solute = u's2_5_6_diene_m_7',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 188,
+	label = "s2_5_6_diene_m_7",
+	group = 
+"""
+1 * R!H u0 {2,D} {3,S} {5,S}
+2   R!H u0 {1,D} {4,S} {6,S}
+3   R!H u0 {1,S} {8,S}
+4   R!H u0 {2,S} {7,S}
+5   R!H u0 {1,S} {7,D}
+6   R!H u0 {2,S} {9,S}
+7   R!H u0 {4,S} {5,D}
+8   R!H u0 {3,S} {9,S}
+9   R!H u0 {6,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.00510,
+		B = -0.01207,
+		E = 0.01266,
+		L = 0.06481,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 1,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 189,
+	label = "s2_5_6_diene_m_7_hetero",
+	group = 
+"""
+1 * C   u0 {2,D} {3,S} {5,S}
+2   C   u0 {1,D} {4,S} {6,S}
+3   N   u0 {1,S} {8,S}
+4   N   u0 {2,S} {7,S}
+5   N   u0 {1,S} {7,D}
+6   C   u0 {2,S} {9,S}
+7   C   u0 {4,S} {5,D}
+8   C   u0 {3,S} {9,S}
+9   N   u0 {6,S} {8,S}
+""",
+	solute = u's2_5_6_diene_xanthine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 190,
+	label = "s2_5_6_diene_xanthine",
+	group = 
+"""
+1 * C   u0 {2,D} {3,S} {5,S}
+2   C   u0 {1,D} {4,S} {6,S}
+3   N   u0 {1,S} {8,S}
+4   N   u0 {2,S} {7,S}
+5   N   u0 {1,S} {7,D}
+6   CO  u0 {2,S} {9,S}
+7   C   u0 {4,S} {5,D}
+8   CO  u0 {3,S} {9,S}
+9   N   u0 {6,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.06485,
+		B = 0.04158,
+		E = 0.06747,
+		L = 0.28290,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 23,
+		L = 22,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 191,
+	label = "s2_5_6_triene",
+	group =  "OR{s2_5_6_triene_m_1_7}",
+	solute = u's2_5_6_triene_m_1_7',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 192,
+	label = "s2_5_6_triene_m_1_7",
+	group = 
+"""
+1 * R!H u0 {2,D} {3,S} {6,S}
+2   R!H u0 {1,D} {4,S} {5,S}
+3   R!H u0 {1,S} {9,D}
+4   R!H u0 {2,S} {8,S}
+5   R!H u0 {2,S} {7,S}
+6   R!H u0 {1,S} {7,D}
+7   R!H u0 {5,S} {6,D}
+8   R!H u0 {4,S} {9,S}
+9   R!H u0 {3,D} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.07579,
+		B = 0.01305,
+		E = -0.06278,
+		L = -0.23438,
+		A = 0.02605,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 193,
+	label = "s2_5_6_tetraene",
+	group =  "OR{s2_5_6_tetraene_1_3_5_7, s2_5_6_tetraene_1_3_5_8}",
+	solute = u's2_5_6_tetraene_1_3_5_7',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 194,
+	label = "s2_5_6_tetraene_1_3_5_7",
+	group = 
+"""
+1 * R!H u0 {2,S} {4,S} {5,D}
+2   R!H u0 {1,S} {3,S} {6,S}
+3   R!H u0 {2,S} {8,D}
+4   R!H u0 {1,S} {9,D}
+5   R!H u0 {1,D} {7,S}
+6   R!H u0 {2,S} {7,D}
+7   R!H u0 {5,S} {6,D}
+8   R!H u0 {3,D} {9,S}
+9   R!H u0 {4,D} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.03533,
+		B = -0.00632,
+		E = -0.00303,
+		L = -0.07679,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 3,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 195,
+	label = "s2_5_6_tetraene_1_3_5_8",
+	group = 
+"""
+1 * R!H u0 {2,S} {5,S} {6,D}
+2   R!H u0 {1,S} {3,S} {4,D}
+3   R!H u0 {2,S} {8,D}
+4   R!H u0 {2,D} {7,S}
+5   R!H u0 {1,S} {9,D}
+6   R!H u0 {1,D} {7,S}
+7   R!H u0 {4,S} {6,S}
+8   R!H u0 {3,D} {9,S}
+9   R!H u0 {5,D} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.04788,
+		B = 0.02431,
+		E = 0.06783,
+		L = 0.08692,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 196,
+	label = "s2_5_6_ben",
+	group = 
+"""
+1 * R!H u0 {2,B} {3,S} {5,B}
+2   R!H u0 {1,B} {4,S} {6,B}
+3   R!H u0 {1,S} {7,S}
+4   R!H u0 {2,S} {7,S}
+5   R!H u0 {1,B} {9,B}
+6   R!H u0 {2,B} {8,B}
+7   R!H u0 {3,S} {4,S}
+8   R!H u0 {6,B} {9,B}
+9   R!H u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.05553,
+		B = 0.11066,
+		E = 0.01860,
+		L = -0.15571,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 197,
+	label = "s2_5_6_ben_onlyC",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   C u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   C u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = -0.00818,
+		B = -0.01021,
+		E = 0.00879,
+		L = 0.00438,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 22,
+		E = 30,
+		L = 29,
+		A = 29,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 198,
+	label = "s2_5_6_phthalan",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   C u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   O u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.15106,
+		B = -0.03653,
+		E = 0.07424,
+		L = 0.18762,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 199,
+	label = "s2_5_6_2,3-dihydrobenzofuran",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   O u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   C u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = -0.12431,
+		B = 0.05867,
+		E = -0.07069,
+		L = -0.27658,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 200,
+	label = "s2_5_6_indoline",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   N u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   C u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.02074,
+		B = 0.06276,
+		E = -0.03188,
+		L = 0.20864,
+		A = -0.01765,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 4,
+		E = 10,
+		L = 10,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 201,
+	label = "s2_5_6_isatin",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   N u0 {1,S} {7,S}
+4   CO u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   CO u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.04765,
+		B = -0.04551,
+		E = -0.07313,
+		L = -0.10695,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 202,
+	label = "s2_5_6_oxindole",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   N u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   CO u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.17678,
+		B = 0.01136,
+		E = 0.00837,
+		L = 0.21558,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 203,
+	label = "s2_5_6_isoindoline",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   C u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   N u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.13789,
+		B = -0.07897,
+		E = -0.04305,
+		L = -0.07442,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 4,
+		L = 4,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 204,
+	label = "s2_5_6_isoindole-1,3-dione",
+	group = 
+"""
+1 * C  u0 {2,B} {3,S} {5,B}
+2   C  u0 {1,B} {4,S} {6,B}
+3   CO u0 {1,S} {7,S}
+4   CO u0 {2,S} {7,S}
+5   C  u0 {1,B} {9,B}
+6   C  u0 {2,B} {8,B}
+7   N  u0 {3,S} {4,S}
+8   C  u0 {6,B} {9,B}
+9   C  u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.01774,
+		B = -0.30115,
+		E = -0.17385,
+		L = -0.75088,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 205,
+	label = "s2_5_6_1,3-benzodioxole",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   O u0 {1,S} {7,S}
+4   O u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   C u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.00001,
+		B = -0.04312,
+		E = -0.04733,
+		L = -0.12137,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 12,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 206,
+	label = "s2_5_6_2,3-dihydrobenzothiophene",
+	group = 
+"""
+1 * C u0 {2,B} {3,S} {5,B}
+2   C u0 {1,B} {4,S} {6,B}
+3   S u0 {1,S} {7,S}
+4   C u0 {2,S} {7,S}
+5   C u0 {1,B} {9,B}
+6   C u0 {2,B} {8,B}
+7   C u0 {3,S} {4,S}
+8   C u0 {6,B} {9,B}
+9   C u0 {5,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.00187,
+		B = -0.00339,
+		E = -0.02439,
+		L = 0.06063,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 207,
+	label = "s2_5_6_heteroaromatic_general",
+	group =  "OR{s2_5_6_purine_general, s2_5_6_heteroaromatic1, s2_5_6_heteroaromatic2, s2_5_6_heteroaromatic3}",
+	solute = u's2_5_6_purine_general',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 208,
+	label = "s2_5_6_heteroaromatic1",
+	group = 
+"""
+1  [C,N,S] u0 {5,S} {9,S}
+2  [C,N,S] u0 {4,S} {7,S}
+3  [C,N,S] u0 {7,S} {9,D}
+4  [C,N,S] u0 {2,S} {8,D}
+5  [C,N,S] u0 {1,S} {6,S}
+6  [C,N,S] u0 {5,S} {7,D} {8,S}
+7  [C,N,S] u0 {2,S} {3,S} {6,D}
+8  [C,N,S] u0 {4,D} {6,S}
+9  [C,N,S] u0 {1,S} {3,D}
+""",
+	solute = u's2_5_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 209,
+	label = "s2_5_6_heteroaromatic2",
+	group = 
+"""
+1  [C,N,S] u0 {5,S} {9,D}
+2  [C,N,S] u0 {4,D} {7,S}
+3  [C,N,S] u0 {7,D} {9,S}
+4  [C,N,S] u0 {2,D} {8,S}
+5  [C,N,S] u0 {1,S} {6,D}
+6  [C,N,S] u0 {5,D} {7,S} {8,S}
+7  [C,N,S] u0 {2,S} {3,D} {6,S}
+8  [C,N,S] u0 {4,S} {6,S}
+9  [C,N,S] u0 {1,D} {3,S}
+""",
+	solute = u's2_5_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 210,
+	label = "s2_5_6_heteroaromatic3",
+	group = 
+"""
+1  [C,N,S] u0 {4,S} {7,S}
+2  [C,N,S] u0 {4,S} {9,D}
+3  [C,N,S] u0 {4,D} {5,S} {6,S}
+4  * [C,N,S] u0 {1,S} {2,S} {3,D}
+5  [C,N,S] u0 {3,S} {8,D}
+6  [C,N,S] u0 {3,S} {7,D}
+7  [C,N,S] u0 {1,S} {6,D}
+8  [C,N,S] u0 {5,D} {9,S}
+9  [C,N,S] u0 {2,D} {8,S}
+""",
+	solute = u's2_5_6_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_heteroaromatic
+""",
+)
+
+entry(
+	index = 211,
+	label = "s2_5_6_purine_general",
+	group =  "OR{s2_5_6_purine1, s2_5_6_purine2, s2_5_6_purine3, s2_5_6_purine4, s2_5_6_purine5, s2_5_6_purine6, \
+s2_5_6_purine7, s2_5_6_purine8, s2_5_6_hypoxanthine_general}",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 212,
+	label = "s2_5_6_purine1",
+	group = 
+"""
+1 * C u0 {2,S} {3,S} {5,D}
+2   C u0 {1,S} {4,S} {6,D}
+3   N u0 {1,S} {7,D}
+4   N u0 {2,S} {7,S}
+5   N u0 {1,D} {9,S}
+6   C u0 {2,D} {8,S}
+7   C u0 {3,D} {4,S}
+8   N u0 {6,S} {9,D}
+9   C u0 {5,S} {8,D}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 213,
+	label = "s2_5_6_purine2",
+	group = 
+"""
+1 * C u0 {2,D} {3,S} {5,S}
+2   C u0 {1,D} {4,S} {6,S}
+3   N u0 {1,S} {7,D}
+4   N u0 {2,S} {7,S}
+5   N u0 {1,S} {9,D}
+6   C u0 {2,S} {8,D}
+7   C u0 {3,D} {4,S}
+8   N u0 {6,D} {9,S}
+9   C u0 {5,D} {8,S}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 214,
+	label = "s2_5_6_purine3",
+	group = 
+"""
+1 * C u0 {2,S} {3,S} {5,D}
+2   C u0 {1,S} {4,S} {6,D}
+3   N u0 {1,S} {7,S}
+4   N u0 {2,S} {7,D}
+5   N u0 {1,D} {9,S}
+6   C u0 {2,D} {8,S}
+7   C u0 {3,S} {4,D}
+8   N u0 {6,S} {9,D}
+9   C u0 {5,S} {8,D}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 215,
+	label = "s2_5_6_purine4",
+	group = 
+"""
+1  N u0 {5,S} {8,S}
+2  N u0 {6,S} {8,D}
+3  N u0 {6,S} {9,D}
+4  N u0 {7,D} {9,S}
+5  * C u0 {1,S} {6,D} {7,S}
+6  C u0 {2,S} {3,S} {5,D}
+7  C u0 {4,D} {5,S}
+8  C u0 {1,S} {2,D}
+9  C u0 {3,D} {4,S}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 216,
+	label = "s2_5_6_purine5",
+	group = 
+"""
+1  N u0 {5,S} {7,S}
+2  N u0 {6,S} {7,D}
+3  N u0 {5,S} {9,D}
+4  N u0 {8,D} {9,S}
+5  * C u0 {1,S} {3,S} {6,D}
+6  C u0 {2,S} {5,D} {8,S}
+7  C u0 {1,S} {2,D}
+8  C u0 {4,D} {6,S}
+9  C u0 {3,D} {4,S}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 217,
+	label = "s2_5_6_purine6",
+	group = 
+"""
+1  N u0 {7,S} {8,S}
+2  N u0 {5,S} {9,D}
+3  N u0 {6,S} {8,D}
+4  N u0 {6,D} {9,S}
+5  * C u0 {2,S} {6,S} {7,D}
+6  C u0 {3,S} {4,D} {5,S}
+7  C u0 {1,S} {5,D}
+8  C u0 {1,S} {3,D}
+9  C u0 {2,D} {4,S}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 218,
+	label = "s2_5_6_purine7",
+	group = 
+"""
+1  N u0 {6,S} {9,S}
+2  N u0 {7,S} {8,S}
+3  N u0 {5,S} {8,D}
+4  N u0 {7,S} {9,D}
+5  C u0 {3,S} {6,S}
+6  * C u0 {1,S} {5,S} {7,D}
+7  C u0 {2,S} {4,S} {6,D}
+8  C u0 {2,S} {3,D}
+9  C u0 {1,S} {4,D}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 219,
+	label = "s2_5_6_purine8",
+	group = 
+"""
+1  N u0 {5,S} {8,S}
+2  N u0 {7,S} {9,S}
+3  N u0 {6,S} {9,D}
+4  N u0 {7,S} {8,D}
+5  C u0 {1,S} {6,S}
+6  * C u0 {3,S} {5,S} {7,D}
+7  C u0 {2,S} {4,S} {6,D}
+8  C u0 {1,S} {4,D}
+9  C u0 {2,S} {3,D}
+""",
+	solute = u's2_5_6_purine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_purine
+""",
+)
+
+entry(
+	index = 220,
+	label = "s2_5_6_purine",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H u0 {2,[S,D,T,B]} {9,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+8   R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {3,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.22179,
+		B = -0.04470,
+		E = 0.19292,
+		L = 0.59304,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 25,
+		E = 27,
+		L = 25,
+		A = 27,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_5_6_purine groups (s2_5_6_purine1-8) together
+""",
+)
+
+entry(
+	index = 221,
+	label = "s2_5_6_hypoxanthine_general",
+	group =  "OR{s2_5_6_hypoxanthine1, s2_5_6_hypoxanthine2}",
+	solute = u's2_5_6_hypoxanthine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 222,
+	label = "s2_5_6_hypoxanthine1",
+	group = 
+"""
+1  N  u0 {6,S} {9,S}
+2  N  u0 {7,S} {8,S}
+3  N  u0 {5,S} {8,D}
+4  N  u0 {7,S} {9,D}
+5  CO u0 {3,S} {6,S}
+6  * C u0 {1,S} {5,S} {7,D}
+7  C  u0 {2,S} {4,S} {6,D}
+8  C  u0 {2,S} {3,D}
+9  C  u0 {1,S} {4,D}
+""",
+	solute = u's2_5_6_hypoxanthine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_hypoxanthine
+""",
+)
+
+entry(
+	index = 223,
+	label = "s2_5_6_hypoxanthine2",
+	group = 
+"""
+1  N u0 {5,S} {8,S}
+2  N u0 {7,S} {9,S}
+3  N u0 {6,S} {9,D}
+4  N u0 {7,S} {8,D}
+5  CO u0 {1,S} {6,S}
+6  * C u0 {3,S} {5,S} {7,D}
+7  C u0 {2,S} {4,S} {6,D}
+8  C u0 {1,S} {4,D}
+9  C u0 {2,S} {3,D}
+""",
+	solute = u's2_5_6_hypoxanthine',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_5_6_hypoxanthine
+""",
+)
+
+entry(
+	index = 224,
+	label = "s2_5_6_hypoxanthine",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H u0 {2,[S,D,T,B]} {9,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+8   R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {3,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = -0.05496,
+		B = 0.02645,
+		E = 0.07175,
+		L = 0.02655,
+		A = 0.08134,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_5_6_hypoxanthine groups (s2_5_6_hypoxanthine1-2) together
+""",
+)
+
+entry(
+	index = 225,
+	label = "s2_5_6_heteroaromatic",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H u0 {2,[S,D,T,B]} {9,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+8   R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {3,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.01345,
+		B = -0.00024,
+		E = 0.14259,
+		L = 0.24269,
+		A = 0.06991,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_5_6_heteroaromatic groups (s2_5_6_heteroaromatic1-3) together
+""",
+)
+
+entry(
+	index = 226,
+	label = "s2_5_6_indene_general",
+	group = 
+"""
+1 * R!H u0 {2,B} {3,S} {4,B}
+2   R!H u0 {1,B} {5,S} {6,B}
+3   R!H u0 {1,S} {7,S}
+4   R!H u0 {1,B} {8,B}
+5   R!H u0 {2,S} {7,D}
+6   R!H u0 {2,B} {9,B}
+7   R!H u0 {3,S} {5,D}
+8   R!H u0 {4,B} {9,B}
+9   R!H u0 {6,B} {8,B}
+""",
+	solute = u's2_5_6_indene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 227,
+	label = "s2_5_6_indene",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   C    u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   C   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   C   u0 {4,B} {9,B}
+9   C   u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.03757,
+		B = -0.01964,
+		E = -0.01333,
+		L = -0.24232,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 228,
+	label = "s2_5_6_indole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   N   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   C   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = -0.05644,
+		B = -0.06163,
+		E = 0.00162,
+		L = -0.05036,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 42,
+		B = 34,
+		E = 44,
+		L = 42,
+		A = 42,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 229,
+	label = "s2_5_6_benzimidazole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   N   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   N   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.09078,
+		B = 0.07990,
+		E = -0.03745,
+		L = 0.24075,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 27,
+		B = 27,
+		E = 27,
+		L = 25,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 230,
+	label = "s2_5_6_indazole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   N   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   C   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   N   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.06449,
+		B = -0.02986,
+		E = 0.10654,
+		L = 0.12670,
+		A = 0.03879,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 231,
+	label = "s2_5_6_benzofuran",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   O   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   C   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.07506,
+		B = -0.04433,
+		E = 0.00880,
+		L = 0.06866,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 232,
+	label = "s2_5_6_benzothiophene",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   S   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   C   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.01941,
+		B = -0.01943,
+		E = 0.03815,
+		L = 0.17716,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 26,
+		E = 27,
+		L = 27,
+		A = 27,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 233,
+	label = "s2_5_6_benzoxazole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   O   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   N   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.07845,
+		B = -0.02596,
+		E = 0.02581,
+		L = 0.12560,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 234,
+	label = "s2_5_6_benzisoxazole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   O   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   C   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   N   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.09013,
+		B = 0.02305,
+		E = 0.00484,
+		L = 0.23195,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 235,
+	label = "s2_5_6_benzothiazole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   S   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   N   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   C   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.08575,
+		B = -0.01901,
+		E = 0.03474,
+		L = 0.35652,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 236,
+	label = "s2_5_6_benzotriazole",
+	group = 
+"""
+1 * Cb  u0 {2,B} {3,S} {4,B}
+2   Cb  u0 {1,B} {5,S} {6,B}
+3   N   u0 {1,S} {7,S}
+4   Cb  u0 {1,B} {8,B}
+5   N   u0 {2,S} {7,D}
+6   Cb  u0 {2,B} {9,B}
+7   N   u0 {3,S} {5,D}
+8   Cb  u0 {4,B} {9,B}
+9   Cb  u0 {6,B} {8,B}
+""",
+	solute = SoluteData(
+		S = 0.12936,
+		B = 0.03289,
+		E = 0.13340,
+		L = 0.28689,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 237,
+	label = "s2_5_7",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+3    R!H u0 {2,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+5    R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+7    R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+8    R!H u0 {4,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {10,[S,D,T,B]}
+10   R!H u0 {8,[S,D,T,B]} {9,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.01109,
+		B = 0.05613,
+		E = 0.08479,
+		L = 0.08047,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 14,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 238,
+	label = "s2_5_7_azulene",
+	group = 
+"""
+1  * C u0 {2,S} {3,D} {4,S}
+2  C u0 {1,S} {5,D} {6,S}
+3  C u0 {1,D} {8,S}
+4  C u0 {1,S} {9,D}
+5  C u0 {2,D} {9,S}
+6  C u0 {2,S} {10,D} 
+7  C u0 {8,D} {10,S}
+8  C u0 {3,S} {7,D}
+9  C u0 {4,D} {5,S}
+10 C u0 {6,D} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00554,
+		B = -0.06118,
+		E = 0.02397,
+		L = 0.26676,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 239,
+	label = "s2_5_7_ene_1",
+	group = 
+"""
+1  * C u0 {2,D} {4,S} {5,S}
+2    C u0 {1,D} {3,S} {6,S}
+3    C u0 {2,S} {9,S}
+4    C u0 {1,S} {8,S}
+5    C u0 {1,S} {7,S}
+6    C u0 {2,S} {7,S}
+7    C u0 {5,S} {6,S}
+8    C u0 {4,S} {10,S}
+9    C u0 {3,S} {10,S}
+10   C u0 {8,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.06294,
+		B = -0.09034,
+		E = -0.03948,
+		L = -0.39742,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 240,
+	label = "s2_5_7_ene_2",
+	group = 
+"""
+1  * C u0 {2,S} {4,D} {5,S}
+2    C u0 {1,S} {3,S} {6,S}
+3    C u0 {2,S} {9,S}
+4    C u0 {1,D} {8,S}
+5    C u0 {1,S} {7,S}
+6    C u0 {2,S} {7,S}
+7    C u0 {5,S} {6,S}
+8    C u0 {4,S} {10,S}
+9    C u0 {3,S} {10,S}
+10   C u0 {8,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.04974,
+		B = -0.04786,
+		E = -0.01945,
+		L = -0.09382,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 241,
+	label = "s2_6_6",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = -0.16867,
+		B = 0.13981,
+		E = -0.05694,
+		L = -0.42139,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 242,
+	label = "s2_6_6_ane",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {6,S}
+2    R!H u0 {1,S} {4,S} {5,S}
+3    R!H u0 {1,S} {9,S}
+4    R!H u0 {2,S} {7,S}
+5    R!H u0 {2,S} {8,S}
+6    R!H u0 {1,S} {10,S}
+7  * R!H u0 {4,S} {9,S}
+8    R!H u0 {5,S} {10,S}
+9    R!H u0 {3,S} {7,S}
+10   R!H u0 {6,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.04038,
+		B = 0.00000,
+		E = -0.04689,
+		L = -0.13896,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 22,
+		L = 12,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 243,
+	label = "s2_6_6_ene",
+	group =  "OR{s2_6_6_ene_0, s2_6_6_ene_1, s2_6_6_ene_2, s2_6_6_ene_m}",
+	solute = u's2_6_6_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 244,
+	label = "s2_6_6_ene_0",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {5,S}
+2    R!H u0 {1,S} {4,D} {6,S}
+3    R!H u0 {1,S} {7,S}
+4    R!H u0 {2,D} {8,S}
+5    R!H u0 {1,S} {10,S}
+6    R!H u0 {2,S} {9,S}
+7  * R!H u0 {3,S} {8,S}
+8    R!H u0 {4,S} {7,S}
+9    R!H u0 {6,S} {10,S}
+10   R!H u0 {5,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.09435,
+		B = -0.00904,
+		E = 0.03891,
+		L = -0.04303,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 5,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 245,
+	label = "s2_6_6_ene_1",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {5,S}
+2    R!H u0 {1,S} {4,S} {6,S}
+3    R!H u0 {1,S} {9,D}
+4    R!H u0 {2,S} {7,S}
+5    R!H u0 {1,S} {10,S}
+6    R!H u0 {2,S} {8,S}
+7  * R!H u0 {4,S} {10,S}
+8    R!H u0 {6,S} {9,S}
+9    R!H u0 {3,D} {8,S}
+10   R!H u0 {5,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.00903,
+		B = 0.02653,
+		E = 0.04275,
+		L = 0.10620,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 14,
+		L = 13,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 246,
+	label = "s2_6_6_ene_2",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,S}
+2    R!H u0 {1,S} {5,S} {6,S}
+3    R!H u0 {1,S} {10,S}
+4    R!H u0 {1,S} {7,S}
+5    R!H u0 {2,S} {8,S}
+6    R!H u0 {2,S} {9,S}
+7  * R!H u0 {4,S} {8,S}
+8    R!H u0 {5,S} {7,S}
+9    R!H u0 {6,S} {10,D}
+10   R!H u0 {3,S} {9,D}
+""",
+	solute = SoluteData(
+		S = -0.01391,
+		B = 0.00500,
+		E = 0.25196,
+		L = -0.00083,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 247,
+	label = "s2_6_6_ene_m",
+	group = 
+"""
+1    R!H u0 {2,D} {5,S} {6,S}
+2    R!H u0 {1,D} {3,S} {4,S}
+3    R!H u0 {2,S} {7,S}
+4    R!H u0 {2,S} {8,S}
+5    R!H u0 {1,S} {10,S}
+6    R!H u0 {1,S} {9,S}
+7  * R!H u0 {3,S} {9,S}
+8    R!H u0 {4,S} {10,S}
+9    R!H u0 {6,S} {7,S}
+10   R!H u0 {5,S} {8,S}
+""",
+	solute = u's2_6_6_ene_0',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 248,
+	label = "s2_6_6_diene",
+	group =  "OR{s2_6_6_diene_0_2, s2_6_6_diene_0_3, s2_6_6_diene_0_6, s2_6_6_diene_0_8, s2_6_6_diene_1_6, s2_6_6_diene_1_7}",
+	solute = u's2_6_6_diene_0_8',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 249,
+	label = "s2_6_6_diene_0_2",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {5,S}
+2    R!H u0 {1,S} {4,S} {6,D}
+3    R!H u0 {1,S} {8,S}
+4    R!H u0 {2,S} {10,S}
+5    R!H u0 {1,S} {9,S}
+6    R!H u0 {2,D} {7,S}
+7  * R!H u0 {6,S} {8,D}
+8    R!H u0 {3,S} {7,D}
+9    R!H u0 {5,S} {10,S}
+10   R!H u0 {4,S} {9,S}
+""",
+	solute = SoluteData(
+		S = 0.06559,
+		B = 0.08608,
+		E = 0.03331,
+		L = 0.22695,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 250,
+	label = "s2_6_6_diene_0_3",
+	group = 
+"""
+1    R!H u0 {2,S} {4,S} {6,D}
+2    R!H u0 {1,S} {3,S} {5,S}
+3    R!H u0 {2,S} {10,S}
+4    R!H u0 {1,S} {9,S}
+5    R!H u0 {2,S} {7,D}
+6    R!H u0 {1,D} {8,S}
+7  * R!H u0 {5,D} {8,S}
+8    R!H u0 {6,S} {7,S}
+9    R!H u0 {4,S} {10,S}
+10   R!H u0 {3,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.01643,
+		B = 0.03143,
+		E = 0.05837,
+		L = 0.10156,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 251,
+	label = "s2_6_6_diene_0_6",
+	group = 
+"""
+1    R!H u0 {2,S} {5,S} {6,D}
+2    R!H u0 {1,S} {3,S} {4,S}
+3    R!H u0 {2,S} {10,S}
+4    R!H u0 {2,S} {9,D}
+5    R!H u0 {1,S} {8,S}
+6    R!H u0 {1,D} {7,S}
+7  * R!H u0 {6,S} {10,S}
+8    R!H u0 {5,S} {9,S}
+9    R!H u0 {4,D} {8,S}
+10   R!H u0 {3,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.00420,
+		B = 0.01231,
+		E = 0.04223,
+		L = 0.04220,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 252,
+	label = "s2_6_6_diene_0_8",
+	group = 
+"""
+1    R!H u0 {2,S} {4,S} {6,D}
+2    R!H u0 {1,S} {3,S} {5,S}
+3    R!H u0 {2,S} {9,S}
+4    R!H u0 {1,S} {10,D}
+5    R!H u0 {2,S} {8,S}
+6    R!H u0 {1,D} {7,S}
+7  * R!H u0 {6,S} {8,S}
+8    R!H u0 {5,S} {7,S}
+9    R!H u0 {3,S} {10,S}
+10   R!H u0 {4,D} {9,S}
+""",
+	solute = SoluteData(
+		S = 0.13668,
+		B = 0.02840,
+		E = 0.13603,
+		L = 0.37567,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 253,
+	label = "s2_6_6_diene_1_6",
+	group = 
+"""
+1    R!H u0 {2,S} {5,S} {6,S}
+2    R!H u0 {1,S} {3,S} {4,S}
+3    R!H u0 {2,S} {10,S}
+4    R!H u0 {2,S} {8,D}
+5    R!H u0 {1,S} {9,S}
+6    R!H u0 {1,S} {7,D}
+7  * R!H u0 {6,D} {10,S}
+8    R!H u0 {4,D} {9,S}
+9    R!H u0 {5,S} {8,S}
+10   R!H u0 {3,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.03418,
+		B = -0.03389,
+		E = 0.02793,
+		L = 0.04067,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 254,
+	label = "s2_6_6_diene_1_7",
+	group = 
+"""
+1    R!H u0 {2,S} {4,S} {6,S}
+2    R!H u0 {1,S} {3,S} {5,S}
+3    R!H u0 {2,S} {10,S}
+4    R!H u0 {1,S} {7,S}
+5    R!H u0 {2,S} {8,D}
+6    R!H u0 {1,S} {9,S}
+7  * R!H u0 {4,S} {10,D}
+8    R!H u0 {5,D} {9,S}
+9    R!H u0 {6,S} {8,S}
+10   R!H u0 {3,S} {7,D}
+""",
+	solute = SoluteData(
+		S = 0.00753,
+		B = 0.01840,
+		E = 0.01157,
+		L = 0.00120,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 255,
+	label = "s2_6_6_tetraene",
+	group =  "OR{s2_6_6_tetraene_0_2_4_7, s2_6_6_tetraene_0_2_6_8}",
+	solute = u's2_6_6_tetraene_0_2_6_8',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 256,
+	label = "s2_6_6_tetraene_0_2_4_7",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {4,D}
+2    R!H u0 {1,S} {5,D} {6,S}
+3    R!H u0 {1,S} {8,S}
+4    R!H u0 {1,D} {7,S}
+5    R!H u0 {2,D} {10,S}
+6    R!H u0 {2,S} {9,S}
+7  * R!H u0 {4,S} {10,D}
+8    R!H u0 {3,S} {9,D}
+9    R!H u0 {6,S} {8,D}
+10   R!H u0 {5,S} {7,D}
+""",
+	solute = SoluteData(
+		S = -0.05566,
+		B = 0.05940,
+		E = -0.03677,
+		L = -0.16307,
+		A = 0.04066,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 257,
+	label = "s2_6_6_tetraene_0_2_6_8",
+	group = 
+"""
+1    R!H u0 {2,S} {3,S} {6,S}
+2    R!H u0 {1,S} {4,D} {5,S}
+3    R!H u0 {1,S} {8,D}
+4    R!H u0 {2,D} {7,S}
+5    R!H u0 {2,S} {10,D}
+6    R!H u0 {1,S} {9,S}
+7  * R!H u0 {4,S} {9,D}
+8    R!H u0 {3,D} {10,S}
+9    R!H u0 {6,S} {7,D}
+10   R!H u0 {5,D} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.03623,
+		B = 0.02064,
+		E = 0.02425,
+		L = -0.09794,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 258,
+	label = "s2_6_6_ben",
+	group = 
+"""
+1    R!H u0 {2,B} {3,B} {5,S}
+2    R!H u0 {1,B} {4,B} {6,S}
+3    R!H u0 {1,B} {7,B}
+4    R!H u0 {2,B} {9,B}
+5    R!H u0 {1,S} {10,S}
+6    R!H u0 {2,S} {8,S}
+7  * R!H u0 {3,B} {9,B}
+8    R!H u0 {6,S} {10,S}
+9    R!H u0 {4,B} {7,B}
+10   R!H u0 {5,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.07905,
+		B = -0.01768,
+		E = 0.08820,
+		L = 0.11933,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 14,
+		L = 11,
+		A = 14,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 259,
+	label = "s2_6_6_ben_onlyC",
+	group = 
+"""
+1    C u0 {2,B} {3,B} {5,S}
+2    C u0 {1,B} {4,B} {6,S}
+3    C u0 {1,B} {7,B}
+4    C u0 {2,B} {9,B}
+5    C u0 {1,S} {10,S}
+6    C u0 {2,S} {8,S}
+7  * C u0 {3,B} {9,B}
+8    C u0 {6,S} {10,S}
+9    C u0 {4,B} {7,B}
+10   C u0 {5,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.04077,
+		B = 0.00568,
+		E = -0.02663,
+		L = -0.29995,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 24,
+		B = 24,
+		E = 25,
+		L = 23,
+		A = 25,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 260,
+	label = "s2_6_6_ben_chromane",
+	group = 
+"""
+1    C u0 {2,B} {3,B} {5,S}
+2    C u0 {1,B} {4,B} {6,S}
+3    C u0 {1,B} {7,B}
+4    C u0 {2,B} {9,B}
+5    C u0 {1,S} {10,S}
+6    O u0 {2,S} {8,S}
+7  * C u0 {3,B} {9,B}
+8    C u0 {6,S} {10,S}
+9    C u0 {4,B} {7,B}
+10   C u0 {5,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.25794,
+		B = 0.03181,
+		E = 0.06359,
+		L = -0.27370,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 261,
+	label = "s2_6_6_ben_1,4-dioxane",
+	group = 
+"""
+1    C u0 {2,B} {3,B} {5,S}
+2    C u0 {1,B} {4,B} {6,S}
+3    C u0 {1,B} {7,B}
+4    C u0 {2,B} {9,B}
+5    O u0 {1,S} {10,S}
+6    O u0 {2,S} {8,S}
+7  * C u0 {3,B} {9,B}
+8    C u0 {6,S} {10,S}
+9    C u0 {4,B} {7,B}
+10   C u0 {5,S} {8,S}
+""",
+	solute = SoluteData(
+		S = -0.02661,
+		B = 0.03512,
+		E = 0.00848,
+		L = -0.13700,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 262,
+	label = "s2_6_6_ben_ene",
+	group =  "OR{s2_6_6_ben_ene_1, s2_6_6_ben_ene_2}",
+	solute = u's2_6_6_ben_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 263,
+	label = "s2_6_6_ben_ene_1",
+	group = 
+"""
+1    R!H u0 {2,B} {3,S} {4,B}
+2    R!H u0 {1,B} {5,B} {6,S}
+3    R!H u0 {1,S} {7,D}
+4    R!H u0 {1,B} {8,B}
+5    R!H u0 {2,B} {9,B}
+6    R!H u0 {2,S} {10,S}
+7  * R!H u0 {3,D} {10,S}
+8    R!H u0 {4,B} {9,B}
+9    R!H u0 {5,B} {8,B}
+10   R!H u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.09384,
+		B = 0.00273,
+		E = -0.12769,
+		L = -0.19321,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 8,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 264,
+	label = "s2_6_6_ben_ene_1_2-Benzothiazine-1,1-dioxide",
+	group = 
+"""
+1    C    u0 {2,B} {3,S} {4,B}
+2    C    u0 {1,B} {5,B} {6,S}
+3    C    u0 {1,S} {7,D}
+4    C    u0 {1,B} {8,B}
+5    C    u0 {2,B} {9,B}
+6    S6dd u0 {2,S} {10,S} {11,D} {12,D}
+7  * C    u0 {3,D} {10,S}
+8    C    u0 {4,B} {9,B}
+9    C    u0 {5,B} {8,B}
+10   N    u0 {6,S} {7,S}
+11   O    u0 {6,D}
+12   O    u0 {6,D}
+""",
+	solute = SoluteData(
+		S = 0.00607,
+		B = 0.02677,
+		E = 0.01380,
+		L = 0.09781,
+		A = -0.02712,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 265,
+	label = "s2_6_6_ben_ene_1_coumarin",
+	group = 
+"""
+1    C  u0 {2,B} {3,S} {4,B}
+2    C  u0 {1,B} {5,B} {6,S}
+3    C  u0 {1,S} {7,D}
+4    C  u0 {1,B} {8,B}
+5    C  u0 {2,B} {9,B}
+6    O  u0 {2,S} {10,S}
+7  * C  u0 {3,D} {10,S}
+8    C  u0 {4,B} {9,B}
+9    C  u0 {5,B} {8,B}
+10   CO u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.04893,
+		B = -0.00137,
+		E = -0.08314,
+		L = -0.02796,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 266,
+	label = "s2_6_6_ben_ene_2",
+	group = 
+"""
+1    R!H u0 {2,B} {4,B} {5,S}
+2    R!H u0 {1,B} {3,S} {6,B}
+3    R!H u0 {2,S} {8,S}
+4    R!H u0 {1,B} {10,B}
+5    R!H u0 {1,S} {7,S}
+6    R!H u0 {2,B} {9,B}
+7  * R!H u0 {5,S} {8,D}
+8    R!H u0 {3,S} {7,D}
+9    R!H u0 {6,B} {10,B}
+10   R!H u0 {4,B} {9,B}
+""",
+	solute = SoluteData(
+		S = -0.13822,
+		B = 0.14838,
+		E = 0.00490,
+		L = -0.19335,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 22,
+		L = 21,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 267,
+	label = "s2_6_6_chromen-4-one",
+	group = 
+"""
+1    Cb  u0 {2,B} {4,B} {5,S}
+2    Cb  u0 {1,B} {3,S} {6,B}
+3    CO  u0 {2,S} {8,S}
+4    Cb  u0 {1,B} {10,B}
+5    O2s u0 {1,S} {7,S}
+6    Cb  u0 {2,B} {9,B}
+7  * Cd  u0 {5,S} {8,D}
+8    Cd  u0 {3,S} {7,D}
+9    Cb  u0 {6,B} {10,B}
+10   Cb  u0 {4,B} {9,B}
+""",
+	solute = SoluteData(
+		S = -0.02043,
+		B = 0.08406,
+		E = 0.10458,
+		L = 0.47957,
+		A = 0.17123,
+	),
+	dataCount = DataCountGAV(
+		S = 86,
+		B = 86,
+		E = 87,
+		L = 85,
+		A = 86,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 268,
+	label = "s2_6_6_ben_heteroaromatic_general",
+	group =  "OR{s2_6_6_ben_heteroaromatic1, s2_6_6_ben_heteroaromatic2, s2_6_6_ben_heteroaromatic3, s2_6_6_ben_heteroaromatic4,\
+s2_6_6_isoquinoline_general, s2_6_6_quinoline_general}",
+	solute = u's2_6_6_quinoline_general',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 269,
+	label = "s2_6_6_ben_heteroaromatic1",
+	group = 
+"""
+1  * [C,N] u0 {9,D} {10,S}
+2  [C,N] u0 {3,B} {5,B} {6,S}
+3  [C,N] u0 {2,B} {4,B} {9,S}
+4  [C,N] u0 {3,B} {8,B}
+5  [C,N] u0 {2,B} {7,B}
+6  [C,N] u0 {2,S} {10,D}
+7  [C,N] u0 {5,B} {8,B}
+8  [C,N] u0 {4,B} {7,B}
+9  [C,N] u0 {1,D} {3,S}
+10 [C,N] u0 {1,S} {6,D}
+""",
+	solute = u's2_6_6_ben_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_ben_heteroaromatic
+""",
+)
+
+entry(
+	index = 270,
+	label = "s2_6_6_ben_heteroaromatic2",
+	group = 
+"""
+1  [C,N] u0 {3,S} {9,D}
+2  [C,N] u0 {4,S} {10,D}
+3  [C,N] u0 {1,S} {4,D} {5,S}
+4  [C,N] u0 {2,S} {3,D} {6,S}
+5  [C,N] u0 {3,S} {7,D}
+6  [C,N] u0 {4,S} {8,D}
+7  [C,N] u0 {5,D} {10,S}
+8  * [C,N] u0 {6,D} {9,S}
+9  [C,N] u0 {1,D} {8,S}
+10 [C,N] u0 {2,D} {7,S}
+""",
+	solute = u's2_6_6_ben_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_ben_heteroaromatic
+""",
+)
+
+entry(
+	index = 271,
+	label = "s2_6_6_ben_heteroaromatic3",
+	group = 
+"""
+1  [C,N] u0 p1 c0 {9,S} {10,D}
+2  [C,N] u0 p0 c0 {3,S} {4,S} {6,D}
+3  [C,N] u0 p0 c0 {2,S} {5,S} {9,D}
+4  [C,N] u0 p0 c0 {2,S} {7,D}
+5  [C,N] u0 p0 c0 {3,S} {8,D}
+6  [C,N] u0 p0 c0 {2,D} {10,S}
+7  [C,N] u0 p0 c0 {4,D} {8,S}
+8  [C,N] u0 p0 c0 {5,D} {7,S}
+9  [C,N] u0 p0 c0 {1,S} {3,D}
+10 [C,N] u0 p0 c0 {1,D} {6,S}
+""",
+	solute = u's2_6_6_ben_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_ben_heteroaromatic
+""",
+)
+
+entry(
+	index = 272,
+	label = "s2_6_6_ben_heteroaromatic4",
+	group = 
+"""
+1  [C,N] u0 {5,S} {8,S}
+2  [C,N] u0 {5,S} {10,D}
+3  [C,N] u0 {4,S} {6,S}
+4  [C,N] u0 {3,S} {5,D} {7,S}
+5  [C,N] u0 {1,S} {2,S} {4,D}
+6  [C,N] u0 {3,S} {8,D}
+7  [C,N] u0 {4,S} {9,D}
+8  [C,N] u0 {1,S} {6,D}
+9  [C,N] u0 {7,D} {10,S}
+10 [C,N] u0 {2,D} {9,S}
+""",
+	solute = u's2_6_6_ben_heteroaromatic',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_ben_heteroaromatic
+""",
+)
+
+entry(
+	index = 273,
+	label = "s2_6_6_quinoline_general",
+	group =  "OR{s2_6_6_quinoline1, s2_6_6_quinoline2, s2_6_6_8-Hydroxyquinoline_general, s2_6_6_quinoline_nitro_general}",
+	solute = u's2_6_6_quinoline',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 274,
+	label = "s2_6_6_quinoline1",
+	group = 
+"""
+1    Cb  u0 {2,B} {4,B} {5,S}
+2    Cb  u0 {1,B} {3,S} {6,B}
+3    N   u0 {2,S} {8,D}
+4    Cb  u0 {1,B} {10,B}
+5    Cd  u0 {1,S} {7,D}
+6    Cb  u0 {2,B} {9,B}
+7  * Cd  u0 {5,D} {8,S}
+8    Cd  u0 {3,D} {7,S}
+9    Cb  u0 {6,B} {10,B}
+10   Cb  u0 {4,B} {9,B}
+""",
+	solute = u's2_6_6_quinoline',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_quinoline
+""",
+)
+
+entry(
+	index = 275,
+	label = "s2_6_6_quinoline2",
+	group = 
+"""
+1  N u0 {3,D} {10,S}
+2  C u0 {3,S} {4,D} {5,S}
+3  C u0 {1,D} {2,S} {6,S}
+4  C u0 {2,D} {9,S}
+5  C u0 {2,S} {7,D}
+6  C u0 {3,S} {8,D}
+7  C u0 {5,D} {8,S}
+8  C u0 {6,D} {7,S}
+9  * C u0 {4,S} {10,D}
+10 C u0 {1,S} {9,D}
+""",
+	solute = u's2_6_6_quinoline',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_quinoline
+""",
+)
+
+entry(
+	index = 276,
+	label = "s2_6_6_8-Hydroxyquinoline_general",
+	group =  "OR{s2_6_6_8-Hydroxyquinoline1, s2_6_6_8-Hydroxyquinoline2}",
+	solute = u's2_6_6_8-Hydroxyquinoline',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 277,
+	label = "s2_6_6_8-Hydroxyquinoline1",
+	group = 
+"""
+1    Cb  u0 {2,B} {4,B} {5,S}
+2    Cb  u0 {1,B} {3,S} {6,B}
+3    N3d u0 {2,S} {8,D}
+4    Cb  u0 {1,B} {10,B}
+5    Cd  u0 {1,S} {7,D}
+6    Cb  u0 {2,B} {9,B} {11,S}
+7  * Cd  u0 {5,D} {8,S}
+8    Cd  u0 {3,D} {7,S}
+9    Cb  u0 {6,B} {10,B}
+10   Cb  u0 {4,B} {9,B}
+11   O   u0 {6,S} {12,S}
+12   H   u0 {11,S}
+""",
+	solute = u's2_6_6_8-Hydroxyquinoline',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_8-Hydroxyquinoline
+""",
+)
+
+entry(
+	index = 278,
+	label = "s2_6_6_8-Hydroxyquinoline2",
+	group = 
+"""
+1  N u0 {3,D} {10,S}
+2  C u0 {3,S} {4,D} {5,S}
+3  C u0 {1,D} {2,S} {6,S}
+4  C u0 {2,D} {9,S}
+5  C u0 {2,S} {7,D}
+6  C u0 {3,S} {8,D} {11,S}
+7  C u0 {5,D} {8,S}
+8  C u0 {6,D} {7,S}
+9  * C u0 {4,S} {10,D}
+10   C u0 {1,S} {9,D}
+11   O   u0 {6,S} {12,S}
+12   H   u0 {11,S}
+""",
+	solute = u's2_6_6_8-Hydroxyquinoline',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_8-Hydroxyquinoline
+""",
+)
+
+entry(
+	index = 279,
+	label = "s2_6_6_8-Hydroxyquinoline",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = -0.14265,
+		B = -0.03943,
+		E = -0.06617,
+		L = -0.17238,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 40,
+		B = 40,
+		E = 40,
+		L = 40,
+		A = 40,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_6_6_8-Hydroxyquinoline groups (s2_6_6_8-Hydroxyquinoline1-2) together
+""",
+)
+
+entry(
+	index = 280,
+	label = "s2_6_6_quinoline_nitro_general",
+	group =  "OR{s2_6_6_quinoline_nitro1, s2_6_6_quinoline_nitro2}",
+	solute = u's2_6_6_quinoline_nitro',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 281,
+	label = "s2_6_6_quinoline_nitro1",
+	group = 
+"""
+1    Cb  u0 {2,B} {4,B} {5,S}
+2    Cb  u0 {1,B} {3,S} {6,B}
+3    N5dc  u0 {2,S} {8,D}
+4    Cb  u0 {1,B} {10,B}
+5    Cd  u0 {1,S} {7,D}
+6    Cb  u0 {2,B} {9,B}
+7  * Cd  u0 {5,D} {8,S}
+8    Cd  u0 {3,D} {7,S}
+9    Cb  u0 {6,B} {10,B}
+10   Cb  u0 {4,B} {9,B}
+""",
+	solute = u's2_6_6_quinoline_nitro',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_quinoline_nitro
+""",
+)
+
+entry(
+	index = 282,
+	label = "s2_6_6_quinoline_nitro2",
+	group = 
+"""
+1  N5dc u0 {3,D} {10,S}
+2  C u0 {3,S} {4,D} {5,S}
+3  C u0 {1,D} {2,S} {6,S}
+4  C u0 {2,D} {9,S}
+5  C u0 {2,S} {7,D}
+6  C u0 {3,S} {8,D}
+7  C u0 {5,D} {8,S}
+8  C u0 {6,D} {7,S}
+9  * C u0 {4,S} {10,D}
+10 C u0 {1,S} {9,D}
+""",
+	solute = u's2_6_6_quinoline_nitro',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_quinoline_nitro
+""",
+)
+
+entry(
+	index = 283,
+	label = "s2_6_6_quinoline_nitro",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.10305,
+		B = 0.02319,
+		E = 0.05358,
+		L = 0.27670,
+		A = -0.00735,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_6_6_quinoline_nitro groups (s2_6_6_quinoline_nitro1-2) together
+""",
+)
+
+entry(
+	index = 284,
+	label = "s2_6_6_quinoline",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = -0.09548,
+		B = 0.03091,
+		E = -0.01508,
+		L = 0.08005,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 39,
+		B = 39,
+		E = 41,
+		L = 36,
+		A = 41,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_6_6_quinoline groups (s2_6_6_quinoline1-2) together
+""",
+)
+
+entry(
+	index = 285,
+	label = "s2_6_6_isoquinoline_general",
+	group =  "OR{s2_6_6_isoquinoline1, s2_6_6_isoquinoline2}",
+	solute = u's2_6_6_isoquinoline',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 286,
+	label = "s2_6_6_isoquinoline1",
+	group = 
+"""
+1  * N u0 {9,D} {10,S}
+2  C u0 {3,B} {5,B} {6,S}
+3  C u0 {2,B} {4,B} {9,S}
+4  C u0 {3,B} {8,B}
+5  C u0 {2,B} {7,B}
+6  C u0 {2,S} {10,D}
+7  C u0 {5,B} {8,B}
+8  C u0 {4,B} {7,B}
+9  C u0 {1,D} {3,S}
+10 C u0 {1,S} {6,D}
+""",
+	solute = u's2_6_6_isoquinoline',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_isoquinoline
+""",
+)
+
+entry(
+	index = 287,
+	label = "s2_6_6_isoquinoline2",
+	group = 
+"""
+1  * N u0 {9,S} {10,D}
+2  C u0 {3,S} {4,S} {6,D}
+3  C u0 {2,S} {5,S} {9,D}
+4  C u0 {2,S} {7,D}
+5  C u0 {3,S} {8,D}
+6  C u0 {2,D} {10,S}
+7  C u0 {4,D} {8,S}
+8  C u0 {5,D} {7,S}
+9  C u0 {1,S} {3,D}
+10 C u0 {1,D} {6,S}
+""",
+	solute = u's2_6_6_isoquinoline',
+	dataCount = None,
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+this is one of the groups that belong to s2_6_6_isoquinoline
+""",
+)
+
+entry(
+	index = 288,
+	label = "s2_6_6_isoquinoline",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.03888,
+		B = 0.02608,
+		E = -0.00598,
+		L = 0.16069,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 3,
+		E = 5,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_6_6_isoquinoline groups (s2_6_6_isoquinoline1-2) together
+""",
+)
+
+entry(
+	index = 289,
+	label = "s2_6_6_ben_heteroaromatic",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {10,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.12359,
+		B = -0.01719,
+		E = 0.09017,
+		L = 0.31087,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""special solvation polycyclic group""",
+	longDesc = 
+u"""
+dummy group to put all s2_6_6_ben_heteroaromatic groups (s2_6_6_ben_heteroaromatic1-4) together
+""",
+)
+
+entry(
+	index = 290,
+	label = "s2_6_6_naphthalene",
+	group = 
+"""
+1    R!H u0 {2,B} {3,B} {4,B}
+2    R!H u0 {1,B} {5,B} {6,B}
+3    R!H u0 {1,B} {9,B}
+4    R!H u0 {1,B} {8,B}
+5    R!H u0 {2,B} {10,B}
+6    R!H u0 {2,B} {7,B}
+7  * R!H u0 {6,B} {8,B}
+8    R!H u0 {4,B} {7,B}
+9    R!H u0 {3,B} {10,B}
+10   R!H u0 {5,B} {9,B}
+""",
+	solute = SoluteData(
+		S = -0.11108,
+		B = 0.03868,
+		E = -0.10182,
+		L = -0.02138,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 221,
+		B = 219,
+		E = 236,
+		L = 216,
+		A = 235,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 291,
+	label = "s2_6_7",
+	group = 
+"""
+1    R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]} {6,[S,D,T,B]}
+2    R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3    R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+4    R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,[S,D,T,B]} {9,[S,D,T,B]}
+8    R!H u0 {5,[S,D,T,B]} {11,[S,D,T,B]}
+9    R!H u0 {3,[S,D,T,B]} {7,[S,D,T,B]}
+10   R!H u0 {6,[S,D,T,B]} {11,[S,D,T,B]}
+11   R!H u0 {8,[S,D,T,B]} {10,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.04430,
+		B = -0.04834,
+		E = 0.09810,
+		L = 0.02258,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 292,
+	label = "s2_6_7_ben",
+	group = 
+"""
+1    R!H u0 {2,B} {3,B} {6,[S,D,T,B]}
+2    R!H u0 {1,B} {4,B} {5,[S,D,T,B]}
+3    R!H u0 {1,B} {9,B}
+4    R!H u0 {2,B} {7,B}
+5    R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,B} {9,B}
+8    R!H u0 {5,[S,D,T,B]} {11,[S,D,T,B]}
+9    R!H u0 {3,B} {7,B}
+10   R!H u0 {6,[S,D,T,B]} {11,[S,D,T,B]}
+11   R!H u0 {8,[S,D,T,B]} {10,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = 0.02284,
+		B = 0.02362,
+		E = -0.03239,
+		L = 0.03414,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 293,
+	label = "s2_6_7_ben_ene",
+	group =  "OR{s2_6_7_ben_ene_1}",
+	solute = u's2_6_7_ben_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 294,
+	label = "s2_6_7_ben_ene_1",
+	group = 
+"""
+1    R!H u0 {2,B} {3,B} {6,[S,D,T,B]}
+2    R!H u0 {1,B} {4,B} {5,[S,D,T,B]}
+3    R!H u0 {1,B} {9,B}
+4    R!H u0 {2,B} {7,B}
+5    R!H u0 {2,[S,D,T,B]} {8,D}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,B} {9,B}
+8    R!H u0 {5,D} {11,[S,D,T,B]}
+9    R!H u0 {3,B} {7,B}
+10   R!H u0 {6,[S,D,T,B]} {11,[S,D,T,B]}
+11   R!H u0 {8,[S,D,T,B]} {10,[S,D,T,B]}
+""",
+	solute = SoluteData(
+		S = -0.19877,
+		B = 0.13041,
+		E = -0.09436,
+		L = -0.16154,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 31,
+		B = 31,
+		E = 31,
+		L = 10,
+		A = 31,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 295,
+	label = "s2_6_7_ben_diene_1_3",
+	group = 
+"""
+1    R!H u0 {2,B} {3,B} {6,[S,D,T,B]}
+2    R!H u0 {1,B} {4,B} {5,[S,D,T,B]}
+3    R!H u0 {1,B} {9,B}
+4    R!H u0 {2,B} {7,B}
+5    R!H u0 {2,[S,D,T,B]} {8,D}
+6    R!H u0 {1,[S,D,T,B]} {10,[S,D,T,B]}
+7  * R!H u0 {4,B} {9,B}
+8    R!H u0 {5,D} {11,[S,D,T,B]}
+9    R!H u0 {3,B} {7,B}
+10   R!H u0 {6,[S,D,T,B]} {11,D}
+11   R!H u0 {8,[S,D,T,B]} {10,D}
+""",
+	solute = SoluteData(
+		S = -0.04432,
+		B = 0.04576,
+		E = -0.02546,
+		L = -0.04960,
+		A = -0.01639,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 296,
+	label = "s2_9_4",
+	group = 
+"""
+1  * R!H u0 {2,[S,D,B]} {4,[S,D,B]} {6,[S,D,B]}
+2  R!H u0 {1,[S,D,B]} {3,[S,D,B]} {5,[S,D,B]}
+3  R!H u0 {2,[S,D,B]} {7,[S,D,B]}
+4  R!H u0 {1,[S,D,B]} {5,[S,D,B]}
+5  R!H u0 {2,[S,D,B]} {4,[S,D,B]}
+6  R!H u0 {1,[S,D,B]} {9,[S,D,B]}
+7  R!H u0 {3,[S,D,B]} {8,[S,D,B]}
+8  R!H u0 {7,[S,D,B]} {10,[S,D,B]}
+9  R!H u0 {6,[S,D,B]} {11,[S,D,B]}
+10 R!H u0 {8,[S,D,B]} {11,[S,D,B]}
+11 R!H u0 {9,[S,D,B]} {10,[S,D,B]}
+""",
+	solute = u's2_9_4_ene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 297,
+	label = "s2_9_4_ene",
+	group = 
+"""
+1  * R!H u0 {2,S} {4,S} {6,S}
+2  R!H u0 {1,S} {3,S} {5,S}
+3  R!H u0 {2,S} {7,S}
+4  R!H u0 {1,S} {5,S}
+5  R!H u0 {2,S} {4,S}
+6  R!H u0 {1,S} {9,S}
+7  R!H u0 {3,S} {8,S}
+8  R!H u0 {7,S} {10,S}
+9  R!H u0 {6,S} {11,S}
+10 R!H u0 {8,S} {11,D}
+11 R!H u0 {9,S} {10,D}
+""",
+	solute = SoluteData(
+		S = 0.03321,
+		B = 0.00107,
+		E = -0.03469,
+		L = -0.18576,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 298,
+	label = "s3_4_4",
+	group = 
+"""
+1   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3 * R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+""",
+	solute = u's3_4_4_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 299,
+	label = "s3_4_4_ane",
+	group = 
+"""
+1   R!H u0 {3,S} {4,S} {5,S}
+2   R!H u0 {3,S} {4,S} {5,S}
+3 * R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {2,S}
+5   R!H u0 {1,S} {2,S}
+""",
+	solute = SoluteData(
+		S = 0.03269,
+		B = 0.01550,
+		E = 0.05130,
+		L = -0.03673,
+		A = 0.00139,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 300,
+	label = "s3_4_6",
+	group = 
+"""
+1   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {6,[S,D,T,B]}
+2   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3 * R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+5   R!H u0 {2,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+7   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+""",
+	solute = u's3_4_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 301,
+	label = "s3_4_6_ane",
+	group = 
+"""
+1   R!H u0 {3,S} {4,S} {6,S}
+2   R!H u0 {3,S} {4,S} {5,S}
+3 * R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {2,S}
+5   R!H u0 {2,S} {7,S}
+6   R!H u0 {1,S} {7,S}
+7   R!H u0 {5,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.03200,
+		B = 0.04435,
+		E = 0.02742,
+		L = -0.03462,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 302,
+	label = "s3_4_6_ene",
+	group =  "OR{s3_4_6_ene_1}",
+	solute = u's3_4_6_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 303,
+	label = "s3_4_6_ene_1",
+	group = 
+"""
+1   R!H u0 {3,S} {4,S} {6,S}
+2   R!H u0 {3,S} {4,S} {5,S}
+3 * R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {2,S}
+5   R!H u0 {2,S} {7,S}
+6   R!H u0 {1,S} {7,D}
+7   R!H u0 {5,S} {6,D}
+""",
+	solute = SoluteData(
+		S = -0.02747,
+		B = 0.01408,
+		E = -0.01073,
+		L = -0.22894,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 304,
+	label = "s3_5_5",
+	group = 
+"""
+1   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+2   R!H u0 {3,[S,D,T,B]} {6,[S,D,T,B]} {7,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4 * R!H u0 {1,[S,D,T,B]} {6,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+7   R!H u0 {2,[S,D,T,B]} {5,[S,D,T,B]}
+""",
+	solute = u's3_5_5_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 305,
+	label = "s3_5_5_ene",
+	group =  "OR{s3_5_5_ene_1, s3_5_5_ene_side}",
+	solute = u's3_5_5_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 306,
+	label = "s3_5_5_ene_1",
+	group = 
+"""
+1   R!H u0 {3,S} {5,S} {6,S}
+2   R!H u0 {3,S} {4,S} {7,S}
+3   R!H u0 {1,S} {2,S}
+4 * R!H u0 {2,S} {5,S}
+5   R!H u0 {1,S} {4,S}
+6   R!H u0 {1,S} {7,D}
+7   R!H u0 {2,S} {6,D}
+""",
+	solute = SoluteData(
+		S = -0.05483,
+		B = -0.11774,
+		E = -0.01759,
+		L = -0.30255,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 17,
+		E = 22,
+		L = 18,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 307,
+	label = "s3_5_5_ene_side",
+	group = 
+"""
+1   R!H u0 {3,S} {4,S} {6,S}
+2   R!H u0 {4,S} {5,S} {7,S}
+3 * R!H u0 {1,S} {5,S} {8,D}
+4   R!H u0 {1,S} {2,S}
+5   R!H u0 {2,S} {3,S}
+6   R!H u0 {1,S} {7,S}
+7   R!H u0 {2,S} {6,S}
+8   R!H ux {3,D}
+""",
+	solute = SoluteData(
+		S = -0.00708,
+		B = 0.02176,
+		E = -0.00349,
+		L = -0.10827,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 308,
+	label = "s3_5_5_ene_side_norcamphor",
+	group = 
+"""
+1   C  u0 {3,S} {4,S} {6,S}
+2   C  u0 {4,S} {5,S} {7,S}
+3 * CO u0 {1,S} {5,S} {8,D}
+4   C  u0 {1,S} {2,S}
+5   C  u0 {2,S} {3,S}
+6   C  u0 {1,S} {7,S}
+7   C  u0 {2,S} {6,S}
+8   O2d u0 {3,D}
+""",
+	solute = SoluteData(
+		S = -0.01799,
+		B = 0.04560,
+		E = -0.01425,
+		L = -0.25746,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 309,
+	label = "s3_5_5_ane",
+	group = 
+"""
+1   R!H u0 {3,S} {4,S} {5,S}
+2   R!H u0 {3,S} {6,S} {7,S}
+3   R!H u0 {1,S} {2,S}
+4 * R!H u0 {1,S} {6,S}
+5   R!H u0 {1,S} {7,S}
+6   R!H u0 {2,S} {4,S}
+7   R!H u0 {2,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.11270,
+		B = 0.00000,
+		E = -0.00276,
+		L = -0.44472,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 22,
+		L = 21,
+		A = 23,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 310,
+	label = "s3_5_5_diene",
+	group =  "OR{s3_5_5_diene_1_4}",
+	solute = u's3_5_5_diene_1_4',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 311,
+	label = "s3_5_5_diene_1_4",
+	group = 
+"""
+1   R!H u0 {3,S} {6,S} {7,S}
+2   R!H u0 {3,S} {4,S} {5,S}
+3   R!H u0 {1,S} {2,S}
+4 * R!H u0 {2,S} {6,D}
+5   R!H u0 {2,S} {7,D}
+6   R!H u0 {1,S} {4,D}
+7   R!H u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = -0.00176,
+		B = 0.00155,
+		E = -0.01260,
+		L = -0.01478,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 312,
+	label = "s3_5_6",
+	group = 
+"""
+1   R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]} {6,[S,D,T,B]}
+2   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {7,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {5,[S,D,T,B]}
+5   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]}
+6   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+7   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+8 * R!H u0 {6,[S,D,T,B]} {7,[S,D,T,B]}
+""",
+	solute = u's3_5_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 313,
+	label = "s3_5_6_ane",
+	group = 
+"""
+1   R!H u0 {3,S} {5,S} {6,S}
+2   R!H u0 {3,S} {4,S} {7,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {2,S} {5,S}
+5   R!H u0 {1,S} {4,S}
+6   R!H u0 {1,S} {8,S}
+7   R!H u0 {2,S} {8,S}
+8 * R!H u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.04708,
+		B = 0.06188,
+		E = -0.04224,
+		L = -0.15630,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 314,
+	label = "s3_5_6_ane_tropane",
+	group = 
+"""
+1   C u0 {3,S} {5,S} {6,S}
+2   C u0 {3,S} {4,S} {7,S}
+3   N u0 {1,S} {2,S}
+4   C u0 {2,S} {5,S}
+5   C u0 {1,S} {4,S}
+6   C u0 {1,S} {8,S}
+7   C u0 {2,S} {8,S}
+8 * C u0 {6,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.05339,
+		B = 0.06184,
+		E = -0.01742,
+		L = -0.25923,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 315,
+	label = "s3_5_6_ene",
+	group =  "OR{s3_5_6_ene_1}",
+	solute = u's3_5_6_ene_1',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 316,
+	label = "s3_5_6_ene_1",
+	group = 
+"""
+1   R!H u0 {3,S} {4,S} {7,S}
+2   R!H u0 {3,S} {5,S} {6,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {5,S}
+5   R!H u0 {2,S} {4,S}
+6   R!H u0 {2,S} {8,S}
+7   R!H u0 {1,S} {8,D}
+8 * R!H u0 {6,S} {7,D}
+""",
+	solute = SoluteData(
+		S = -0.04624,
+		B = -0.01231,
+		E = -0.00390,
+		L = -0.08479,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 317,
+	label = "s3_5_7",
+	group = 
+"""
+1 * R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {7,[S,D,T,B]}
+2   R!H u0 {3,[S,D,T,B]} {5,[S,D,T,B]} {6,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4   R!H u0 {1,[S,D,T,B]} {5,[S,D,T,B]}
+5   R!H u0 {2,[S,D,T,B]} {4,[S,D,T,B]}
+6   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+7   R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+8   R!H u0 {6,[S,D,T,B]} {9,[S,D,T,B]}
+9   R!H u0 {7,[S,D,T,B]} {8,[S,D,T,B]}
+""",
+	solute = u's3_5_7_ane_0',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 318,
+	label = "s3_5_7_ane_0",
+	group = 
+"""
+1 * R!H u0 {3,S} {4,S} {7,S}
+2   R!H u0 {3,S} {5,S} {6,S}
+3   R!H u0 {1,S} {2,S}
+4   R!H u0 {1,S} {5,S}
+5   R!H u0 {2,S} {4,S}
+6   R!H u0 {2,S} {8,S}
+7   R!H u0 {1,S} {9,S}
+8   R!H u0 {6,S} {9,S}
+9   R!H u0 {7,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.01611,
+		B = -0.07058,
+		E = 0.07610,
+		L = 0.04672,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 1,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 319,
+	label = "s3_6_6",
+	group = 
+"""
+1   R!H u0 {3,[S,D,T,B]} {6,[S,D,T,B]} {7,[S,D,T,B]}
+2   R!H u0 {3,[S,D,T,B]} {4,[S,D,T,B]} {5,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {2,[S,D,T,B]}
+4 * R!H u0 {2,[S,D,T,B]} {9,[S,D,T,B]}
+5   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+6   R!H u0 {1,[S,D,T,B]} {8,[S,D,T,B]}
+7   R!H u0 {1,[S,D,T,B]} {9,[S,D,T,B]}
+8   R!H u0 {5,[S,D,T,B]} {6,[S,D,T,B]}
+9   R!H u0 {4,[S,D,T,B]} {7,[S,D,T,B]}
+""",
+	solute = u's3_6_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 320,
+	label = "s3_6_6_ane",
+	group = 
+"""
+1   R!H u0 {3,S} {6,S} {7,S}
+2   R!H u0 {3,S} {4,S} {5,S}
+3   R!H u0 {1,S} {2,S}
+4 * R!H u0 {2,S} {9,S}
+5   R!H u0 {2,S} {8,S}
+6   R!H u0 {1,S} {8,S}
+7   R!H u0 {1,S} {9,S}
+8   R!H u0 {5,S} {6,S}
+9   R!H u0 {4,S} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.02842,
+		B = 0.09046,
+		E = 0.05043,
+		L = 0.12760,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 5,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 321,
+	label = "s4_6_6",
+	group = 
+"""
+1 * R!H u0 {3,[S,D,T,B]} {6,[S,D,T,B]} {8,[S,D,T,B]}
+2   R!H u0 {4,[S,D,T,B]} {5,[S,D,T,B]} {7,[S,D,T,B]}
+3   R!H u0 {1,[S,D,T,B]} {4,[S,D,T,B]}
+4   R!H u0 {2,[S,D,T,B]} {3,[S,D,T,B]}
+5   R!H u0 {2,[S,D,T,B]} {6,[S,D,T,B]}
+6   R!H u0 {1,[S,D,T,B]} {5,[S,D,T,B]}
+7   R!H u0 {2,[S,D,T,B]} {8,[S,D,T,B]}
+8   R!H u0 {1,[S,D,T,B]} {7,[S,D,T,B]}
+""",
+	solute = u's4_6_6_ane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 322,
+	label = "s4_6_6_ane",
+	group = 
+"""
+1 * R!H u0 {3,S} {6,S} {8,S}
+2   R!H u0 {4,S} {5,S} {7,S}
+3   R!H u0 {1,S} {4,S}
+4   R!H u0 {2,S} {3,S}
+5   R!H u0 {2,S} {6,S}
+6   R!H u0 {1,S} {5,S}
+7   R!H u0 {2,S} {8,S}
+8   R!H u0 {1,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.07049,
+		B = 0.07524,
+		E = 0.03424,
+		L = -0.03434,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 9,
+		L = 8,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+tree(
+"""
+L1: PolycyclicRing
+	L2: polycyclic_7fused
+		L3: Strychnine_general
+			L4: Strychnine
+	L2: polycyclic_5fused
+		L3: Porphyrin
+		L3: Morphine_general
+			L4: Dihydro-normorphine,3-desoxy-
+			L4: Morphine
+			L4: Dihydromorphine
+		L3: Benzo[e]pyrene_general
+			L4: Benzo[e]pyrene
+		L3: Benzo[a]pyrene_general
+			L4: Benzo[a]pyrene
+		L3: Fluoran_general
+			L4: Fluoran
+		L3: Picene_general
+			L4: Picene
+			L4: Icosahydropicene
+		L3: 1H-Cyclopenta[a]chrysene_general
+			L4: 1H-Cyclopenta[a]chrysene
+		L3: Benzo[ghi]fluoranthene_general
+			L4: Benzo[ghi]fluoranthene
+		L3: Cholanthrene_general
+			L4: Cholanthrene
+		L3: 5fused_r6_r6_r6_r5_r5
+			L4: 5fused_r6_diene_r6_r6_r5_r5_dioxo
+	L2: polycyclic_4fused
+		L3: Artemether_general
+			L4: Artemether
+		L3: Fluoranthene_general
+			L4: Fluoranthene
+		L3: s3_6_6_s3_6_6_s3_6_6
+			L4: s3_6_6_s3_6_6_s3_6_6_pyrene
+		L3: s2_5_6_s2_6_6_s2_6_6
+			L4: s2_5_6_s2_6_6_s2_6_6_ben
+				L5: s2_5_6_s2_6_6_s2_6_6_ben_onlyC
+			L4: s2_5_6_s2_6_6_s2_6_6_ane
+				L5: s2_5_6_s2_6_6_s2_6_6_ane_onlyC
+					L6: s2_5_6_s2_6_6_s2_6_6_ane_onlyC(=O)
+			L4: s2_5_6_s2_6_6_s2_6_6_ene_2
+				L5: s2_5_6_s2_6_6_s2_6_6_ene_2_onlyC
+					L6: s2_5_6_s2_6_6_s2_6_6_ene_2_onlyC(=O)
+			L4: s2_5_6_s2_6_6_s2_6_6_ene_3
+				L5: s2_5_6_s2_6_6_s2_6_6_ene_3_onlyC
+			L4: s2_5_6_s2_6_6_s2_6_6_diene_2_16
+				L5: s2_5_6_s2_6_6_s2_6_6_diene_2_16_onlyC
+					L6: s2_5_6_s2_6_6_s2_6_6_diene_2_16_onlyC(=O)
+			L4: s2_5_6_s2_6_6_s2_6_6_diene_2_4
+				L5: s2_5_6_s2_6_6_s2_6_6_diene_2_4_onlyC
+					L6: s2_5_6_s2_6_6_s2_6_6_diene_2_4_onlyC(=O)
+			L4: s2_5_6_s2_6_6_s2_6_6_triene_2_12_14
+				L5: s2_5_6_s2_6_6_s2_6_6_triene_2_12_14_onlyC
+		L3: s2_6_6_s2_6_6_s2_6_6
+			L4: s2_6_6_s2_6_6_s2_6_6_aromatic
+				L5: s2_6_6_s2_6_6_s2_6_6_benz[a]anthracene
+				L5: s2_6_6_s2_6_6_s2_6_6_benzacridine
+		L3: s2_6_6_s2_6_6_s2_6_6_A
+			L4: s2_6_6_s2_6_6_s2_6_6_A_chrysene
+		L3: s2_6_6_s2_6_6_s2_6_6_B
+			L4: s2_6_6_s2_6_6_s2_6_6_B_tetracene
+			L4: s2_6_6_s2_6_6_s2_6_6_B_1,2,3,4,6,11-hexahydrotetracene
+			L4: s2_6_6_s2_6_6_s2_6_6_B_ben_diene
+		L3: s2_6_5_s2_5_9_s3_9_6
+			L4: s2_6_5_ben_ene_s2_5_9_s3_9_6_hetero
+		L3: s2_6_7_s2_7_6_s2_7_6
+			L4: s2_6_7_ben_s2_7_6_ben_s2_7_6_piperidine
+		L3: Quadricyclane_general
+			L4: Quadricyclane
+	L2: polycyclic_3fused
+		L3: Adamantane_general
+			L4: Adamantane
+		L3: s2_6_7_s2_7_6
+			L4: s2_6_7_ben_s2_7_6_ben_general
+				L5: s2_6_7_ben_s2_7_6_ben_iminodibenzyl_general
+					L6: s2_6_7_ben_s2_7_6_ben_iminodibenzyl
+				L5: s2_6_7_ben_s2_7_6_ben
+			L4: s2_6_7_ben_s2_7_6_ben_ene
+		L3: s2_6_6_s2_6_5
+			L4: s2_6_6_s2_6_5_ben_ene
+			L4: s2_6_6_s2_6_5_ben_diene
+				L5: s2_6_6_s2_6_5_ben_diene_psoralen
+		L3: s2_6_6_s2_6_6
+			L4: s2_6_6_s2_6_6_aromatic
+				L5: s2_6_6_s2_6_6_all_ben
+				L5: s2_6_6_s2_6_6_heteroaromatic
+			L4: s2_6_6_ben_s2_6_6_ben
+			L4: s2_6_6_ene_s2_6_6_ene
+			L4: s2_6_6_ben_s2_6_6_ane
+		L3: s2_6_6_s2_6_6_A
+			L4: s2_6_6_s2_6_6_A_aromatic
+				L5: s2_6_6_s2_6_6_A_anthracene
+				L5: s2_6_6_s2_6_6_A_acridine
+			L4: s2_6_6_ben_s2_6_6_ben_A
+				L5: s2_6_6_ben_s2_6_6_ben_A_anthraquinone
+				L5: s2_6_6_ben_s2_6_6_ben_A_phenothiazine
+				L5: s2_6_6_ben_s2_6_6_ben_A_9H-xanthene
+		L3: s2_6_5_s2_5_6
+			L4: s2_6_5_ben_s2_5_6_ben
+				L5: s2_6_5_s2_5_6_fluorene
+				L5: s2_6_5_s2_5_6_carbazole
+				L5: s2_6_5_s2_5_6_dibenzofuran
+				L5: s2_6_5_s2_5_6_dibenzothiophene
+			L4: s2_6_5_ben_s2_5_6
+				L5: s2_6_5_ben_s2_5_6_hetero
+		L3: s2_5_6_s2_6_6
+			L4: s2_5_6_ben_s2_6_6_ben
+				L5: s2_5_6_s2_6_6_naphtho[2,1-b]thiophene
+				L5: s2_5_6_s2_6_6_benzo[g][1]benzothiole
+		L3: s2_5_7_s2_7_3
+			L4: s2_5_7_s2_7_3_ane
+				L5: s2_5_7_s2_7_3_ane_side_ene
+			L4: s2_5_7_s2_7_3_ene
+		L3: Nortricyclene_general
+			L4: Nortricyclene
+		L3: s3_6_3_s3_3_6
+			L4: s3_6_3_s3_3_6_ane
+			L4: s3_6_3_s3_3_6_ene
+		L3: Acenaphthene_general
+			L4: Acenaphthene
+			L4: Acenaphthylene
+		L3: s2_5_5_s2_5_5_ane
+	L2: s1_3_6
+		L3: s1_3_6_ane
+	L2: s1_5_5
+		L3: s1_5_5_ane
+	L2: s1_5_6
+		L3: s1_5_6_ane
+		L3: s1_5_6_ene
+			L4: s1_5_6_ene_1
+			L4: s1_5_6_ene_2
+			L4: s1_5_6_ene_7
+			L4: s1_5_6_ene_8
+	L2: s1_6_6
+		L3: s1_6_6_ane
+			L4: s1_6_6_ane_2,4,8,10-Tetraoxa-3,9-diphosphaspiro-3,9-dioxide
+	L2: s2_3_5
+		L3: s2_3_5_ene
+			L4: s2_3_5_ene_1
+			L4: s2_3_5_ene_side
+		L3: s2_3_5_ane
+	L2: s2_3_6
+		L3: s2_3_6_ane
+		L3: s2_3_6_ene
+			L4: s2_3_6_ene_1
+			L4: s2_3_6_ene_2
+	L2: s2_3_8
+		L3: s2_3_8_ane
+	L2: s2_4_5
+		L3: s2_4_5_ane
+			L4: s2_4_5_ane_hetero_N_S
+	L2: s2_4_6
+		L3: s2_4_6_ene
+			L4: s2_4_6_ene_1
+	L2: s2_5_5
+		L3: s2_5_5_ane
+		L3: s2_5_5_ene
+			L4: s2_5_5_ene_0
+			L4: s2_5_5_ene_1
+		L3: s2_5_5_diene
+			L4: s2_5_5_diene_0_2
+			L4: s2_5_5_diene_0_4
+	L2: s2_5_6
+		L3: s2_5_6_ane
+		L3: s2_5_6_ene
+			L4: s2_5_6_ene_0
+			L4: s2_5_6_ene_1
+			L4: s2_5_6_ene_m
+			L4: s2_5_6_ene_2
+			L4: s2_5_6_ene_5
+		L3: s2_5_6_diene
+			L4: s2_5_6_diene_m_2
+			L4: s2_5_6_diene_m_7
+				L5: s2_5_6_diene_m_7_hetero
+					L6: s2_5_6_diene_xanthine
+		L3: s2_5_6_triene
+			L4: s2_5_6_triene_m_1_7
+		L3: s2_5_6_tetraene
+			L4: s2_5_6_tetraene_1_3_5_7
+			L4: s2_5_6_tetraene_1_3_5_8
+		L3: s2_5_6_ben
+			L4: s2_5_6_ben_onlyC
+			L4: s2_5_6_phthalan
+			L4: s2_5_6_2,3-dihydrobenzofuran
+			L4: s2_5_6_indoline
+				L5: s2_5_6_isatin
+				L5: s2_5_6_oxindole
+			L4: s2_5_6_isoindoline
+				L5: s2_5_6_isoindole-1,3-dione
+			L4: s2_5_6_1,3-benzodioxole
+			L4: s2_5_6_2,3-dihydrobenzothiophene
+		L3: s2_5_6_heteroaromatic_general
+			L4: s2_5_6_purine_general
+				L5: s2_5_6_purine
+					L6: s2_5_6_hypoxanthine_general
+						L7: s2_5_6_hypoxanthine
+			L4: s2_5_6_heteroaromatic
+		L3: s2_5_6_indene_general
+			L4: s2_5_6_indene
+			L4: s2_5_6_indole
+			L4: s2_5_6_benzimidazole
+			L4: s2_5_6_indazole
+			L4: s2_5_6_benzofuran
+			L4: s2_5_6_benzothiophene
+			L4: s2_5_6_benzoxazole
+			L4: s2_5_6_benzisoxazole
+			L4: s2_5_6_benzothiazole
+			L4: s2_5_6_benzotriazole
+	L2: s2_5_7
+		L3: s2_5_7_azulene
+		L3: s2_5_7_ene_1
+		L3: s2_5_7_ene_2
+	L2: s2_6_6
+		L3: s2_6_6_ane
+		L3: s2_6_6_ene
+			L4: s2_6_6_ene_0
+			L4: s2_6_6_ene_1
+			L4: s2_6_6_ene_2
+			L4: s2_6_6_ene_m
+		L3: s2_6_6_diene
+			L4: s2_6_6_diene_0_2
+			L4: s2_6_6_diene_0_3
+			L4: s2_6_6_diene_0_6
+			L4: s2_6_6_diene_0_8
+			L4: s2_6_6_diene_1_6
+			L4: s2_6_6_diene_1_7
+		L3: s2_6_6_tetraene
+			L4: s2_6_6_tetraene_0_2_4_7
+			L4: s2_6_6_tetraene_0_2_6_8
+		L3: s2_6_6_ben
+			L4: s2_6_6_ben_onlyC
+			L4: s2_6_6_ben_chromane
+			L4: s2_6_6_ben_1,4-dioxane
+		L3: s2_6_6_ben_ene
+			L4: s2_6_6_ben_ene_1
+				L5: s2_6_6_ben_ene_1_2-Benzothiazine-1,1-dioxide
+				L5: s2_6_6_ben_ene_1_coumarin
+			L4: s2_6_6_ben_ene_2
+				L5: s2_6_6_chromen-4-one
+		L3: s2_6_6_ben_heteroaromatic_general
+			L4: s2_6_6_quinoline_general
+				L5: s2_6_6_8-Hydroxyquinoline_general
+					L6: s2_6_6_8-Hydroxyquinoline
+				L5: s2_6_6_quinoline_nitro_general
+					L6: s2_6_6_quinoline_nitro
+				L5: s2_6_6_quinoline
+			L4: s2_6_6_isoquinoline_general
+				L5: s2_6_6_isoquinoline
+			L4: s2_6_6_ben_heteroaromatic
+		L3: s2_6_6_naphthalene
+	L2: s2_6_7
+		L3: s2_6_7_ben
+			L4: s2_6_7_ben_ene
+				L5: s2_6_7_ben_ene_1
+					L6: s2_6_7_ben_diene_1_3
+	L2: s2_9_4
+		L3: s2_9_4_ene
+	L2: s3_4_4
+		L3: s3_4_4_ane
+	L2: s3_4_6
+		L3: s3_4_6_ane
+		L3: s3_4_6_ene
+			L4: s3_4_6_ene_1
+	L2: s3_5_5
+		L3: s3_5_5_ene
+			L4: s3_5_5_ene_1
+			L4: s3_5_5_ene_side
+				L5: s3_5_5_ene_side_norcamphor
+		L3: s3_5_5_ane
+		L3: s3_5_5_diene
+			L4: s3_5_5_diene_1_4
+	L2: s3_5_6
+		L3: s3_5_6_ane
+			L4: s3_5_6_ane_tropane
+		L3: s3_5_6_ene
+			L4: s3_5_6_ene_1
+	L2: s3_5_7
+		L3: s3_5_7_ane_0
+	L2: s3_6_6
+		L3: s3_6_6_ane
+	L2: s4_6_6
+		L3: s4_6_6_ane
+"""
+)

--- a/input/solvation/groups/radical.py
+++ b/input/solvation/groups/radical.py
@@ -8,130 +8,137 @@ H-bonding parameter A should be modified for when we saturate
 radical molecules with hydrogens and look up the saturated
 structure.
 """
+
 entry(
-    index = 0,
-    label = "R_rad",
-    group = 
+	index = 0,
+	label = "R_rad",
+	group = 
 """
 1 * R u1
 """,
-    solute = None,
-    shortDesc = u"""""",
-    longDesc = 
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 1,
-    label = "O_rad",
-    group = 
+	index = 1,
+	label = "O_rad",
+	group = 
 """
 1 * O u1 p2
 """,
-    solute = None,
-    shortDesc = u"""""",
-    longDesc = 
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 2,
-    label = "ROJ",
-    group = 
+	index = 2,
+	label = "ROJ",
+	group = 
 """
 1 * O u1 p2 c0 {2,S}
 2   R u0 {1,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.345,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.345,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 3,
-    label = "ROOJ",
-    group = 
+	index = 3,
+	label = "ROOJ",
+	group = 
 """
 1 * O u1 p2 c0 {2,S}
 2   O u0 p2 {1,S} {3,S}
 3   R u0 {2,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.345,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.345,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 4,
-    label = "RC(O)OJ",
-    group = 
+	index = 4,
+	label = "RC(O)OJ",
+	group = 
 """
 1 * O u1 p2 c0 {2,S}
 2   C u0 p0 {1,S} {3,D} {4,S}
 3   O u0 p2 {2,D}
 4   R u0 {2,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.243,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.243,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 5,
-    label = "N3s_rad",
-    group = 
+	index = 5,
+	label = "N3s_rad",
+	group = 
 """
 1 * N3s u1 p1 
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.087,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.087,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 6,
-    label = "N3_pyrrole",
-    group = 
+	index = 6,
+	label = "N3_pyrrole",
+	group = 
 """
 1 * N3s u1 p1 {2,S} {3,S}
 2   Cb  u0 {1,S} {4,B}
@@ -139,46 +146,48 @@ entry(
 4   Cb  u0 {2,B} {5,B}
 5   Cb  u0 {3,B} {4,B}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.371,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.371,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 7,
-    label = "phenoxy",
-    group = 
+	index = 7,
+	label = "phenoxy",
+	group = 
 """
 1 * O  u1 p2 c0 {2,S}
 2   Cb u0 {1,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.543,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.543,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 8,
-    label = "N3_aniline",
-    group = 
+	index = 8,
+	label = "N3_aniline",
+	group = 
 """
 1 * N3s u1 p1 c0 {2,S} {3,S}
 2   H   u0 p0 c0 {1,S}
@@ -189,96 +198,100 @@ entry(
 7   Cb  u0 {5,B} {8,B}
 8   Cb  u0 {6,B} {7,B}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.247,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.247,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 9,
-    label = "N3_amide_pri",
-    group = 
+	index = 9,
+	label = "N3_amide_pri",
+	group = 
 """
 1 * N3s u1 p1 c0 {2,S} {3,S}
 2   H   u0 p0 c0 {1,S}
 3   CO  u0 {1,S} {4,D}
 4   O   u0 p2 {3,D}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.275,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.275,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 10,
-    label = "N3_amide_sec",
-    group = 
+	index = 10,
+	label = "N3_amide_sec",
+	group = 
 """
 1 * N3s u1 p1 c0 {2,S} {3,S}
 2   R!H u0 {1,S}
 3   CO  u0 {1,S} {4,D}
 4   O   u0 p2 {3,D}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.281,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.281,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 11,
-    label = "N3_amide_aromatic",
-    group = 
+	index = 11,
+	label = "N3_amide_aromatic",
+	group = 
 """
-1 * N3s      u1 p1 c0 {2,S} {3,S}
+1 * N3s	  u1 p1 c0 {2,S} {3,S}
 2   [Cb,N3b] u0 {1,S}
-3   CO       u0 {1,S} {4,D}
-4   O        u0 p2 {3,D}
+3   CO	   u0 {1,S} {4,D}
+4   O		u0 p2 {3,D}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = 0.091,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = 0.091,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 12,
-    label = "N3_urea_pri",
-    group = 
+	index = 12,
+	label = "N3_urea_pri",
+	group = 
 """
 1 * N3s u1 p1 c0 {2,S} {3,S}
 2   R!H u0 p0 c0 {1,S}
@@ -287,24 +300,25 @@ entry(
 5   N3s u0 p1 {3,S} {6,S}
 6   H   u0 p0 c0 {5,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = 0.0825,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = 0.0825,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 13,
-    label = "N3_urea_sec",
-    group = 
+	index = 13,
+	label = "N3_urea_sec",
+	group = 
 """
 1 * N3s u1 p1 c0 {2,S} {3,S}
 2   R!H u0 p0 c0 {1,S}
@@ -314,24 +328,25 @@ entry(
 6   R!H u0 {5,S}
 7   R!H u0 {5,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = 0.119,
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = 0.119,
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
 
 entry(
-    index = 14,
-    label = "N3d_guanidine",
-    group = 
+	index = 14,
+	label = "N3d_guanidine",
+	group = 
 """
 1   Cd  u0 {2,D} {3,S} {4,S}
 2 * N3d u1 {1,D}
@@ -342,37 +357,39 @@ entry(
 7   H   u0 {4,S}
 8   H   u0 {4,S}
 """,
-    solute = SoluteData(
-        S = 0.0,
-        B = 0.0,
-        E = 0.0,
-        L = 0.0,
-        A = -0.17
-    ),
-    shortDesc = u"""""",
-    longDesc = 
+	solute = SoluteData(
+		S = 0.0,
+		B = 0.0,
+		E = 0.0,
+		L = 0.0,
+		A = -0.17
+	),
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
 u"""
 
 """,
 )
+
 tree(
 """
 L1: R_rad
-    L2: O_rad
-        L3: ROJ
-            L4: RC(O)OJ
-            L4: ROOJ
-            L4: phenoxy
-    L2: N3s_rad
-        L3: N3_pyrrole
-        L3: N3_aniline
-        L3: N3_amide_pri
-            L4: N3_urea_pri
-        L3: N3_amide_sec
-            L4: N3_urea_pri
-            L4: N3_urea_sec
-            L4: N3_amide_aromatic
-    L2: N3d_guanidine
+	L2: O_rad
+		L3: ROJ
+			L4: RC(O)OJ
+			L4: ROOJ
+			L4: phenoxy
+	L2: N3s_rad
+		L3: N3_pyrrole
+		L3: N3_aniline
+		L3: N3_amide_pri
+			L4: N3_urea_pri
+		L3: N3_amide_sec
+			L4: N3_urea_pri
+			L4: N3_urea_sec
+			L4: N3_amide_aromatic
+	L2: N3d_guanidine
 """
 )
 

--- a/input/solvation/groups/ring.py
+++ b/input/solvation/groups/ring.py
@@ -1,0 +1,4891 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "ring"
+shortDesc = u""
+longDesc = u""" 
+All groups are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter data (manuscript in preparation)
+unless written otherwise.
+"""
+
+entry(
+	index = 1,
+	label = "Ring",
+	group = 
+"""
+1 * R u0
+""",
+	solute = None,
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 2,
+	label = "Aromatic",
+	group = 
+"""
+1 * Cb u0
+""",
+	solute = u'Benzene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 3,
+	label = "Benzene",
+	group = 
+"""
+1 * Cb u0 {2,B} {6,B}
+2   Cb u0 {1,B} {3,B}
+3   Cb u0 {2,B} {4,B}
+4   Cb u0 {3,B} {5,B}
+5   Cb u0 {4,B} {6,B}
+6   Cb u0 {1,B} {5,B}
+""",
+	solute = SoluteData(
+		S = -0.08211,
+		B = 0.03455,
+		E = -0.09106,
+		L = -0.06839,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3037,
+		B = 2925,
+		E = 3195,
+		L = 2736,
+		A = 3192,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 4,
+	label = "ThreeMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T]} {3,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
+3   R!H u0 {1,[S,D]} {2,[S,D]}
+""",
+	solute = u'Cyclopropane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 5,
+	label = "Cyclopropane",
+	group = 
+"""
+1 * Cs u0 {2,S} {3,S}
+2   Cs u0 {1,S} {3,S}
+3   Cs u0 {1,S} {2,S}
+""",
+	solute = SoluteData(
+		S = 0.08944,
+		B = 0.00000,
+		E = 0.12286,
+		L = -0.02938,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 46,
+		B = 45,
+		E = 45,
+		L = 36,
+		A = 46,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 6,
+	label = "Ethylene_oxide",
+	group = 
+"""
+1 * O2s    u0 {2,S} {3,S}
+2   [Cs,N] u0 {1,S} {3,S}
+3   [Cs,N] u0 {1,S} {2,S}
+""",
+	solute = SoluteData(
+		S = 0.26498,
+		B = -0.00442,
+		E = 0.07866,
+		L = 0.07046,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 20,
+		E = 22,
+		L = 20,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 7,
+	label = "Ethyleneimine",
+	group = 
+"""
+1 * N       u0 {2,S} {3,S}
+2   [Cs,N,S]  u0 {1,S} {3,S}
+3   [Cs,N,S]  u0 {1,S} {2,S}
+""",
+	solute = SoluteData(
+		S = 0.07140,
+		B = -0.02734,
+		E = 0.04383,
+		L = 0.07610,
+		A = 0.00704,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 8,
+	label = "FourMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D]} {4,[S,D]}
+2   R!H u0 {1,[S,D]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {1,[S,D]} {3,[S,D]}
+""",
+	solute = u'Cyclobutane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 9,
+	label = "Cyclobutane",
+	group = 
+"""
+1 * C  u0 {2,S} {4,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {1,S} {3,S}
+""",
+	solute = SoluteData(
+		S = 0.05047,
+		B = 0.00000,
+		E = 0.03551,
+		L = -0.04096,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 19,
+		B = 19,
+		E = 20,
+		L = 17,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 10,
+	label = "Oxetane",
+	group = 
+"""
+1 * O2s  u0 {2,S} {4,S}
+2   C    u0 {1,S} {3,S}
+3   C    u0 {2,S} {4,S}
+4   C    u0 {1,S} {3,S}
+""",
+	solute = SoluteData(
+		S = 0.07828,
+		B = -0.08516,
+		E = 0.08708,
+		L = 0.21831,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 10,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 11,
+	label = "Beta-Propiolactone",
+	group = 
+"""
+1 * O2s      u0 {2,S} {4,S}
+2   C        u0 {1,S} {3,S}
+3   C        u0 {2,S} {4,S}
+4   [CO,CS]  u0 {1,S} {3,S}
+""",
+	solute = SoluteData(
+		S = 0.03077,
+		B = -0.01204,
+		E = 0.05842,
+		L = 0.00337,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 12,
+	label = "Azetidine",
+	group = 
+"""
+1 * N       u0 {4,S} {2,S}
+2   [Cs,N,O,S]  u0 {1,S} {3,S}
+3   [Cs,N,O,S]  u0 {2,S} {4,S}
+4   [Cs,N,O,S]  u0 {3,S} {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05099,
+		B = -0.02619,
+		E = 0.04282,
+		L = 0.06247,
+		A = 0.02704,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 13,
+	label = "FiveMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T]} {5,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D,T]}
+5   R!H u0 {1,[S,D]} {4,[S,D,T]}
+""",
+	solute = u'Cyclopentane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 14,
+	label = "five-0double",
+	group = 
+"""
+1 * R!H u0 {2,S} {5,S}
+2   R!H u0 {1,S} {3,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,S}
+5   R!H u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = -0.04857,
+		B = 0.02233,
+		E = 0.10263,
+		L = 0.12483,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 15,
+	label = "Cyclopentane",
+	group = 
+"""
+1 * C  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.02389,
+		B = 0.00000,
+		E = 0.01582,
+		L = -0.07917,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 70,
+		B = 70,
+		E = 75,
+		L = 69,
+		A = 74,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 16,
+	label = "Cyclopentanone",
+	group = 
+"""
+1 * CO  u0 {2,S} {5,S}
+2   Cs  u0 {1,S} {3,S}
+3   Cs  u0 {2,S} {4,S}
+4   Cs  u0 {3,S} {5,S}
+5   Cs  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.04966,
+		B = 0.02069,
+		E = 0.00933,
+		L = -0.25376,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 17,
+	label = "Cyclopentanol",
+	group = 
+"""
+1 * Cs       u0 {2,S} {5,S} {6,S}
+2   [Cs,Cb]  u0 {1,S} {3,S}
+3   [Cs,Cb]  u0 {2,S} {4,S}
+4   [Cs,Cb]  u0 {3,S} {5,S}
+5   [Cs,Cb]  u0 {1,S} {4,S}
+6   O2s		 u0 {1,S} {7,S}
+7   H		 u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.09449,
+		B = 0.11164,
+		E = 0.03198,
+		L = 0.08964,
+		A = -0.00191,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 18,
+	label = "methylenecyclopentane",
+	group = 
+"""
+1 * Cd     u0 {2,S} {5,S} {6,D}
+2   Cs     u0 {1,S} {3,S}
+3   Cs     u0 {2,S} {4,S}
+4   Cs     u0 {3,S} {5,S}
+5   Cs     u0 {1,S} {4,S}
+6   [Cd,N] u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.02089,
+		B = 0.01448,
+		E = 0.02130,
+		L = -0.05434,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 19,
+	label = "Tetrahydrofuran",
+	group = 
+"""
+1 * O  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.00107,
+		B = 0.02952,
+		E = 0.02196,
+		L = -0.15476,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 37,
+		B = 37,
+		E = 39,
+		L = 34,
+		A = 38,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 20,
+	label = "butyrolactone",
+	group = 
+"""
+1   CO   u0 {2,S} {5,S}
+2 * O2s  u0 {1,S} {3,S}
+3   Cs   u0 {2,S} {4,S}
+4   Cs   u0 {3,S} {5,S}
+5   Cs   u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.09798,
+		B = 0.13193,
+		E = 0.03445,
+		L = -0.07526,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 15,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 21,
+	label = "Pyrrolidine",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = u'Pyrrolidine(N-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 22,
+	label = "Pyrrolidine(N-H)",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S} {6,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+6   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.11593,
+		B = -0.10524,
+		E = -0.00262,
+		L = 0.06511,
+		A = 0.07453,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 13,
+		L = 13,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 23,
+	label = "Pyrrolidine(N-R)",
+	group = 
+"""
+1 * N    u0 {2,S} {5,S} {6,S}
+2   C    u0 {1,S} {3,S}
+3   C    u0 {2,S} {4,S}
+4   C    u0 {3,S} {5,S}
+5   C    u0 {1,S} {4,S}
+6   R!H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.02640,
+		B = 0.03290,
+		E = 0.07170,
+		L = -0.06756,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 32,
+		B = 32,
+		E = 33,
+		L = 32,
+		A = 32,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 24,
+	label = "1,3-Dioxolane",
+	group = 
+"""
+1 * C      u0 {2,S} {5,S}
+2   O      u0 {1,S} {3,S}
+3   C      u0 {2,S} {4,S}
+4   C      u0 {3,S} {5,S}
+5   O      u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.10708,
+		B = 0.05187,
+		E = 0.03192,
+		L = 0.04193,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 12,
+		L = 11,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 25,
+	label = "thiolane",
+	group = 
+"""
+1 * S u0 {2,S} {5,S}
+2   C u0 {1,S} {3,S}
+3   C u0 {2,S} {4,S}
+4   C u0 {3,S} {5,S}
+5   C u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.00514,
+		B = 0.05321,
+		E = 0.07800,
+		L = 0.04336,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 26,
+	label = "Imidazolidine",
+	group = 
+"""
+1 * N u0 {2,S} {5,S}
+2   C u0 {1,S} {3,S}
+3   N u0 {2,S} {4,S}
+4   C u0 {3,S} {5,S}
+5   C u0 {1,S} {4,S}
+""",
+	solute = u'imidazolidine-2,4-dione',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 27,
+	label = "imidazolidine-2,4-dione",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S}
+2   CO u0 {1,S} {3,S}
+3   N  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   CO u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.11276,
+		B = 0.02014,
+		E = -0.02176,
+		L = 0.13047,
+		A = 0.08853,
+	),
+	dataCount = DataCountGAV(
+		S = 17,
+		B = 17,
+		E = 17,
+		L = 10,
+		A = 17,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 28,
+	label = "five-1double",
+	group = 
+"""
+1 * R!H u0 {2,S} {5,S}
+2   R!H u0 {1,S} {3,D}
+3   R!H u0 {2,D} {4,S}
+4   R!H u0 {3,S} {5,S}
+5   R!H u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = -0.01665,
+		B = 0.03634,
+		E = 0.05573,
+		L = 0.12296,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 8,
+		L = 5,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 29,
+	label = "Cyclopentene",
+	group = 
+"""
+1 * C  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.06054,
+		B = 0.00866,
+		E = -0.00089,
+		L = 0.08210,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 14,
+		B = 14,
+		E = 15,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 30,
+	label = "2-pyrroline",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.02913,
+		B = -0.04147,
+		E = -0.10757,
+		L = 0.04343,
+		A = 0.04506,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 31,
+	label = "3-pyrroline",
+	group = 
+"""
+1 * C  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   N  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.05384,
+		B = -0.10975,
+		E = -0.00421,
+		L = -0.10537,
+		A = 0.03208,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 32,
+	label = "2-pyrazoline",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S}
+2   N  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = -0.14489,
+		B = -0.03317,
+		E = 0.01938,
+		L = -0.18258,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 12,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 33,
+	label = "2-imidazoline",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   N  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.15325,
+		B = -0.00728,
+		E = -0.07526,
+		L = 0.24613,
+		A = 0.05429,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 34,
+	label = "five-N1NC=CC1",
+	group = 
+"""
+1 * N  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   N  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.02465,
+		B = 0.19015,
+		E = -0.01792,
+		L = 0.29907,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 35,
+	label = "2,5-Dihydrofuran",
+	group = 
+"""
+1 * C  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   O  u0 {1,S} {4,S}
+""",
+	solute = u'5H-furan-2-one',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 36,
+	label = "5H-furan-2-one",
+	group = 
+"""
+1 * C  u0 {2,S} {5,S}
+2   C  u0 {1,S} {3,D}
+3   C  u0 {2,D} {4,S}
+4   CO u0 {3,S} {5,S}
+5   O  u0 {1,S} {4,S}
+""",
+	solute = SoluteData(
+		S = 0.14770,
+		B = 0.07187,
+		E = 0.00883,
+		L = 0.27225,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 6,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 37,
+	label = "five-2double",
+	group = 
+"""
+1 * R!H u0 {2,S} {5,S}
+2   R!H u0 {1,S} {3,D}
+3   R!H u0 {2,D} {4,S}
+4   R!H u0 {3,S} {5,D}
+5   R!H u0 {1,S} {4,D}
+""",
+	solute = u'Furan',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 38,
+	label = "Cyclopentadiene",
+	group = 
+"""
+1 * C     u0 {2,S} {5,S}
+2   Cd    u0 {1,S} {3,D}
+3   Cd    u0 {2,D} {4,S}
+4   Cd    u0 {3,S} {5,D}
+5   Cd    u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = -0.03717,
+		B = -0.01300,
+		E = -0.03319,
+		L = -0.03893,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 3,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 39,
+	label = "Furan",
+	group = 
+"""
+1 * O      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.02936,
+		B = -0.00815,
+		E = 0.03637,
+		L = 0.26485,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 51,
+		B = 50,
+		E = 56,
+		L = 32,
+		A = 61,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 40,
+	label = "1H-Pyrrole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.09574,
+		B = -0.05707,
+		E = 0.02275,
+		L = 0.18058,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 17,
+		L = 12,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 41,
+	label = "Thiophene",
+	group = 
+"""
+1 * S    u0 {2,S} {5,S}
+2   Cd   u0 {1,S} {3,D}
+3   Cd   u0 {2,D} {4,S}
+4   Cd   u0 {3,S} {5,D}
+5   Cd   u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = -0.00182,
+		B = -0.00298,
+		E = 0.07126,
+		L = 0.14607,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 21,
+		L = 20,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 42,
+	label = "Pyrazole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   N      u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.05857,
+		B = -0.04645,
+		E = 0.05620,
+		L = 0.25672,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 9,
+		E = 13,
+		L = 11,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 43,
+	label = "Imidazole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D}
+3   N      u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.00875,
+		B = 0.01088,
+		E = -0.03837,
+		L = 0.13736,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 16,
+		E = 22,
+		L = 14,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 44,
+	label = "2-Nitroimidazole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D} {6,S}
+3   N      u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+6   N5dc   u0 {2,S} {7,D} {8,S}
+7   O2d    u0 {6,D}
+8   O0sc   u0 {6,S}
+""",
+	solute = SoluteData(
+		S = 0.05294,
+		B = -0.00271,
+		E = -0.08480,
+		L = 0.06636,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 7,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 45,
+	label = "1,2,4-Triazole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   N      u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   N      u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.11808,
+		B = 0.00069,
+		E = 0.01312,
+		L = 0.28014,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 22,
+		B = 22,
+		E = 22,
+		L = 20,
+		A = 22,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 46,
+	label = "Tetrazole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   N      u0 {1,S} {3,D}
+3   N      u0 {2,D} {4,S}
+4   N      u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = -0.02691,
+		B = 0.03029,
+		E = 0.02081,
+		L = 0.14437,
+		A = 0.03053,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 7,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 47,
+	label = "2H-Tetrazole",
+	group = 
+"""
+1 * N      u0 {2,S} {5,S}
+2   N      u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   N      u0 {3,S} {5,D}
+5   N      u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.18461,
+		B = -0.03115,
+		E = 0.16165,
+		L = 0.61297,
+		A = 0.02963,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 48,
+	label = "Oxazole",
+	group = 
+"""
+1 * O      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D}
+3   N      u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.03086,
+		B = 0.04483,
+		E = -0.05703,
+		L = 0.06932,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 49,
+	label = "Isoxazole",
+	group = 
+"""
+1 * O      u0 {2,S} {5,S}
+2   N      u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.09827,
+		B = 0.04350,
+		E = 0.09967,
+		L = 0.45513,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 10,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 50,
+	label = "Thiazole",
+	group = 
+"""
+1 * S      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D}
+3   N      u0 {2,D} {4,S}
+4   Cd     u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = 0.21117,
+		B = 0.01353,
+		E = 0.06885,
+		L = 0.35218,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 26,
+		B = 25,
+		E = 31,
+		L = 18,
+		A = 29,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 51,
+	label = "1,2,4-Thiadiazole",
+	group = 
+"""
+1 * S      u0 {2,S} {5,S}
+2   N      u0 {1,S} {3,D}
+3   Cd     u0 {2,D} {4,S}
+4   N      u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = -0.01544,
+		B = 0.02840,
+		E = 0.10558,
+		L = 0.17477,
+		A = 0.02649,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 52,
+	label = "1,3,4-Thiadiazole",
+	group = 
+"""
+1 * S      u0 {2,S} {5,S}
+2   Cd     u0 {1,S} {3,D}
+3   N      u0 {2,D} {4,S}
+4   N      u0 {3,S} {5,D}
+5   Cd     u0 {1,S} {4,D}
+""",
+	solute = SoluteData(
+		S = -0.05576,
+		B = 0.00184,
+		E = 0.01926,
+		L = -0.00711,
+		A = -0.02186,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 53,
+	label = "SixMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T]} {6,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D,T]}
+4   R!H u0 {3,[S,D,T]} {5,[S,D]}
+5   R!H u0 {4,[S,D]} {6,[S,D,T]}
+6   R!H u0 {1,[S,D]} {5,[S,D,T]}
+""",
+	solute = u'Cyclohexane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 54,
+	label = "six-0double",
+	group = 
+"""
+1 * R!H  u0 {2,S} {6,S}
+2   R!H  u0 {1,S} {3,S}
+3   R!H  u0 {2,S} {4,S}
+4   R!H  u0 {3,S} {5,S}
+5   R!H  u0 {4,S} {6,S}
+6   R!H  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.00862,
+		B = -0.02503,
+		E = 0.00687,
+		L = -0.11632,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 55,
+	label = "Cyclohexane",
+	group = 
+"""
+1 * C  u0 {2,S} {6,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02883,
+		B = 0.00000,
+		E = 0.00866,
+		L = -0.03759,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 140,
+		B = 128,
+		E = 150,
+		L = 133,
+		A = 150,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 56,
+	label = "Cyclohexanone",
+	group = 
+"""
+1 * CO u0 {2,S} {6,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.00752,
+		B = -0.01727,
+		E = -0.01754,
+		L = -0.32084,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 57,
+	label = "Cyclohexanol",
+	group = 
+"""
+1 * Cs  u0 {2,S} {6,S} {7,S}
+2   Cs  u0 {1,S} {3,S}
+3   Cs  u0 {2,S} {4,S}
+4   Cs  u0 {3,S} {5,S}
+5   Cs  u0 {4,S} {6,S}
+6   Cs  u0 {1,S} {5,S}
+7   O2s u0 {1,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.07636,
+		B = 0.04768,
+		E = -0.01796,
+		L = -0.25025,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 20,
+		B = 21,
+		E = 27,
+		L = 20,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 58,
+	label = "N-Cyclohexylacetamide",
+	group = 
+"""
+1 * Cs  u0 {2,S} {6,S} {7,S}
+2   Cs  u0 {1,S} {3,S}
+3   Cs  u0 {2,S} {4,S}
+4   Cs  u0 {3,S} {5,S}
+5   Cs  u0 {4,S} {6,S}
+6   Cs  u0 {1,S} {5,S}
+7   N3s u0 {1,S} {8,S} {10,S}
+8   CO  u0 {7,S} {9,S}
+9   Cs  u0 {8,S} {11,S} {12,S} {13,S}
+10  H   u0 {7,S}
+11  H   u0 {9,S}
+12  H   u0 {9,S}
+13  H   u0 {9,S}
+""",
+	solute = SoluteData(
+		S = 0.10298,
+		B = 0.06161,
+		E = -0.06255,
+		L = -0.00249,
+		A = 0.05654,
+	),
+	dataCount = DataCountGAV(
+		S = 12,
+		B = 12,
+		E = 14,
+		L = 13,
+		A = 12,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 59,
+	label = "1,3-Dioxane",
+	group = 
+"""
+1   O2s u0 {2,S} {6,S}
+2 * Cs u0 {1,S} {3,S}
+3   O2s u0 {2,S} {4,S}
+4   Cs u0 {3,S} {5,S}
+5   Cs u0 {4,S} {6,S}
+6   Cs u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.15619,
+		B = 0.02040,
+		E = 0.03079,
+		L = 0.34104,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 6,
+		L = 4,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 60,
+	label = "1,4-Dioxane",
+	group = 
+"""
+1   Cs u0 {2,S} {6,S}
+2   Cs u0 {1,S} {3,S}
+3 * O2s u0 {2,S} {4,S}
+4   Cs u0 {3,S} {5,S}
+5   Cs u0 {4,S} {6,S}
+6   O2s u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02654,
+		B = -0.00711,
+		E = 0.05594,
+		L = 0.06724,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 61,
+	label = "1,3,5-Trioxane",
+	group = 
+"""
+1   Cs u0 {2,S} {6,S}
+2   O2s u0 {1,S} {3,S}
+3   Cs u0 {2,S} {4,S}
+4 * O2s u0 {3,S} {5,S}
+5   Cs u0 {4,S} {6,S}
+6   O2s u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.07825,
+		B = 0.00203,
+		E = -0.03849,
+		L = 0.09794,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 62,
+	label = "Oxane",
+	group = 
+"""
+1 * C   u0 {2,S} {6,S}
+2   O2s u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.05249,
+		B = -0.04367,
+		E = 0.03659,
+		L = -0.08531,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 43,
+		B = 43,
+		E = 44,
+		L = 39,
+		A = 44,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 63,
+	label = "4-Hydroxyoxan-2-one",
+	group = 
+"""
+1 * CO  u0 {2,S} {6,S}
+2   O2s u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S} {7,S}
+6   C   u0 {1,S} {5,S}
+7   O   u0 {5,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.03292,
+		B = 0.02288,
+		E = -0.06405,
+		L = 0.01672,
+		A = 0.02481,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 64,
+	label = "Piperidine",
+	group = 
+"""
+1 * N  u0 {2,S} {6,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {1,S} {5,S}
+""",
+	solute = u'Piperidine(N-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 65,
+	label = "Piperidine(N-H)",
+	group = 
+"""
+1 * N  u0 {2,S} {6,S} {7,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {1,S} {5,S}
+7   H  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.06484,
+		B = -0.03563,
+		E = 0.03502,
+		L = -0.06851,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 21,
+		B = 21,
+		E = 23,
+		L = 18,
+		A = 21,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 66,
+	label = "Piperidine(N-R)",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   R!H u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.00587,
+		B = 0.04542,
+		E = 0.03765,
+		L = 0.07983,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 53,
+		B = 53,
+		E = 54,
+		L = 47,
+		A = 53,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 67,
+	label = "1-Piperidinecarboxaldehyde",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   CO  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06312,
+		B = 0.15569,
+		E = -0.01468,
+		L = -0.07140,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 8,
+		L = 4,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 68,
+	label = "Piperidine-2,6-dione",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   CO  u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   CO  u0 {1,S} {5,S}
+7   R!H u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.06255,
+		B = -0.11688,
+		E = -0.04693,
+		L = -0.34557,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 69,
+	label = "Piperazine",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   N   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'Piperazine(N-R,N-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 70,
+	label = "Piperazine(N-H,N-H)",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   N   u0 {3,S} {5,S} {8,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   H   u0 {1,S}
+8   H   u0 {4,S}
+""",
+	solute = SoluteData(
+		S = 0.06403,
+		B = 0.01781,
+		E = 0.02413,
+		L = 0.10650,
+		A = 0.04340,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 71,
+	label = "Piperazine(N-H,N-R)",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   N   u0 {3,S} {5,S} {8,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   H   u0 {1,S}
+8   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.04453,
+		B = 0.07822,
+		E = -0.00584,
+		L = -0.01954,
+		A = 0.02095,
+	),
+	dataCount = DataCountGAV(
+		S = 11,
+		B = 11,
+		E = 11,
+		L = 11,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 72,
+	label = "Piperazine(N-R,N-R)",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   N   u0 {3,S} {5,S} {8,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   R!H u0 {1,S}
+8   R!H u0 {4,S}
+""",
+	solute = SoluteData(
+		S = -0.16121,
+		B = -0.01928,
+		E = 0.01774,
+		L = -0.01659,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 44,
+		B = 44,
+		E = 46,
+		L = 42,
+		A = 45,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 73,
+	label = "Morpholine",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   O   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'Morpholine(N-R)',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 74,
+	label = "Morpholine(N-H)",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   O   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   H   u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.01327,
+		B = -0.06638,
+		E = -0.07542,
+		L = -0.03160,
+		A = 0.04649,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 75,
+	label = "Morpholine(N-R)",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   O   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+7   R!H u0 {1,S}
+""",
+	solute = SoluteData(
+		S = 0.05837,
+		B = -0.04950,
+		E = 0.05420,
+		L = -0.09903,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 9,
+		B = 9,
+		E = 10,
+		L = 9,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 76,
+	label = "1,3-Diazinane",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   C   u0 {1,S} {3,S}
+3   N   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'1,3-Diazinane-2,4,6-trione',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 77,
+	label = "1,3-Diazinane-2,4,6-trione",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   CO  u0 {1,S} {3,S}
+3   N   u0 {2,S} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   CO  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.09205,
+		B = 0.15211,
+		E = 0.10004,
+		L = -0.02775,
+		A = 0.04082,
+	),
+	dataCount = DataCountGAV(
+		S = 56,
+		B = 56,
+		E = 57,
+		L = 15,
+		A = 56,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 78,
+	label = "2-Sulfanylidene-1,3-diazinane-4,6-dione",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   CS  u0 {1,S} {3,S}
+3   N   u0 {2,S} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   CO  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.03277,
+		B = 0.00993,
+		E = 0.03043,
+		L = 0.09017,
+		A = 0.03900,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 79,
+	label = "1,3,5-Triazinane",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   C   u0 {1,S} {3,S}
+3   N   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   N   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.04044,
+		B = -0.09095,
+		E = 0.00405,
+		L = 0.13839,
+		A = 0.16025,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 80,
+	label = "1,3,2-Dioxaphosphorinane",
+	group = 
+"""
+1 * P   u0 {2,S} {6,S}
+2   O   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   O   u0 {1,S} {5,S}
+""",
+	solute = u'1,3,2-Dioxaphosphorinane-2-oxide',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 81,
+	label = "1,3,2-Dioxaphosphorinane-2-oxide",
+	group = 
+"""
+1 * P5d u0 {2,S} {6,S} {7,D}
+2   O   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   O   u0 {1,S} {5,S}
+7   O2d u0 {1,D}
+""",
+	solute = SoluteData(
+		S = 0.28243,
+		B = -0.10632,
+		E = 0.11941,
+		L = 0.68994,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 82,
+	label = "six-1double",
+	group = 
+"""
+1   R!H  u0 {2,S} {6,S}
+2 * R!H  u0 {1,S} {3,D}
+3   R!H  u0 {2,D} {4,S}
+4   R!H  u0 {3,S} {5,S}
+5   R!H  u0 {4,S} {6,S}
+6   R!H  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.06432,
+		B = 0.05672,
+		E = 0.07427,
+		L = 0.23213,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 83,
+	label = "Cyclohexene",
+	group = 
+"""
+1   C  u0 {2,S} {6,S}
+2   C  u0 {1,S} {3,S}
+3 * Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02591,
+		B = 0.00923,
+		E = 0.00877,
+		L = 0.06028,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 66,
+		B = 54,
+		E = 67,
+		L = 58,
+		A = 67,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 84,
+	label = "Tetrahydropyrimidine",
+	group = 
+"""
+1   N  u0 {2,S} {6,S}
+2   C  u0 {1,S} {3,S}
+3 * Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   N  u0 {4,S} {6,S}
+6   C  u0 {1,S} {5,S}
+""",
+	solute = u'Uracil',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 85,
+	label = "Uracil",
+	group = 
+"""
+1   N  u0 {2,S} {6,S}
+2   CO u0 {1,S} {3,S}
+3 * Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   N  u0 {4,S} {6,S}
+6   CO u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.06262,
+		B = 0.00158,
+		E = -0.00151,
+		L = 0.04941,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 60,
+		B = 60,
+		E = 63,
+		L = 55,
+		A = 61,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 86,
+	label = "1,2,3,6-Tetrahydropyridine",
+	group = 
+"""
+1   N   u0 {2,S} {6,S}
+2   C   u0 {1,S} {3,S}
+3 * Cd  u0 {2,S} {4,D}
+4   Cd  u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.00389,
+		B = -0.03247,
+		E = 0.07600,
+		L = 0.10213,
+		A = 0.00315,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 87,
+	label = "1,4,5,6-Tetrahydropyridazine",
+	group = 
+"""
+1   C   u0 {2,S} {6,S}
+2   N3s u0 {1,S} {3,S}
+3 * N3d u0 {2,S} {4,D}
+4   Cd  u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'4,5-Dihydro-2H-pyridazin-3-one',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 88,
+	label = "4,5-Dihydro-2H-pyridazin-3-one",
+	group = 
+"""
+1   CO  u0 {2,S} {6,S}
+2   N3s u0 {1,S} {3,S}
+3 * N3d u0 {2,S} {4,D}
+4   Cd  u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.02390,
+		B = 0.00677,
+		E = 0.01159,
+		L = -0.10729,
+		A = 0.06687,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 3,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 89,
+	label = "six-2double-1,3",
+	group = 
+"""
+1 * R!H  u0 {2,S} {6,S}
+2   R!H  u0 {1,S} {3,D}
+3   R!H  u0 {2,D} {4,S}
+4   R!H  u0 {3,S} {5,D}
+5   R!H  u0 {4,D} {6,S}
+6   R!H  u0 {1,S} {5,S}
+""",
+	solute = u'1,3-Cyclohexadiene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 90,
+	label = "1,3-Cyclohexadiene",
+	group = 
+"""
+1 * C   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   Cd  u0 {4,D} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = -0.03540,
+		B = 0.00316,
+		E = 0.04465,
+		L = 0.10760,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 9,
+		L = 7,
+		A = 9,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 91,
+	label = "1,2-Dihydropyridine",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   Cd  u0 {4,D} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.02281,
+		B = 0.07135,
+		E = -0.05827,
+		L = -0.03410,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 5,
+		E = 6,
+		L = 6,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 92,
+	label = "2,3-Dihydropyridine",
+	group = 
+"""
+1 * C   u0 {2,S} {6,S}
+2   N   u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   Cd  u0 {4,D} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'1,2-Dihydropyridine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 93,
+	label = "1,2-Dihydropyrimidine",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   N   u0 {4,D} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'1H-Pyrimidin-2-one',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 94,
+	label = "1H-Pyrimidin-2-one",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   N   u0 {4,D} {6,S}
+6   CO  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.00569,
+		B = 0.08118,
+		E = 0.03568,
+		L = -0.16033,
+		A = -0.03955,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 6,
+		E = 7,
+		L = 5,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 95,
+	label = "N1C=NC=CC1",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   N   u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   Cd  u0 {4,D} {6,S}
+6   C   u0 {1,S} {5,S}
+""",
+	solute = u'3H-Pyrimidin-4-one',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 96,
+	label = "3H-Pyrimidin-4-one",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   N   u0 {2,D} {4,S}
+4   Cd  u0 {3,S} {5,D}
+5   Cd  u0 {4,D} {6,S}
+6   CO  u0 {1,S} {5,S}
+""",
+	solute = SoluteData(
+		S = 0.06823,
+		B = -0.01484,
+		E = 0.05632,
+		L = 0.10899,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 5,
+		E = 7,
+		L = 2,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 97,
+	label = "six-2double-1,4",
+	group = 
+"""
+1 * R!H  u0 {2,S} {6,S}
+2   R!H  u0 {1,S} {3,D}
+3   R!H  u0 {2,D} {4,S}
+4   R!H  u0 {3,S} {5,S}
+5   R!H  u0 {4,S} {6,D}
+6   R!H  u0 {1,S} {5,D}
+""",
+	solute = u'1,4-Dihydropyridine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 98,
+	label = "1,4-Cyclohexadiene",
+	group = 
+"""
+1 * C  u0 {2,S} {6,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = 0.01625,
+		B = 0.01045,
+		E = 0.04315,
+		L = 0.22985,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 99,
+	label = "p-Benzoquinone",
+	group = 
+"""
+1 * CO  u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S}
+4   CO  u0 {3,S} {5,S}
+5   Cd  u0 {4,S} {6,D}
+6   Cd  u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = -0.26091,
+		B = -0.05845,
+		E = 0.02068,
+		L = -0.29764,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 8,
+		B = 8,
+		E = 8,
+		L = 8,
+		A = 11,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 100,
+	label = "1,4-Dihydropyridine",
+	group = 
+"""
+1 * N  u0 {2,S} {6,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = -0.02787,
+		B = -0.01409,
+		E = 0.01803,
+		L = 0.30997,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 101,
+	label = "3,4-Dihydroxypyridine",
+	group = 
+"""
+1 * N   u0 {2,S} {6,S}
+2   Cd  u0 {1,S} {3,D}
+3   Cd  u0 {2,D} {4,S} {7,S}
+4   CO  u0 {3,S} {5,S}
+5   Cd  u0 {4,S} {6,D}
+6   Cd  u0 {1,S} {5,D}
+7   O2s u0 {3,S} {8,S}
+8   H   u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.07515,
+		B = 0.11103,
+		E = 0.01227,
+		L = 0.01058,
+		A = 0.11713,
+	),
+	dataCount = DataCountGAV(
+		S = 18,
+		B = 18,
+		E = 18,
+		L = 1,
+		A = 18,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 102,
+	label = "4H-Pyran",
+	group = 
+"""
+1 * O  u0 {2,S} {6,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   C  u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = 0.03439,
+		B = 0.00080,
+		E = 0.08281,
+		L = 0.23859,
+		A = 0.10000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 103,
+	label = "3-Hydroxypyran-4-one",
+	group = 
+"""
+1 * O  u0 {2,S} {6,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   CO u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D} {7,S}
+6   Cd u0 {1,S} {5,D}
+7   O  u0 {5,S} {8,S}
+8   H  u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.04191,
+		B = 0.02863,
+		E = 0.08525,
+		L = 0.30922,
+		A = 0.09491,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 104,
+	label = "six-3double",
+	group = 
+"""
+1 * R!H  u0 {2,D} {6,S}
+2   R!H  u0 {1,D} {3,S}
+3   R!H  u0 {2,S} {4,D}
+4   R!H  u0 {3,D} {5,S}
+5   R!H  u0 {4,S} {6,D}
+6   R!H  u0 {1,S} {5,D}
+""",
+	solute = u'Pyridine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 105,
+	label = "Pyridine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   C   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = -0.04652,
+		B = 0.06745,
+		E = -0.04982,
+		L = -0.00812,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 202,
+		B = 151,
+		E = 232,
+		L = 184,
+		A = 226,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 106,
+	label = "Pyridine-N-oxide",
+	group = 
+"""
+1 * N5dc  u0 {2,D} {6,S} {7,S}
+2   C     u0 {1,D} {3,S}
+3   C     u0 {2,S} {4,D}
+4   C     u0 {3,D} {5,S}
+5   C     u0 {4,S} {6,D}
+6   C     u0 {1,S} {5,D}
+7   O0sc  u0 {1,S}
+""",
+	solute = SoluteData(
+		S = -0.01816,
+		B = 0.10560,
+		E = 0.06933,
+		L = 0.08089,
+		A = 0.07458,
+	),
+	dataCount = DataCountGAV(
+		S = 13,
+		B = 13,
+		E = 13,
+		L = 13,
+		A = 13,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 107,
+	label = "Isonicotinamide",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   C   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S} {7,S}
+5   C   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+7   CO  u0 {4,S} {8,S}
+8   N3s u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00166,
+		B = 0.04407,
+		E = -0.03798,
+		L = 0.06717,
+		A = 0.18332,
+	),
+	dataCount = DataCountGAV(
+		S = 35,
+		B = 35,
+		E = 35,
+		L = 35,
+		A = 35,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 108,
+	label = "NicotinicAcidEster",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   C   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,D} {7,S}
+6   C   u0 {1,S} {5,D}
+7   CO  u0 {5,S} {8,S}
+8   O2s u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.07264,
+		B = 0.00023,
+		E = -0.04917,
+		L = -0.08813,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 10,
+		B = 10,
+		E = 10,
+		L = 8,
+		A = 10,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 109,
+	label = "Pyridazine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   C   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,D}
+6   N   u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = 0.11794,
+		B = -0.01258,
+		E = 0.03256,
+		L = 0.23892,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 110,
+	label = "Pyrimidine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   C   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   N   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = 0.06005,
+		B = 0.01742,
+		E = -0.01599,
+		L = 0.02219,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 44,
+		B = 45,
+		E = 47,
+		L = 42,
+		A = 49,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 111,
+	label = "Pyrazine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   C   u0 {2,S} {4,D}
+4   N   u0 {3,D} {5,S}
+5   C   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+""",
+	solute = SoluteData(
+		S = 0.04189,
+		B = -0.02262,
+		E = -0.10548,
+		L = -0.00391,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 45,
+		B = 45,
+		E = 52,
+		L = 31,
+		A = 53,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 112,
+	label = "1,3,5-Triazine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S}
+3   N   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   N   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+""",
+	solute = u'2-Methylsulfanyl-1,3,5-triazine',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 113,
+	label = "2-Methylsulfanyl-1,3,5-triazine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S} {7,S}
+3   N   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   N   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+7   S2s u0 {2,S} {8,S}
+8   Cs  u0 {7,S}
+""",
+	solute = SoluteData(
+		S = 0.02772,
+		B = 0.00427,
+		E = -0.04375,
+		L = -0.04546,
+		A = -0.06201,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 114,
+	label = "2-Methoxy-1,3,5-triazine",
+	group = 
+"""
+1 * N   u0 {2,D} {6,S}
+2   C   u0 {1,D} {3,S} {7,S}
+3   N   u0 {2,S} {4,D}
+4   C   u0 {3,D} {5,S}
+5   N   u0 {4,S} {6,D}
+6   C   u0 {1,S} {5,D}
+7   O2s u0 {2,S} {8,S}
+8   Cs  u0 {7,S}
+""",
+	solute = SoluteData(
+		S = -0.04153,
+		B = 0.06045,
+		E = -0.05898,
+		L = -0.00615,
+		A = -0.02708,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 7,
+		L = 6,
+		A = 7,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 115,
+	label = "SevenMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D,T]} {7,[S,D]}
+2   R!H u0 {1,[S,D,T]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H u0 {4,[S,D]} {6,[S,D]}
+6   R!H u0 {5,[S,D]} {7,[S,D]}
+7   R!H u0 {1,[S,D]} {6,[S,D]}
+""",
+	solute = u'Cycloheptane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 116,
+	label = "seven-0double",
+	group = 
+"""
+1 * R!H u0 {2,S} {7,S}
+2   R!H u0 {1,S} {3,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,S}
+5   R!H u0 {4,S} {6,S}
+6   R!H u0 {5,S} {7,S}
+7   R!H u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03666,
+		B = 0.06054,
+		E = -0.01122,
+		L = 0.17728,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 117,
+	label = "Cycloheptane",
+	group = 
+"""
+1 * C  u0 {2,S} {7,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03156,
+		B = 0.00000,
+		E = 0.03666,
+		L = -0.02859,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 16,
+		B = 16,
+		E = 16,
+		L = 15,
+		A = 16,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 118,
+	label = "Oxepane",
+	group = 
+"""
+1 * O2s u0 {2,S} {7,S}
+2   C   u0 {1,S} {3,S}
+3   C   u0 {2,S} {4,S}
+4   C   u0 {3,S} {5,S}
+5   C   u0 {4,S} {6,S}
+6   C   u0 {5,S} {7,S}
+7   C   u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.00354,
+		B = 0.14608,
+		E = -0.06788,
+		L = 0.10552,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 2,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 119,
+	label = "seven-0double_N",
+	group = 
+"""
+1 * N  u0 {2,S} {7,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.05043,
+		B = 0.06559,
+		E = 0.02447,
+		L = -0.02088,
+		A = 0.00598,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 6,
+		L = 4,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 120,
+	label = "seven-1double",
+	group = 
+"""
+1 * R!H u0 {2,S} {7,S}
+2   R!H u0 {1,S} {3,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,D}
+5   R!H u0 {4,D} {6,S}
+6   R!H u0 {5,S} {7,S}
+7   R!H u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.13718,
+		B = -0.04473,
+		E = -0.08816,
+		L = -0.29254,
+		A = -0.00069,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 121,
+	label = "Cycloheptene",
+	group = 
+"""
+1 * C  u0 {2,S} {7,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   Cd u0 {3,S} {5,D}
+5   Cd u0 {4,D} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = -0.01654,
+		B = 0.01326,
+		E = -0.00236,
+		L = 0.05312,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 122,
+	label = "seven-2double-1,3",
+	group = 
+"""
+1 * R!H u0 {2,S} {7,S}
+2   R!H u0 {1,S} {3,S}
+3   R!H u0 {2,S} {4,D}
+4   R!H u0 {3,D} {5,S}
+5   R!H u0 {4,S} {6,D}
+6   R!H u0 {5,D} {7,S}
+7   R!H u0 {1,S} {6,S}
+""",
+	solute = SoluteData(
+		S = 0.03404,
+		B = -0.03575,
+		E = 0.03007,
+		L = 0.05843,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 123,
+	label = "seven-3double-1,3,5",
+	group = 
+"""
+1 * R!H u0 {2,S} {7,S}
+2   R!H u0 {1,S} {3,D}
+3   R!H u0 {2,D} {4,S}
+4   R!H u0 {3,S} {5,D}
+5   R!H u0 {4,D} {6,S}
+6   R!H u0 {5,S} {7,D}
+7   R!H u0 {1,S} {6,D}
+""",
+	solute = u'1,3,5-Cycloheptatriene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 124,
+	label = "1,3,5-Cycloheptatriene",
+	group = 
+"""
+1 * C  u0 {2,S} {7,S}
+2   Cd u0 {1,S} {3,D}
+3   Cd u0 {2,D} {4,S}
+4   Cd u0 {3,S} {5,D}
+5   Cd u0 {4,D} {6,S}
+6   Cd u0 {5,S} {7,D}
+7   Cd u0 {1,S} {6,D}
+""",
+	solute = SoluteData(
+		S = 0.05462,
+		B = 0.00045,
+		E = 0.00191,
+		L = 0.11308,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 125,
+	label = "EightMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D]} {8,[S,D]}
+2   R!H u0 {1,[S,D]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H u0 {4,[S,D]} {6,[S,D]}
+6   R!H u0 {5,[S,D]} {7,[S,D]}
+7   R!H u0 {6,[S,D]} {8,[S,D]}
+8   R!H u0 {1,[S,D]} {7,[S,D]}
+""",
+	solute = u'Cyclooctane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 126,
+	label = "eight-0double",
+	group = 
+"""
+1 * R!H u0 {2,S} {8,S}
+2   R!H u0 {1,S} {3,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,S}
+5   R!H u0 {4,S} {6,S}
+6   R!H u0 {5,S} {7,S}
+7   R!H u0 {6,S} {8,S}
+8   R!H u0 {1,S} {7,S}
+""",
+	solute = u'Cyclooctane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 127,
+	label = "Cyclooctane",
+	group = 
+"""
+1 * C  u0 {2,S} {8,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {6,S} {8,S}
+8   C  u0 {1,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.08204,
+		B = 0.00000,
+		E = -0.03351,
+		L = -0.04409,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 15,
+		B = 15,
+		E = 15,
+		L = 14,
+		A = 15,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 128,
+	label = "Azocane",
+	group = 
+"""
+1 * N  u0 {2,S} {8,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {6,S} {8,S}
+8   C  u0 {1,S} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.04326,
+		B = 0.01385,
+		E = -0.00953,
+		L = 0.00592,
+		A = -0.00529,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 129,
+	label = "Octasulfur",
+	group = 
+"""
+1 * S2s u0 {2,S} {8,S}
+2   S2s u0 {1,S} {3,S}
+3   S2s u0 {2,S} {4,S}
+4   S2s u0 {3,S} {5,S}
+5   S2s u0 {4,S} {6,S}
+6   S2s u0 {5,S} {7,S}
+7   S2s u0 {6,S} {8,S}
+8   S2s u0 {1,S} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.01041,
+		B = 0.00000,
+		E = 0.01201,
+		L = 0.07767,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 130,
+	label = "eight-1double",
+	group = 
+"""
+1 * R!H  u0 {2,D} {8,S}
+2   R!H  u0 {1,D} {3,S}
+3   R!H  u0 {2,S} {4,S}
+4   R!H  u0 {3,S} {5,S}
+5   R!H  u0 {4,S} {6,S}
+6   R!H  u0 {5,S} {7,S}
+7   R!H  u0 {6,S} {8,S}
+8   R!H  u0 {1,S} {7,S}
+""",
+	solute = u'Cyclooctene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 131,
+	label = "Cyclooctene",
+	group = 
+"""
+1 * Cd u0 {2,D} {8,S}
+2   Cd u0 {1,D} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {6,S} {8,S}
+8   C  u0 {1,S} {7,S}
+""",
+	solute = SoluteData(
+		S = -0.00706,
+		B = 0.00243,
+		E = 0.01477,
+		L = 0.05954,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 2,
+		B = 2,
+		E = 2,
+		L = 2,
+		A = 2,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 132,
+	label = "eight-2double-1,3",
+	group = 
+"""
+1 * R!H u0 {2,D} {8,S}
+2   R!H u0 {1,D} {3,S}
+3   R!H u0 {2,S} {4,D}
+4   R!H u0 {3,D} {5,S}
+5   R!H u0 {4,S} {6,S}
+6   R!H u0 {5,S} {7,S}
+7   R!H u0 {6,S} {8,S}
+8   R!H u0 {1,S} {7,S}
+""",
+	solute = u'1,3-cyclooctadiene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 133,
+	label = "1,3-cyclooctadiene",
+	group = 
+"""
+1 * Cd u0 {2,D} {8,S}
+2   Cd u0 {1,D} {3,S}
+3   Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {6,S} {8,S}
+8   C  u0 {1,S} {7,S}
+""",
+	solute = u'1,5-cyclooctadiene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 134,
+	label = "eight-2double-1,5",
+	group = 
+"""
+1 * R!H u0 {2,D} {8,S}
+2   R!H u0 {1,D} {3,S}
+3   R!H u0 {2,S} {4,S}
+4   R!H u0 {3,S} {5,S}
+5   R!H u0 {4,S} {6,D}
+6   R!H u0 {5,D} {7,S}
+7   R!H u0 {6,S} {8,S}
+8   R!H u0 {1,S} {7,S}
+""",
+	solute = u'1,5-cyclooctadiene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 135,
+	label = "1,5-cyclooctadiene",
+	group = 
+"""
+1 * Cd u0 {2,D} {8,S}
+2   Cd u0 {1,D} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {5,D} {7,S}
+7   C  u0 {6,S} {8,S}
+8   C  u0 {1,S} {7,S}
+""",
+	solute = SoluteData(
+		S = 0.00474,
+		B = -0.00024,
+		E = 0.01211,
+		L = 0.01926,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 2,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 136,
+	label = "eight-4double",
+	group = 
+"""
+1 * R!H u0 {2,D} {8,S}
+2   R!H u0 {1,D} {3,S}
+3   R!H u0 {2,S} {4,D}
+4   R!H u0 {3,D} {5,S}
+5   R!H u0 {4,S} {6,D}
+6   R!H u0 {5,D} {7,S}
+7   R!H u0 {6,S} {8,D}
+8   R!H u0 {1,S} {7,D}
+""",
+	solute = u'Cyclooctatetraene',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 137,
+	label = "Cyclooctatetraene",
+	group = 
+"""
+1 * Cd u0 {2,D} {8,S}
+2   Cd u0 {1,D} {3,S}
+3   Cd u0 {2,S} {4,D}
+4   Cd u0 {3,D} {5,S}
+5   Cd u0 {4,S} {6,D}
+6   Cd u0 {5,D} {7,S}
+7   Cd u0 {6,S} {8,D}
+8   Cd u0 {1,S} {7,D}
+""",
+	solute = SoluteData(
+		S = -0.04873,
+		B = -0.02685,
+		E = -0.06156,
+		L = -0.10408,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 138,
+	label = "NineMember",
+	group = 
+"""
+1 * R!H u0 {2,[S,D]} {9,[S,D]}
+2   R!H u0 {1,[S,D]} {3,[S,D]}
+3   R!H u0 {2,[S,D]} {4,[S,D]}
+4   R!H u0 {3,[S,D]} {5,[S,D]}
+5   R!H u0 {4,[S,D]} {6,[S,D]}
+6   R!H u0 {5,[S,D]} {7,[S,D]}
+7   R!H u0 {6,[S,D]} {8,[S,D]}
+8   R!H u0 {7,[S,D]} {9,[S,D]}
+9   R!H u0 {1,[S,D]} {8,[S,D]}
+""",
+	solute = u'Cyclononane',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 139,
+	label = "Cyclononane",
+	group = 
+"""
+1 * C  u0 {2,S} {9,S}
+2   C  u0 {1,S} {3,S}
+3   C  u0 {2,S} {4,S}
+4   C  u0 {3,S} {5,S}
+5   C  u0 {4,S} {6,S}
+6   C  u0 {5,S} {7,S}
+7   C  u0 {6,S} {8,S}
+8   C  u0 {7,S} {9,S}
+9   C  u0 {1,S} {8,S}
+""",
+	solute = SoluteData(
+		S = 0.01787,
+		B = 0.00000,
+		E = 0.00507,
+		L = 0.06278,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 5,
+		L = 4,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 140,
+	label = "TenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {10,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {1,[S,D]} {9,[S,D]}
+""",
+	solute = SoluteData(
+		S = 0.03628,
+		B = -0.01901,
+		E = -0.00872,
+		L = 0.04759,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 3,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 141,
+	label = "Cyclodecane",
+	group = 
+"""
+1  * C  u0 {2,S} {10,S}
+2    C  u0 {1,S} {3,S}
+3    C  u0 {2,S} {4,S}
+4    C  u0 {3,S} {5,S}
+5    C  u0 {4,S} {6,S}
+6    C  u0 {5,S} {7,S}
+7    C  u0 {6,S} {8,S}
+8    C  u0 {7,S} {9,S}
+9    C  u0 {8,S} {10,S}
+10   C  u0 {1,S} {9,S}
+""",
+	solute = SoluteData(
+		S = -0.04460,
+		B = 0.00000,
+		E = 0.00203,
+		L = 0.05150,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 142,
+	label = "ElevenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {11,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {1,[S,D]} {10,[S,D]}
+""",
+	solute = SoluteData(
+		S = -0.07953,
+		B = 0.00000,
+		E = -0.00309,
+		L = 0.03128,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 6,
+		B = 6,
+		E = 6,
+		L = 5,
+		A = 6,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 143,
+	label = "TwelveMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {12,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {1,[S,D]} {11,[S,D]}
+""",
+	solute = SoluteData(
+		S = -0.07121,
+		B = 0.00000,
+		E = -0.01820,
+		L = 0.07672,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 7,
+		B = 7,
+		E = 8,
+		L = 5,
+		A = 8,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 144,
+	label = "ThirteenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {13,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {11,[S,D]} {13,[S,D]}
+13   R!H u0 {1,[S,D]} {12,[S,D]}
+""",
+	solute = SoluteData(
+		S = -0.08200,
+		B = 0.00000,
+		E = -0.02425,
+		L = 0.15033,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 145,
+	label = "FourteenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {14,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {11,[S,D]} {13,[S,D]}
+13   R!H u0 {12,[S,D]} {14,[S,D]}
+14   R!H u0 {1,[S,D]} {13,[S,D]}
+""",
+	solute = SoluteData(
+		S = -0.07302,
+		B = 0.00000,
+		E = 0.02093,
+		L = 0.79366,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 5,
+		B = 5,
+		E = 5,
+		L = 5,
+		A = 5,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 146,
+	label = "FifteenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {15,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {11,[S,D]} {13,[S,D]}
+13   R!H u0 {12,[S,D]} {14,[S,D]}
+14   R!H u0 {13,[S,D]} {15,[S,D]}
+15   R!H u0 {1,[S,D]} {14,[S,D]}
+""",
+	solute = SoluteData(
+		S = -0.13937,
+		B = 0.01533,
+		E = -0.10564,
+		L = 0.06886,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 3,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 147,
+	label = "SixteenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {16,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {11,[S,D]} {13,[S,D]}
+13   R!H u0 {12,[S,D]} {14,[S,D]}
+14   R!H u0 {13,[S,D]} {15,[S,D]}
+15   R!H u0 {14,[S,D]} {16,[S,D]}
+16   R!H u0 {1,[S,D]} {15,[S,D]}
+""",
+	solute = SoluteData(
+		S = -0.18716,
+		B = 0.08901,
+		E = 0.00251,
+		L = -0.05472,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 4,
+		B = 4,
+		E = 4,
+		L = 4,
+		A = 4,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 148,
+	label = "EighteenMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {18,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {11,[S,D]} {13,[S,D]}
+13   R!H u0 {12,[S,D]} {14,[S,D]}
+14   R!H u0 {13,[S,D]} {15,[S,D]}
+15   R!H u0 {14,[S,D]} {16,[S,D]}
+16   R!H u0 {15,[S,D]} {17,[S,D]}
+17   R!H u0 {16,[S,D]} {18,[S,D]}
+18   R!H u0 {1,[S,D]} {17,[S,D]}
+""",
+	solute = SoluteData(
+		S = 0.03458,
+		B = -0.06708,
+		E = 0.00255,
+		L = 0.11260,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 149,
+	label = "TwentyfourMember",
+	group = 
+"""
+1  * R!H u0 {2,[S,D]} {24,[S,D]}
+2    R!H u0 {1,[S,D]} {3,[S,D]}
+3    R!H u0 {2,[S,D]} {4,[S,D]}
+4    R!H u0 {3,[S,D]} {5,[S,D]}
+5    R!H u0 {4,[S,D]} {6,[S,D]}
+6    R!H u0 {5,[S,D]} {7,[S,D]}
+7    R!H u0 {6,[S,D]} {8,[S,D]}
+8    R!H u0 {7,[S,D]} {9,[S,D]}
+9    R!H u0 {8,[S,D]} {10,[S,D]}
+10   R!H u0 {9,[S,D]} {11,[S,D]}
+11   R!H u0 {10,[S,D]} {12,[S,D]}
+12   R!H u0 {11,[S,D]} {13,[S,D]}
+13   R!H u0 {12,[S,D]} {14,[S,D]}
+14   R!H u0 {13,[S,D]} {15,[S,D]}
+15   R!H u0 {14,[S,D]} {16,[S,D]}
+16   R!H u0 {15,[S,D]} {17,[S,D]}
+17   R!H u0 {16,[S,D]} {18,[S,D]}
+18   R!H u0 {17,[S,D]} {19,[S,D]}
+19   R!H u0 {18,[S,D]} {20,[S,D]}
+20   R!H u0 {19,[S,D]} {21,[S,D]}
+21   R!H u0 {20,[S,D]} {22,[S,D]}
+22   R!H u0 {21,[S,D]} {23,[S,D]}
+23   R!H u0 {22,[S,D]} {24,[S,D]}
+24   R!H u0 {1,[S,D]} {23,[S,D]}
+""",
+	solute = SoluteData(
+		S = 0.09300,
+		B = -0.13005,
+		E = 0.15788,
+		L = -0.01905,
+		A = 0.00000,
+	),
+	dataCount = DataCountGAV(
+		S = 3,
+		B = 3,
+		E = 3,
+		L = 3,
+		A = 3,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 150,
+	label = "ThirtythreeMember",
+	group = 
+"""
+1  * R!H u0 {13,[S,D]} {14,[S,D]}
+2  R!H u0 {15,[S,D]} {16,[S,D]}
+3  R!H u0 {17,[S,D]} {18,[S,D]}
+4  R!H u0 {19,[S,D]} {20,[S,D]}
+5  R!H u0 {21,[S,D]} {22,[S,D]}
+6  R!H u0 {23,[S,D]} {24,[S,D]}
+7  R!H u0 {25,[S,D]} {26,[S,D]}
+8  R!H u0 {27,[S,D]} {28,[S,D]}
+9  R!H u0 {29,[S,D]} {30,[S,D]}
+10 R!H u0 {31,[S,D]} {32,[S,D]}
+11 R!H u0 {12,[S,D]} {33,[S,D]}
+12 R!H u0 {11,[S,D]} {13,[S,D]}
+13 R!H u0 {1,[S,D]} {12,[S,D]}
+14 R!H u0 {1,[S,D]} {15,[S,D]}
+15 R!H u0 {2,[S,D]} {14,[S,D]}
+16 R!H u0 {2,[S,D]} {17,[S,D]}
+17 R!H u0 {3,[S,D]} {16,[S,D]}
+18 R!H u0 {3,[S,D]} {19,[S,D]}
+19 R!H u0 {4,[S,D]} {18,[S,D]}
+20 R!H u0 {4,[S,D]} {21,[S,D]}
+21 R!H u0 {5,[S,D]} {20,[S,D]}
+22 R!H u0 {5,[S,D]} {23,[S,D]}
+23 R!H u0 {6,[S,D]} {22,[S,D]}
+24 R!H u0 {6,[S,D]} {25,[S,D]}
+25 R!H u0 {7,[S,D]} {24,[S,D]}
+26 R!H u0 {7,[S,D]} {27,[S,D]}
+27 R!H u0 {8,[S,D]} {26,[S,D]}
+28 R!H u0 {8,[S,D]} {29,[S,D]}
+29 R!H u0 {9,[S,D]} {28,[S,D]}
+30 R!H u0 {9,[S,D]} {31,[S,D]}
+31 R!H u0 {10,[S,D]} {30,[S,D]}
+32 R!H u0 {10,[S,D]} {33,[S,D]}
+33 R!H u0 {11,[S,D]} {32,[S,D]}
+""",
+	solute = u'Cyclosporin',
+	dataCount = None,
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+entry(
+	index = 151,
+	label = "Cyclosporin",
+	group = 
+"""
+1  O u0 {34,D}
+2  O u0 {35,D}
+3  O u0 {36,D}
+4  O u0 {37,D}
+5  O u0 {38,D}
+6  O u0 {39,D}
+7  O u0 {40,D}
+8  O u0 {41,D}
+9  O u0 {42,D}
+10 O u0 {43,D}
+11 O u0 {44,D}
+12 N u0 {24,S} {34,S}
+13 N u0 {25,S} {35,S}
+14 N u0 {26,S} {36,S}
+15 N u0 {27,S} {37,S}
+16 N u0 {28,S} {38,S}
+17 N u0 {29,S} {39,S}
+18 N u0 {30,S} {40,S}
+19 N u0 {31,S} {41,S}
+20 N u0 {32,S} {42,S}
+21 N u0 {33,S} {43,S}
+22 N u0 {23,S} {44,S}
+23 * C u0 {22,S} {34,S}
+24 C u0 {12,S} {35,S}
+25 C u0 {13,S} {36,S}
+26 C u0 {14,S} {37,S}
+27 C u0 {15,S} {38,S}
+28 C u0 {16,S} {39,S}
+29 C u0 {17,S} {40,S}
+30 C u0 {18,S} {41,S}
+31 C u0 {19,S} {42,S}
+32 C u0 {20,S} {43,S}
+33 C u0 {21,S} {44,S}
+34 CO u0 {1,D} {12,S} {23,S}
+35 CO u0 {2,D} {13,S} {24,S}
+36 CO u0 {3,D} {14,S} {25,S}
+37 CO u0 {4,D} {15,S} {26,S}
+38 CO u0 {5,D} {16,S} {27,S}
+39 CO u0 {6,D} {17,S} {28,S}
+40 CO u0 {7,D} {18,S} {29,S}
+41 CO u0 {8,D} {19,S} {30,S}
+42 CO u0 {9,D} {20,S} {31,S}
+43 CO u0 {10,D} {21,S} {32,S}
+44 CO u0 {11,D} {22,S} {33,S}
+""",
+	solute = SoluteData(
+		S = 0.05579,
+		B = -0.01893,
+		E = -0.12556,
+		L = 0.20437,
+		A = -0.02278,
+	),
+	dataCount = DataCountGAV(
+		S = 1,
+		B = 1,
+		E = 1,
+		L = 1,
+		A = 1,
+	),
+	shortDesc = u"""""",
+	longDesc = 
+u"""
+
+""",
+)
+
+tree(
+"""
+L1: Ring
+	L2: Aromatic
+		L3: Benzene
+	L2: ThreeMember
+		L3: Cyclopropane
+		L3: Ethylene_oxide
+		L3: Ethyleneimine
+	L2: FourMember
+		L3: Cyclobutane
+		L3: Oxetane
+			L4: Beta-Propiolactone
+		L3: Azetidine
+	L2: FiveMember
+		L3: five-0double
+			L4: Cyclopentane
+				L5: Cyclopentanone
+				L5: Cyclopentanol
+				L5: methylenecyclopentane
+			L4: Tetrahydrofuran
+				L5: butyrolactone
+			L4: Pyrrolidine
+				L5: Pyrrolidine(N-H)
+				L5: Pyrrolidine(N-R)
+			L4: 1,3-Dioxolane
+			L4: thiolane
+			L4: Imidazolidine
+				L5: imidazolidine-2,4-dione
+		L3: five-1double
+			L4: Cyclopentene
+			L4: 2-pyrroline
+			L4: 3-pyrroline
+			L4: 2-pyrazoline
+			L4: 2-imidazoline
+			L4: five-N1NC=CC1
+			L4: 2,5-Dihydrofuran
+				L5: 5H-furan-2-one
+		L3: five-2double
+			L4: Cyclopentadiene
+			L4: Furan
+			L4: 1H-Pyrrole
+			L4: Thiophene
+			L4: Pyrazole
+			L4: Imidazole
+				L5: 2-Nitroimidazole
+			L4: 1,2,4-Triazole
+			L4: Tetrazole
+			L4: 2H-Tetrazole
+			L4: Oxazole
+			L4: Isoxazole
+			L4: Thiazole
+			L4: 1,2,4-Thiadiazole
+			L4: 1,3,4-Thiadiazole
+	L2: SixMember
+		L3: six-0double
+			L4: Cyclohexane
+				L5: Cyclohexanone
+				L5: Cyclohexanol
+				L5: N-Cyclohexylacetamide
+			L4: 1,3-Dioxane
+			L4: 1,4-Dioxane
+			L4: 1,3,5-Trioxane
+			L4: Oxane
+				L5: 4-Hydroxyoxan-2-one
+			L4: Piperidine
+				L5: Piperidine(N-H)
+				L5: Piperidine(N-R)
+					L6: 1-Piperidinecarboxaldehyde
+					L6: Piperidine-2,6-dione
+			L4: Piperazine
+				L5: Piperazine(N-H,N-H)
+				L5: Piperazine(N-H,N-R)
+				L5: Piperazine(N-R,N-R)
+			L4: Morpholine
+				L5: Morpholine(N-H)
+				L5: Morpholine(N-R)
+			L4: 1,3-Diazinane
+				L5: 1,3-Diazinane-2,4,6-trione
+				L5: 2-Sulfanylidene-1,3-diazinane-4,6-dione
+			L4: 1,3,5-Triazinane
+			L4: 1,3,2-Dioxaphosphorinane
+				L5: 1,3,2-Dioxaphosphorinane-2-oxide
+		L3: six-1double
+			L4: Cyclohexene
+			L4: Tetrahydropyrimidine
+				L5: Uracil
+			L4: 1,2,3,6-Tetrahydropyridine
+			L4: 1,4,5,6-Tetrahydropyridazine
+				L5: 4,5-Dihydro-2H-pyridazin-3-one
+		L3: six-2double-1,3
+			L4: 1,3-Cyclohexadiene
+			L4: 1,2-Dihydropyridine
+			L4: 2,3-Dihydropyridine
+			L4: 1,2-Dihydropyrimidine
+				L5: 1H-Pyrimidin-2-one
+			L4: N1C=NC=CC1
+				L5: 3H-Pyrimidin-4-one
+		L3: six-2double-1,4
+			L4: 1,4-Cyclohexadiene
+				L5: p-Benzoquinone
+			L4: 1,4-Dihydropyridine
+				L5: 3,4-Dihydroxypyridine
+			L4: 4H-Pyran
+				L5: 3-Hydroxypyran-4-one
+		L3: six-3double
+			L4: Pyridine
+				L5: Pyridine-N-oxide
+				L5: Isonicotinamide
+				L5: NicotinicAcidEster
+			L4: Pyridazine
+			L4: Pyrimidine
+			L4: Pyrazine
+			L4: 1,3,5-Triazine
+				L5: 2-Methylsulfanyl-1,3,5-triazine
+				L5: 2-Methoxy-1,3,5-triazine
+	L2: SevenMember
+		L3: seven-0double
+			L4: Cycloheptane
+			L4: Oxepane
+			L4: seven-0double_N
+		L3: seven-1double
+			L4: Cycloheptene
+		L3: seven-2double-1,3
+		L3: seven-3double-1,3,5
+			L4: 1,3,5-Cycloheptatriene
+	L2: EightMember
+		L3: eight-0double
+			L4: Cyclooctane
+			L4: Azocane
+			L4: Octasulfur
+		L3: eight-1double
+			L4: Cyclooctene
+		L3: eight-2double-1,3
+			L4: 1,3-cyclooctadiene
+		L3: eight-2double-1,5
+			L4: 1,5-cyclooctadiene
+		L3: eight-4double
+			L4: Cyclooctatetraene
+	L2: NineMember
+		L3: Cyclononane
+	L2: TenMember
+		L3: Cyclodecane
+	L2: ElevenMember
+	L2: TwelveMember
+	L2: ThirteenMember
+	L2: FourteenMember
+	L2: FifteenMember
+	L2: SixteenMember
+	L2: EighteenMember
+	L2: TwentyfourMember
+	L2: ThirtythreeMember
+		L3: Cyclosporin
+"""
+)

--- a/input/solvation/libraries/solute.py
+++ b/input/solvation/libraries/solute.py
@@ -4,8 +4,10 @@
 name = "Solute Descriptors"
 shortDesc = u""
 longDesc = u"""
-From Abraham J. Chem. Soc. 1994
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791, DOI: 10.1039/P29940001777
+or from in-house database received from Prof. Abraham
 """
+
 entry(
     index = 1,
     label = "methane",
@@ -21,7 +23,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -40,7 +43,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -59,7 +63,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -78,7 +83,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -97,7 +103,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -116,7 +123,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -135,7 +143,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -154,7 +163,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -173,7 +183,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -192,7 +203,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -211,7 +223,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -230,7 +243,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -249,7 +263,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -268,7 +283,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -287,7 +303,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -306,7 +323,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -325,7 +343,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -344,7 +363,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -363,7 +383,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -382,7 +403,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -401,7 +423,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -420,7 +443,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -439,7 +463,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -458,7 +483,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -477,7 +503,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -496,7 +523,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -515,7 +543,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -534,7 +563,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -553,7 +583,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -572,7 +603,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -591,7 +623,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -610,7 +643,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -629,7 +663,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -648,7 +683,8 @@ entry(
     shortDesc = u"""E, L values are the average of those for cis and trans isomers.""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -667,7 +703,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -686,7 +723,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -705,7 +743,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -724,7 +763,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -743,7 +783,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -762,7 +803,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -781,7 +823,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -800,7 +843,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -819,7 +863,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -838,7 +883,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -857,7 +903,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -876,7 +923,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -895,7 +943,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -914,7 +963,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -933,7 +983,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -952,7 +1003,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -971,7 +1023,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -990,7 +1043,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1009,7 +1063,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1028,7 +1083,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1047,7 +1103,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1066,7 +1123,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1085,7 +1143,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1104,7 +1163,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1123,7 +1183,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1142,7 +1203,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1161,7 +1223,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1180,7 +1243,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1199,7 +1263,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1218,7 +1283,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1237,7 +1303,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1256,7 +1323,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1275,7 +1343,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1294,7 +1363,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1313,7 +1383,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1332,7 +1403,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1351,7 +1423,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1370,7 +1443,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1389,7 +1463,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1408,7 +1483,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1427,7 +1503,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1446,7 +1523,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1465,7 +1543,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1484,7 +1563,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1503,7 +1583,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1522,7 +1603,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1541,7 +1623,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1560,7 +1643,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1579,7 +1663,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1598,7 +1683,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1617,7 +1703,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1636,7 +1723,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1655,7 +1743,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1674,7 +1763,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1693,7 +1783,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1712,7 +1803,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1731,7 +1823,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1750,7 +1843,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1769,7 +1863,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1788,7 +1883,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1807,7 +1903,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1826,7 +1923,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1845,7 +1943,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1864,7 +1963,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1883,7 +1983,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1902,7 +2003,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1921,7 +2023,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1940,7 +2043,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1959,7 +2063,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1978,7 +2083,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -1997,7 +2103,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2016,7 +2123,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2035,7 +2143,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2054,7 +2163,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2073,7 +2183,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2092,7 +2203,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2111,7 +2223,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2130,7 +2243,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2149,7 +2263,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2168,7 +2283,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2187,7 +2303,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2206,7 +2323,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2225,7 +2343,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2244,7 +2363,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2263,7 +2383,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2282,7 +2403,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2301,7 +2423,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2320,7 +2443,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2339,7 +2463,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2358,7 +2483,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2377,7 +2503,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2396,7 +2523,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2415,7 +2543,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2434,7 +2563,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2453,7 +2583,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2472,7 +2603,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2491,7 +2623,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2510,7 +2643,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2529,7 +2663,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2548,7 +2683,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2567,7 +2703,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2586,7 +2723,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2605,7 +2743,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2624,7 +2763,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2643,7 +2783,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2662,7 +2803,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2681,7 +2823,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2700,7 +2843,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2719,7 +2863,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2738,7 +2883,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2757,7 +2903,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2776,7 +2923,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2795,7 +2943,8 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-
+From Abarahm et al., J. Chem. Soc., Perkin Trans. 2, 1994, 1777-1791,
+DOI: 10.1039/P29940001777
 """,
 )
 
@@ -2807,14 +2956,14 @@ entry(
         S = 0.0,
         B = 0.0,
         E = 0.0,
-        L = 0.0,
+        L = -0.688,
         A = 0.0,
-        V = 18.99,
+        V = 0.19,
     ),
     shortDesc = u"""""",
     longDesc = 
 u"""
-Dummy values set to solve issue #285 on RMGPY
+From in-house database received from Prof. Abraham
 """,
 )
 
@@ -2826,14 +2975,14 @@ entry(
         S = 0.0,
         B = 0.0,
         E = 0.0,
-        L = 0.0,
+        L = -1.575,
         A = 0.0,
-        V = 8.51,
+        V = 0.085,
     ),
     shortDesc = u"""""",
     longDesc = 
 u"""
-Dummy values set to solve issue #285 on RMGPY
+From in-house database received from Prof. Abraham
 """,
 )
 
@@ -2845,22 +2994,21 @@ entry(
         S = 0.0,
         B = 0.0,
         E = 0.0,
-        L = 0.0,
+        L = -1.741,
         A = 0.0,
-        V = 6.75,
+        V = 0.068,
     ),
     shortDesc = u"""""",
     longDesc = 
 u"""
-Dummy values set to solve issue #285 on RMGPY
+From in-house database received from Prof. Abraham
 """,
 )
 
-#chatelak: New  data found in litterature
 entry(
     index = 151,
     label = "N2",
-    molecule = 'N#N',
+    molecule = "N#N",
     solute = SoluteData(
         S = 0.0,
         B = 0.00,
@@ -2881,7 +3029,7 @@ DOI: 10.1039/B104682A
 entry(
     index = 152,
     label = "O2",
-    molecule = '[O][O]',
+    molecule = "[O][O]",
     solute = SoluteData(
         S = 0.0,
         B = 0.00,
@@ -2898,3 +3046,3007 @@ Phys. Chem. Chem. Phys., 2001,3, 3732-3736
 DOI: 10.1039/B104682A 
 """,
 )
+
+entry(
+    index = 153,
+    label = "3-Chloropropan-1-ol",
+    molecule = "OCCCCl",
+    solute = SoluteData(
+        S = 0.71,
+        B = 0.50,
+        E = 0.407,
+        L = 2.651,
+        A = 0.40,
+        V = 0.7124
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+
+entry(
+    index = 154,
+    label = "hydrogen",
+    molecule = "[H][H]",
+    solute = SoluteData(
+        S = 0.0,
+        B = 0.0,
+        E = 0.0,
+        L = -1.2,
+        A = 0.0,
+        V = 0.1086,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 155,
+    label = "ozone",
+    molecule = "[O-][O+]=O",
+    solute = SoluteData(
+        S = 0.1,
+        B = 0.0,
+        E = 0.0,
+        L = 0.039,
+        A = 0.09,
+        V = 0.2417,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 156,
+    label = "nitrous oxide",
+    molecule = "[N-]=[N+]=O",
+    solute = SoluteData(
+        S = 0.35,
+        B = 0.1,
+        E = 0.068,
+        L = 0.164,
+        A = 0.0,
+        V = 0.2809,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 157,
+    label = "nitric oxide",
+    molecule = "[N]=O",
+    solute = SoluteData(
+        S = -0.1,
+        B = 0.05,
+        E = -0.1,
+        L = -0.596,
+        A = 0.0,
+        V = 0.2026,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 158,
+    label = "carbon monoxide",
+    molecule = "[C-]#[O+]",
+    solute = SoluteData(
+        S = 0.0,
+        B = 0.04,
+        E = 0.0,
+        L = -0.836,
+        A = 0.0,
+        V = 0.222,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 159,
+    label = "carbon dioxide",
+    molecule = "C(=O)=O",
+    solute = SoluteData(
+        S = 0.28,
+        B = 0.1,
+        E = 0.0,
+        L = 0.058,
+        A = 0.05,
+        V = 0.2809,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 160,
+    label = "hydrogen peroxide",
+    molecule = "OO",
+    solute = SoluteData(
+        S = 0.66,
+        B = 0.41,
+        E = 0.451,
+        L = 1.226,
+        A = 0.78,
+        V = 0.226,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 161,
+    label = "sulfur dioxide",
+    molecule = "O=S=O",
+    solute = SoluteData(
+        S = 0.66,
+        B = 0.1,
+        E = 0.37,
+        L = 0.778,
+        A = 0.28,
+        V = 0.3465,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 162,
+    label = "carbonoxysulfide",
+    molecule = "C(=O)=S",
+    solute = SoluteData(
+        S = 0.28,
+        B = 0.0,
+        E = 0.487,
+        L = 1.137,
+        A = 0.0,
+        V = 0.3857,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 163,
+    label = "chlorine",
+    molecule = "ClCl",
+    solute = SoluteData(
+        S = 0.32,
+        B = 0.0,
+        E = 0.36,
+        L = 1.193,
+        A = 0.1,
+        V = 0.3534,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 164,
+    label = "bromine",
+    molecule = "BrBr",
+    solute = SoluteData(
+        S = 0.62,
+        B = 0.0,
+        E = 0.918,
+        L = 2.4748,
+        A = 0.18,
+        V = 0.4586,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 165,
+    label = "iodine",
+    molecule = "II",
+    solute = SoluteData(
+        S = 0.63,
+        B = 0.0,
+        E = 1.216,
+        L = 3.036,
+        A = 0.28,
+        V = 0.625,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 166,
+    label = "hydrazine",
+    molecule = "NN",
+    solute = SoluteData(
+        S = 1.21,
+        B = 0.71,
+        E = 0.514,
+        L = 1.6277,
+        A = 0.39,
+        V = 0.3082,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 167,
+    label = "nitrogen trifluoride",
+    molecule = "N(F)(F)F",
+    solute = SoluteData(
+        S = -0.2,
+        B = 0.0,
+        E = 0.099,
+        L = -0.2078,
+        A = 0.0,
+        V = 0.2615,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 168,
+    label = "dinitrogen tetrafluoride",
+    molecule = "N(N(F)F)(F)F",
+    solute = SoluteData(
+        S = -0.15,
+        B = 0.0,
+        E = 0.044,
+        L = 0.172,
+        A = 0.0,
+        V = 0.379,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 169,
+    label = "phosphine",
+    molecule = "P",
+    solute = SoluteData(
+        S = 0.11,
+        B = 0.05,
+        E = 0.2,
+        L = 0.34,
+        A = 0.0,
+        V = 0.3132,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 170,
+    label = "nitrosylchloride",
+    molecule = "N(=O)Cl",
+    solute = SoluteData(
+        S = 0.38,
+        B = 0.21,
+        E = 0.23,
+        L = 0.9167,
+        A = 0.1,
+        V = 0.3465,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 171,
+    label = "hydrogen chloride",
+    molecule = "Cl",
+    solute = SoluteData(
+        S = 0.3,
+        B = 0.089,
+        E = 0.287,
+        L = 0.489,
+        A = 0.467,
+        V = 0.231,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 172,
+    label = "hydrogen bromide",
+    molecule = "Br",
+    solute = SoluteData(
+        S = 0.344,
+        B = 0.078,
+        E = 0.374,
+        L = 0.931,
+        A = 0.373,
+        V = 0.2836,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 173,
+    label = "hydrogen iodide",
+    molecule = "I",
+    solute = SoluteData(
+        S = 0.4,
+        B = 0.183,
+        E = 0.49,
+        L = 1.43,
+        A = 0.255,
+        V = 0.3668,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 174,
+    label = "hydrogen cyanide",
+    molecule = "C#N",
+    solute = SoluteData(
+        S = 0.66,
+        B = 0.14,
+        E = 0.213,
+        L = 0.8289,
+        A = 0.38,
+        V = 0.2633,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 175,
+    label = "hydrazoic acid",
+    molecule = "N=[N+]=[N-]",
+    solute = SoluteData(
+        S = 0.78,
+        B = 0.0,
+        E = 0.26,
+        L = 1.1508,
+        A = 0.45,
+        V = 0.322,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 176,
+    label = "ethyne",
+    molecule = "C#C",
+    solute = SoluteData(
+        S = 0.13,
+        B = 0.21,
+        E = 0.1,
+        L = 0.236,
+        A = 0.0,
+        V = 0.3044,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 177,
+    label = "fluoromethane",
+    molecule = "CF",
+    solute = SoluteData(
+        S = 0.35,
+        B = 0.09,
+        E = 0.066,
+        L = 0.057,
+        A = 0.0,
+        V = 0.2672,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 178,
+    label = "fluoroethane",
+    molecule = "CCF",
+    solute = SoluteData(
+        S = 0.34,
+        B = 0.05,
+        E = 0.052,
+        L = 0.751,
+        A = 0.0,
+        V = 0.4081,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 179,
+    label = "1,1-difluoroethane",
+    molecule = "CC(F)F",
+    solute = SoluteData(
+        S = 0.46,
+        B = 0.07,
+        E = -0.204,
+        L = 0.5954,
+        A = 0.03,
+        V = 0.4258,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 180,
+    label = "1,1,1-trifluoroethane",
+    molecule = "CC(F)(F)F",
+    solute = SoluteData(
+        S = 0.1,
+        B = 0.1,
+        E = -0.33,
+        L = 0.324,
+        A = 0.0,
+        V = 0.4435,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 181,
+    label = "1,1,2-trifluoroethane",
+    molecule = "C(C(F)F)F",
+    solute = SoluteData(
+        S = 0.3,
+        B = 0.12,
+        E = -0.3,
+        L = 0.513,
+        A = 0.16,
+        V = 0.4435,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 182,
+    label = "1,1,1,2-tetrafluoroethane",
+    molecule = "C(C(F)(F)F)F",
+    solute = SoluteData(
+        S = 0.45,
+        B = 0.0,
+        E = -0.408,
+        L = 0.4172,
+        A = 0.06,
+        V = 0.4612,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 183,
+    label = "1,1,2,2-tetrafluoroethane",
+    molecule = "C(C(F)F)(F)F",
+    solute = SoluteData(
+        S = 0.24,
+        B = 0.12,
+        E = -0.394,
+        L = 0.394,
+        A = 0.1,
+        V = 0.4612,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 184,
+    label = "pentafluoroethane",
+    molecule = "C(C(F)(F)F)(F)F",
+    solute = SoluteData(
+        S = 0.12,
+        B = 0.0,
+        E = -0.51,
+        L = 0.1419,
+        A = 0.12,
+        V = 0.4789,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 185,
+    label = "difluoromethane",
+    molecule = "C(F)F",
+    solute = SoluteData(
+        S = 0.54,
+        B = 0.04,
+        E = -0.204,
+        L = 0.1699,
+        A = 0.03,
+        V = 0.2849,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 186,
+    label = "trifluoromethane",
+    molecule = "C(F)(F)F",
+    solute = SoluteData(
+        S = 0.32,
+        B = 0.0,
+        E = -0.306,
+        L = -0.0956,
+        A = 0.06,
+        V = 0.3026,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 187,
+    label = "tetrafluoromethane",
+    molecule = "C(F)(F)(F)F",
+    solute = SoluteData(
+        S = -0.23,
+        B = 0.0,
+        E = -0.408,
+        L = -0.799,
+        A = 0.0,
+        V = 0.3203,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 188,
+    label = "hexafluoroethane",
+    molecule = "C(C(F)(F)F)(F)(F)F",
+    solute = SoluteData(
+        S = -0.4,
+        B = 0.0,
+        E = -0.64,
+        L = -0.429,
+        A = 0.0,
+        V = 0.4966,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 189,
+    label = "fluoroethene",
+    molecule = "C=CF",
+    solute = SoluteData(
+        S = 0.1,
+        B = 0.06,
+        E = 0.03,
+        L = 0.5386,
+        A = 0.0,
+        V = 0.3651,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 190,
+    label = "1,1-difluoroethene",
+    molecule = "C=C(F)F",
+    solute = SoluteData(
+        S = 0.01,
+        B = 0.05,
+        E = -0.1,
+        L = 0.331,
+        A = 0.0,
+        V = 0.3828,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 191,
+    label = "chloromethane",
+    molecule = "CCl",
+    solute = SoluteData(
+        S = 0.47,
+        B = 0.07,
+        E = 0.249,
+        L = 1.1487,
+        A = 0.0,
+        V = 0.3719,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 192,
+    label = "dichloromethane",
+    molecule = "C(Cl)Cl",
+    solute = SoluteData(
+        S = 0.58,
+        B = 0.05,
+        E = 0.387,
+        L = 1.818,
+        A = 0.12,
+        V = 0.4943,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 193,
+    label = "trichloromethane",
+    molecule = "C(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.49,
+        B = 0.04,
+        E = 0.425,
+        L = 2.4085,
+        A = 0.15,
+        V = 0.6167,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 194,
+    label = "tetrachloromethane",
+    molecule = "C(Cl)(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.38,
+        B = 0.0,
+        E = 0.458,
+        L = 2.823,
+        A = 0.0,
+        V = 0.7391,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 195,
+    label = "chloroethane",
+    molecule = "CCCl",
+    solute = SoluteData(
+        S = 0.4,
+        B = 0.12,
+        E = 0.227,
+        L = 1.664,
+        A = 0.0,
+        V = 0.5128,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 196,
+    label = "1,1-dichloroethane",
+    molecule = "CC(Cl)Cl",
+    solute = SoluteData(
+        S = 0.53,
+        B = 0.07,
+        E = 0.322,
+        L = 2.133,
+        A = 0.07,
+        V = 0.6352,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 197,
+    label = "1,2-dichloroethane",
+    molecule = "C(CCl)Cl",
+    solute = SoluteData(
+        S = 0.71,
+        B = 0.09,
+        E = 0.416,
+        L = 2.55,
+        A = 0.09,
+        V = 0.6352,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 198,
+    label = "1,1,1-trichloroethane",
+    molecule = "CC(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.48,
+        B = 0.08,
+        E = 0.369,
+        L = 2.751,
+        A = 0.0,
+        V = 0.7576,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 199,
+    label = "1,1,2-trichloroethane",
+    molecule = "C(C(Cl)Cl)Cl",
+    solute = SoluteData(
+        S = 0.68,
+        B = 0.13,
+        E = 0.499,
+        L = 3.29,
+        A = 0.13,
+        V = 0.7576,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 200,
+    label = "1,1,2,2-tetrachloroethane",
+    molecule = "C(C(Cl)Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.76,
+        B = 0.12,
+        E = 0.595,
+        L = 3.803,
+        A = 0.16,
+        V = 0.88,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 201,
+    label = "1,1,1,2-tetrachloroethane",
+    molecule = "C(C(Cl)(Cl)Cl)Cl",
+    solute = SoluteData(
+        S = 0.63,
+        B = 0.08,
+        E = 0.542,
+        L = 3.641,
+        A = 0.1,
+        V = 0.88,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 202,
+    label = "pentachloroethane",
+    molecule = "C(C(Cl)(Cl)Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.66,
+        B = 0.06,
+        E = 0.648,
+        L = 4.267,
+        A = 0.17,
+        V = 1.0024,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 203,
+    label = "hexachloroethane",
+    molecule = "C(C(Cl)(Cl)Cl)(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.68,
+        B = 0.0,
+        E = 0.68,
+        L = 4.573,
+        A = 0.0,
+        V = 1.1248,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 204,
+    label = "tetrafluoroethene",
+    molecule = "C(=C(F)F)(F)F",
+    solute = SoluteData(
+        S = -0.21,
+        B = 0.14,
+        E = -0.31,
+        L = 0.0826,
+        A = 0.0,
+        V = 0.4182,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 205,
+    label = "chloroethene",
+    molecule = "C=CCl",
+    solute = SoluteData(
+        S = 0.38,
+        B = 0.05,
+        E = 0.258,
+        L = 1.404,
+        A = 0.0,
+        V = 0.4698,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 206,
+    label = "1,1-dichloroethene",
+    molecule = "C=C(Cl)Cl",
+    solute = SoluteData(
+        S = 0.34,
+        B = 0.05,
+        E = 0.362,
+        L = 2.11,
+        A = 0.0,
+        V = 0.5922,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 207,
+    label = "trans-1,2,-dichloroethene",
+    molecule = "C(=C/Cl)\Cl",
+    solute = SoluteData(
+        S = 0.41,
+        B = 0.05,
+        E = 0.425,
+        L = 2.278,
+        A = 0.09,
+        V = 0.5922,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 208,
+    label = "trichloroethene",
+    molecule = "C(=C(Cl)Cl)Cl",
+    solute = SoluteData(
+        S = 0.66,
+        B = 0.01,
+        E = 0.524,
+        L = 3.0292,
+        A = 0.0,
+        V = 0.7146,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 209,
+    label = "tetrachloroethene",
+    molecule = "C(=C(Cl)Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.44,
+        B = 0.0,
+        E = 0.639,
+        L = 3.584,
+        A = 0.0,
+        V = 0.837,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 210,
+    label = "bromomethane",
+    molecule = "CBr",
+    solute = SoluteData(
+        S = 0.43,
+        B = 0.1,
+        E = 0.399,
+        L = 1.63,
+        A = 0.0,
+        V = 0.4245,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 211,
+    label = "dibromomethane",
+    molecule = "C(Br)Br",
+    solute = SoluteData(
+        S = 0.69,
+        B = 0.07,
+        E = 0.714,
+        L = 2.886,
+        A = 0.11,
+        V = 0.5995,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 212,
+    label = "tribromomethane",
+    molecule = "C(Br)(Br)Br",
+    solute = SoluteData(
+        S = 0.68,
+        B = 0.06,
+        E = 0.974,
+        L = 3.784,
+        A = 0.15,
+        V = 0.7745,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 213,
+    label = "tetrabromomethane",
+    molecule = "C(Br)(Br)(Br)Br",
+    solute = SoluteData(
+        S = 0.94,
+        B = 0.0,
+        E = 1.19,
+        L = 4.557,
+        A = 0.0,
+        V = 0.9495,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 214,
+    label = "bromoethane",
+    molecule = "CCBr",
+    solute = SoluteData(
+        S = 0.4,
+        B = 0.12,
+        E = 0.366,
+        L = 2.12,
+        A = 0.0,
+        V = 0.5654,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 215,
+    label = "1,1-dibromoethane",
+    molecule = "CC(Br)Br",
+    solute = SoluteData(
+        S = 0.64,
+        B = 0.16,
+        E = 0.653,
+        L = 3.174,
+        A = 0.1,
+        V = 0.7404,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 216,
+    label = "1,2-dibromoethane",
+    molecule = "C(CBr)Br",
+    solute = SoluteData(
+        S = 0.76,
+        B = 0.17,
+        E = 0.747,
+        L = 3.382,
+        A = 0.1,
+        V = 0.7404,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 217,
+    label = "1,1,2,2-tetrabromoethane",
+    molecule = "C(C(Br)Br)(Br)Br",
+    solute = SoluteData(
+        S = 0.93,
+        B = 0.24,
+        E = 1.343,
+        L = 5.6,
+        A = 0.17,
+        V = 1.0904,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 218,
+    label = "bromoethene",
+    molecule = "C=CBr",
+    solute = SoluteData(
+        S = 0.44,
+        B = 0.08,
+        E = 0.426,
+        L = 1.8871,
+        A = 0.0,
+        V = 0.5224,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 219,
+    label = "trans-1,2-dibromoethene",
+    molecule = "C(=C/Br)\Br",
+    solute = SoluteData(
+        S = 0.53,
+        B = 0.07,
+        E = 0.771,
+        L = 3.132,
+        A = 0.09,
+        V = 0.6974,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 220,
+    label = "iodomethane",
+    molecule = "CI",
+    solute = SoluteData(
+        S = 0.43,
+        B = 0.12,
+        E = 0.676,
+        L = 2.106,
+        A = 0.0,
+        V = 0.5077,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 221,
+    label = "diiodomethane",
+    molecule = "C(I)I",
+    solute = SoluteData(
+        S = 0.69,
+        B = 0.17,
+        E = 1.2,
+        L = 3.857,
+        A = 0.05,
+        V = 0.7659,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 222,
+    label = "triiodomethane",
+    molecule = "C(I)(I)I",
+    solute = SoluteData(
+        S = 1.17,
+        B = 0.26,
+        E = 1.95,
+        L = 6.42,
+        A = 0.09,
+        V = 1.0241,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 223,
+    label = "iodoethane",
+    molecule = "CCI",
+    solute = SoluteData(
+        S = 0.4,
+        B = 0.14,
+        E = 0.64,
+        L = 2.573,
+        A = 0.0,
+        V = 0.6486,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 224,
+    label = "fluorochloromethane",
+    molecule = "C(F)Cl",
+    solute = SoluteData(
+        S = 0.61,
+        B = 0.04,
+        E = 0.042,
+        L = 0.9818,
+        A = 0.07,
+        V = 0.3896,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 225,
+    label = "chlorobromomethane",
+    molecule = "C(Cl)Br",
+    solute = SoluteData(
+        S = 0.8,
+        B = 0.06,
+        E = 0.541,
+        L = 2.445,
+        A = 0.01,
+        V = 0.5469,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 226,
+    label = "chloroiodomethane",
+    molecule = "C(Cl)I",
+    solute = SoluteData(
+        S = 0.66,
+        B = 0.08,
+        E = 0.845,
+        L = 2.947,
+        A = 0.13,
+        V = 0.6301,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 227,
+    label = "fluorochlorobromomethane",
+    molecule = "C(F)(Cl)Br",
+    solute = SoluteData(
+        S = 0.45,
+        B = 0.07,
+        E = 0.345,
+        L = 1.95,
+        A = 0.11,
+        V = 0.5646,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 228,
+    label = "fluorodichloromethane",
+    molecule = "C(F)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.39,
+        B = 0.05,
+        E = 0.174,
+        L = 1.5356,
+        A = 0.15,
+        V = 0.512,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 229,
+    label = "difluorochloromethane",
+    molecule = "C(F)(F)Cl",
+    solute = SoluteData(
+        S = 0.4,
+        B = 0.01,
+        E = -0.066,
+        L = 0.6955,
+        A = 0.09,
+        V = 0.4073,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 230,
+    label = "fluorodibromomethane",
+    molecule = "C(F)(Br)Br",
+    solute = SoluteData(
+        S = 0.7,
+        B = 0.05,
+        E = 0.495,
+        L = 2.4709,
+        A = 0.15,
+        V = 0.6172,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 231,
+    label = "dichlorobromomethane",
+    molecule = "C(Cl)(Cl)Br",
+    solute = SoluteData(
+        S = 0.69,
+        B = 0.04,
+        E = 0.593,
+        L = 2.891,
+        A = 0.1,
+        V = 0.6693,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 232,
+    label = "chlorodibromomethane",
+    molecule = "C(Cl)(Br)Br",
+    solute = SoluteData(
+        S = 0.68,
+        B = 0.1,
+        E = 0.775,
+        L = 3.304,
+        A = 0.12,
+        V = 0.7219,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 233,
+    label = "fluorotrichloromethane",
+    molecule = "C(F)(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.23,
+        B = 0.05,
+        E = 0.318,
+        L = 1.9168,
+        A = 0.0,
+        V = 0.6344,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 234,
+    label = "difluorodichloromethane",
+    molecule = "C(F)(F)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.09,
+        B = 0.02,
+        E = 0.071,
+        L = 1.112,
+        A = 0.0,
+        V = 0.5297,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 235,
+    label = "trifluorochloromethane",
+    molecule = "C(F)(F)(F)Cl",
+    solute = SoluteData(
+        S = -0.08,
+        B = 0.02,
+        E = -0.168,
+        L = 0.193,
+        A = 0.0,
+        V = 0.425,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 236,
+    label = "difluorochlorobromomethane",
+    molecule = "C(F)(F)(Cl)Br",
+    solute = SoluteData(
+        S = 0.25,
+        B = 0.0,
+        E = 0.22,
+        L = 1.5354,
+        A = 0.0,
+        V = 0.5823,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 237,
+    label = "dibromodifluoromethane",
+    molecule = "C(F)(F)(Br)Br",
+    solute = SoluteData(
+        S = 0.36,
+        B = 0.0,
+        E = 0.272,
+        L = 1.961,
+        A = 0.0,
+        V = 0.6349,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 238,
+    label = "trifluorobromomethane",
+    molecule = "C(F)(F)(F)Br",
+    solute = SoluteData(
+        S = -0.02,
+        B = 0.01,
+        E = 0.033,
+        L = 0.8287,
+        A = 0.0,
+        V = 0.4776,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 239,
+    label = "bromotrichloromethane",
+    molecule = "C(Cl)(Cl)(Cl)Br",
+    solute = SoluteData(
+        S = 0.46,
+        B = 0.0,
+        E = 0.637,
+        L = 3.294,
+        A = 0.0,
+        V = 0.7917,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 240,
+    label = "1-fluoro-2-bromoethane",
+    molecule = "C(CBr)F",
+    solute = SoluteData(
+        S = 0.73,
+        B = 0.14,
+        E = 0.23,
+        L = 2.225,
+        A = 0.09,
+        V = 0.5831,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 241,
+    label = "1-chloro-2-bromoethane",
+    molecule = "C(CBr)Cl",
+    solute = SoluteData(
+        S = 0.7,
+        B = 0.09,
+        E = 0.572,
+        L = 2.982,
+        A = 0.1,
+        V = 0.6878,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 242,
+    label = "1,1-difluoro-1-chloroethane",
+    molecule = "CC(F)(F)Cl",
+    solute = SoluteData(
+        S = 0.33,
+        B = 0.05,
+        E = -0.066,
+        L = 1.18,
+        A = 0.0,
+        V = 0.5482,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 243,
+    label = "1,1-difluoro-2-chloroethane",
+    molecule = "C(C(F)F)Cl",
+    solute = SoluteData(
+        S = 0.87,
+        B = 0.04,
+        E = -0.08,
+        L = 1.76,
+        A = 0.09,
+        V = 0.5482,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 244,
+    label = "1-fluoro-1,1-dichloroethane",
+    molecule = "CC(F)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.41,
+        B = 0.06,
+        E = 0.174,
+        L = 1.986,
+        A = 0.0,
+        V = 0.6529,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 245,
+    label = "1,2-difluoro-1,1,2-trichloroethane",
+    molecule = "FC(Cl)C(F)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.39,
+        B = 0.02,
+        E = 0.116,
+        L = 2.54,
+        A = 0.09,
+        V = 0.793,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 246,
+    label = "1,1-difluoro-1-bromo-2-chloroethane",
+    molecule = "FC(F)(Br)CCl",
+    solute = SoluteData(
+        S = 0.51,
+        B = 0.06,
+        E = 0.236,
+        L = 2.54,
+        A = 0.0,
+        V = 0.7232,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 247,
+    label = "1,1-difluoro-1-chloro-2-bromoethane",
+    molecule = "C(C(F)(F)Cl)Br",
+    solute = SoluteData(
+        S = 0.5,
+        B = 0.06,
+        E = 0.236,
+        L = 2.49,
+        A = 0.0,
+        V = 0.7232,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 248,
+    label = "1,2-difluoro-1,2-dichloroethane",
+    molecule = "C(C(F)Cl)(F)Cl",
+    solute = SoluteData(
+        S = 0.65,
+        B = 0.08,
+        E = 0.012,
+        L = 2.21,
+        A = 0.18,
+        V = 0.6706,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 249,
+    label = "1,1-difluoro-1,2-dichloroethane",
+    molecule = "C(C(F)(F)Cl)Cl",
+    solute = SoluteData(
+        S = 0.48,
+        B = 0.05,
+        E = 0.012,
+        L = 2.12,
+        A = 0.0,
+        V = 0.6706,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 250,
+    label = "1,1,1-trifluoro-2-chloroethane",
+    molecule = "C(C(F)(F)F)Cl",
+    solute = SoluteData(
+        S = 0.41,
+        B = 0.06,
+        E = -0.168,
+        L = 1.1726,
+        A = 0.07,
+        V = 0.5659,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 251,
+    label = "1,1,2-trifluoro-1-chloroethane",
+    molecule = "C(C(F)(F)Cl)F",
+    solute = SoluteData(
+        S = 0.35,
+        B = 0.08,
+        E = -0.16,
+        L = 1.186,
+        A = 0.06,
+        V = 0.5659,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 252,
+    label = "1,1,1-trifluoro-2,2-dibromoethane",
+    molecule = "C(C(F)(F)F)(Br)Br",
+    solute = SoluteData(
+        S = 0.56,
+        B = 0.04,
+        E = 0.362,
+        L = 2.889,
+        A = 0.12,
+        V = 0.7935,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 253,
+    label = "1,1,1-trifluoro-2,2-dichloroethane",
+    molecule = "C(C(F)(F)F)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.24,
+        B = 0.03,
+        E = -0.03,
+        L = 1.7577,
+        A = 0.13,
+        V = 0.6883,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 254,
+    label = "1,1,2-trifluoro-1,2-dichloroethane",
+    molecule = "C(C(F)(F)Cl)(F)Cl",
+    solute = SoluteData(
+        S = 0.37,
+        B = 0.03,
+        E = -0.086,
+        L = 1.83,
+        A = 0.09,
+        V = 0.6883,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 255,
+    label = "1,1,2-trifluoro-1,2-dibromoethane",
+    molecule = "C(C(F)(F)Br)(F)Br",
+    solute = SoluteData(
+        S = 0.54,
+        B = 0.04,
+        E = 0.362,
+        L = 2.866,
+        A = 0.07,
+        V = 0.7935,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 256,
+    label = "1,1,1-trifluoro-2-chloro-2-bromoethane",
+    molecule = "C(C(F)(F)F)(Cl)Br",
+    solute = SoluteData(
+        S = 0.39,
+        B = 0.05,
+        E = 0.102,
+        L = 1.982,
+        A = 0.13,
+        V = 0.7409,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 257,
+    label = "1,1,1,2-tetrafluoro-2-bromoethane",
+    molecule = "C(C(F)(F)F)(F)Br",
+    solute = SoluteData(
+        S = 0.3,
+        B = 0.04,
+        E = -0.064,
+        L = 1.54,
+        A = 0.09,
+        V = 0.636,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 258,
+    label = "1,1,2,2-tetrafluoro-1-bromoethane",
+    molecule = "C(C(F)(F)Br)(F)F",
+    solute = SoluteData(
+        S = 0.3,
+        B = 0.04,
+        E = -0.064,
+        L = 1.54,
+        A = 0.09,
+        V = 0.636,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 259,
+    label = "1,1,1,2-tetrafluoro-2-chloroethane",
+    molecule = "FC(Cl)C(F)(F)F",
+    solute = SoluteData(
+        S = 0.34,
+        B = 0.01,
+        E = -0.27,
+        L = 1.006,
+        A = 0.06,
+        V = 0.5836,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 260,
+    label = "1,1-difluoro-1,2,2-trichloroethane",
+    molecule = "C(C(F)(F)Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.38,
+        B = 0.02,
+        E = 0.116,
+        L = 2.5,
+        A = 0.09,
+        V = 0.793,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 261,
+    label = "1,1,2-trifluoro-1-bromo-2-chloroethane",
+    molecule = "C(C(F)(F)Br)(F)Cl",
+    solute = SoluteData(
+        S = 0.37,
+        B = 0.04,
+        E = 0.138,
+        L = 2.227,
+        A = 0.07,
+        V = 0.7409,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 262,
+    label = "1,1,2-trifluoro-1-chloro-2-bromoethane",
+    molecule = "FC(Br)C(F)(F)Cl",
+    solute = SoluteData(
+        S = 0.36,
+        B = 0.04,
+        E = 0.138,
+        L = 2.21,
+        A = 0.07,
+        V = 0.7409,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 263,
+    label = "1,1-difluoro-1,2-dichloro-2-bromoethane",
+    molecule = "FC(F)(Cl)C(Cl)Br",
+    solute = SoluteData(
+        S = 0.46,
+        B = 0.04,
+        E = 0.34,
+        L = 2.953,
+        A = 0.09,
+        V = 0.8456,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 264,
+    label = "1,1,1-trifluorotrichloroethane",
+    molecule = "C(C(Cl)(Cl)Cl)(F)(F)F",
+    solute = SoluteData(
+        S = -0.12,
+        B = 0.09,
+        E = 0.126,
+        L = 2.0,
+        A = 0.0,
+        V = 0.8107,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 265,
+    label = "1,1,2-trifluorotrichloroethane",
+    molecule = "C(C(F)(Cl)Cl)(F)(F)Cl",
+    solute = SoluteData(
+        S = 0.14,
+        B = 0.02,
+        E = 0.108,
+        L = 2.3309,
+        A = 0.0,
+        V = 0.8107,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 266,
+    label = "1,1-difluorotetrachloroethane",
+    molecule = "C(C(Cl)(Cl)Cl)(F)(F)Cl",
+    solute = SoluteData(
+        S = 0.61,
+        B = 0.04,
+        E = 0.042,
+        L = 0.9818,
+        A = 0.07,
+        V = 0.3896,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 267,
+    label = "1,2-difluorotetrachloroethane",
+    molecule = "C(C(F)(Cl)Cl)(F)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.33,
+        B = 0.03,
+        E = 0.364,
+        L = 3.094,
+        A = 0.0,
+        V = 0.9154,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 268,
+    label = "1,2-dichlorotetrafluoroethane",
+    molecule = "C(C(F)(F)Cl)(F)(F)Cl",
+    solute = SoluteData(
+        S = 0.02,
+        B = 0.01,
+        E = -0.132,
+        L = 1.4049,
+        A = 0.0,
+        V = 0.706,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 269,
+    label = "1,2-dibromotetrafluoroethane",
+    molecule = "C(C(F)(F)Br)(F)(F)Br",
+    solute = SoluteData(
+        S = 0.1,
+        B = 0.0,
+        E = 0.068,
+        L = 2.169,
+        A = 0.0,
+        V = 0.8112,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 270,
+    label = "1,1,1,2-tetrafluoro-2-chloro-2-bromoethane",
+    molecule = "C(C(F)(Cl)Br)(F)(F)F",
+    solute = SoluteData(
+        S = 0.21,
+        B = 0.0,
+        E = 0.04,
+        L = 1.9,
+        A = 0.0,
+        V = 0.7586,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 271,
+    label = "chloropentafluoroethane",
+    molecule = "C(C(F)(F)Cl)(F)(F)F",
+    solute = SoluteData(
+        S = -0.18,
+        B = 0.03,
+        E = -0.372,
+        L = 0.5158,
+        A = 0.0,
+        V = 0.6013,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 272,
+    label = "bromopentafluoroethane",
+    molecule = "C(C(F)(F)Br)(F)(F)F",
+    solute = SoluteData(
+        S = -0.2,
+        B = 0.04,
+        E = -0.16,
+        L = 0.97,
+        A = 0.0,
+        V = 0.6539,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 273,
+    label = "chlorotrifluoroethene",
+    molecule = "C(=C(F)Cl)(F)F",
+    solute = SoluteData(
+        S = 0.12,
+        B = 0.07,
+        E = -0.06,
+        L = 0.977,
+        A = 0.0,
+        V = 0.5229,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 274,
+    label = "bromotrifluoroethene",
+    molecule = "C(=C(F)Br)(F)F",
+    solute = SoluteData(
+        S = 0.36,
+        B = 0.05,
+        E = 0.13,
+        L = 1.652,
+        A = 0.0,
+        V = 0.5755,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 275,
+    label = "1,1,-difluoro-2-chloroethene",
+    molecule = "C(=C(F)F)Cl",
+    solute = SoluteData(
+        S = 0.3,
+        B = 0.04,
+        E = 0.116,
+        L = 1.2414,
+        A = 0.02,
+        V = 0.5052,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 276,
+    label = "dimethyl ether",
+    molecule = "COC",
+    solute = SoluteData(
+        S = 0.27,
+        B = 0.41,
+        E = 0.0,
+        L = 1.285,
+        A = 0.0,
+        V = 0.4491,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 277,
+    label = "ethylene oxide",
+    molecule = "C1CO1",
+    solute = SoluteData(
+        S = 0.73,
+        B = 0.35,
+        E = 0.25,
+        L = 1.371,
+        A = 0.02,
+        V = 0.3405,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 278,
+    label = "chloromethyl methyl ether",
+    molecule = "COCCl",
+    solute = SoluteData(
+        S = 0.52,
+        B = 0.36,
+        E = 0.17,
+        L = 1.783,
+        A = 0.0,
+        V = 0.5715,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 279,
+    label = "ketene",
+    molecule = "C=C=O",
+    solute = SoluteData(
+        S = 0.75,
+        B = 0.39,
+        E = 0.28,
+        L = 1.402,
+        A = 0.0,
+        V = 0.3631,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 280,
+    label = "trichloroethanal",
+    molecule = "C(=O)C(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.9,
+        B = 0.21,
+        E = 0.437,
+        L = 3.213,
+        A = 0.0,
+        V = 0.7733,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 281,
+    label = "acetonitrile",
+    molecule = "CC#N",
+    solute = SoluteData(
+        S = 0.9,
+        B = 0.32,
+        E = 0.237,
+        L = 1.739,
+        A = 0.07,
+        V = 0.4042,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 282,
+    label = "chloroacetonitrile",
+    molecule = "C(C#N)Cl",
+    solute = SoluteData(
+        S = 0.99,
+        B = 0.24,
+        E = 0.372,
+        L = 2.4196,
+        A = 0.13,
+        V = 0.5266,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 283,
+    label = "dichloroacetonitrile",
+    molecule = "ClC(Cl)C#N",
+    solute = SoluteData(
+        S = 0.96,
+        B = 0.17,
+        E = 0.428,
+        L = 2.949,
+        A = 0.2,
+        V = 0.649,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 284,
+    label = "trichloroacetonitrile",
+    molecule = "C(#N)C(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 1.2,
+        B = 0.0,
+        E = 0.378,
+        L = 3.567,
+        A = 0.0,
+        V = 0.7714,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 285,
+    label = "dibromoacetonitrile",
+    molecule = "BrC(Br)C#N",
+    solute = SoluteData(
+        S = 1.24,
+        B = 0.26,
+        E = 0.766,
+        L = 3.996,
+        A = 0.25,
+        V = 0.7542,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 286,
+    label = "bromochloroacetonitrile",
+    molecule = "C(#N)C(Cl)Br",
+    solute = SoluteData(
+        S = 1.1,
+        B = 0.21,
+        E = 0.597,
+        L = 3.434,
+        A = 0.22,
+        V = 0.7016,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 287,
+    label = "methylisocyanide",
+    molecule = "C[N+]#[C-]",
+    solute = SoluteData(
+        S = 0.43,
+        B = 0.09,
+        E = 0.2,
+        L = 1.146,
+        A = 0.0,
+        V = 0.4042,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 288,
+    label = "ammonia",
+    molecule = "N",
+    solute = SoluteData(
+        S = 0.39,
+        B = 0.56,
+        E = 0.139,
+        L = 0.319,
+        A = 0.16,
+        V = 0.2084,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 289,
+    label = "methylamine",
+    molecule = "CN",
+    solute = SoluteData(
+        S = 0.35,
+        B = 0.58,
+        E = 0.25,
+        L = 1.3,
+        A = 0.16,
+        V = 0.3493,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 290,
+    label = "ethylamine",
+    molecule = "CCN",
+    solute = SoluteData(
+        S = 0.35,
+        B = 0.61,
+        E = 0.236,
+        L = 1.677,
+        A = 0.16,
+        V = 0.4902,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 291,
+    label = "dimethylamine",
+    molecule = "CNC",
+    solute = SoluteData(
+        S = 0.3,
+        B = 0.66,
+        E = 0.189,
+        L = 1.6,
+        A = 0.08,
+        V = 0.4902,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 292,
+    label = "aziridine",
+    molecule = "C1CN1",
+    solute = SoluteData(
+        S = 0.92,
+        B = 0.44,
+        E = 0.37,
+        L = 1.8,
+        A = 0.17,
+        V = 0.3816,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 293,
+    label = "cyanamide",
+    molecule = "C(#N)N",
+    solute = SoluteData(
+        S = 1.36,
+        B = 0.32,
+        E = 0.45,
+        L = 2.265,
+        A = 0.26,
+        V = 0.3631,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 294,
+    label = "formamide",
+    molecule = "C(=O)N",
+    solute = SoluteData(
+        S = 1.31,
+        B = 0.57,
+        E = 0.468,
+        L = 2.447,
+        A = 0.64,
+        V = 0.365,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 295,
+    label = "formic acid",
+    molecule = "C(=O)O",
+    solute = SoluteData(
+        S = 0.75,
+        B = 0.33,
+        E = 0.343,
+        L = 1.545,
+        A = 0.76,
+        V = 0.3239,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 296,
+    label = "chloroacetoyl chloride",
+    molecule = "C(C(=O)Cl)Cl",
+    solute = SoluteData(
+        S = 0.93,
+        B = 0.33,
+        E = 0.442,
+        L = 2.799,
+        A = 0.0,
+        V = 0.6509,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 297,
+    label = "2,2,2-trifluoroethanol",
+    molecule = "C(C(F)(F)F)O",
+    solute = SoluteData(
+        S = 0.6,
+        B = 0.25,
+        E = 0.015,
+        L = 1.224,
+        A = 0.57,
+        V = 0.5022,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 298,
+    label = "2-chloroethanol",
+    molecule = "C(CCl)O",
+    solute = SoluteData(
+        S = 0.77,
+        B = 0.49,
+        E = 0.419,
+        L = 2.429,
+        A = 0.39,
+        V = 0.5715,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 299,
+    label = "2,2,2-trichloroethanol",
+    molecule = "C(C(Cl)(Cl)Cl)O",
+    solute = SoluteData(
+        S = 1.02,
+        B = 0.3,
+        E = 0.558,
+        L = 3.488,
+        A = 0.4,
+        V = 0.8163,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 300,
+    label = "2-bromoethanol",
+    molecule = "C(CBr)O",
+    solute = SoluteData(
+        S = 0.86,
+        B = 0.49,
+        E = 0.567,
+        L = 2.913,
+        A = 0.38,
+        V = 0.6241,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 301,
+    label = "sulfur hexafluoride",
+    molecule = "FS(F)(F)(F)(F)F",
+    solute = SoluteData(
+        S = -0.2,
+        B = 0.0,
+        E = -0.6,
+        L = -0.12,
+        A = 0.0,
+        V = 0.4643,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 302,
+    label = "carbon disulphide",
+    molecule = "C(=S)=S",
+    solute = SoluteData(
+        S = 0.26,
+        B = 0.03,
+        E = 0.876,
+        L = 2.37,
+        A = 0.0,
+        V = 0.4905,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 303,
+    label = "hydrogen sulfide",
+    molecule = "S",
+    solute = SoluteData(
+        S = 0.32,
+        B = 0.08,
+        E = 0.31,
+        L = 0.706,
+        A = 0.1,
+        V = 0.2721,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 304,
+    label = "methylthiol",
+    molecule = "CS",
+    solute = SoluteData(
+        S = 0.6,
+        B = 0.12,
+        E = 0.4,
+        L = 1.611,
+        A = 0.0,
+        V = 0.413,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 305,
+    label = "ethylthiol",
+    molecule = "CCS",
+    solute = SoluteData(
+        S = 0.42,
+        B = 0.2,
+        E = 0.392,
+        L = 2.079,
+        A = 0.0,
+        V = 0.5539,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 306,
+    label = "vinylthiol",
+    molecule = "C=CS",
+    solute = SoluteData(
+        S = 0.51,
+        B = 0.27,
+        E = 0.446,
+        L = 1.931,
+        A = 0.0,
+        V = 0.5109,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 307,
+    label = "trichloromethylmercaptan",
+    molecule = "SC(Cl)(Cl)Cl",
+    solute = SoluteData(
+        S = 0.61,
+        B = 0.12,
+        E = 0.76,
+        L = 3.394,
+        A = 0.0,
+        V = 0.7802,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 308,
+    label = "dimethyl sulfide",
+    molecule = "CSC",
+    solute = SoluteData(
+        S = 0.43,
+        B = 0.27,
+        E = 0.404,
+        L = 2.037,
+        A = 0.0,
+        V = 0.5539,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 309,
+    label = "ethylene sulfide",
+    molecule = "C1CS1",
+    solute = SoluteData(
+        S = 0.54,
+        B = 0.38,
+        E = 0.56,
+        L = 1.867,
+        A = 0.0,
+        V = 0.4453,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+
+entry(
+    index = 310,
+    label = "benzene",
+    molecule = "C1=CC=CC=C1",
+    solute = SoluteData(
+        S = 0.52,
+        B = 0.14,
+        E = 0.61,
+        L = 2.786,
+        A = 0.0,
+        V = 0.7164,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+From in-house database received from Prof. Abraham
+""",
+)
+

--- a/input/solvation/libraries/solvent.py
+++ b/input/solvation/libraries/solvent.py
@@ -4,12 +4,26 @@
 name = "Solvent Descriptors"
 shortDesc = u""
 longDesc = u"""
-Abraham solvent parameters (s_g, b_g, e_g, l_g, a_g, c_g) are from:
-Jalan, Amrit. (2014). Predictive kinetic modeling of low-temperature hydrocarbon oxidation (Doctoral dissertation).
-Cambridge, MA: Massachusetts Institute of Technology.
+Most of the Abraham (s_g, b_g, e_g, l_g, a_g, c_g) and Mintz solvent parameters (s_h, b_h, e_h, l_h, a_h, c_h) 
+are fitted by Yunsie Chung and Pierre Walker using experimental solute parameter, solvation free energy, 
+and solvation enthalpy data (manuscript in preparation). Abraham solvent parameters are used for solvation 
+free energy (dGsolv) calculations, and Mintz solvent parameters are used for solvation enthalpy (dHsolv) calculations.
+
+The majority of the viscosity parameters (A, B, C, D, E) are obtained from:
+    Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K., Rani, K. Y. (2007) Viscosity of Liquids.
+    Springer, The Netherlands: Dordrecht.
+The rest of the viscosity parameters are found from the DIPPR.
+
+'alpha' and 'beta' are the SOLUTE parameters A and B that can be potentially used for intrinsic rate correction 
+in H-abstraction rxns. But these parameters are currently not used in RMG.
+
+'eps' is the dielectric constant of a solvent. It is currently not used in RMG.
 
 'name_in_coolprop' represents the solvent's name used in the external package CoolProp. CoolProp is used for
 fluid property calculation. If the solvent is not available in CoolProp, 'name_in_coolprop' is set to None.
+
+'dataCount' stores the information on the number of data used to fit the Abraham and Mintz solvent parameters and 
+their associated solvation free energy and solvation enthalpy mean absolute error (MAE).
 
 Reference legend:
 [Abraham2012] The hydrogen bond properties of water from 273 K to 573 K; equations for the prediction of gas-water partition coefficients Michael H. Abraham and William E. Acree Jr Phys. Chem. Chem. Phys., 2012,14, 7433–7440
@@ -18,37 +32,53 @@ Reference legend:
 [JIRKAL2016] Application of Solvation Model to Prediction of the Solute Retention in Liquid Chromatography over a Wide Range of Mobile-Phase Compositions S. JIRKAL, M. MACHOVCOVA, AND J.G.K. SEVCIK DOI: 10.1556/1326.2016.28.1.06
 [Mohsen-Nia2012] Measurement and modelling of static dielectric constants of aqueous solutions of methanol, ethanol and acetic acid at T = 293.15 K and 91.3 kPa M.Mohsen-Nia, H.Amiria https://doi.org/10.1016/j.jct.2012.08.009
 """
+
 entry(
     index = 1,
     label = "water",
     molecule = "O",
     solvent = SolventData(
-        s_g = 2.743,
-        b_g = 4.814,
-        e_g = 0.822,
-        l_g = -0.213,
-        a_g = 3.904,
-        c_g = -1.271,
-        s_h = 2.836,
-        b_h = -41.816,
-        e_h = 9.91,
-        l_h = -6.354,
-        a_h = -32.01,
-        c_h = -13.31,
+        # Abraham gas-to-solvent parameters for solvation free energy (dGsolv) correction at 298K
+        s_g = 2.74983,
+        b_g = 4.84491,
+        e_g = 0.83346,
+        l_g = -0.22544,
+        a_g = 3.92725,
+        c_g = -1.26188,
+        # Mintz parameters for solvation enthaly (dHsolv) correction at 298K
+        s_h = -0.75922,
+        b_h = -28.45067,
+        e_h = 10.57331,
+        l_h = -5.87032,
+        a_h = -26.34783,
+        c_h = -11.63882,
+        # viscosity parameters
         A = -52.843,
         B = 3703.6,
         C = 5.866,
         D = -5.88e-29,
         E = 10,
+        # These are SOLUTE parameters that can be potentially used for intrinsic rate correction in H-abstraction rxns
         alpha = 0.353,
         beta = 0.38,
+        # Dielectric constant
         eps = 80.4,
+        # Name of the solvent used in the external fluid property calculation package, CoolProp.
         name_in_coolprop = "water",
     ),
+    # The number of data used to fit the Abraham and Mintz parameters and their associated solvation free energy and
+    # solvation enthalpy mean absolute error.
+    dataCount = DataCountSolvent(
+        dGsolvCount = 5224,
+        dGsolvMAE = (0.17,'kcal/mol'),
+        dHsolvCount = 58,
+        dHsolvMAE = (1.04,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -57,18 +87,18 @@ entry(
     label = "1-octanol",
     molecule = "CCCCCCCCO",
     solvent = SolventData(
-        s_g = 0.56,
-        b_g = 0.702,
-        e_g = -0.203,
-        l_g = 0.939,
-        a_g = 3.56,
-        c_g = -0.12,
-        s_h = 5.89,
-        b_h = -8.99,
-        e_h = -1.04,
-        l_h = -9.18,
-        a_h = -53.99,
-        c_h = -6.49,
+        s_g = 0.71369,
+        b_g = 1.42785,
+        e_g = 0.01254,
+        l_g = 0.85312,
+        a_g = 3.52275,
+        c_g = -0.18795,
+        s_h = 4.37833,
+        b_h = -9.58119,
+        e_h = -0.21959,
+        l_h = -9.17596,
+        a_h = -53.32202,
+        c_h = -5.69815,
         A = -0.022128,
         B = 3018.4,
         C = -2.8054,
@@ -79,11 +109,19 @@ entry(
         eps = 10.3,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 4189,
+        dGsolvMAE = (0.21,'kcal/mol'),
+        dHsolvCount = 164,
+        dHsolvMAE = (0.5,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
 alpha = 0.328, #primary alcohols
 beta = 0.45, #primary alcohols,
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -92,18 +130,18 @@ entry(
     label = "benzene",
     molecule = "C1=CC=CC=C1",
     solvent = SolventData(
-        s_g = 1.053,
-        b_g = 0.169,
-        e_g = -0.313,
-        l_g = 1.02,
-        a_g = 0.457,
-        c_g = 0.107,
-        s_h = -12.599,
-        b_h = -4.023,
-        e_h = 4.446,
-        l_h = -8.488,
-        a_h = -9.775,
-        c_h = -4.637,
+        s_g = 1.0749,
+        b_g = 0.17492,
+        e_g = -0.32585,
+        l_g = 1.01356,
+        a_g = 0.56683,
+        c_g = 0.11597,
+        s_h = -13.8578,
+        b_h = -2.60662,
+        e_h = 6.4422,
+        l_h = -8.52047,
+        a_h = -10.36551,
+        c_h = -4.56882,
         A = 7.5117,
         B = 294.68,
         C = -2.794,
@@ -114,10 +152,17 @@ entry(
         eps = 2.3,
         name_in_coolprop = "benzene",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 110,
+        dGsolvMAE = (0.19,'kcal/mol'),
+        dHsolvCount = 200,
+        dHsolvMAE = (0.35,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -126,18 +171,18 @@ entry(
     label = "cyclohexane",
     molecule = "C1CCCCC1",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.11,
-        l_g = 1.013,
-        a_g = 0,
-        c_g = 0.163,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 3.375,
-        l_h = -9.078,
-        a_h = 0.0,
-        c_h = -6.507,
+        s_g = 0.0,
+        b_g = -0.03443,
+        e_g = -0.32662,
+        l_g = 1.0347,
+        a_g = 0.0,
+        c_g = 0.24224,
+        s_h = 1.62599,
+        b_h = -1.42092,
+        e_h = 2.5915,
+        l_h = -9.03756,
+        a_h = 2.25788,
+        c_h = -6.74492,
         A = -33.763,
         B = 2497.2,
         C = 3.2236,
@@ -148,10 +193,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "CycloHexane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 122,
+        dGsolvMAE = (0.22,'kcal/mol'),
+        dHsolvCount = 226,
+        dHsolvMAE = (0.31,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -160,18 +212,18 @@ entry(
     label = "dibutylether",
     molecule = "CCCCOCCCC",
     solvent = SolventData(
-        s_g = 0.026,
-        b_g = -0.499,
-        e_g = -0.216,
-        l_g = 1.124,
-        a_g = 2.626,
-        c_g = 0.369,
-        s_h = -5.105,
-        b_h = 0.0,
-        e_h = 3.943,
-        l_h = -9.325,
-        a_h = -33.97,
-        c_h = -6.366,
+        s_g = 0.63588,
+        b_g = -0.27257,
+        e_g = -0.36266,
+        l_g = 0.98243,
+        a_g = 2.44885,
+        c_g = 0.21775,
+        s_h = -7.52607,
+        b_h = 4.62445,
+        e_h = 5.80308,
+        l_h = -9.23463,
+        a_h = -38.23245,
+        c_h = -7.1917,
         A = 10.027,
         B = 206,
         C = -3.1607,
@@ -182,10 +234,17 @@ entry(
         eps = 3.1,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 90,
+        dGsolvMAE = (0.2,'kcal/mol'),
+        dHsolvCount = 78,
+        dHsolvMAE = (0.27,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -194,18 +253,18 @@ entry(
     label = "octane",
     molecule = "CCCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.049,
-        l_g = 0.967,
-        a_g = 0,
-        c_g = 0.215,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = -0.03379,
+        b_g = -0.15888,
+        e_g = -0.14544,
+        l_g = 1.00321,
+        a_g = 0.01519,
+        c_g = 0.21422,
+        s_h = -0.97536,
+        b_h = 0.96573,
+        e_h = 2.83093,
+        l_h = -9.21398,
+        a_h = -2.37839,
+        c_h = -6.58298,
         A = -98.805,
         B = 3905.5,
         C = 14.103,
@@ -216,10 +275,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "Octane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 185,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = 53,
+        dHsolvMAE = (0.29,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -228,18 +294,18 @@ entry(
     label = "butanol",
     molecule = "CCCCO",
     solvent = SolventData(
-        s_g = 0.539,
-        b_g = 0.995,
-        e_g = -0.276,
-        l_g = 0.934,
-        a_g = 3.781,
-        c_g = -0.039,
-        s_h = 0.0,
-        b_h = -4.261,
-        e_h = 0.0,
-        l_h = -8.507,
-        a_h = -50.806,
-        c_h = -7.629,
+        s_g = 0.61135,
+        b_g = 1.15917,
+        e_g = -0.20375,
+        l_g = 0.89029,
+        a_g = 3.71643,
+        c_g = 0.00297,
+        s_h = 0.08507,
+        b_h = -6.52791,
+        e_h = 0.12537,
+        l_h = -8.50864,
+        a_h = -53.49993,
+        c_h = -7.3014,
         A = -82.851,
         B = 4481.8,
         C = 11.182,
@@ -250,10 +316,17 @@ entry(
         eps = 17.8,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 180,
+        dGsolvMAE = (0.22,'kcal/mol'),
+        dHsolvCount = 133,
+        dHsolvMAE = (0.47,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -262,18 +335,18 @@ entry(
     label = "carbontet",
     molecule = "ClC(Cl)(Cl)Cl",
     solvent = SolventData(
-        s_g = 0.46,
-        b_g = 0,
-        e_g = -0.303,
-        l_g = 1.047,
-        a_g = 0,
-        c_g = 0.282,
-        s_h = -4.824,
-        b_h = -7.045,
-        e_h = 3.517,
-        l_h = -8.886,
-        a_h = 0.0,
-        c_h = -6.441,
+        s_g = 0.4843,
+        b_g = 0.23943,
+        e_g = -0.32919,
+        l_g = 1.03861,
+        a_g = 0.11573,
+        c_g = 0.2241,
+        s_h = -5.25927,
+        b_h = -6.24698,
+        e_h = 3.73908,
+        l_h = -8.92989,
+        a_h = -0.85123,
+        c_h = -6.17215,
         A = -8.0738,
         B = 1121.1,
         C = -0.4726,
@@ -284,10 +357,18 @@ entry(
         eps = 2.23,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 196,
+        dGsolvMAE = (0.17,'kcal/mol'),
+        dHsolvCount = 180,
+        dHsolvMAE = (0.37,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
 beta = 0.05, # Note 24 in Snelgrove et al. 2001
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -296,18 +377,18 @@ entry(
     label = "chloroform",
     molecule = "ClC(Cl)Cl",
     solvent = SolventData(
-        s_g = 1.256,
-        b_g = 1.37,
-        e_g = -0.595,
-        l_g = 0.981,
-        a_g = 0.28,
-        c_g = 0.168,
-        s_h = -13.956,
-        b_h = -17.334,
-        e_h = 8.628,
-        l_h = -8.739,
-        a_h = -2.712,
-        c_h = -6.516,
+        s_g = 1.10673,
+        b_g = 1.35711,
+        e_g = -0.60197,
+        l_g = 1.00722,
+        a_g = 0.39491,
+        c_g = 0.18777,
+        s_h = -13.13153,
+        b_h = -17.63679,
+        e_h = 8.58592,
+        l_h = -8.57967,
+        a_h = 0.85071,
+        c_h = -7.4096,
         A = -14.109,
         B = 1049.2,
         C = 0.5377,
@@ -318,10 +399,17 @@ entry(
         eps = 4.8,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 157,
+        dGsolvMAE = (0.33,'kcal/mol'),
+        dHsolvCount = 102,
+        dHsolvMAE = (0.39,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -330,18 +418,18 @@ entry(
     label = "decane",
     molecule = "CCCCCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.143,
-        l_g = 0.989,
-        a_g = 0,
-        c_g = 0.156,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 0.0,
+        b_g = -0.08648,
+        e_g = -0.10001,
+        l_g = 0.99285,
+        a_g = 0.10602,
+        c_g = 0.16551,
+        s_h = -2.28895,
+        b_h = 4.22993,
+        e_h = 2.52946,
+        l_h = -9.16104,
+        a_h = -4.30351,
+        c_h = -6.80538,
         A = -97.662,
         B = 4342.7,
         C = 13.645,
@@ -352,10 +440,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "decane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 142,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = 48,
+        dHsolvMAE = (0.35,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -386,10 +481,12 @@ entry(
         eps = 10.7,
         name_in_coolprop = "Dichloroethane",
     ),
+    dataCount = None,
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+The source of the Abarham and Mintz parameters is unknown.
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -398,18 +495,18 @@ entry(
     label = "dimethylformamide",
     molecule = "N(C)(C)C=O",
     solvent = SolventData(
-        s_g = 2.315,
-        b_g = 0,
-        e_g = -0.339,
-        l_g = 0.83,
-        a_g = 4.112,
-        c_g = -0.174,
-        s_h = -15.168,
-        b_h = -8.253,
-        e_h = 0.0,
-        l_h = -7.118,
-        a_h = -42.211,
-        c_h = -4.324,
+        s_g = 2.21609,
+        b_g = -0.09698,
+        e_g = -0.57987,
+        l_g = 0.91023,
+        a_g = 3.92841,
+        c_g = -0.23856,
+        s_h = -10.44289,
+        b_h = -8.66852,
+        e_h = -1.54729,
+        l_h = -7.50889,
+        a_h = -47.20336,
+        c_h = -3.38497,
         A = -20.425,
         B = 1515.5,
         C = 1.4444,
@@ -420,10 +517,17 @@ entry(
         eps = 36.7,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 169,
+        dGsolvMAE = (0.38,'kcal/mol'),
+        dHsolvCount = 173,
+        dHsolvMAE = (0.71,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -432,18 +536,18 @@ entry(
     label = "dimethylsulfoxide",
     molecule = "CS(C)=O",
     solvent = SolventData(
-        s_g = 2.89,
-        b_g = 0,
-        e_g = -0.2,
-        l_g = 0.732,
-        a_g = 5.46,
-        c_g = -0.59,
-        s_h = -18.448,
-        b_h = -5.861,
-        e_h = -0.329,
-        l_h = -6.38,
-        a_h = -47.419,
-        c_h = -2.546,
+        s_g = 2.63069,
+        b_g = 0.04601,
+        e_g = 0.1768,
+        l_g = 0.67431,
+        a_g = 5.5534,
+        c_g = -0.43166,
+        s_h = -19.09336,
+        b_h = -4.51314,
+        e_h = 0.32593,
+        l_h = -6.36508,
+        a_h = -47.86878,
+        c_h = -2.59929,
         A = -37.347,
         B = 2835,
         C = 3.7937,
@@ -454,11 +558,17 @@ entry(
         eps = 46.7,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 63,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 157,
+        dHsolvMAE = (0.53,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-Molecule Search on RMG website cannot draw molecule and says "Invalid adjacency list" although it can give the
-adjacency list with the solvent name or its correct SMILES representation
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -467,18 +577,18 @@ entry(
     label = "dodecane",
     molecule = "CCCCCCCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = 0,
-        l_g = 0.986,
-        a_g = 0,
-        c_g = 0.053,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 2e-05,
+        b_g = -0.21632,
+        e_g = -0.00463,
+        l_g = 0.98261,
+        a_g = 0.0,
+        c_g = 0.11778,
+        s_h = -2.32655,
+        b_h = 1.7677,
+        e_h = 2.17321,
+        l_h = -9.25544,
+        a_h = 5.82361,
+        c_h = -6.24401,
         A = -134.91,
         B = 6054.2,
         C = 19.337,
@@ -489,10 +599,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "Dodecane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 36,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = 35,
+        dHsolvMAE = (0.3,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -501,18 +618,18 @@ entry(
     label = "ethanol",
     molecule = "CCO",
     solvent = SolventData(
-        s_g = 0.789,
-        b_g = 1.311,
-        e_g = -0.206,
-        l_g = 0.853,
-        a_g = 3.635,
-        c_g = 0.012,
-        s_h = 0.0,
-        b_h = -11.899,
-        e_h = 0.0,
-        l_h = -8.298,
-        a_h = -48.6,
-        c_h = -6.558,
+        s_g = 0.7177,
+        b_g = 1.36437,
+        e_g = -0.12249,
+        l_g = 0.84352,
+        a_g = 3.86403,
+        c_g = 0.01722,
+        s_h = 0.31824,
+        b_h = -11.60122,
+        e_h = -1.23158,
+        l_h = -7.85082,
+        a_h = -50.23362,
+        c_h = -7.3821,
         A = 7.875,
         B = 781.98,
         C = -3.0418,
@@ -523,10 +640,17 @@ entry(
         eps = 24.3,
         name_in_coolprop = "ethanol",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 231,
+        dGsolvMAE = (0.22,'kcal/mol'),
+        dHsolvCount = 144,
+        dHsolvMAE = (0.53,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -535,18 +659,18 @@ entry(
     label = "heptane",
     molecule = "CCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.162,
-        l_g = 0.983,
-        a_g = 0,
-        c_g = 0.275,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 0.0,
+        b_g = -0.14762,
+        e_g = -0.16189,
+        l_g = 0.9899,
+        a_g = 0.04796,
+        c_g = 0.28069,
+        s_h = -0.51333,
+        b_h = 0.26048,
+        e_h = 4.61586,
+        l_h = -9.06675,
+        a_h = 0.25492,
+        c_h = -7.32177,
         A = -98.159,
         B = 3592.6,
         C = 14.197,
@@ -557,10 +681,17 @@ entry(
         eps = 1.9,
         name_in_coolprop = "Heptane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 218,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 162,
+        dHsolvMAE = (0.34,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -569,18 +700,18 @@ entry(
     label = "hexadecane",
     molecule = "CCCCCCCCCCCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = 0,
-        l_g = 1,
-        a_g = 0,
-        c_g = 0,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 0.0,
+        b_g = -0.02644,
+        e_g = 0.00864,
+        l_g = 0.99636,
+        a_g = 0.01678,
+        c_g = 0.00648,
+        s_h = -1.09109,
+        b_h = -0.03074,
+        e_h = 1.6109,
+        l_h = -9.31861,
+        a_h = -1.95026,
+        c_h = -4.51577,
         A = -20.182,
         B = 2203.5,
         C = 1.2289,
@@ -591,10 +722,17 @@ entry(
         eps = 2.08,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 260,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = 127,
+        dHsolvMAE = (0.38,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -603,18 +741,18 @@ entry(
     label = "hexane",
     molecule = "CCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.169,
-        l_g = 0.979,
-        a_g = 0,
-        c_g = 0.292,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 0.0,
+        b_g = -0.13414,
+        e_g = -0.24417,
+        l_g = 0.9988,
+        a_g = 0.0,
+        c_g = 0.30308,
+        s_h = 0.41891,
+        b_h = 0.80271,
+        e_h = 4.26513,
+        l_h = -9.60641,
+        a_h = 2.36579,
+        c_h = -6.43283,
         A = -56.569,
         B = 2140.5,
         C = 7.5175,
@@ -625,10 +763,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "Hexane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 223,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 124,
+        dHsolvMAE = (0.29,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -637,12 +782,12 @@ entry(
     label = "isooctane",
     molecule = "CC(C)CC(C)(C)C",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.244,
-        l_g = 0.972,
-        a_g = 0,
-        c_g = 0.275,
+        s_g = 2e-05,
+        b_g = -0.01222,
+        e_g = -0.23538,
+        l_g = 0.97967,
+        a_g = 4e-05,
+        c_g = 0.27445,
         s_h = 0.0,
         b_h = 0.0,
         e_h = 0.0,
@@ -659,10 +804,17 @@ entry(
         eps = 1.94,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 163,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = 7,
+        dHsolvMAE = None,
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -671,18 +823,18 @@ entry(
     label = "nonane",
     molecule = "CCCCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.145,
-        l_g = 0.98,
-        a_g = 0,
-        c_g = 0.2,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 0.04101,
+        b_g = -0.21832,
+        e_g = 0.01551,
+        l_g = 0.9918,
+        a_g = 0.0,
+        c_g = 0.18699,
+        s_h = 1.05931,
+        b_h = -5.78133,
+        e_h = 3.09976,
+        l_h = -9.10555,
+        a_h = 2.52293,
+        c_h = -5.20391,
         A = -68.54,
         B = 3165.3,
         C = 9.0919,
@@ -693,10 +845,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "nonane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 69,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = 35,
+        dHsolvMAE = (0.28,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -705,18 +864,18 @@ entry(
     label = "pentane",
     molecule = "CCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = -0.276,
-        l_g = 0.968,
-        a_g = 0,
-        c_g = 0.335,
-        s_h = 0.0,
-        b_h = 0.0,
-        e_h = 2.999,
-        l_h = -9.279,
-        a_h = 0.0,
-        c_h = -6.708,
+        s_g = 0.36197,
+        b_g = -0.48912,
+        e_g = -0.55148,
+        l_g = 0.99415,
+        a_g = -0.10836,
+        c_g = 0.32869,
+        s_h = -2.22875,
+        b_h = -3.97897,
+        e_h = 6.88359,
+        l_h = -8.80102,
+        a_h = -13.55874,
+        c_h = -6.72014,
         A = -53.509,
         B = 1836.6,
         C = 7.1409,
@@ -727,10 +886,17 @@ entry(
         eps = 1.8,
         name_in_coolprop = "Pentane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 51,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = 24,
+        dHsolvMAE = (0.26,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -739,18 +905,18 @@ entry(
     label = "toluene",
     molecule = "CC1C=CC=CC=1",
     solvent = SolventData(
-        s_g = 0.938,
-        b_g = 0.099,
-        e_g = -0.222,
-        l_g = 1.012,
-        a_g = 0.467,
-        c_g = 0.121,
-        s_h = -11.339,
-        b_h = -6.984,
-        e_h = 0.226,
-        l_h = -8.272,
-        a_h = -2.25,
-        c_h = -5.107,
+        s_g = 0.90449,
+        b_g = 0.11827,
+        e_g = -0.31755,
+        l_g = 1.03217,
+        a_g = 0.58744,
+        c_g = 0.08115,
+        s_h = -13.6363,
+        b_h = -3.5148,
+        e_h = 6.20815,
+        l_h = -8.36546,
+        a_h = -8.10462,
+        c_h = -5.65601,
         A = -226.08,
         B = 6805.7,
         C = 37.542,
@@ -761,10 +927,18 @@ entry(
         eps = 2.2,
         name_in_coolprop = "toluene",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 77,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 111,
+        dHsolvMAE = (0.36,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
 eps = 2.2 # aerage of range 2.0-2.4
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -773,12 +947,12 @@ entry(
     label = "undecane",
     molecule = "CCCCCCCCCCC",
     solvent = SolventData(
-        s_g = 0,
-        b_g = 0,
-        e_g = 0,
-        l_g = 0.971,
-        a_g = 0,
-        c_g = 0.113,
+        s_g = 0.0,
+        b_g = -0.13838,
+        e_g = 0.03537,
+        l_g = 0.96727,
+        a_g = 0.05748,
+        c_g = 0.13729,
         s_h = 0.0,
         b_h = 0.0,
         e_h = 2.999,
@@ -795,10 +969,17 @@ entry(
         eps = 2.0,
         name_in_coolprop = "Undecane",
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 24,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -807,18 +988,18 @@ entry(
     label = "acetonitrile",
     molecule = "CC#N",
     solvent = SolventData(
-        s_g = 2.461,
-        b_g = 0.418,
-        e_g = -0.595,
-        l_g = 0.738,
-        a_g = 2.085,
-        c_g = -0.007,
-        s_h = -18.43,
-        b_h = -7.535,
-        e_h = -3.304,
-        l_h = -6.727,
-        a_h = -26.104,
-        c_h = -4.148,
+        s_g = 2.485,
+        b_g = 0.28401,
+        e_g = -0.4984,
+        l_g = 0.72236,
+        a_g = 2.6609,
+        c_g = 0.02099,
+        s_h = -20.50487,
+        b_h = -6.74961,
+        e_h = 4.52844,
+        l_h = -6.61759,
+        a_h = -27.51588,
+        c_h = -3.24474,
         A = -10.906,
         B = 872.02,
         C = 0,
@@ -829,10 +1010,17 @@ entry(
         eps = 37.5,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 70,
+        dGsolvMAE = (0.1,'kcal/mol'),
+        dHsolvCount = 81,
+        dHsolvMAE = (0.51,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -841,18 +1029,18 @@ entry(
     label = "ethylacetate",
     molecule = "CCOC(C)=O",
     solvent = SolventData(
-        s_g = 1.251,
-        b_g = 0,
-        e_g = -0.335,
-        l_g = 0.917,
-        a_g = 2.949,
-        c_g = 0.203,
-        s_h = -15.141,
-        b_h = 0.0,
-        e_h = 4.671,
-        l_h = -7.691,
-        a_h = -28.763,
-        c_h = -7.063,
+        s_g = 1.309,
+        b_g = 0.09959,
+        e_g = -0.33256,
+        l_g = 0.90668,
+        a_g = 2.85098,
+        c_g = 0.21521,
+        s_h = -14.52901,
+        b_h = -2.30629,
+        e_h = 4.39262,
+        l_h = -7.7917,
+        a_h = -29.06403,
+        c_h = -6.06258,
         A = 14.354,
         B = -154.6,
         C = -3.7887,
@@ -863,10 +1051,17 @@ entry(
         eps = 6.0,
         name_in_coolprop = None,
     ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 134,
+        dGsolvMAE = (0.25,'kcal/mol'),
+        dHsolvCount = 82,
+        dHsolvMAE = (0.4,'kcal/mol'),
+    ),
     shortDesc = u""" """,
-    longDesc =
+    longDesc = 
 u"""
-
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): the DIPPR
 """,
 )
 
@@ -875,37 +1070,40 @@ entry(
     label = "methanol",
     molecule = "CO",
     solvent = SolventData(
-        # Abraham gas-to-solvent (NOT water-to-solvent) parameters for free energy (G) correction at 298K
-        s_g = 1.317,
-        b_g = 1.396,
-        e_g = -0.338,
-        l_g = 0.773,
-        a_g = 3.826,
-        c_g = -0.039,
-        # Mintz parameters for enthalpy (H) correction
-        s_h = None,
-        b_h = None,
-        e_h = None,
-        l_h = None,
-        a_h = None,
-        c_h = None,
-        # viscosity parameters
+        s_g = 1.04295,
+        b_g = 1.61785,
+        e_g = -0.16578,
+        l_g = 0.7628,
+        a_g = 3.9997,
+        c_g = 0.00565,
+        s_h = -0.38202,
+        b_h = -17.68008,
+        e_h = -3.30961,
+        l_h = -7.50486,
+        a_h = -39.3694,
+        c_h = -6.78364,
         A = None,
         B = None,
         C = None,
         D = None,
         E = None,
-        # These are SOLUTE parameters used for intrinsic rate correction in H-abstraction rxns
         alpha = None,
         beta = None,
-        # Dielectric constant
         eps = 33.0,
         name_in_coolprop = "Methanol",
     ),
-    shortDesc = u"""[Abraham2012], [Mohsen-Nia2012]""",
-    longDesc =
+    dataCount = DataCountSolvent(
+        dGsolvCount = 173,
+        dGsolvMAE = (0.22,'kcal/mol'),
+        dHsolvCount = 211,
+        dHsolvMAE = (0.57,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
 u"""
-
+[Abraham2012]: Michael H. Abraham and William E. Acree Jr Phys. Chem. Chem. Phys., 2012,14, 7433–7440
+[Mohsen-Nia2012]: DOI: 10.1016/j.jct.2012.08.009
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
 """,
 )
 
@@ -922,30 +1120,28 @@ entry(
         l_g = 1.449, # -0.213 + 1.662
         a_g = 4.168, # 3.904 + 0.264
         c_g = -1.248, # -1.271 + 0.023
-        # Mintz parameters for enthalpy (H) correction
         s_h = None,
         b_h = None,
         e_h = None,
         l_h = None,
         a_h = None,
         c_h = None,
-        # viscosity parameters
         A = None,
         B = None,
         C = None,
         D = None,
         E = None,
-        # These are SOLUTE parameters used for intrinsic rate correction in H-abstraction rxns
         alpha = None,
         beta = None,
-        # Dielectric constant
         eps = 50.22,
         name_in_coolprop = None,
     ),
-    shortDesc = u"""[Abraham2016], [Mohsen-Nia2012]""",
-    longDesc =
+    dataCount = None,
+    shortDesc = u""" """,
+    longDesc = 
 u"""
-
+[Abraham2016]: Michael H. Abraham and William E. Acree Jr J Solution Chem (2016) 45:861–874
+[Mohsen-Nia2012]: DOI: 10.1016/j.jct.2012.08.009
 """,
 )
 
@@ -962,30 +1158,28 @@ entry(
         l_g = 1.347, # -0.213 + 1.56
         a_g = 3.454, # 3.904 + -0.45
         c_g = -1.441, # -1.271 + -0.17
-        # Mintz parameters for enthalpy (H) correction
         s_h = None,
         b_h = None,
         e_h = None,
         l_h = None,
         a_h = None,
         c_h = None,
-        # viscosity parameters
         A = None,
         B = None,
         C = None,
         D = None,
         E = None,
-        # These are SOLUTE parameters used for intrinsic rate correction in H-abstraction rxns
         alpha = None,
         beta = None,
-        # Dielectric constant
         eps = 60.61,
         name_in_coolprop = None,
     ),
-    shortDesc = u"""[JIRKAL2016], [Gagliardi2007]""",
-    longDesc =
+    dataCount = None,
+    shortDesc = u""" """,
+    longDesc = 
 u"""
-
+[JIRKAL2016]: DOI: 10.1556/1326.2016.28.1.06
+[Gagliardi2007]: DOI: 10.1021/je700055p
 """,
 )
 
@@ -1002,29 +1196,7159 @@ entry(
         l_g = 0.717, # -0.213 + 0.93
         a_g = 3.464, # 3.904 + -0.44
         c_g = -1.451, # -1.271 + -0.18
-        # Mintz parameters for enthalpy (H) correction
         s_h = None,
         b_h = None,
         e_h = None,
         l_h = None,
         a_h = None,
         c_h = None,
-        # viscosity parameters
         A = None,
         B = None,
         C = None,
         D = None,
         E = None,
-        # These are SOLUTE parameters used for intrinsic rate correction in H-abstraction rxns
         alpha = None,
         beta = None,
-        # Dielectric constant
         eps = 51.05,
         name_in_coolprop = None,
     ),
-    shortDesc = u"""[JIRKAL2016], [Gagliardi2007]""",
-    longDesc =
+    dataCount = None,
+    shortDesc = u""" """,
+    longDesc = 
 u"""
-
+[JIRKAL2016]: DOI: 10.1556/1326.2016.28.1.06
+[Gagliardi2007]: DOI: 10.1021/je700055p
 """,
 )
+
+
+entry(
+    index = 30,
+    label = "2-methylpyridine",
+    molecule = "Cc1ccccn1",
+    solvent = SolventData(
+        s_g = 1.83487,
+        b_g = -0.18942,
+        e_g = -0.60952,
+        l_g = 0.95433,
+        a_g = 4.59331,
+        c_g = 0.00409,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -23.569,
+        B = 1733.2,
+        C = 0,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 31,
+    label = "4-methylpentan-2-one",
+    molecule = "CC(=O)CC(C)C",
+    solvent = SolventData(
+        s_g = 0.88639,
+        b_g = 0.5647,
+        e_g = -0.13,
+        l_g = 0.83639,
+        a_g = 3.11628,
+        c_g = 0.42248,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -33.781,
+        B = 1955.3,
+        C = 3.4673,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 24,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 32,
+    label = "acetic acid",
+    molecule = "CC(=O)O",
+    solvent = SolventData(
+        s_g = 1.85476,
+        b_g = 1.27257,
+        e_g = -0.73865,
+        l_g = 0.77684,
+        a_g = 1.75126,
+        c_g = 0.04995,
+        s_h = -2.41206,
+        b_h = -24.31182,
+        e_h = 2.05446,
+        l_h = -8.87062,
+        a_h = -33.36862,
+        c_h = -1.5337,
+        A = -9.03,
+        B = 1212.3,
+        C = -0.332,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = 92,
+        dHsolvMAE = (0.41,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 33,
+    label = "1-phenylethanone",
+    molecule = "CC(=O)c1ccccc1",
+    solvent = SolventData(
+        s_g = 1.84302,
+        b_g = 0.09327,
+        e_g = -0.117,
+        l_g = 0.84379,
+        a_g = 2.97677,
+        c_g = -0.0226,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 2.372,
+        B = 807.0,
+        C = -2.0158,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 24,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = 7,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 34,
+    label = "aniline",
+    molecule = "Nc1ccccc1",
+    solvent = SolventData(
+        s_g = 2.20298,
+        b_g = 0.96128,
+        e_g = -0.30323,
+        l_g = 0.77504,
+        a_g = 2.78323,
+        c_g = -0.2674,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -98.301,
+        B = 6524.4,
+        C = 1.8548,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 38,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 35,
+    label = "anisole",
+    molecule = "COc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.7292,
+        b_g = -0.02172,
+        e_g = -0.49711,
+        l_g = 0.92445,
+        a_g = 1.61291,
+        c_g = 0.03186,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -7.893,
+        B = 1100.0,
+        C = -0.477,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 36,
+    label = "benzonitrile",
+    molecule = "N#Cc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.83958,
+        b_g = 0.16621,
+        e_g = -0.29361,
+        l_g = 0.86898,
+        a_g = 1.7869,
+        c_g = -0.05162,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -20.236,
+        B = 1737.4,
+        C = 1.3531,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 57,
+        dGsolvMAE = (0.1,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 37,
+    label = "phenylmethanol",
+    molecule = "OCc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.49435,
+        b_g = 1.27917,
+        e_g = -0.25117,
+        l_g = 0.82923,
+        a_g = 3.87953,
+        c_g = -0.26352,
+        s_h = 204.97922,
+        b_h = -500.02056,
+        e_h = -71.66326,
+        l_h = -5.01687,
+        a_h = 390.86719,
+        c_h = -15.17002,
+        A = -14.859,
+        B = 2865.7,
+        C = 0,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 37,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = 8,
+        dHsolvMAE = (0.06,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 38,
+    label = "bromobenzene",
+    molecule = "Brc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.22545,
+        b_g = 0.15934,
+        e_g = -0.38545,
+        l_g = 1.02925,
+        a_g = 0.6297,
+        c_g = -0.08273,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -12.307,
+        B = 1173.4,
+        C = 0.28397,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 76,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 39,
+    label = "bromoethane",
+    molecule = "CCBr",
+    solvent = SolventData(
+        s_g = 1.15717,
+        b_g = 0.12059,
+        e_g = -0.47702,
+        l_g = 0.90841,
+        a_g = 1.14817,
+        c_g = 0.57026,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -8.3081,
+        B = 764.58,
+        C = -0.37699,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 40,
+    label = "bromoform",
+    molecule = "BrC(Br)Br",
+    solvent = SolventData(
+        s_g = -4.18454,
+        b_g = -3.3668,
+        e_g = 0.8598,
+        l_g = 1.06256,
+        a_g = 5.36705,
+        c_g = 1.91762,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -13.586,
+        B = 1295.5,
+        C = 0.519,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 41,
+    label = "butan-2-one",
+    molecule = "CCC(C)=O",
+    solvent = SolventData(
+        s_g = 1.28552,
+        b_g = 0.23586,
+        e_g = -0.21354,
+        l_g = 0.90855,
+        a_g = 2.89388,
+        c_g = 0.13707,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -8.134,
+        B = 509.78,
+        C = -1.5324,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 100,
+        dGsolvMAE = (0.2,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 42,
+    label = "butyl acetate",
+    molecule = "CCCCOC(C)=O",
+    solvent = SolventData(
+        s_g = 1.34703,
+        b_g = -0.24086,
+        e_g = -0.47867,
+        l_g = 0.94689,
+        a_g = 2.68184,
+        c_g = 0.17904,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -5.402,
+        B = 688.0,
+        C = -0.7296,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 97,
+        dGsolvMAE = (0.22,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 43,
+    label = "butylbenzene",
+    molecule = "CCCCc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.72279,
+        b_g = -0.8784,
+        e_g = -0.47146,
+        l_g = 0.90944,
+        a_g = 0.6158,
+        c_g = 0.27038,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -25.102,
+        B = 1949.6,
+        C = 2.0385,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 44,
+    label = "carbon disulfide",
+    molecule = "S=C=S",
+    solvent = SolventData(
+        s_g = 0.40523,
+        b_g = -0.12687,
+        e_g = 0.17788,
+        l_g = 1.01672,
+        a_g = 0.11052,
+        c_g = 0.24135,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -51.111,
+        B = 2466.5,
+        C = 6.1227,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 32,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 45,
+    label = "chlorobenzene",
+    molecule = "Clc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.11261,
+        b_g = 0.13081,
+        e_g = -0.48771,
+        l_g = 1.0438,
+        a_g = 0.54146,
+        c_g = 0.04732,
+        s_h = -9.69601,
+        b_h = -5.2003,
+        e_h = 4.49706,
+        l_h = -9.03846,
+        a_h = -12.90418,
+        c_h = -5.28551,
+        A = -20.611,
+        B = 1656.5,
+        C = 1.4415,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 107,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = 127,
+        dHsolvMAE = (0.31,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 46,
+    label = "1-chlorohexane",
+    molecule = "CCCCCCCl",
+    solvent = SolventData(
+        s_g = 1.06284,
+        b_g = 1.12712,
+        e_g = -2.26132,
+        l_g = 0.8388,
+        a_g = 0.07874,
+        c_g = 0.21368,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 47,
+    label = "cyclohexanone",
+    molecule = "O=C1CCCCC1",
+    solvent = SolventData(
+        s_g = 1.55262,
+        b_g = 0.00942,
+        e_g = -0.25545,
+        l_g = 0.91371,
+        a_g = 2.7127,
+        c_g = 0.03532,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 65,
+        dGsolvMAE = (0.27,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 48,
+    label = "decalin",
+    molecule = "C1CCC2CCCCC2C1",
+    solvent = SolventData(
+        s_g = 0.44228,
+        b_g = 0.81749,
+        e_g = -0.10283,
+        l_g = 0.96219,
+        a_g = 0.18356,
+        c_g = -0.34604,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 27,
+        dGsolvMAE = (0.24,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 49,
+    label = "decan-1-ol",
+    molecule = "CCCCCCCCCCO",
+    solvent = SolventData(
+        s_g = 0.32457,
+        b_g = 0.80963,
+        e_g = -0.04793,
+        l_g = 0.94427,
+        a_g = 3.58108,
+        c_g = -0.11436,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -80.656,
+        B = 6325.5,
+        C = 9.646,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 94,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 50,
+    label = "1,1-dibromoethane",
+    molecule = "CC(Br)Br",
+    solvent = SolventData(
+        s_g = -2.32449,
+        b_g = -8.12457,
+        e_g = -1.71075,
+        l_g = 1.08506,
+        a_g = 5.22341,
+        c_g = 3.8382,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.1,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 51,
+    label = "1,2-dichloroethane",
+    molecule = "ClCCCl",
+    solvent = SolventData(
+        s_g = 1.82442,
+        b_g = 0.34095,
+        e_g = -0.50577,
+        l_g = 0.92031,
+        a_g = 0.82692,
+        c_g = 0.06113,
+        s_h = -18.66947,
+        b_h = -6.67126,
+        e_h = 5.89296,
+        l_h = -8.06112,
+        a_h = -9.78992,
+        c_h = -2.39299,
+        A = 8.875,
+        B = 264.0,
+        C = -2.9714,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 115,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 92,
+        dHsolvMAE = (0.34,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 52,
+    label = "ethoxyethane",
+    molecule = "CCOCC",
+    solvent = SolventData(
+        s_g = 0.70667,
+        b_g = -0.32535,
+        e_g = -0.27937,
+        l_g = 0.96121,
+        a_g = 3.31215,
+        c_g = 0.36129,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 10.197,
+        B = -63.8,
+        C = -3.226,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 143,
+        dGsolvMAE = (0.31,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 53,
+    label = "2-propan-2-yloxypropane",
+    molecule = "CC(C)OC(C)C",
+    solvent = SolventData(
+        s_g = 0.65056,
+        b_g = -0.28503,
+        e_g = -0.34893,
+        l_g = 0.94504,
+        a_g = 2.94474,
+        c_g = 0.39615,
+        s_h = -8.31857,
+        b_h = 0.05378,
+        e_h = 6.2166,
+        l_h = -6.28874,
+        a_h = -0.0,
+        c_h = -13.29248,
+        A = -11.5,
+        B = 993.0,
+        C = 0.29272,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 63,
+        dGsolvMAE = (0.2,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.1,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 54,
+    label = "N,N-dimethylacetamide",
+    molecule = "CC(=O)N(C)C",
+    solvent = SolventData(
+        s_g = 1.91518,
+        b_g = -0.35012,
+        e_g = -0.79736,
+        l_g = 1.03469,
+        a_g = 4.85283,
+        c_g = -0.26318,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 22.738,
+        B = -428.5,
+        C = -4.967,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 101,
+        dGsolvMAE = (0.34,'kcal/mol'),
+        dHsolvCount = 7,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 55,
+    label = "ethoxybenzene",
+    molecule = "CCOc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.56905,
+        b_g = -0.3437,
+        e_g = -0.22907,
+        l_g = 0.93061,
+        a_g = 1.60257,
+        c_g = 0.07477,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -55.996,
+        B = 3521.6,
+        C = 6.5648,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 56,
+    label = "ethylbenzene",
+    molecule = "CCc1ccccc1",
+    solvent = SolventData(
+        s_g = 0.99102,
+        b_g = -0.24581,
+        e_g = -0.24576,
+        l_g = 1.00485,
+        a_g = 0.26071,
+        c_g = 0.20989,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -10.452,
+        B = 1048.4,
+        C = -0.0715,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 33,
+        dGsolvMAE = (0.18,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 57,
+    label = "fluorobenzene",
+    molecule = "Fc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.16035,
+        b_g = 0.4474,
+        e_g = -0.51966,
+        l_g = 0.97958,
+        a_g = 0.63162,
+        c_g = 0.17985,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -10.064,
+        B = 1058.7,
+        C = -0.17162,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 30,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 58,
+    label = "heptan-1-ol",
+    molecule = "CCCCCCCO",
+    solvent = SolventData(
+        s_g = 0.53076,
+        b_g = 0.81028,
+        e_g = -0.23386,
+        l_g = 0.93819,
+        a_g = 3.62031,
+        c_g = -0.04861,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -88.623,
+        B = 6463.8,
+        C = 10.846,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 83,
+        dGsolvMAE = (0.14,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 59,
+    label = "1-iodohexadecane",
+    molecule = "CCCCCCCCCCCCCCCCI",
+    solvent = SolventData(
+        s_g = 1.19885,
+        b_g = -3.01135,
+        e_g = 0.07743,
+        l_g = 0.9049,
+        a_g = -1.26212,
+        c_g = -0.027,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 9,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 60,
+    label = "hexan-1-ol",
+    molecule = "CCCCCCO",
+    solvent = SolventData(
+        s_g = 0.53349,
+        b_g = 0.90075,
+        e_g = -0.20991,
+        l_g = 0.92234,
+        a_g = 3.68129,
+        c_g = -0.02862,
+        s_h = 2.04603,
+        b_h = -11.44571,
+        e_h = -0.525,
+        l_h = -9.21845,
+        a_h = -45.73846,
+        c_h = -4.98156,
+        A = -38.503,
+        B = 3810.4,
+        C = -0.89719,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 107,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 85,
+        dHsolvMAE = (0.44,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 61,
+    label = "iodobenzene",
+    molecule = "Ic1ccccc1",
+    solvent = SolventData(
+        s_g = 1.29387,
+        b_g = 0.33603,
+        e_g = -0.21232,
+        l_g = 1.0175,
+        a_g = 0.31999,
+        c_g = -0.25948,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 0.25,
+        B = 535.2,
+        C = -1.6207,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 39,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 62,
+    label = "2-methylpropan-1-ol",
+    molecule = "CC(C)CO",
+    solvent = SolventData(
+        s_g = 0.53584,
+        b_g = 1.44702,
+        e_g = -0.26984,
+        l_g = 0.87559,
+        a_g = 3.63592,
+        c_g = 0.01174,
+        s_h = 1.9962,
+        b_h = -8.70067,
+        e_h = 4.63079,
+        l_h = -8.61458,
+        a_h = -53.97057,
+        c_h = -7.13202,
+        A = -48.035,
+        B = 4306.7,
+        C = 4.8948,
+        D = -3.5e-28,
+        E = 10,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 120,
+        dGsolvMAE = (0.19,'kcal/mol'),
+        dHsolvCount = 98,
+        dHsolvMAE = (0.41,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 63,
+    label = "propan-2-ol",
+    molecule = "CC(C)O",
+    solvent = SolventData(
+        s_g = 0.65341,
+        b_g = 1.14881,
+        e_g = -0.31864,
+        l_g = 0.88495,
+        a_g = 4.0022,
+        c_g = -0.02455,
+        s_h = 3.84923,
+        b_h = -8.74711,
+        e_h = -1.46393,
+        l_h = -8.00127,
+        a_h = -48.6278,
+        c_h = -7.79417,
+        A = -8.23,
+        B = 2282.2,
+        C = -0.98495,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 157,
+        dGsolvMAE = (0.19,'kcal/mol'),
+        dHsolvCount = 112,
+        dHsolvMAE = (0.48,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 64,
+    label = "cumene",
+    molecule = "CC(C)c1ccccc1",
+    solvent = SolventData(
+        s_g = 0.08762,
+        b_g = -0.06313,
+        e_g = -0.54482,
+        l_g = 0.95983,
+        a_g = 0.0185,
+        c_g = 0.82117,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -24.438,
+        B = 1785.9,
+        C = 1.972,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 21,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 65,
+    label = "3-methylphenol",
+    molecule = "Cc1cccc(O)c1",
+    solvent = SolventData(
+        s_g = 0.82561,
+        b_g = 3.62143,
+        e_g = -0.45065,
+        l_g = 0.78463,
+        a_g = 2.02685,
+        c_g = 0.08479,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -124.95,
+        B = 8727.8,
+        C = 16.012,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 14,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 66,
+    label = "2-methoxyethanol",
+    molecule = "COCCO",
+    solvent = SolventData(
+        s_g = 2.34242,
+        b_g = -0.1546,
+        e_g = -0.57619,
+        l_g = 0.76933,
+        a_g = 4.54298,
+        c_g = -0.07992,
+        s_h = -30.69328,
+        b_h = 0.11722,
+        e_h = 12.75437,
+        l_h = -8.84607,
+        a_h = -37.86032,
+        c_h = 1.58484,
+        A = -3.4217,
+        B = 1792.6,
+        C = -1.5878,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 39,
+        dGsolvMAE = (0.2,'kcal/mol'),
+        dHsolvCount = 23,
+        dHsolvMAE = (0.3,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 67,
+    label = "dichloromethane",
+    molecule = "ClCCl",
+    solvent = SolventData(
+        s_g = 1.71687,
+        b_g = 0.57955,
+        e_g = -0.69144,
+        l_g = 0.96665,
+        a_g = 0.35236,
+        c_g = 0.18753,
+        s_h = -14.36353,
+        b_h = -10.79672,
+        e_h = 4.7822,
+        l_h = -7.75762,
+        a_h = -2.39211,
+        c_h = -5.36242,
+        A = -13.071,
+        B = 940.03,
+        C = 0.3733,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 58,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 108,
+        dHsolvMAE = (0.4,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 68,
+    label = "N-methylformamide",
+    molecule = "CNC=O",
+    solvent = SolventData(
+        s_g = 1.89971,
+        b_g = 0.63051,
+        e_g = -0.194,
+        l_g = 0.71737,
+        a_g = 4.03684,
+        c_g = -0.18927,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 9.9223,
+        B = 466.32,
+        C = -3.1375,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 54,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 69,
+    label = "nitrobenzene",
+    molecule = "O=[N+]([O-])c1ccccc1",
+    solvent = SolventData(
+        s_g = 1.84995,
+        b_g = 0.28563,
+        e_g = -0.22978,
+        l_g = 0.89259,
+        a_g = 1.35539,
+        c_g = -0.18912,
+        s_h = -46.29472,
+        b_h = 44.50457,
+        e_h = 27.13188,
+        l_h = -6.47435,
+        a_h = -0.0,
+        c_h = -9.65935,
+        A = -34.557,
+        B = 2611.3,
+        C = 3.4283,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 54,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.27,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 70,
+    label = "1-nitroethane",
+    molecule = "CC[N+](=O)[O-]",
+    solvent = SolventData(
+        s_g = 2.2979,
+        b_g = -0.04923,
+        e_g = -0.57792,
+        l_g = 0.64296,
+        a_g = 1.66858,
+        c_g = 0.51669,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -4.438,
+        B = 746.5,
+        C = -0.9385,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 71,
+    label = "nitromethane",
+    molecule = "C[N+](=O)[O-]",
+    solvent = SolventData(
+        s_g = 1.76232,
+        b_g = 1.1804,
+        e_g = 0.27851,
+        l_g = 0.62995,
+        a_g = 1.80611,
+        c_g = 0.00448,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -17.684,
+        B = 1358.0,
+        C = 1.011,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 21,
+        dGsolvMAE = (0.19,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 72,
+    label = "nonan-1-ol",
+    molecule = "CCCCCCCCCO",
+    solvent = SolventData(
+        s_g = 0.4669,
+        b_g = 1.33538,
+        e_g = -0.06234,
+        l_g = 0.88487,
+        a_g = 3.8611,
+        c_g = -0.15305,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -7.1348,
+        B = 2776.3,
+        C = -1.2064,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 28,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 73,
+    label = "1,2-dichlorobenzene",
+    molecule = "Clc1ccccc1Cl",
+    solvent = SolventData(
+        s_g = 0.90799,
+        b_g = 0.86727,
+        e_g = 0.12499,
+        l_g = 1.12073,
+        a_g = 0.42881,
+        c_g = -0.85004,
+        s_h = -9.81485,
+        b_h = -5.48747,
+        e_h = 4.46035,
+        l_h = -9.14429,
+        a_h = -8.69333,
+        c_h = -4.66197,
+        A = -22.216,
+        B = 1758.2,
+        C = 1.7011,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = 91,
+        dHsolvMAE = (0.31,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 74,
+    label = "pentadecane",
+    molecule = "CCCCCCCCCCCCCCC",
+    solvent = SolventData(
+        s_g = 0.24876,
+        b_g = -0.32594,
+        e_g = 0.06094,
+        l_g = 0.98868,
+        a_g = 0.9794,
+        c_g = 0.07093,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -19.299,
+        B = 2088.6,
+        C = 1.1091,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 20,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 75,
+    label = "pentan-1-ol",
+    molecule = "CCCCCO",
+    solvent = SolventData(
+        s_g = 0.55018,
+        b_g = 1.04699,
+        e_g = -0.21225,
+        l_g = 0.90653,
+        a_g = 3.74136,
+        c_g = -0.00817,
+        s_h = 1.94124,
+        b_h = -9.01807,
+        e_h = 3.97932,
+        l_h = -9.16523,
+        a_h = -53.07544,
+        c_h = -6.22045,
+        A = -22.758,
+        B = 2916.9,
+        C = 1.2839,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 146,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 92,
+        dHsolvMAE = (0.46,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 76,
+    label = "hexafluorobenzene",
+    molecule = "Fc1c(F)c(F)c(F)c(F)c1F",
+    solvent = SolventData(
+        s_g = 1.18649,
+        b_g = -0.03657,
+        e_g = -0.3372,
+        l_g = 0.8015,
+        a_g = -0.79769,
+        c_g = 0.74792,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 13.687,
+        B = 1916.0,
+        C = 0.24197,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 20,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 77,
+    label = "propan-1-ol",
+    molecule = "CCCO",
+    solvent = SolventData(
+        s_g = 0.79125,
+        b_g = 1.13116,
+        e_g = -0.2722,
+        l_g = 0.86906,
+        a_g = 3.82092,
+        c_g = -0.01635,
+        s_h = 5.86728,
+        b_h = -9.40849,
+        e_h = -3.32505,
+        l_h = -8.10341,
+        a_h = -50.00797,
+        c_h = -8.6506,
+        A = 0.571,
+        B = 1521.0,
+        C = -2.0894,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 164,
+        dGsolvMAE = (0.22,'kcal/mol'),
+        dHsolvCount = 119,
+        dHsolvMAE = (0.55,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 78,
+    label = "pyridine",
+    molecule = "c1ccncc1",
+    solvent = SolventData(
+        s_g = 2.38048,
+        b_g = -0.64239,
+        e_g = -0.55343,
+        l_g = 0.893,
+        a_g = 4.9189,
+        c_g = 0.00782,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -51.584,
+        B = 3135.5,
+        C = 5.9733,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 19,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = 4,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 79,
+    label = "butan-2-ol",
+    molecule = "CCC(C)O",
+    solvent = SolventData(
+        s_g = 0.6972,
+        b_g = 0.9333,
+        e_g = -0.38628,
+        l_g = 0.90951,
+        a_g = 3.8415,
+        c_g = -0.0095,
+        s_h = 3.62815,
+        b_h = -9.24459,
+        e_h = 1.5237,
+        l_h = -8.34576,
+        a_h = -50.69463,
+        c_h = -6.74398,
+        A = -10.638,
+        B = 7434.0,
+        C = 13.285,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 110,
+        dGsolvMAE = (0.18,'kcal/mol'),
+        dHsolvCount = 89,
+        dHsolvMAE = (0.46,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 80,
+    label = "tert-butylbenzene",
+    molecule = "CC(C)(C)c1ccccc1",
+    solvent = SolventData(
+        s_g = 0.88156,
+        b_g = -0.54391,
+        e_g = -0.62169,
+        l_g = 0.93527,
+        a_g = 0.0,
+        c_g = 0.56955,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -11.51,
+        B = 1357.4,
+        C = 0.0088106,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 15,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 81,
+    label = "1,1,2,2-tetrachloroethene",
+    molecule = "ClC(Cl)=C(Cl)Cl",
+    solvent = SolventData(
+        s_g = 0.42821,
+        b_g = 0.55989,
+        e_g = -0.02845,
+        l_g = 1.02443,
+        a_g = -0.04645,
+        c_g = 0.1245,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -1.978,
+        B = 555.0,
+        C = -1.2216,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 82,
+    label = "oxolane",
+    molecule = "C1CCOC1",
+    solvent = SolventData(
+        s_g = 1.33018,
+        b_g = -0.03767,
+        e_g = -0.492,
+        l_g = 1.0155,
+        a_g = 3.11944,
+        c_g = 0.16482,
+        s_h = -17.07744,
+        b_h = 3.04258,
+        e_h = 4.98498,
+        l_h = -8.5809,
+        a_h = -42.01867,
+        c_h = -5.70097,
+        A = -10.335,
+        B = 883.6,
+        C = -0.05265,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 125,
+        dGsolvMAE = (0.17,'kcal/mol'),
+        dHsolvCount = 90,
+        dHsolvMAE = (0.39,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 83,
+    label = "1,2,3,4-tetrahydronaphthalene",
+    molecule = "c1ccc2c(c1)CCCC2",
+    solvent = SolventData(
+        s_g = 1.05459,
+        b_g = -1.43576,
+        e_g = -0.23041,
+        l_g = 1.00834,
+        a_g = -0.58503,
+        c_g = 0.15803,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -45.327,
+        B = 3241.8,
+        C = 4.9583,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 20,
+        dGsolvMAE = (0.1,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 84,
+    label = "tributyl phosphate",
+    molecule = "CCCCOP(=O)(OCCCC)OCCCC",
+    solvent = SolventData(
+        s_g = 1.49741,
+        b_g = 1.33253,
+        e_g = -0.43108,
+        l_g = 1.00757,
+        a_g = 5.1522,
+        c_g = -1.30418,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 85,
+    label = "N,N-diethylethanamine",
+    molecule = "CCN(CC)CC",
+    solvent = SolventData(
+        s_g = 0.42376,
+        b_g = -0.0887,
+        e_g = -0.29856,
+        l_g = 1.006,
+        a_g = 3.06973,
+        c_g = 0.25515,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -1.033,
+        B = 458.2,
+        C = -1.4867,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = 4,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 86,
+    label = "1,2,4-trimethylbenzene",
+    molecule = "Cc1ccc(C)c(C)c1",
+    solvent = SolventData(
+        s_g = 1.76422,
+        b_g = -1.04965,
+        e_g = -0.79671,
+        l_g = 0.97318,
+        a_g = -0.0,
+        c_g = 0.19512,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 7.168,
+        B = 1156.0,
+        C = -0.6556,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 87,
+    label = "1,4-xylene",
+    molecule = "Cc1ccc(C)cc1",
+    solvent = SolventData(
+        s_g = 0.84532,
+        b_g = 0.11893,
+        e_g = -0.33317,
+        l_g = 1.02073,
+        a_g = 0.59666,
+        c_g = 0.10408,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -5.775,
+        B = 826.2,
+        C = -0.7739,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 129,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 7,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 88,
+    label = "2-methylpropan-2-ol",
+    molecule = "CC(C)(C)O",
+    solvent = SolventData(
+        s_g = 0.65023,
+        b_g = 0.90834,
+        e_g = -0.40573,
+        l_g = 0.90299,
+        a_g = 4.05031,
+        c_g = 0.05883,
+        s_h = 1.43136,
+        b_h = -12.14402,
+        e_h = 4.73946,
+        l_h = -8.7327,
+        a_h = -57.55969,
+        c_h = -3.38765,
+        A = -216.4,
+        B = 13205.0,
+        C = 29.254,
+        D = -2.4615999999999997e-27,
+        E = 10,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 113,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 83,
+        dHsolvMAE = (0.41,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 89,
+    label = "3-methylbutan-1-ol",
+    molecule = "CC(C)CCO",
+    solvent = SolventData(
+        s_g = 0.65923,
+        b_g = 0.91017,
+        e_g = -0.41341,
+        l_g = 0.92143,
+        a_g = 3.65458,
+        c_g = -4e-05,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -38.131,
+        B = 3773.0,
+        C = 3.4876,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 81,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 90,
+    label = "undecan-1-ol",
+    molecule = "CCCCCCCCCCCO",
+    solvent = SolventData(
+        s_g = 0.58076,
+        b_g = 1.73101,
+        e_g = 0.06242,
+        l_g = 0.97442,
+        a_g = 1.33432,
+        c_g = -0.08866,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -83.771,
+        B = 6606.1,
+        C = 10.065,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 91,
+    label = "propan-2-one",
+    molecule = "CC(C)=O",
+    solvent = SolventData(
+        s_g = 1.69516,
+        b_g = 0.17306,
+        e_g = -0.32032,
+        l_g = 0.86014,
+        a_g = 2.93123,
+        c_g = 0.12029,
+        s_h = -16.7202,
+        b_h = -4.40072,
+        e_h = 2.98338,
+        l_h = -6.84571,
+        a_h = -34.47063,
+        c_h = -5.88329,
+        A = -14.918,
+        B = 1023.4,
+        C = 0.05961,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 116,
+        dGsolvMAE = (0.2,'kcal/mol'),
+        dHsolvCount = 87,
+        dHsolvMAE = (0.46,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 92,
+    label = "methyl acetate",
+    molecule = "COC(C)=O",
+    solvent = SolventData(
+        s_g = 1.69088,
+        b_g = 0.19255,
+        e_g = -0.38531,
+        l_g = 0.86104,
+        a_g = 2.62676,
+        c_g = 0.15436,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 13.557,
+        B = -187.3,
+        C = -3.6592,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 87,
+        dGsolvMAE = (0.19,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 93,
+    label = "propyl acetate",
+    molecule = "CCCOC(C)=O",
+    solvent = SolventData(
+        s_g = 1.06304,
+        b_g = 0.47577,
+        e_g = -0.1366,
+        l_g = 0.89271,
+        a_g = 2.45421,
+        c_g = 0.24482,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 18.851,
+        B = -303.96,
+        C = -4.4468,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.17,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 94,
+    label = "pentyl acetate",
+    molecule = "CCCCCOC(C)=O",
+    solvent = SolventData(
+        s_g = 0.75079,
+        b_g = 0.47914,
+        e_g = -0.37424,
+        l_g = 1.03007,
+        a_g = 2.71499,
+        c_g = -0.14138,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -10.639,
+        B = 1263.6,
+        C = -0.12151,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 95,
+    label = "2-methylbutan-2-ol",
+    molecule = "CCC(C)(C)O",
+    solvent = SolventData(
+        s_g = 0.42769,
+        b_g = 0.54099,
+        e_g = -0.17081,
+        l_g = 0.89026,
+        a_g = 3.20106,
+        c_g = 0.1256,
+        s_h = -9.31722,
+        b_h = -2.70468,
+        e_h = 13.90703,
+        l_h = -8.66954,
+        a_h = -62.44515,
+        c_h = -7.30891,
+        A = -195.84,
+        B = 11895.0,
+        C = 26.385,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 23,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = 22,
+        dHsolvMAE = (0.36,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 96,
+    label = "4-methylpentan-2-ol",
+    molecule = "CC(C)CC(C)O",
+    solvent = SolventData(
+        s_g = 1.28796,
+        b_g = 0.30443,
+        e_g = -0.55005,
+        l_g = 0.82133,
+        a_g = 3.26911,
+        c_g = 0.3368,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -15.465,
+        B = 9891.9,
+        C = 203.56,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 15,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 97,
+    label = "2-methylpentan-1-ol",
+    molecule = "CCCC(C)CO",
+    solvent = SolventData(
+        s_g = 0.36741,
+        b_g = 1.66352,
+        e_g = -0.10714,
+        l_g = 0.9159,
+        a_g = 3.90308,
+        c_g = -0.41998,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -95.728,
+        B = 7010.0,
+        C = -0.18892,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 14,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 98,
+    label = "2-ethylhexan-1-ol",
+    molecule = "CCCCC(CC)CO",
+    solvent = SolventData(
+        s_g = 0.71109,
+        b_g = 0.02229,
+        e_g = -0.43734,
+        l_g = 0.97233,
+        a_g = 3.70508,
+        c_g = -0.03541,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 8.6589,
+        B = 2685.5,
+        C = -0.944,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 20,
+        dGsolvMAE = (0.21,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 99,
+    label = "2-methoxy-2-methylpropane",
+    molecule = "COC(C)(C)C",
+    solvent = SolventData(
+        s_g = 0.78713,
+        b_g = -0.11669,
+        e_g = -0.4719,
+        l_g = 0.99125,
+        a_g = 2.8507,
+        c_g = 0.29355,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -7.3165,
+        B = 810.5,
+        C = -0.59662,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 58,
+        dGsolvMAE = (0.14,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 100,
+    label = "dodecan-1-ol",
+    molecule = "CCCCCCCCCCCCO",
+    solvent = SolventData(
+        s_g = -0.24089,
+        b_g = 0.85679,
+        e_g = 0.38284,
+        l_g = 0.98644,
+        a_g = 3.39667,
+        c_g = -0.20543,
+        s_h = 37.43903,
+        b_h = 8.72408,
+        e_h = -12.9742,
+        l_h = -9.53791,
+        a_h = -119.92309,
+        c_h = -1.21466,
+        A = -70.023,
+        B = 5998.0,
+        C = 8.0302,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.05,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 101,
+    label = "2-butoxyethanol",
+    molecule = "CCCCOCCO",
+    solvent = SolventData(
+        s_g = 1.06857,
+        b_g = 0.80183,
+        e_g = -0.1346,
+        l_g = 0.88807,
+        a_g = 3.63702,
+        c_g = -0.15955,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -5.6874,
+        B = 2197.4,
+        C = -1.2979,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 16,
+        dGsolvMAE = (0.14,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 102,
+    label = "2-ethoxyethanol",
+    molecule = "CCOCCO",
+    solvent = SolventData(
+        s_g = 1.13283,
+        b_g = 0.91003,
+        e_g = -0.19334,
+        l_g = 0.88639,
+        a_g = 3.83642,
+        c_g = -0.1727,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 13.653,
+        B = 2393.7,
+        C = -0.10063,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 26,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 103,
+    label = "1-propoxypropane",
+    molecule = "CCCOCCC",
+    solvent = SolventData(
+        s_g = 0.5014,
+        b_g = 0.16617,
+        e_g = -0.00317,
+        l_g = 0.97292,
+        a_g = 1.50002,
+        c_g = 0.26125,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -8.2119,
+        B = 893.52,
+        C = 0.022,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 16,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 104,
+    label = "pentan-2-ol",
+    molecule = "CCCC(C)O",
+    solvent = SolventData(
+        s_g = 0.46762,
+        b_g = 1.01443,
+        e_g = -0.30386,
+        l_g = 0.9319,
+        a_g = 3.89726,
+        c_g = -0.02451,
+        s_h = 1.2695,
+        b_h = -5.27753,
+        e_h = 5.07207,
+        l_h = -8.60835,
+        a_h = -70.70626,
+        c_h = -6.54809,
+        A = -12.233,
+        B = 8149.3,
+        C = 15.678,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 58,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = 34,
+        dHsolvMAE = (0.3,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 105,
+    label = "2-methylbutan-1-ol",
+    molecule = "CCC(C)CO",
+    solvent = SolventData(
+        s_g = 0.82358,
+        b_g = 0.73546,
+        e_g = -1.07594,
+        l_g = 1.10639,
+        a_g = 3.19871,
+        c_g = -0.25016,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -68.504,
+        B = 5455.0,
+        C = 7.85,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 106,
+    label = "pentan-3-ol",
+    molecule = "CCC(O)CC",
+    solvent = SolventData(
+        s_g = 0.22011,
+        b_g = 0.79138,
+        e_g = -0.10424,
+        l_g = 0.8562,
+        a_g = 3.80202,
+        c_g = 0.11455,
+        s_h = 0.37738,
+        b_h = -5.35537,
+        e_h = 8.79012,
+        l_h = -8.53651,
+        a_h = -60.73674,
+        c_h = -6.01692,
+        A = 26.244,
+        B = 911.06,
+        C = -6.1542,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = 19,
+        dHsolvMAE = (0.3,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 107,
+    label = "2-propoxyethanol",
+    molecule = "CCCOCCO",
+    solvent = SolventData(
+        s_g = 0.85931,
+        b_g = 0.68779,
+        e_g = -0.07125,
+        l_g = 0.96146,
+        a_g = 4.08579,
+        c_g = -0.54036,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.14,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 108,
+    label = "2-propan-2-yloxyethanol",
+    molecule = "CC(C)OCCO",
+    solvent = SolventData(
+        s_g = 0.83732,
+        b_g = 0.46411,
+        e_g = 0.01452,
+        l_g = 0.96999,
+        a_g = 4.32879,
+        c_g = -0.6685,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 109,
+    label = "3-methoxybutan-1-ol",
+    molecule = "COC(C)CCO",
+    solvent = SolventData(
+        s_g = 1.01253,
+        b_g = 1.2551,
+        e_g = 0.13478,
+        l_g = 0.66182,
+        a_g = 3.63703,
+        c_g = 0.70704,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.13,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 110,
+    label = "1-tert-butoxy-2-propanol",
+    molecule = "CC(O)COC(C)(C)C",
+    solvent = SolventData(
+        s_g = 1.10965,
+        b_g = 0.00506,
+        e_g = -0.58039,
+        l_g = 1.07942,
+        a_g = 3.8557,
+        c_g = -0.70228,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 111,
+    label = "2-methoxy-2-methylbutane",
+    molecule = "CCC(C)(C)OC",
+    solvent = SolventData(
+        s_g = 0.504,
+        b_g = 0.03943,
+        e_g = 0.32158,
+        l_g = 1.02616,
+        a_g = 2.22194,
+        c_g = 0.14583,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -11.276,
+        B = 991.96,
+        C = 3.5693,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 112,
+    label = "pentan-2-one",
+    molecule = "CCCC(C)=O",
+    solvent = SolventData(
+        s_g = -14.76691,
+        b_g = 20.21026,
+        e_g = 5.19846,
+        l_g = 0.93164,
+        a_g = -0.0,
+        c_g = 0.09677,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -13.181,
+        B = 1147.0,
+        C = 0.31253,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 113,
+    label = "ethyl butanoate",
+    molecule = "CCCC(=O)OCC",
+    solvent = SolventData(
+        s_g = -13.45737,
+        b_g = 18.25613,
+        e_g = 4.69803,
+        l_g = 0.92582,
+        a_g = 0.0,
+        c_g = 0.21529,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -15.485,
+        B = 1325.6,
+        C = 0.6432,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 114,
+    label = "heptan-2-one",
+    molecule = "CCCCCC(C)=O",
+    solvent = SolventData(
+        s_g = -12.95934,
+        b_g = 17.9718,
+        e_g = 4.62621,
+        l_g = 0.91635,
+        a_g = 0.0,
+        c_g = 0.16247,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -13.565,
+        B = 1308.2,
+        C = 0.3485,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 115,
+    label = "hexyl acetate",
+    molecule = "CCCCCCOC(C)=O",
+    solvent = SolventData(
+        s_g = -13.25703,
+        b_g = 18.86058,
+        e_g = 4.71488,
+        l_g = 0.93318,
+        a_g = 0.0,
+        c_g = 0.16962,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 116,
+    label = "1-nitro-2-octoxybenzene",
+    molecule = "CCCCCCCCOc1ccccc1[N+](=O)[O-]",
+    solvent = SolventData(
+        s_g = 1.47277,
+        b_g = 0.81904,
+        e_g = 0.16487,
+        l_g = 0.79158,
+        a_g = 1.19347,
+        c_g = -0.2117,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 81,
+        dGsolvMAE = (0.3,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 117,
+    label = "1-methylpyrrolidin-2-one",
+    molecule = "CN1CCCC1=O",
+    solvent = SolventData(
+        s_g = 2.05547,
+        b_g = 0.12822,
+        e_g = 0.08961,
+        l_g = 0.78018,
+        a_g = 4.49382,
+        c_g = -0.11795,
+        s_h = -24.40451,
+        b_h = 5.51139,
+        e_h = 20.66699,
+        l_h = -8.5427,
+        a_h = -48.04472,
+        c_h = -3.44818,
+        A = -12.503,
+        B = 1850.2,
+        C = -0.017697,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 127,
+        dGsolvMAE = (0.17,'kcal/mol'),
+        dHsolvCount = 21,
+        dHsolvMAE = (0.62,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 118,
+    label = "N-methylacetamide",
+    molecule = "CNC(C)=O",
+    solvent = SolventData(
+        s_g = 1.62919,
+        b_g = 0.36038,
+        e_g = -0.2321,
+        l_g = 0.85148,
+        a_g = 4.92155,
+        c_g = -0.235,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 55,
+        dGsolvMAE = (0.1,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 119,
+    label = "morpholine-4-carbaldehyde",
+    molecule = "O=CN1CCOCC1",
+    solvent = SolventData(
+        s_g = 1.9355,
+        b_g = 0.78605,
+        e_g = 0.43133,
+        l_g = 0.69498,
+        a_g = 3.67841,
+        c_g = -0.37729,
+        s_h = 0.54676,
+        b_h = -23.51752,
+        e_h = -22.55574,
+        l_h = -6.68785,
+        a_h = -15.91698,
+        c_h = 0.96495,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 65,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = 17,
+        dHsolvMAE = (0.18,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 120,
+    label = "N,N-dibutylformamide",
+    molecule = "CCCCN(C=O)CCCC",
+    solvent = SolventData(
+        s_g = 1.30427,
+        b_g = 0.07472,
+        e_g = -0.12307,
+        l_g = 0.88351,
+        a_g = 3.88766,
+        c_g = 0.04721,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 41,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 121,
+    label = "formamide",
+    molecule = "NC=O",
+    solvent = SolventData(
+        s_g = 2.24092,
+        b_g = 1.78587,
+        e_g = -0.00272,
+        l_g = 0.41666,
+        a_g = 4.41662,
+        c_g = -0.58509,
+        s_h = -6.92729,
+        b_h = -23.07347,
+        e_h = 3.55662,
+        l_h = -7.16221,
+        a_h = -29.49074,
+        c_h = -5.30108,
+        A = -62.009,
+        B = 447.02,
+        C = 7.2515,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 78,
+        dGsolvMAE = (0.15,'kcal/mol'),
+        dHsolvCount = 81,
+        dHsolvMAE = (0.41,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 122,
+    label = "N,N-diethylacetamide",
+    molecule = "CCN(CC)C(C)=O",
+    solvent = SolventData(
+        s_g = 1.65648,
+        b_g = 0.1428,
+        e_g = -0.1476,
+        l_g = 0.87168,
+        a_g = 4.56367,
+        c_g = -0.00177,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 27,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 123,
+    label = "1-methylpiperidin-2-one",
+    molecule = "CN1CCCCC1=O",
+    solvent = SolventData(
+        s_g = 1.97732,
+        b_g = 0.191,
+        e_g = -0.05682,
+        l_g = 0.8891,
+        a_g = 4.98342,
+        c_g = -0.31184,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 36,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 124,
+    label = "N-ethylformamide",
+    molecule = "CCNC=O",
+    solvent = SolventData(
+        s_g = 1.74287,
+        b_g = 0.3951,
+        e_g = -0.2594,
+        l_g = 0.80837,
+        a_g = 4.57895,
+        c_g = -0.16063,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 26,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 125,
+    label = "N-ethylacetamide",
+    molecule = "CCNC(C)=O",
+    solvent = SolventData(
+        s_g = 1.21667,
+        b_g = 0.39264,
+        e_g = 0.06026,
+        l_g = 0.83373,
+        a_g = 4.68764,
+        c_g = -0.05093,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 33,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 126,
+    label = "triolein",
+    molecule = "CCCCCCCC/C=C\CCCCCCCC(=O)OCC(COC(=O)CCCCCCC/C=C\CCCCCCCC)OC(=O)CCCCCCC/C=C\CCCCCCCC",
+    solvent = SolventData(
+        s_g = 0.22861,
+        b_g = 0.87324,
+        e_g = 0.17311,
+        l_g = 0.90303,
+        a_g = 0.83268,
+        c_g = 0.15358,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 87,
+        dGsolvMAE = (0.36,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 127,
+    label = "deca-1,9-diene",
+    molecule = "C=CCCCCCCC=C",
+    solvent = SolventData(
+        s_g = -0.49957,
+        b_g = 1.40849,
+        e_g = 0.07562,
+        l_g = 0.98336,
+        a_g = 0.34207,
+        c_g = 0.00964,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 26,
+        dGsolvMAE = (0.23,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 128,
+    label = "hexadec-1-ene",
+    molecule = "C=CCCCCCCCCCCCCCC",
+    solvent = SolventData(
+        s_g = 0.09755,
+        b_g = 0.05257,
+        e_g = 0.03711,
+        l_g = 0.99232,
+        a_g = 0.28477,
+        c_g = -0.04688,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -43.375,
+        B = 3289.1,
+        C = 4.6393,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 94,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 129,
+    label = "1,3-xylene",
+    molecule = "Cc1cccc(C)c1",
+    solvent = SolventData(
+        s_g = 1.00139,
+        b_g = -0.00257,
+        e_g = -0.37907,
+        l_g = 1.01758,
+        a_g = 0.54254,
+        c_g = 0.08732,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -9.647,
+        B = 983.0,
+        C = -0.01928,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 81,
+        dGsolvMAE = (0.14,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 130,
+    label = "1,2-xylene",
+    molecule = "Cc1ccccc1C",
+    solvent = SolventData(
+        s_g = 0.92629,
+        b_g = 0.19207,
+        e_g = -0.31782,
+        l_g = 1.01746,
+        a_g = 0.51918,
+        c_g = 0.04592,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -15.678,
+        B = 1404.0,
+        C = 0.6641,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 61,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 131,
+    label = "1,4-dioxane",
+    molecule = "C1COCCO1",
+    solvent = SolventData(
+        s_g = 1.7944,
+        b_g = 0.01531,
+        e_g = -0.36532,
+        l_g = 0.90657,
+        a_g = 2.97516,
+        c_g = -0.02415,
+        s_h = -19.56181,
+        b_h = -0.36477,
+        e_h = 5.40015,
+        l_h = -7.71945,
+        a_h = -34.74552,
+        c_h = -4.19887,
+        A = -36.706,
+        B = 2691.5,
+        C = 3.6741,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 137,
+        dGsolvMAE = (0.18,'kcal/mol'),
+        dHsolvCount = 118,
+        dHsolvMAE = (0.36,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 132,
+    label = "1-chlorobutane",
+    molecule = "CCCCCl",
+    solvent = SolventData(
+        s_g = 0.90664,
+        b_g = 0.02496,
+        e_g = -0.40444,
+        l_g = 0.98621,
+        a_g = 0.70786,
+        c_g = 0.26487,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 8.91,
+        B = 49.58,
+        C = -2.9568,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 57,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = 7,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 133,
+    label = "1,1,2,2-tetrabromoethane",
+    molecule = "BrC(Br)C(Br)Br",
+    solvent = SolventData(
+        s_g = 0.205,
+        b_g = 1.60401,
+        e_g = 1.10605,
+        l_g = 0.81585,
+        a_g = 0.53612,
+        c_g = -0.18218,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -7.5336,
+        B = 5578.3,
+        C = 9.0957,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 9,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 134,
+    label = "1,1,2,2-tetrachloroethane",
+    molecule = "ClC(Cl)C(Cl)Cl",
+    solvent = SolventData(
+        s_g = 0.22952,
+        b_g = 1.77858,
+        e_g = 0.781,
+        l_g = 0.94058,
+        a_g = 0.84434,
+        c_g = -0.07845,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -29.579,
+        B = 2285.4,
+        C = 2.7189,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 135,
+    label = "propane-1,2-diol",
+    molecule = "CC(O)CO",
+    solvent = SolventData(
+        s_g = 2.28963,
+        b_g = -0.42705,
+        e_g = -0.43702,
+        l_g = 0.67616,
+        a_g = 5.47787,
+        c_g = -0.41667,
+        s_h = -14.7135,
+        b_h = -1.26316,
+        e_h = 7.27675,
+        l_h = -8.49655,
+        a_h = -46.35901,
+        c_h = -2.92944,
+        A = -293.07,
+        B = 17494.0,
+        C = 40.576,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 19,
+        dHsolvMAE = (0.1,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 136,
+    label = "1,3-dimethylimidazolidin-2-one",
+    molecule = "CN1CCN(C)C1=O",
+    solvent = SolventData(
+        s_g = 1.81674,
+        b_g = 0.38939,
+        e_g = 0.10789,
+        l_g = 0.8109,
+        a_g = 4.64145,
+        c_g = -0.30057,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 137,
+    label = "propane-1,3-diol",
+    molecule = "OCCCO",
+    solvent = SolventData(
+        s_g = 1.1692,
+        b_g = 0.75617,
+        e_g = 0.45259,
+        l_g = 0.60581,
+        a_g = 4.63421,
+        c_g = -0.40968,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -14.436,
+        B = 3177.9,
+        C = 0.012322,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 138,
+    label = "butane-1,4-diol",
+    molecule = "OCCCCO",
+    solvent = SolventData(
+        s_g = 0.43797,
+        b_g = 1.73876,
+        e_g = 0.76809,
+        l_g = 0.60858,
+        a_g = 4.38218,
+        c_g = -0.17545,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -76.012,
+        B = 6966.8,
+        C = 8.7765,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 139,
+    label = "pentane-1,5-diol",
+    molecule = "OCCCCCO",
+    solvent = SolventData(
+        s_g = -0.39893,
+        b_g = 3.52249,
+        e_g = 0.9632,
+        l_g = 0.69625,
+        a_g = 2.5135,
+        c_g = -0.3546,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -76.248,
+        B = 7080.9,
+        C = 8.8187,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 140,
+    label = "1-bromonaphthalene",
+    molecule = "Brc1cccc2ccccc12",
+    solvent = SolventData(
+        s_g = 0.91909,
+        b_g = 0.49103,
+        e_g = 0.15934,
+        l_g = 0.86216,
+        a_g = 0.94625,
+        c_g = 0.01742,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 141,
+    label = "1-chloronaphthalene",
+    molecule = "Clc1cccc2ccccc12",
+    solvent = SolventData(
+        s_g = -0.76995,
+        b_g = 0.12984,
+        e_g = 1.44727,
+        l_g = 1.00069,
+        a_g = 0.0,
+        c_g = -0.33148,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 9.2058,
+        B = 1134.0,
+        C = -3.3047,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 142,
+    label = "dec-1-ene",
+    molecule = "C=CCCCCCCCC",
+    solvent = SolventData(
+        s_g = -13.77923,
+        b_g = 10.52025,
+        e_g = 4.75674,
+        l_g = 0.97507,
+        a_g = 55.48955,
+        c_g = 0.2317,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -15.858,
+        B = 1430.5,
+        C = 0.68113,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 143,
+    label = "hex-1-ene",
+    molecule = "C=CCCCC",
+    solvent = SolventData(
+        s_g = 0.13822,
+        b_g = 0.28251,
+        e_g = -0.51018,
+        l_g = 1.00075,
+        a_g = 0.06344,
+        c_g = 0.28234,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -6.909,
+        B = 656.9,
+        C = -0.062835,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 144,
+    label = "1-nitropropane",
+    molecule = "CCC[N+](=O)[O-]",
+    solvent = SolventData(
+        s_g = 1.50765,
+        b_g = 1.28832,
+        e_g = -0.08106,
+        l_g = 0.8041,
+        a_g = 0.0,
+        c_g = 0.17553,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -24.521,
+        B = 1788.6,
+        C = 1.9988,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 16,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 145,
+    label = "oct-1-ene",
+    molecule = "C=CCCCCCC",
+    solvent = SolventData(
+        s_g = -17.42443,
+        b_g = 12.83873,
+        e_g = 5.97004,
+        l_g = 1.00831,
+        a_g = 73.77575,
+        c_g = 0.17757,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 15.841,
+        B = -194.4,
+        C = -4.018,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 16,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = 4,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 146,
+    label = "2-sulfanylethanol",
+    molecule = "OCCS",
+    solvent = SolventData(
+        s_g = 1.00047,
+        b_g = 1.93431,
+        e_g = 0.60278,
+        l_g = 0.691,
+        a_g = 3.11754,
+        c_g = -0.43075,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 147,
+    label = "3-methylthiolane 1,1-dioxide",
+    molecule = "CC1CCS(=O)(=O)C1",
+    solvent = SolventData(
+        s_g = 2.91218,
+        b_g = -0.90316,
+        e_g = -0.07112,
+        l_g = 0.71957,
+        a_g = 2.02325,
+        c_g = -0.3364,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -72.515,
+        B = 5360.1,
+        C = 8.7917,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 148,
+    label = "hexanedinitrile",
+    molecule = "N#CCCCCC#N",
+    solvent = SolventData(
+        s_g = 1.33529,
+        b_g = 2.93914,
+        e_g = 0.47315,
+        l_g = 0.75883,
+        a_g = 5.12869,
+        c_g = -0.63501,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -18.181,
+        B = 2014.8,
+        C = 1.0968,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 21,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 149,
+    label = "benzyl acetate",
+    molecule = "CC(=O)OCc1ccccc1",
+    solvent = SolventData(
+        s_g = 1.21772,
+        b_g = 0.66574,
+        e_g = 0.14372,
+        l_g = 0.87976,
+        a_g = 2.69437,
+        c_g = -0.09201,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -18.431,
+        B = 2179.5,
+        C = 0.865,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 150,
+    label = "cyclohexylcyclohexane",
+    molecule = "C1CCC(C2CCCCC2)CC1",
+    solvent = SolventData(
+        s_g = -0.61183,
+        b_g = 0.37019,
+        e_g = 0.47242,
+        l_g = 0.94953,
+        a_g = 0.94623,
+        c_g = 0.23128,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = 24.519,
+        B = -9629.1,
+        C = -0.38364,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 151,
+    label = "butanenitrile",
+    molecule = "CCCC#N",
+    solvent = SolventData(
+        s_g = 2.31213,
+        b_g = -0.20123,
+        e_g = -0.66216,
+        l_g = 0.8891,
+        a_g = 2.7938,
+        c_g = -0.06015,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -7.7634,
+        B = 925.92,
+        C = -0.49345,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 25,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 152,
+    label = "cis-1,2-dichloroethene",
+    molecule = "Cl/C=C\Cl",
+    solvent = SolventData(
+        s_g = 0.61086,
+        b_g = 0.91679,
+        e_g = -0.1365,
+        l_g = 1.05819,
+        a_g = 0.2456,
+        c_g = 0.12124,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -13.508,
+        B = 964.23,
+        C = 0.44868,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 153,
+    label = "cis-decaline",
+    molecule = "C1CC[C@H]2CCCC[C@H]2C1",
+    solvent = SolventData(
+        s_g = 0.26567,
+        b_g = 0.10948,
+        e_g = -0.2302,
+        l_g = 1.03696,
+        a_g = 0.0,
+        c_g = 0.01578,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -44.032,
+        B = 3379.6,
+        C = 4.7234,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 19,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 154,
+    label = "cyclohexanol",
+    molecule = "OC1CCCCC1",
+    solvent = SolventData(
+        s_g = -8.24639,
+        b_g = 17.62908,
+        e_g = 3.70331,
+        l_g = 0.91097,
+        a_g = -13.05371,
+        c_g = -0.15469,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -87.257,
+        B = 7419.6,
+        C = 10.327,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 155,
+    label = "cyclohexylbenzene",
+    molecule = "c1ccc(C2CCCCC2)cc1",
+    solvent = SolventData(
+        s_g = 0.00051,
+        b_g = 0.71012,
+        e_g = 0.28745,
+        l_g = 1.00324,
+        a_g = 2.02234,
+        c_g = -0.00919,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -12.051,
+        B = 1819.4,
+        C = 0,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 156,
+    label = "cyclopentanone",
+    molecule = "O=C1CCCC1",
+    solvent = SolventData(
+        s_g = -0.02313,
+        b_g = 2.01236,
+        e_g = 0.32827,
+        l_g = 0.98855,
+        a_g = 9.24619,
+        c_g = -0.06679,
+        s_h = 3.99827,
+        b_h = -26.54762,
+        e_h = -1.90582,
+        l_h = -8.00511,
+        a_h = -142.42979,
+        c_h = -3.09625,
+        A = -23.53,
+        B = 5012.0,
+        C = 0,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 16,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = 16,
+        dHsolvMAE = (0.06,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 157,
+    label = "deuterated water",
+    molecule = "[2H]O[2H]",
+    solvent = SolventData(
+        s_g = 2.4615,
+        b_g = 4.28228,
+        e_g = 0.83887,
+        l_g = -0.15639,
+        a_g = 4.13302,
+        c_g = -0.98972,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 69,
+        dGsolvMAE = (0.18,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 158,
+    label = "bis(2-ethylhexyl) hexanedioate",
+    molecule = "CCCCC(CC)COC(=O)CCCCC(=O)OCC(CC)CCCC",
+    solvent = SolventData(
+        s_g = 3.17646,
+        b_g = -3.3948,
+        e_g = -1.15624,
+        l_g = 0.70313,
+        a_g = 3.46268,
+        c_g = 0.72829,
+        s_h = -39.34604,
+        b_h = 45.27509,
+        e_h = 16.99983,
+        l_h = -5.85499,
+        a_h = -44.90653,
+        c_h = -12.84426,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 21,
+        dGsolvMAE = (0.18,'kcal/mol'),
+        dHsolvCount = 21,
+        dHsolvMAE = (0.44,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 159,
+    label = "2,2-dichloroacetic acid",
+    molecule = "O=C(O)C(Cl)Cl",
+    solvent = SolventData(
+        s_g = 0.01233,
+        b_g = 2.04468,
+        e_g = 0.97722,
+        l_g = 0.89087,
+        a_g = 2.46663,
+        c_g = -0.36831,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 160,
+    label = "diethyl benzene-1,2-dicarboxylate",
+    molecule = "CCOC(=O)c1ccccc1C(=O)OCC",
+    solvent = SolventData(
+        s_g = 1.71569,
+        b_g = 0.20205,
+        e_g = -0.14121,
+        l_g = 0.84214,
+        a_g = 2.18408,
+        c_g = -0.20108,
+        s_h = -13.18857,
+        b_h = -6.83214,
+        e_h = 2.04035,
+        l_h = -7.95025,
+        a_h = -26.24228,
+        c_h = -1.10161,
+        A = -14.11,
+        B = 2851.0,
+        C = 0,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 31,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = 13,
+        dHsolvMAE = (0.17,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 161,
+    label = "2-(2-hydroxyethoxy)ethanol",
+    molecule = "OCCOCCO",
+    solvent = SolventData(
+        s_g = 1.80371,
+        b_g = 1.402,
+        e_g = 0.26276,
+        l_g = 0.63336,
+        a_g = 4.68302,
+        c_g = -0.65618,
+        s_h = -8.06601,
+        b_h = -34.64865,
+        e_h = 1.0923,
+        l_h = -6.06505,
+        a_h = -22.01269,
+        c_h = -2.85078,
+        A = -6.2425,
+        B = 5966.9,
+        C = 6.8296,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 56,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = 16,
+        dHsolvMAE = (0.54,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 162,
+    label = "1-ethoxy-2-(2-ethoxyethoxy)ethane",
+    molecule = "CCOCCOCCOCC",
+    solvent = SolventData(
+        s_g = 2.12002,
+        b_g = -0.86531,
+        e_g = -0.59725,
+        l_g = 0.9525,
+        a_g = 3.82094,
+        c_g = -0.07032,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 163,
+    label = "1-methoxy-2-(2-methoxyethoxy)ethane",
+    molecule = "COCCOCCOC",
+    solvent = SolventData(
+        s_g = 0.99865,
+        b_g = 0.59136,
+        e_g = -0.35265,
+        l_g = 0.91477,
+        a_g = 6.1889,
+        c_g = -0.0855,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -12.272,
+        B = 1422.3,
+        C = 0.10585,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 164,
+    label = "diiodomethane",
+    molecule = "ICI",
+    solvent = SolventData(
+        s_g = 1.02264,
+        b_g = 0.89843,
+        e_g = 1.47668,
+        l_g = 0.74636,
+        a_g = 0.35558,
+        c_g = -0.38941,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -34.41,
+        B = 241.96,
+        C = 3.5698,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 165,
+    label = "dibutyl benzene-1,2-dicarboxylate",
+    molecule = "CCCCOC(=O)c1ccccc1C(=O)OCCCC",
+    solvent = SolventData(
+        s_g = 1.05461,
+        b_g = 0.29007,
+        e_g = -0.00181,
+        l_g = 0.85846,
+        a_g = 2.03696,
+        c_g = 0.12025,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -250.53,
+        B = 14426.0,
+        C = 34.706,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 15,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = 4,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 166,
+    label = "dinonyl benzene-1,2-dicarboxylate",
+    molecule = "CCCCCCCCCOC(=O)c1ccccc1C(=O)OCCCCCCCCC",
+    solvent = SolventData(
+        s_g = -3.09707,
+        b_g = 0.51717,
+        e_g = 3.24168,
+        l_g = 0.97978,
+        a_g = 3.89549,
+        c_g = -0.2515,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 9,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 167,
+    label = "bis(2-ethylhexyl) phthalate",
+    molecule = "CCCCC(CC)COC(=O)c1ccccc1C(=O)OCC(CC)CCCC",
+    solvent = SolventData(
+        s_g = 0.6464,
+        b_g = -0.37408,
+        e_g = 0.19661,
+        l_g = 0.88781,
+        a_g = 3.02399,
+        c_g = -0.01824,
+        s_h = -8.33767,
+        b_h = -3.57747,
+        e_h = 3.75614,
+        l_h = -8.27821,
+        a_h = 0.0,
+        c_h = -3.96357,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 11,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.12,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 168,
+    label = "3-(3-hydroxypropoxy)propan-1-ol",
+    molecule = "OCCCOCCCO",
+    solvent = SolventData(
+        s_g = 1.44969,
+        b_g = 0.13747,
+        e_g = 0.22552,
+        l_g = 0.83553,
+        a_g = 2.14692,
+        c_g = -0.44041,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 169,
+    label = "ethane-1,2-diol",
+    molecule = "OCCO",
+    solvent = SolventData(
+        s_g = 2.27301,
+        b_g = 1.10258,
+        e_g = -0.06179,
+        l_g = 0.54103,
+        a_g = 5.34026,
+        c_g = -0.84237,
+        s_h = -11.73905,
+        b_h = -8.01831,
+        e_h = -4.82369,
+        l_h = -6.23321,
+        a_h = -44.28415,
+        c_h = -3.22667,
+        A = -10.352,
+        B = 7563.0,
+        C = 13.009,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 53,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 25,
+        dHsolvMAE = (0.78,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 170,
+    label = "furan-2-carbaldehyde",
+    molecule = "O=Cc1ccco1",
+    solvent = SolventData(
+        s_g = 0.96881,
+        b_g = 3.05671,
+        e_g = 0.25523,
+        l_g = 0.77784,
+        a_g = 4.10348,
+        c_g = -0.32828,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -69.008,
+        B = 3950.4,
+        C = 8.655,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 21,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = 7,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 171,
+    label = "furan-2-ylmethanol",
+    molecule = "OCc1ccco1",
+    solvent = SolventData(
+        s_g = 1.67116,
+        b_g = 0.4943,
+        e_g = 0.21862,
+        l_g = 0.82156,
+        a_g = 3.98036,
+        c_g = -0.49784,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -37.008,
+        B = 3555.0,
+        C = 3.4664,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 172,
+    label = "oxolan-2-one",
+    molecule = "O=C1CCCO1",
+    solvent = SolventData(
+        s_g = 2.68701,
+        b_g = -0.1148,
+        e_g = -0.06359,
+        l_g = 0.6827,
+        a_g = 3.65486,
+        c_g = -0.1692,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 23,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = 6,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 173,
+    label = "1H-indene",
+    molecule = "C1=Cc2ccccc2C1",
+    solvent = SolventData(
+        s_g = 0.27525,
+        b_g = -0.02319,
+        e_g = 0.70179,
+        l_g = 0.9297,
+        a_g = 0.0,
+        c_g = 0.02898,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -18.972,
+        B = 1929.9,
+        C = 1.0707,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 174,
+    label = "2-aminoethanol",
+    molecule = "NCCO",
+    solvent = SolventData(
+        s_g = 1.53429,
+        b_g = 0.68228,
+        e_g = 0.94825,
+        l_g = 0.58841,
+        a_g = 6.3679,
+        c_g = -0.88936,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -8.583,
+        B = 3152.0,
+        C = -1.0266,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 22,
+        dGsolvMAE = (0.06,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 175,
+    label = "1-ethylpyrrolidin-2-one",
+    molecule = "CCN1CCCC1=O",
+    solvent = SolventData(
+        s_g = 1.79889,
+        b_g = 0.10918,
+        e_g = 0.14087,
+        l_g = 0.8415,
+        a_g = 5.06353,
+        c_g = -0.09604,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 23,
+        dGsolvMAE = (0.07,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 176,
+    label = "tetradecane",
+    molecule = "CCCCCCCCCCCCCC",
+    solvent = SolventData(
+        s_g = -0.36094,
+        b_g = 0.52976,
+        e_g = 0.22467,
+        l_g = 0.9831,
+        a_g = 1.08505,
+        c_g = 0.05999,
+        s_h = -3.37063,
+        b_h = -1.57818,
+        e_h = 6.51703,
+        l_h = -9.12045,
+        a_h = -4.27501,
+        c_h = -6.93941,
+        A = -20.486,
+        B = 2088.4,
+        C = 1.2852,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 21,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 22,
+        dHsolvMAE = (0.33,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 177,
+    label = "tridecane",
+    molecule = "CCCCCCCCCCCCC",
+    solvent = SolventData(
+        s_g = 0.08172,
+        b_g = -0.07718,
+        e_g = 0.08018,
+        l_g = 0.9907,
+        a_g = -0.09899,
+        c_g = 0.09537,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.01,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 178,
+    label = "octamethylcyclotetrasiloxane",
+    molecule = "C[Si]1(C)O[Si](C)(C)O[Si](C)(C)O[Si](C)(C)O1",
+    solvent = SolventData(
+        s_g = 1.77556,
+        b_g = 4.33929,
+        e_g = -0.95093,
+        l_g = 0.91268,
+        a_g = 0.21782,
+        c_g = 0.20416,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 179,
+    label = "perflexane",
+    molecule = "FC(F)(F)C(F)(F)C(F)(F)C(F)(F)C(F)(F)C(F)(F)F",
+    solvent = SolventData(
+        s_g = -0.44688,
+        b_g = 0.71818,
+        e_g = -0.4199,
+        l_g = 0.51144,
+        a_g = -1.17023,
+        c_g = 0.71204,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 18,
+        dGsolvMAE = (0.14,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 180,
+    label = "perfluorooctane",
+    molecule = "FC(F)(F)C(F)(F)C(F)(F)C(F)(F)C(F)(F)C(F)(F)C(F)(F)C(F)(F)F",
+    solvent = SolventData(
+        s_g = -7.94397,
+        b_g = -16.30332,
+        e_g = 2.54941,
+        l_g = 0.66865,
+        a_g = -0.0,
+        c_g = 0.09721,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 181,
+    label = "2-phenylacetonitrile",
+    molecule = "N#CCc1ccccc1",
+    solvent = SolventData(
+        s_g = 0.4927,
+        b_g = 2.71631,
+        e_g = 0.58287,
+        l_g = 1.00108,
+        a_g = 0.0,
+        c_g = -0.71915,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -25.663,
+        B = 2207.1,
+        C = 2.1116,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 182,
+    label = "propanenitrile",
+    molecule = "CCC#N",
+    solvent = SolventData(
+        s_g = 2.17242,
+        b_g = 0.09059,
+        e_g = -0.27225,
+        l_g = 0.77038,
+        a_g = -2.58108,
+        c_g = 0.24229,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -5.7136,
+        B = 703.6,
+        C = -0.78123,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 22,
+        dGsolvMAE = (0.12,'kcal/mol'),
+        dHsolvCount = 4,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 183,
+    label = "4-methyl-1,3-dioxolan-2-one",
+    molecule = "CC1COC(=O)O1",
+    solvent = SolventData(
+        s_g = 3.15302,
+        b_g = -0.09687,
+        e_g = -0.61225,
+        l_g = 0.70877,
+        a_g = 3.33033,
+        c_g = -0.37072,
+        s_h = -16.08778,
+        b_h = -11.51353,
+        e_h = 1.91472,
+        l_h = -6.51177,
+        a_h = -17.84913,
+        c_h = -4.22151,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 39,
+        dGsolvMAE = (0.16,'kcal/mol'),
+        dHsolvCount = 113,
+        dHsolvMAE = (0.46,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 184,
+    label = "quinoline",
+    molecule = "c1ccc2ncccc2c1",
+    solvent = SolventData(
+        s_g = 1.10867,
+        b_g = 0.4956,
+        e_g = 0.22457,
+        l_g = 0.85655,
+        a_g = 3.37876,
+        c_g = 0.00456,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -51.162,
+        B = 3942.4,
+        C = 5.6579,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 29,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 185,
+    label = "2-chlorobutane",
+    molecule = "CCC(C)Cl",
+    solvent = SolventData(
+        s_g = 1.02846,
+        b_g = -0.02593,
+        e_g = -1.32513,
+        l_g = 0.93204,
+        a_g = 3.84033,
+        c_g = 0.45323,
+        s_h = -0.70075,
+        b_h = -0.56283,
+        e_h = 6.42173,
+        l_h = -8.84955,
+        a_h = 0.0,
+        c_h = -8.24864,
+        A = -42.417,
+        B = 2410.5,
+        C = 4.6466,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 8,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 8,
+        dHsolvMAE = (0.04,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 186,
+    label = "squalane",
+    molecule = "CC(C)CCCC(C)CCCC(C)CCCCC(C)CCCC(C)CCCC(C)C",
+    solvent = SolventData(
+        s_g = 0.28485,
+        b_g = -0.17076,
+        e_g = -0.14957,
+        l_g = 0.97416,
+        a_g = 0.0,
+        c_g = -0.04211,
+        s_h = -10.53039,
+        b_h = 7.8714,
+        e_h = 8.38144,
+        l_h = -7.42254,
+        a_h = 3.14948,
+        c_h = -8.38603,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 41,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = 25,
+        dHsolvMAE = (0.18,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 187,
+    label = "tetraethylene glycol",
+    molecule = "OCCOCCOCCOCCO",
+    solvent = SolventData(
+        s_g = 1.3414,
+        b_g = 1.44335,
+        e_g = 0.57393,
+        l_g = 0.68468,
+        a_g = 1.74944,
+        c_g = -0.57574,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -18.728,
+        B = 4056.8,
+        C = 0.34542,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 16,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 188,
+    label = "tetraglyme",
+    molecule = "COCCOCCOCCOCCOC",
+    solvent = SolventData(
+        s_g = 1.22215,
+        b_g = 0.51311,
+        e_g = -0.12957,
+        l_g = 0.84506,
+        a_g = 5.59973,
+        c_g = -0.18184,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 189,
+    label = "thiodiglycol",
+    molecule = "OCCSCCO",
+    solvent = SolventData(
+        s_g = -2.05002,
+        b_g = 9.51053,
+        e_g = 1.36088,
+        l_g = 0.5325,
+        a_g = -6.90194,
+        c_g = -0.24616,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 9,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 4,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 190,
+    label = "trans-1,2-dichloroethene",
+    molecule = "Cl/C=C/Cl",
+    solvent = SolventData(
+        s_g = 0.56394,
+        b_g = 0.67954,
+        e_g = -0.09174,
+        l_g = 1.13617,
+        a_g = 1.25327,
+        c_g = -0.07564,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -14.078,
+        B = 981.81,
+        C = 0.513,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.08,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 191,
+    label = "trans-decalin",
+    molecule = "C1CC[C@H]2CCCC[C@@H]2C1",
+    solvent = SolventData(
+        s_g = 0.62739,
+        b_g = -0.29334,
+        e_g = -0.30332,
+        l_g = 0.97922,
+        a_g = 0.21566,
+        c_g = 0.16573,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -28.692,
+        B = 2396.7,
+        C = 2.5297,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 14,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 192,
+    label = "N,N-dipentylpentan-1-amine",
+    molecule = "CCCCCN(CCCCC)CCCCC",
+    solvent = SolventData(
+        s_g = -0.29376,
+        b_g = -0.20942,
+        e_g = 0.50285,
+        l_g = 0.90351,
+        a_g = 2.15054,
+        c_g = 0.26141,
+        s_h = 2.40166,
+        b_h = 11.58811,
+        e_h = -0.50176,
+        l_h = -10.4943,
+        a_h = -56.48737,
+        c_h = -2.89836,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 9,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.06,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 193,
+    label = "tricaprylin",
+    molecule = "CCCCCCCC(=O)OCC(COC(=O)CCCCCCC)OC(=O)CCCCCCC",
+    solvent = SolventData(
+        s_g = 0.82081,
+        b_g = 1.47908,
+        e_g = -0.07952,
+        l_g = 0.92604,
+        a_g = 4.0725,
+        c_g = -0.13206,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 17,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 5,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 194,
+    label = "triethyl phosphate",
+    molecule = "CCOP(=O)(OCC)OCC",
+    solvent = SolventData(
+        s_g = 0.1189,
+        b_g = 0.55442,
+        e_g = -0.97631,
+        l_g = 0.77934,
+        a_g = 3.34021,
+        c_g = 1.0203,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 13,
+        dGsolvMAE = (0.02,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 195,
+    label = "triethylene glycol",
+    molecule = "OCCOCCOCCO",
+    solvent = SolventData(
+        s_g = 1.44217,
+        b_g = 1.00619,
+        e_g = 0.67914,
+        l_g = 0.67162,
+        a_g = 4.36505,
+        c_g = -0.68698,
+        s_h = 3.42969,
+        b_h = -41.46433,
+        e_h = -14.21714,
+        l_h = -4.54942,
+        a_h = -8.7017,
+        c_h = -3.1873,
+        A = -99.75,
+        B = 7640.0,
+        C = 12.43,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 34,
+        dGsolvMAE = (0.09,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.05,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 196,
+    label = "triglyme",
+    molecule = "COCCOCCOCCOC",
+    solvent = SolventData(
+        s_g = 1.86546,
+        b_g = 0.17264,
+        e_g = -0.23118,
+        l_g = 0.88096,
+        a_g = 4.39932,
+        c_g = -0.22892,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 12,
+        dGsolvMAE = (0.05,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 197,
+    label = "N,N-dibutylbutan-1-amine",
+    molecule = "CCCCN(CCCC)CCCC",
+    solvent = SolventData(
+        s_g = -0.32536,
+        b_g = 0.13687,
+        e_g = 0.39488,
+        l_g = 0.96903,
+        a_g = 2.32072,
+        c_g = 0.04705,
+        s_h = 4.53557,
+        b_h = 2.02601,
+        e_h = -0.71163,
+        l_h = -9.68255,
+        a_h = -49.04689,
+        c_h = -6.09563,
+        A = -2.279,
+        B = 2355.1,
+        C = 2.4141,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 10,
+        dGsolvMAE = (0.03,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.09,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 198,
+    label = "N,N-dioctyloctan-1-amine",
+    molecule = "CCCCCCCCN(CCCCCCCC)CCCCCCCC",
+    solvent = SolventData(
+        s_g = -0.3707,
+        b_g = 0.36622,
+        e_g = 0.60141,
+        l_g = 0.86702,
+        a_g = 1.7667,
+        c_g = 0.22219,
+        s_h = 15.98697,
+        b_h = -62.11023,
+        e_h = -9.18597,
+        l_h = -4.37492,
+        a_h = -19.58048,
+        c_h = -16.39085,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 9,
+        dGsolvMAE = (0.04,'kcal/mol'),
+        dHsolvCount = 9,
+        dHsolvMAE = (0.16,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham and Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 199,
+    label = "hexamethylphosphoramide",
+    molecule = "CN(C)P(=O)(N(C)C)N(C)C",
+    solvent = SolventData(
+        s_g = 2.583,
+        b_g = -0.88196,
+        e_g = -0.43921,
+        l_g = 0.88314,
+        a_g = 7.36045,
+        c_g = -0.12452,
+        s_h = None,
+        b_h = None,
+        e_h = None,
+        l_h = None,
+        a_h = None,
+        c_h = None,
+        A = -51.263,
+        B = 3610.7,
+        C = 5.8603,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 33,
+        dGsolvMAE = (0.11,'kcal/mol'),
+        dHsolvCount = None,
+        dHsolvMAE = None,
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Abraham parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+
+entry(
+    index = 200,
+    label = "dimethyl carbonate",
+    molecule = "COC(=O)OC",
+    solvent = SolventData(
+        s_g = None,
+        b_g = None,
+        e_g = None,
+        l_g = None,
+        a_g = None,
+        c_g = None,
+        s_h = -17.43963,
+        b_h = -2.99216,
+        e_h = 6.67692,
+        l_h = -8.18497,
+        a_h = -28.87129,
+        c_h = -3.10893,
+        A = None,
+        B = None,
+        C = None,
+        D = None,
+        E = None,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = 6,
+        dGsolvMAE = None,
+        dHsolvCount = 59,
+        dHsolvMAE = (0.42,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+""",
+)
+
+entry(
+    index = 201,
+    label = "diethyl carbonate",
+    molecule = "CCOC(=O)OCC",
+    solvent = SolventData(
+        s_g = None,
+        b_g = None,
+        e_g = None,
+        l_g = None,
+        a_g = None,
+        c_g = None,
+        s_h = -16.14978,
+        b_h = -0.17336,
+        e_h = 6.62452,
+        l_h = -8.74529,
+        a_h = -25.49243,
+        c_h = -4.31324,
+        A = -47.078,
+        B = 2783.2,
+        C = 5.3617,
+        D = 0,
+        E = 0,
+        alpha = None,
+        beta = None,
+        eps = None,
+        name_in_coolprop = None,
+    ),
+    dataCount = DataCountSolvent(
+        dGsolvCount = None,
+        dGsolvMAE = None,
+        dHsolvCount = 80,
+        dHsolvMAE = (0.29,'kcal/mol'),
+    ),
+    shortDesc = u""" """,
+    longDesc = 
+u"""
+Mintz parameters: fitted by Chung et al. (manuscript in preparation)
+Viscosity parameters (A, B, C, D, E): Viswanath, D. S., Ghosh, T. K., Prasad, D. H. L., Dutt, N. V. K.,
+Rani, K. Y. (2007) Viscosity of Liquids. Springer, The Netherlands: Dordrecht.
+""",
+)
+


### PR DESCRIPTION
_**Note that this pull request requires simultaneous updates of RMG-Py and RMG-database. The pull request on RMG-Py solvation_thermo_GAV branch is https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2112. The last commit needs to be removed before merging this branch.**_

### Motivation or Problem
The previous group additivity (GAV) method for solvation thermo uses very limited number of groups. This pull request will upgrade the solvation thermo GAV method that uses a lot more groups. Also, this pull request adds a lot more solvents and solutes to the solvent and solute libraries. 

### Description of Changes
The major changes include:

1. The solvation GAV now follows an approach similar to the gas-phase thermo GAV and uses `group`, `ring`, `polycyclic`, `longDistanceInteraction_cyclic`, `longDistanceInteraction_noncyclic`, `halogen`, and `radical` corrections to estimate solute parameters (E, S, A, B, L). All the solvation groups are fitted by me (more detailed reference will be added to the RMG-database once this work get published). Each solvation group includes a new attribute `dataCount` stored as either a `DataCountGAV` class or `None`. This new attribute stores the number of experimental solute parameter data used to fit each group value.

2. Many more solutes and solvents are added to the solute and solvent libraries. The new solvent parameters are fitted by me (more detailed reference will be added to the RMG-database once this work get published), and the number of solvation free energy and enthalpy data used to fit these parameters are included in the solvent library entries. The solvation free energy and enthalpy errors associated with the fitted solvent parameters are also included.