### PR TITLE
Fix typo in training reactions name field.

### DIFF
--- a/input/kinetics/families/1,3_Insertion_RSR/training/reactions.py
+++ b/input/kinetics/families/1,3_Insertion_RSR/training/reactions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-name = "1,3_Insertion_RSR//training"
+name = "1,3_Insertion_RSR/training"
 shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
 Put kinetic parameters for specific reactions in this file to use as a

--- a/input/kinetics/families/1,3_NH3_elimination/training/reactions.py
+++ b/input/kinetics/families/1,3_NH3_elimination/training/reactions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-name = "1,2_NH3_elimination/training"
+name = "1,3_NH3_elimination/training"
 shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
 Put kinetic parameters for specific reactions in this file to use as a

--- a/input/kinetics/families/Surface_EleyRideal_Addition_Multiple_Bond/training/reactions.py
+++ b/input/kinetics/families/Surface_EleyRideal_Addition_Multiple_Bond/training/reactions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-name = "Surface_Eleyideal_Addition_Multiple_Bond/training"
+name = "Surface_EleyRideal_Addition_Multiple_Bond/training"
 shortDesc = u"Reaction kinetics used to generate rate rules"
 longDesc = u"""
 Put kinetic parameters for specific reactions in this file to use as a


### PR DESCRIPTION
Noticed that a few families have a training reaction file with a "name" header that doesn't match the family name.
Not sure why this metadata is hard-coded and not checked, but for now I just fixed the errors.