### PR TITLE
Fix the number of unpaired radicals in surface vdW families.

### DIFF
--- a/input/kinetics/families/Surface_Abstraction_Single_vdW/groups.py
+++ b/input/kinetics/families/Surface_Abstraction_Single_vdW/groups.py
@@ -35,8 +35,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 R  ux px cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 R  u0 px cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     # Note: shuold we restrict it so atoms *2 and *3 have no charge?
     # We don't want to end up with charged products....
@@ -74,8 +74,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 O  ux p2 cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 O  u0 p2 cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -144,7 +144,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 N  u0 p1 c0 {2,S} {4,[S,D]}
-4    R  ux px cx {3,[S,D]}
+4    R  u0 px cx {3,[S,D]}
 """,
     kinetics = None,
 )
@@ -158,8 +158,8 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 N  u0 p1 c0 {2,S} {4,S} {5,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -188,7 +188,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *2 O   u0 p2 c0 {3,S}
 3 *3 N   u0 p1 c0 {2,S} {4,D}
-4    R!H ux px cx {3,D}
+4    R!H u0 px cx {3,D}
 """,
     kinetics = None,
 )
@@ -202,7 +202,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 C  u0 p0 c0 {2,S} {4,[S,D,T]}
-4    R  ux px cx {3,[S,D,T]}
+4    R  u0 px cx {3,[S,D,T]}
 """,
     kinetics = None,
 )
@@ -216,9 +216,9 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 C  u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
-6    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
+6    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -232,8 +232,8 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *2 O   u0 p2 c0 {3,S}
 3 *3 C   u0 p0 c0 {2,S} {4,D} {5,S}
-4    R!H ux px cx {3,D}
-5    R   ux px cx {3,S}
+4    R!H u0 px cx {3,D}
+5    R   u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -247,7 +247,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *2 O   u0 p2 c0 {3,S}
 3 *3 C   u0 p0 c0 {2,S} {4,T}
-4    R!H ux px cx {3,T}
+4    R!H u0 px cx {3,T}
 """,
     kinetics = None,
 )
@@ -259,8 +259,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 C  u0 px cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -272,8 +272,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
-3 *3 C  ux px cx {2,S}
+2 *2 C  u0 px cx {3,S}
+3 *3 C  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -285,8 +285,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
-3 *3 O  ux p2 cx {2,S}
+2 *2 C  u0 px cx {3,S}
+3 *3 O  u0 p2 cx {2,S}
 """,
     kinetics = None,
 )
@@ -298,7 +298,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
+2 *2 C  u0 px cx {3,S}
 3 *3 O  u0 p2 c0 {2,S} {4,S}
 4    H  u0 p0 c0 {3,S}
 """,
@@ -312,7 +312,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
+2 *2 C  u0 px cx {3,S}
 3 *3 N  u0 p1 c0 {2,S}
 """,
     kinetics = None,
@@ -325,8 +325,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 N  u0 px cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -338,7 +338,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
+2 *2 N  u0 px cx {3,S}
 3 *3 H  u0 p0 c0 {2,S}
 """,
     kinetics = None,
@@ -366,8 +366,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
-3 *3 N  ux px cx {2,S}
+2 *2 N  u0 px cx {3,S}
+3 *3 N  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -379,7 +379,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
+2 *2 N  u0 px cx {3,S}
 3 *3 O  u0 p2 c0 {2,S}
 """,
     kinetics = None,
@@ -392,8 +392,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
-3 *3 C  ux px cx {2,S}
+2 *2 N  u0 px cx {3,S}
+3 *3 C  u0 px cx {2,S}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Surface_Abstraction_vdW/groups.py
+++ b/input/kinetics/families/Surface_Abstraction_vdW/groups.py
@@ -38,8 +38,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 R  ux px cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 R  u0 px cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -62,8 +62,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 O  ux p2 cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 O  u0 p2 cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -75,8 +75,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 C  u0 px cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -123,8 +123,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
-3 *3 R  ux px cx {2,S}
+2 *2 N  u0 px cx {3,S}
+3 *3 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -306,7 +306,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 N  u0 p1 c0 {2,S} {4,[S,D]}
-4    R  ux px cx {3,[S,D]}
+4    R  u0 px cx {3,[S,D]}
 """,
     kinetics = None,
 )
@@ -320,7 +320,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 C  u0 p0 c0 {2,S} {4,[S,D,T]}
-4    R  ux px cx {3,[S,D,T]}
+4    R  u0 px cx {3,[S,D,T]}
 """,
     kinetics = None,
 )
@@ -334,9 +334,9 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 C  u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
-6    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
+6    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -350,8 +350,8 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *2 O   u0 p2 c0 {3,S}
 3 *3 C   u0 p0 c0 {2,S} {4,D} {5,S}
-4    R!H ux px cx {3,D}
-5    R   ux px cx {3,S}
+4    R!H u0 px cx {3,D}
+5    R   u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -365,7 +365,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *2 O   u0 p2 c0 {3,S}
 3 *3 C   u0 p0 c0 {2,S} {4,T}
-4    R!H ux px cx {3,T}
+4    R!H u0 px cx {3,T}
 """,
     kinetics = None,
 )
@@ -379,8 +379,8 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,S}
 3 *3 N  u0 p1 c0 {2,S} {4,S} {5,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -409,7 +409,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *2 O   u0 p2 c0 {3,S}
 3 *3 N   u0 p1 c0 {2,S} {4,D}
-4    R!H ux px cx {3,D}
+4    R!H u0 px cx {3,D}
 """,
     kinetics = None,
 )
@@ -421,8 +421,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
-3 *3 C  ux px cx {2,S}
+2 *2 C  u0 px cx {3,S}
+3 *3 C  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -434,8 +434,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
-3 *3 O  ux p2 cx {2,S}
+2 *2 C  u0 px cx {3,S}
+3 *3 O  u0 p2 cx {2,S}
 """,
     kinetics = None,
 )
@@ -447,7 +447,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
+2 *2 C  u0 px cx {3,S}
 3 *3 N  u0 p1 c0 {2,S}
 """,
     kinetics = None,
@@ -460,7 +460,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,S}
+2 *2 C  u0 px cx {3,S}
 3 *3 O  u0 p2 c0 {2,S} {4,S}
 4    H  u0 p0 c0 {3,S}
 """,
@@ -474,8 +474,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
-3 *3 N  ux px cx {2,S}
+2 *2 N  u0 px cx {3,S}
+3 *3 N  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -487,7 +487,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
+2 *2 N  u0 px cx {3,S}
 3 *3 O  u0 p2 c0 {2,S}
 """,
     kinetics = None,
@@ -500,8 +500,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,S}
-3 *3 C  ux px cx {2,S}
+2 *2 N  u0 px cx {3,S}
+3 *3 C  u0 px cx {2,S}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Surface_Addition_Single_vdW/groups.py
+++ b/input/kinetics/families/Surface_Addition_Single_vdW/groups.py
@@ -37,8 +37,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 R!H ux px cx {3,[D,T]}
-3 *3 R!H ux px cx {2,[D,T]}
+2 *2 R!H u0 px cx {3,[D,T]}
+3 *3 R!H u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -117,8 +117,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 O   ux px cx {3,D}
-3 *3 R!H ux px cx {2,D}
+2 *2 O   u0 px cx {3,D}
+3 *3 R!H u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -130,8 +130,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 C   ux px cx {3,[D,T]}
-3 *3 R!H ux px cx {2,[D,T]}
+2 *2 C   u0 px cx {3,[D,T]}
+3 *3 R!H u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -143,8 +143,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 O  ux p2 cx {3,D}
-3 *3 C  ux px cx {2,D}
+2 *2 O  u0 p2 cx {3,D}
+3 *3 C  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -197,7 +197,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
-3 *3 N  ux px cx {2,D}
+3 *3 N  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -241,7 +241,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
 3 *3 N  u0 p1 c0 {2,D} {4,S}
-4    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -292,8 +292,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,[D,T]}
-3 *3 N  ux px cx {2,[D,T]}
+2 *2 C  u0 px cx {3,[D,T]}
+3 *3 N  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -319,7 +319,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 C  u0 px cx {3,T}
-3 *3 N  ux px cx {2,T}
+3 *3 N  u0 px cx {2,T}
 """,
     kinetics = None,
 )
@@ -359,8 +359,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 N   ux px cx {3,[D,T]}
-3 *3 R!H ux px cx {2,[D,T]}
+2 *2 N   u0 px cx {3,[D,T]}
+3 *3 R!H u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -372,7 +372,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
+2 *2 N  u0 px cx {3,D}
 3 *3 O  u0 p2 c0 {2,D}
 """,
     kinetics = None,
@@ -385,8 +385,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,[D,T]}
-3 *3 C  ux px cx {2,[D,T]}
+2 *2 N  u0 px cx {3,[D,T]}
+3 *3 C  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -398,8 +398,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
-3 *3 C  ux px cx {2,D}
+2 *2 N  u0 px cx {3,D}
+3 *3 C  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -411,8 +411,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,T}
-3 *3 C  ux px cx {2,T}
+2 *2 N  u0 px cx {3,T}
+3 *3 C  u0 px cx {2,T}
 """,
     kinetics = None,
 )
@@ -484,7 +484,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *3 O  u0 p2 c0 {3,D}
 3 *2 N  u0 p1 c0 {2,D} {4,S}
-4    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -526,8 +526,8 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *3 O  u0 p2 c0 {3,D}
 3 *2 C  u0 p0 c0 {2,D} {4,S} {5,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -541,7 +541,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *3 O   u0 p2 c0 {3,D}
 3 *2 C   u0 p0 c0 {2,D} {4,D}
-4    R!H ux px cx {3,D}
+4    R!H u0 px cx {3,D}
 """,
     kinetics = None,
 )
@@ -553,8 +553,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,[D,T]}
-3 *3 N  ux px cx {2,[D,T]}
+2 *2 N  u0 px cx {3,[D,T]}
+3 *3 N  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -566,8 +566,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
-3 *3 N  ux px cx {2,D}
+2 *2 N  u0 px cx {3,D}
+3 *3 N  u0 px cx {2,D}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Surface_Adsorption_Abstraction_vdW/groups.py
+++ b/input/kinetics/families/Surface_Adsorption_Abstraction_vdW/groups.py
@@ -110,8 +110,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 O   ux px cx {3,D}
-3 *3 R!H ux px cx {2,D}
+2 *2 O   u0 px cx {3,D}
+3 *3 R!H u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -123,8 +123,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 C   ux px cx {3,[D,T]}
-3 *3 R!H ux px cx {2,[D,T]}
+2 *2 C   u0 px cx {3,[D,T]}
+3 *3 R!H u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -136,8 +136,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 O  ux p2 cx {3,D}
-3 *3 C  ux px cx {2,D}
+2 *2 O  u0 p2 cx {3,D}
+3 *3 C  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -190,7 +190,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
-3 *3 N  ux px cx {2,D}
+3 *3 N  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -234,7 +234,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
 3 *3 N  u0 p1 c0 {2,D} {4,S}
-4    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -285,8 +285,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,[D,T]}
-3 *3 N  ux px cx {2,[D,T]}
+2 *2 C  u0 px cx {3,[D,T]}
+3 *3 N  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -312,7 +312,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 C  u0 px cx {3,T}
-3 *3 N  ux px cx {2,T}
+3 *3 N  u0 px cx {2,T}
 """,
     kinetics = None,
 )
@@ -352,8 +352,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 N   ux px cx {3,[D,T]}
-3 *3 R!H ux px cx {2,[D,T]}
+2 *2 N   u0 px cx {3,[D,T]}
+3 *3 R!H u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -365,7 +365,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
+2 *2 N  u0 px cx {3,D}
 3 *3 O  u0 p2 c0 {2,D}
 """,
     kinetics = None,
@@ -378,8 +378,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,[D,T]}
-3 *3 C  ux px cx {2,[D,T]}
+2 *2 N  u0 px cx {3,[D,T]}
+3 *3 C  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -391,8 +391,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
-3 *3 C  ux px cx {2,D}
+2 *2 N  u0 px cx {3,D}
+3 *3 C  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -404,8 +404,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,T}
-3 *3 C  ux px cx {2,T}
+2 *2 N  u0 px cx {3,T}
+3 *3 C  u0 px cx {2,T}
 """,
     kinetics = None,
 )
@@ -477,7 +477,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *3 O  u0 p2 c0 {3,D}
 3 *2 N  u0 p1 c0 {2,D} {4,S}
-4    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -519,8 +519,8 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *3 O  u0 p2 c0 {3,D}
 3 *2 C  u0 p0 c0 {2,D} {4,S} {5,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -534,7 +534,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *3 O   u0 p2 c0 {3,D}
 3 *2 C   u0 p0 c0 {2,D} {4,D}
-4    R!H ux px cx {3,D}
+4    R!H u0 px cx {3,D}
 """,
     kinetics = None,
 )
@@ -546,8 +546,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,[D,T]}
-3 *3 N  ux px cx {2,[D,T]}
+2 *2 N  u0 px cx {3,[D,T]}
+3 *3 N  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -559,8 +559,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
-3 *3 N  ux px cx {2,D}
+2 *2 N  u0 px cx {3,D}
+3 *3 N  u0 px cx {2,D}
 """,
     kinetics = None,
 )

--- a/input/kinetics/families/Surface_Dissociation_Double_vdW/groups.py
+++ b/input/kinetics/families/Surface_Dissociation_Double_vdW/groups.py
@@ -39,9 +39,9 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 Xv  ux px cx
-2 *2 R!H ux px cx {3,D}
-3 *3 R!H ux px cx {2,D}
+1 *1 Xv  u0 p0 c0
+2 *2 R!H u0 px cx {3,D}
+3 *3 R!H u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -151,7 +151,7 @@ forbidden(
     label = "CO",
     group =
 """
-1 *1 Xv ux
+1 *1 Xv u0
 2 *3 O  ux {3,D}
 3 *2 C  ux {2,D}
 """,
@@ -165,7 +165,7 @@ forbidden(
     label = "NO",
     group =
 """
-1 *1 Xv ux
+1 *1 Xv u0
 2 *3 O  ux {3,D}
 3 *2 N  ux {2,D}
 """,
@@ -179,7 +179,7 @@ forbidden(
     label = "CN",
     group =
 """
-1 *1 Xv ux
+1 *1 Xv u0
 2 *3 N  ux {3,D}
 3 *2 C  ux {2,D}
 """,

--- a/input/kinetics/families/Surface_Dissociation_vdW/groups.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/groups.py
@@ -35,8 +35,8 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 R!H ux px cx {2,S}
-2 *2 R   ux px cx {1,S}
+1 *1 R!H u0 px cx {2,S}
+2 *2 R   u0 px cx {1,S}
 3 *3 Xv  u0 p0 c0
 """,
     kinetics = None,
@@ -58,7 +58,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 R!H ux px cx {2,S}
+1 *1 R!H u0 px cx {2,S}
 2 *2 H   u0 p0 c0 {1,S}
 3 *3 Xv  u0 p0 c0
 """,
@@ -71,7 +71,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 C  ux px cx {2,S}
+1 *1 C  u0 px cx {2,S}
 2 *2 H  u0 p0 c0 {1,S}
 3 *3 Xv u0 p0 c0
 """,
@@ -84,7 +84,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 O  ux px cx {2,S}
+1 *1 O  u0 px cx {2,S}
 2 *2 H  u0 p0 c0 {1,S}
 3 *3 Xv u0 p0 c0
 """,
@@ -97,7 +97,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 N  ux px cx {2,S}
+1 *1 N  u0 px cx {2,S}
 2 *2 H  u0 p0 c0 {1,S}
 3 *3 Xv u0 p0 c0
 """,

--- a/input/kinetics/families/Surface_Dual_Adsorption_vdW/groups.py
+++ b/input/kinetics/families/Surface_Dual_Adsorption_vdW/groups.py
@@ -38,8 +38,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 R!H ux px cx {3,[D,T,Q]}
-3 *3 R!H ux px cx {2,[D,T,Q]}
+2 *2 R!H u0 px cx {3,[D,T,Q]}
+3 *3 R!H u0 px cx {2,[D,T,Q]}
 """,
     kinetics = None,
 )
@@ -51,8 +51,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 R  ux px cx {3,S}
-3 *4 R  ux px cx {2,S}
+2 *6 R  u0 px cx {3,S}
+3 *4 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -64,8 +64,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 O   ux px cx {3,D}
-3 *3 R!H ux px cx {2,D}
+2 *2 O   u0 px cx {3,D}
+3 *3 R!H u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -78,7 +78,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
-3 *3 N  ux px cx {2,D}
+3 *3 N  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -104,7 +104,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
-3 *3 C  ux px cx {2,D}
+3 *3 C  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -118,7 +118,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 O  u0 p2 c0 {3,D}
 3 *3 N  u0 p1 c0 {2,D} {4,S}
-4    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -186,8 +186,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 C   ux px cx {3,[D,T,Q]}
-3 *3 R!H ux px cx {2,[D,T,Q]}
+2 *2 C   u0 px cx {3,[D,T,Q]}
+3 *3 R!H u0 px cx {2,[D,T,Q]}
 """,
     kinetics = None,
 )
@@ -252,8 +252,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 C  ux px cx {3,[D,T]}
-3 *3 N  ux px cx {2,[D,T]}
+2 *2 C  u0 px cx {3,[D,T]}
+3 *3 N  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -279,7 +279,7 @@ entry(
 multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *2 C  u0 px cx {3,T}
-3 *3 N  ux px cx {2,T}
+3 *3 N  u0 px cx {2,T}
 """,
     kinetics = None,
 )
@@ -319,8 +319,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv  u0 p0 c0
-2 *2 N   ux px cx {3,[D,T]}
-3 *3 R!H ux px cx {2,[D,T]}
+2 *2 N   u0 px cx {3,[D,T]}
+3 *3 R!H u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -332,7 +332,7 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
+2 *2 N  u0 px cx {3,D}
 3 *3 O  u0 p2 c0 {2,D}
 """,
     kinetics = None,
@@ -345,8 +345,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,[D,T]}
-3 *3 C  ux px cx {2,[D,T]}
+2 *2 N  u0 px cx {3,[D,T]}
+3 *3 C  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -358,8 +358,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
-3 *3 C  ux px cx {2,D}
+2 *2 N  u0 px cx {3,D}
+3 *3 C  u0 px cx {2,D}
 """,
     kinetics = None,
 )
@@ -371,8 +371,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,T}
-3 *3 C  ux px cx {2,T}
+2 *2 N  u0 px cx {3,T}
+3 *3 C  u0 px cx {2,T}
 """,
     kinetics = None,
 )
@@ -444,7 +444,7 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *3 O  u0 p2 c0 {3,D}
 3 *2 N  u0 p1 c0 {2,D} {4,S}
-4    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -456,8 +456,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 O  ux p2 cx {3,S}
-3 *4 R  ux px cx {2,S}
+2 *6 O  u0 p2 cx {3,S}
+3 *4 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -469,8 +469,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 C  ux px cx {3,S}
-3 *4 R  ux px cx {2,S}
+2 *6 C  u0 px cx {3,S}
+3 *4 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -495,8 +495,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 N  ux px cx {3,S}
-3 *4 R  ux px cx {2,S}
+2 *6 N  u0 px cx {3,S}
+3 *4 R  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -538,7 +538,7 @@ multiplicity [1]
 1 *5 Xv u0 p0 c0
 2 *6 O  u0 p2 c0 {3,S}
 3 *4 N  u0 p1 c0 {2,S} {4,[S,D]}
-4    R  ux px cx {3,[S,D]}
+4    R  u0 px cx {3,[S,D]}
 """,
     kinetics = None,
 )
@@ -552,7 +552,7 @@ multiplicity [1]
 1 *5 Xv u0 p0 c0
 2 *6 O  u0 p2 c0 {3,S}
 3 *4 C  u0 p0 c0 {2,S} {4,[S,D,T]}
-4    R  ux px cx {3,[S,D,T]}
+4    R  u0 px cx {3,[S,D,T]}
 """,
     kinetics = None,
 )
@@ -566,9 +566,9 @@ multiplicity [1]
 1 *5 Xv u0 p0 c0
 2 *6 O  u0 p2 c0 {3,S}
 3 *4 C  u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
-6    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
+6    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -582,8 +582,8 @@ multiplicity [1]
 1 *5 Xv  u0 p0 c0
 2 *6 O   u0 p2 c0 {3,S}
 3 *4 C   u0 p0 c0 {2,S} {4,D} {5,S}
-4    R!H ux px cx {3,D}
-5    R   ux px cx {3,S}
+4    R!H u0 px cx {3,D}
+5    R   u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -597,7 +597,7 @@ multiplicity [1]
 1 *5 Xv  u0 p0 c0
 2 *6 O   u0 p2 c0 {3,S}
 3 *4 C   u0 p0 c0 {2,S} {4,T}
-4    R!H ux px cx {3,T}
+4    R!H u0 px cx {3,T}
 """,
     kinetics = None,
 )
@@ -611,8 +611,8 @@ multiplicity [1]
 1 *5 Xv u0 p0 c0
 2 *6 O  u0 p2 c0 {3,S}
 3 *4 N  u0 p1 c0 {2,S} {4,S} {5,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -641,7 +641,7 @@ multiplicity [1]
 1 *5 Xv  u0 p0 c0
 2 *6 O   u0 p2 c0 {3,S}
 3 *4 N   u0 p1 c0 {2,S} {4,D}
-4    R!H ux px cx {3,D}
+4    R!H u0 px cx {3,D}
 """,
     kinetics = None,
 )
@@ -653,8 +653,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 C  ux px cx {3,S}
-3 *4 C  ux px cx {2,S}
+2 *6 C  u0 px cx {3,S}
+3 *4 C  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -666,8 +666,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 C  ux px cx {3,S}
-3 *4 O  ux p2 cx {2,S}
+2 *6 C  u0 px cx {3,S}
+3 *4 O  u0 p2 cx {2,S}
 """,
     kinetics = None,
 )
@@ -679,7 +679,7 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 C  ux px cx {3,S}
+2 *6 C  u0 px cx {3,S}
 3 *4 N  u0 p1 c0 {2,S}
 """,
     kinetics = None,
@@ -692,7 +692,7 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 C  ux px cx {3,S}
+2 *6 C  u0 px cx {3,S}
 3 *4 O  u0 p2 c0 {2,S} {4,S}
 4    H  u0 p0 c0 {3,S}
 """,
@@ -706,8 +706,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 N  ux px cx {3,S}
-3 *4 N  ux px cx {2,S}
+2 *6 N  u0 px cx {3,S}
+3 *4 N  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -719,7 +719,7 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 N  ux px cx {3,S}
+2 *6 N  u0 px cx {3,S}
 3 *4 O  u0 p2 c0 {2,S}
 """,
     kinetics = None,
@@ -732,8 +732,8 @@ entry(
 """
 multiplicity [1]
 1 *5 Xv u0 p0 c0
-2 *6 N  ux px cx {3,S}
-3 *4 C  ux px cx {2,S}
+2 *6 N  u0 px cx {3,S}
+3 *4 C  u0 px cx {2,S}
 """,
     kinetics = None,
 )
@@ -775,8 +775,8 @@ multiplicity [1]
 1 *1 Xv u0 p0 c0
 2 *3 O  u0 p2 c0 {3,D}
 3 *2 C  u0 p0 c0 {2,D} {4,S} {5,S}
-4    R  ux px cx {3,S}
-5    R  ux px cx {3,S}
+4    R  u0 px cx {3,S}
+5    R  u0 px cx {3,S}
 """,
     kinetics = None,
 )
@@ -790,7 +790,7 @@ multiplicity [1]
 1 *1 Xv  u0 p0 c0
 2 *3 O   u0 p2 c0 {3,D}
 3 *2 C   u0 p0 c0 {2,D} {4,D}
-4    R!H ux px cx {3,D}
+4    R!H u0 px cx {3,D}
 """,
     kinetics = None,
 )
@@ -802,8 +802,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,[D,T]}
-3 *3 N  ux px cx {2,[D,T]}
+2 *2 N  u0 px cx {3,[D,T]}
+3 *3 N  u0 px cx {2,[D,T]}
 """,
     kinetics = None,
 )
@@ -815,8 +815,8 @@ entry(
 """
 multiplicity [1]
 1 *1 Xv u0 p0 c0
-2 *2 N  ux px cx {3,D}
-3 *3 N  ux px cx {2,D}
+2 *2 N  u0 px cx {3,D}
+3 *3 N  u0 px cx {2,D}
 """,
     kinetics = None,
 )


### PR DESCRIPTION
Relating to our previous discussions, the Van der Waals species have ```multiplicity [1]```, which means the unpaired radical is 0. This PR revised the entries in the surface vdW families which defined the unpaired radicals of vdW species as ```ux``` rather than ```u0```. I also made a little change of ```Xv  ux px cx``` to ```Xv  u0 p0 c0``` in some surface vdW families.