### PR TITLE
added `vdW_radical` to forbidden structures

### DIFF
--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -440,3 +440,18 @@ u"""
 Geometry could not converge at wB97x-D3/6-311++G(3df,3pd) (alongd ref - xq1492)
 """,
 )
+
+entry(
+    label = "vdW_radical",
+    group = 
+"""
+multiplicity [2,3,4,5]
+1 Xv u0 p0 c0
+""",
+    shortDesc = u"""vdW with radicals""",
+    longDesc = 
+u"""
+Forbid physisorbed vdW adsorbates with radicals.
+If adsorbate has radical(s), it should chemisorb with surface.
+""",
+)


### PR DESCRIPTION
We restrict vdW adsorbates from having radicals in family templates by restricting that the vdW groups have multiplicity 1.  However, it is diffcult to restrict that vdW products have multiplicity 1 in template products.  Since we do this for each vdw family, we should add `vdW_radical` to globally forbidden structures. If an adsorbate has radical(s), we assume that it will chemisorb to the surface, so we should not be making vdW molecules with radicals.


The `Xv` in the group will still allow for chemisorbed adsorbates to have radicals:

<img width="648" alt="Screen Shot 2021-05-17 at 12 54 55 PM" src="https://user-images.githubusercontent.com/32377555/118527243-18005700-b70f-11eb-84db-b664c439c63b.png">
