### PR TITLE
Fixed enthalpy errors in adsorption corrections for O-containing species on Pt(111)

### DIFF
--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -51,7 +51,7 @@ R*bidentate or R*single_chemisorbed and thus not R*vdW.
 #    thermo=ThermoData(
 #        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #        Cpdata=([-2.46, -1.45, -0.78, -0.33, 0.18, 0.46, 0.74], 'cal/(mol*K)'),
-#        H298=(-86.31, 'kcal/mol'),
+#        H298=(-58.43, 'kcal/mol'),
 #        S298=(-26.39, 'cal/(mol*K)'),
 #    ),
 #    shortDesc=u"""Came from H single-bonded on Pt(111)""",
@@ -111,7 +111,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.71, 1.22, 1.49, 1.65, 1.81, 1.9, 1.98], 'cal/(mol*K)'),
-        H298=(6.47, 'kcal/mol'),
+        H298=(-4.86, 'kcal/mol'),
         S298=(-22.53, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2O vdW-bonded on Pt(111)""",
@@ -140,7 +140,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.09, 1.82, 2.2, 2.42, 2.65, 2.75, 2.86], 'cal/(mol*K)'),
-        H298=(-34.86, 'kcal/mol'),
+        H298=(-46.18, 'kcal/mol'),
         S298=(-33.89, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from OH single-bonded on Pt(111)""",
@@ -172,7 +172,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.51, 1.74, 1.85, 1.92, 2.0, 2.05, 2.1], 'cal/(mol*K)'),
-        H298=(15.92, 'kcal/mol'),
+        H298=(-6.72, 'kcal/mol'),
         S298=(-26.31, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HO-OH vdW-bonded on Pt(111)""",
@@ -202,7 +202,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.98, 2.83, 3.18, 3.31, 3.32, 3.26, 3.14], 'cal/(mol*K)'),
-        H298=(14.04, 'kcal/mol'),
+        H298=(-8.60, 'kcal/mol'),
         S298=(-40.49, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O2 bidentate, twice single-bonded on Pt(111)""",
@@ -231,7 +231,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([4.16, 4.53, 4.58, 4.53, 4.37, 4.24, 4.07], 'cal/(mol*K)'),
-        H298=(5.63, 'kcal/mol'),
+        H298=(-17.01, 'kcal/mol'),
         S298=(-36.35, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from OOH single-bonded on Pt(111)""",
@@ -260,7 +260,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.31, 0.21, 0.48, 0.63, 0.78, 0.86, 0.93], 'cal/(mol*K)'),
-        H298=(-88.9, 'kcal/mol'),
+        H298=(-83.76, 'kcal/mol'),
         S298=(-30.95, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O double-bonded on Pt(111)""",
@@ -290,7 +290,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.24, 2.94, 3.33, 3.56, 3.78, 3.87, 3.95], 'cal/(mol*K)'),
-        H298=(-4.94, 'kcal/mol'),
+        H298=(-16.26, 'kcal/mol'),
         S298=(-35.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O-NH2 single-bonded on Pt(111)""",
@@ -323,7 +323,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.18, 2.44, 2.67, 2.86, 3.13, 3.3, 3.56], 'cal/(mol*K)'),
-        H298=(-20.55, 'kcal/mol'),
+        H298=(-31.87, 'kcal/mol'),
         S298=(-40.61, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O-CH3 single-bonded on Pt(111)""",
@@ -438,7 +438,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.93, -0.2, 0.19, 0.42, 0.66, 0.78, 0.9], 'cal/(mol*K)'),
-        H298=(-147.51, 'kcal/mol'),
+        H298=(-101.37, 'kcal/mol'),
         S298=(-32.92, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from N triple-bonded on Pt(111)""",
@@ -469,7 +469,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.36, 0.16, 0.59, 0.93, 1.37, 1.64, 1.92], 'cal/(mol*K)'),
-        H298=(-4.37, 'kcal/mol'),
+        H298=(-15.69, 'kcal/mol'),
         S298=(-32.2, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2N-OH vdW-bonded on Pt(111)""",
@@ -498,15 +498,14 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.22, 0.65, 1.14, 1.4, 1.61, 1.68, 1.77], 'cal/(mol*K)'),
-        H298=(-18.76, 'kcal/mol'),
-        S298=(-32.78, 'cal/(mol*K)'),
+        Cpdata=([1.74, 2.63, 3.12, 3.38, 3.6, 3.67, 3.76], 'cal/(mol*K)'),
+        H298=(-29.64, 'kcal/mol'),
+        S298=(-37.88, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-O vdW-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.270 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.
-            The two lowest frequencies, 36.2 and 74.0 cm-1, where replaced by the 2D gas model.
 
   RN=O
     :
@@ -530,7 +529,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.82, 2.71, 3.18, 3.44, 3.72, 3.86, 3.98], 'cal/(mol*K)'),
-        H298=(-21.0, 'kcal/mol'),
+        H298=(-34.47, 'kcal/mol'),
         S298=(-45.51, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-OH single-bonded on Pt(111)""",
@@ -558,7 +557,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.48, 2.2, 2.6, 2.83, 3.02, 3.07, 3.06], 'cal/(mol*K)'),
-        H298=(-25.86, 'kcal/mol'),
+        H298=(-37.18, 'kcal/mol'),
         S298=(-40.63, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NO single-bonded on Pt(111)""",
@@ -589,7 +588,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.99, 2.43, 2.68, 2.82, 2.96, 3.00, 3.01], 'cal/(mol*K)'),
-        H298=(-20.93, 'kcal/mol'),
+        H298=(-32.25, 'kcal/mol'),
         S298=(-35.43, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NO-h bidentate, double- and single-bonded on Pt(111)""",
@@ -618,7 +617,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.16, 3.09, 3.5, 3.66, 3.71, 3.67, 3.65], 'cal/(mol*K)'),
-        H298=(-64.4, 'kcal/mol'),
+        H298=(-75.72, 'kcal/mol'),
         S298=(-44.7, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NOH double-bonded on Pt(111)""",
@@ -964,7 +963,7 @@ entry(
 #     thermo=ThermoData(
 #         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #         Cpdata=([1.92, 2.12, 2.17, 2.17, 2.13, 2.09, 2.04], 'cal/(mol*K)'),
-#         H298=(-16.1, 'kcal/mol'),
+#         H298=(-16.09, 'kcal/mol'),
 #         S298=(-33.93, 'cal/(mol*K)'),
 #     ),
 #     shortDesc=u"""Came from ON-O single-bonded on Pt(111)""",
@@ -1427,7 +1426,7 @@ entry(
 #     thermo=ThermoData(
 #         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #         Cpdata=([1.81, 2.37, 2.68, 2.88, 3.05, 3.1, 3.08], 'cal/(mol*K)'),
-#         H298=(-23.38, 'kcal/mol'),
+#         H298=(-34.7, 'kcal/mol'),
 #         S298=(-38.09, 'cal/(mol*K)'),
 #     ),
 #     shortDesc=u"""Came from CO-f double-bonded on Pt(111)""",
@@ -1458,7 +1457,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.82, 2.68, 3.13, 3.36, 3.54, 3.6, 3.67], 'cal/(mol*K)'),
-        H298=(-87.68, 'kcal/mol'),
+        H298=(-99.0, 'kcal/mol'),
         S298=(-43.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from COH triple-bonded on Pt(111)""",
@@ -1623,7 +1622,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.91, 1.97, 2.0, 2.01, 2.02, 2.02, 2.01], 'cal/(mol*K)'),
-        H298=(7.31, 'kcal/mol'),
+        H298=(-4.0, 'kcal/mol'),
         S298=(-20.91, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-O vdW-bonded on Pt(111)""",
@@ -1654,7 +1653,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.84, 1.62, 2.2, 2.63, 3.19, 3.51, 3.84], 'cal/(mol*K)'),
-        H298=(-44.61, 'kcal/mol'),
+        H298=(-55.93, 'kcal/mol'),
         S298=(-41.1, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-OH single-bonded on Pt(111)""",
@@ -1722,7 +1721,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.38, 1.68, 1.82, 1.9, 1.96, 1.98, 2.0], 'cal/(mol*K)'),
-        H298=(3.85, 'kcal/mol'),
+        H298=(-7.47, 'kcal/mol'),
         S298=(-28.83, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H3C-OH vdW-bonded on Pt(111)""",
@@ -2007,7 +2006,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.38, 2.19, 2.7, 3.02, 3.37, 3.53, 3.73], 'cal/(mol*K)'),
-        H298=(-40.03, 'kcal/mol'),
+        H298=(-51.35, 'kcal/mol'),
         S298=(-36.89, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCO single-bonded on Pt(111)""",
@@ -2039,7 +2038,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.99, 2.22, 2.94, 3.34, 3.67, 3.78, 3.86], 'cal/(mol*K)'),
-        H298=(-33.39, 'kcal/mol'),
+        H298=(-44.71, 'kcal/mol'),
         S298=(-45.92, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCO-h bidentate, double- and single-bonded on Pt(111)""",
@@ -2071,7 +2070,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.53, 2.45, 2.96, 3.26, 3.59, 3.75, 3.92], 'cal/(mol*K)'),
-        H298=(-57.34, 'kcal/mol'),
+        H298=(-68.65, 'kcal/mol'),
         S298=(-39.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCOH double-bonded on Pt(111)""",
@@ -2136,7 +2135,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.07, 1.05, 1.77, 2.43, 2.8, 3.08, 3.39], 'cal/(mol*K)'),
-        H298=(-41.61, 'kcal/mol'),
+        H298=(-46.18, 'kcal/mol'),
         S298=(-38.17, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Average of C-*R3, N-*R2 and O-*R thermo. """,
@@ -2212,7 +2211,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.51, 2.68, 3.31, 3.65, 3.92, 4.00, 4.02], 'cal/(mol*K)'),
-        H298=(-34.82, 'kcal/mol'),
+        H298=(-37.29, 'kcal/mol'),
         S298=(-43.39, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Average of C-*R2C-*R2, C=*RN-*R, C=*RO-* and N-*RN-*R thermo. """,
@@ -2231,8 +2230,8 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.23, 1.71, 2.00, 2.19, 2.39, 2.50, 2.61], 'cal/(mol*K)'),
-        H298=(6.47, 'kcal/mol'),
-        S298=(-22.53, 'cal/(mol*K)'),
+        H298=(-7.79, 'kcal/mol'),
+        S298=(-20.48, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Average of (CR4)*, (NR3)* and (OR2)* thermo. """,
     metal = "Pt",

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -51,7 +51,7 @@ R*bidentate or R*single_chemisorbed and thus not R*vdW.
 #    thermo=ThermoData(
 #        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #        Cpdata=([-2.46, -1.45, -0.78, -0.33, 0.18, 0.46, 0.74], 'cal/(mol*K)'),
-#        H298=(-58.43, 'kcal/mol'),
+#        H298=(-58.54, 'kcal/mol'),
 #        S298=(-26.39, 'cal/(mol*K)'),
 #    ),
 #    shortDesc=u"""Came from H single-bonded on Pt(111)""",
@@ -81,7 +81,7 @@ R*bidentate or R*single_chemisorbed and thus not R*vdW.
 #     thermo=ThermoData(
 #         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #         Cpdata=([0.92, 0.95, 0.97, 0.98, 0.98, 0.99, 0.99], 'cal/(mol*K)'),
-#         H298=(-1.22, 'kcal/mol'),
+#         H298=(-1.45, 'kcal/mol'),
 #         S298=(-7.73, 'cal/(mol*K)'),
 #     ),
 #     shortDesc=u"""Came from H2 vdW-bonded on Pt(111)""",
@@ -111,7 +111,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.71, 1.22, 1.49, 1.65, 1.81, 1.9, 1.98], 'cal/(mol*K)'),
-        H298=(-4.86, 'kcal/mol'),
+        H298=(-5.3, 'kcal/mol'),
         S298=(-22.53, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2O vdW-bonded on Pt(111)""",
@@ -140,7 +140,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.09, 1.82, 2.2, 2.42, 2.65, 2.75, 2.86], 'cal/(mol*K)'),
-        H298=(-46.18, 'kcal/mol'),
+        H298=(-46.3, 'kcal/mol'),
         S298=(-33.89, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from OH single-bonded on Pt(111)""",
@@ -172,7 +172,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.51, 1.74, 1.85, 1.92, 2.0, 2.05, 2.1], 'cal/(mol*K)'),
-        H298=(-6.72, 'kcal/mol'),
+        H298=(-15.36, 'kcal/mol'),
         S298=(-26.31, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HO-OH vdW-bonded on Pt(111)""",
@@ -202,7 +202,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.98, 2.83, 3.18, 3.31, 3.32, 3.26, 3.14], 'cal/(mol*K)'),
-        H298=(-8.60, 'kcal/mol'),
+        H298=(-27.36, 'kcal/mol'),
         S298=(-40.49, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O2 bidentate, twice single-bonded on Pt(111)""",
@@ -231,7 +231,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([4.16, 4.53, 4.58, 4.53, 4.37, 4.24, 4.07], 'cal/(mol*K)'),
-        H298=(-17.01, 'kcal/mol'),
+        H298=(-33.05, 'kcal/mol'),
         S298=(-36.35, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from OOH single-bonded on Pt(111)""",
@@ -260,7 +260,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.31, 0.21, 0.48, 0.63, 0.78, 0.86, 0.93], 'cal/(mol*K)'),
-        H298=(-83.76, 'kcal/mol'),
+        H298=(-93.14, 'kcal/mol'),
         S298=(-30.95, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O double-bonded on Pt(111)""",
@@ -290,7 +290,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.24, 2.94, 3.33, 3.56, 3.78, 3.87, 3.95], 'cal/(mol*K)'),
-        H298=(-16.26, 'kcal/mol'),
+        H298=(-30.61, 'kcal/mol'),
         S298=(-35.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O-NH2 single-bonded on Pt(111)""",
@@ -323,7 +323,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.18, 2.44, 2.67, 2.86, 3.13, 3.3, 3.56], 'cal/(mol*K)'),
-        H298=(-31.87, 'kcal/mol'),
+        H298=(-43.38, 'kcal/mol'),
         S298=(-40.61, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from O-CH3 single-bonded on Pt(111)""",
@@ -383,7 +383,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.86, 0.72, 1.69, 2.29, 2.94, 3.25, 3.59], 'cal/(mol*K)'),
-        H298=(-48.33, 'kcal/mol'),
+        H298=(-53.39, 'kcal/mol'),
         S298=(-47.88, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NH2 single-bonded on Pt(111)""",
@@ -411,7 +411,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-1.74, -0.24, 0.7, 1.29, 1.93, 2.25, 2.6], 'cal/(mol*K)'),
-        H298=(-80.92, 'kcal/mol'),
+        H298=(-88.28, 'kcal/mol'),
         S298=(-40.72, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NH double-bonded on Pt(111)""",
@@ -438,7 +438,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.93, -0.2, 0.19, 0.42, 0.66, 0.78, 0.9], 'cal/(mol*K)'),
-        H298=(-101.37, 'kcal/mol'),
+        H298=(-103.33, 'kcal/mol'),
         S298=(-32.92, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from N triple-bonded on Pt(111)""",
@@ -469,7 +469,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.36, 0.16, 0.59, 0.93, 1.37, 1.64, 1.92], 'cal/(mol*K)'),
-        H298=(-15.69, 'kcal/mol'),
+        H298=(-18.16, 'kcal/mol'),
         S298=(-32.2, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2N-OH vdW-bonded on Pt(111)""",
@@ -499,7 +499,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.74, 2.63, 3.12, 3.38, 3.6, 3.67, 3.76], 'cal/(mol*K)'),
-        H298=(-29.64, 'kcal/mol'),
+        H298=(-39.84, 'kcal/mol'),
         S298=(-37.88, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-O vdW-bonded on Pt(111)""",
@@ -529,7 +529,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.82, 2.71, 3.18, 3.44, 3.72, 3.86, 3.98], 'cal/(mol*K)'),
-        H298=(-34.47, 'kcal/mol'),
+        H298=(-44.41, 'kcal/mol'),
         S298=(-45.51, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-OH single-bonded on Pt(111)""",
@@ -557,7 +557,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.48, 2.2, 2.6, 2.83, 3.02, 3.07, 3.06], 'cal/(mol*K)'),
-        H298=(-37.18, 'kcal/mol'),
+        H298=(-47.5, 'kcal/mol'),
         S298=(-40.63, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NO single-bonded on Pt(111)""",
@@ -588,7 +588,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.99, 2.43, 2.68, 2.82, 2.96, 3.00, 3.01], 'cal/(mol*K)'),
-        H298=(-32.25, 'kcal/mol'),
+        H298=(-42.57, 'kcal/mol'),
         S298=(-35.43, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NO-h bidentate, double- and single-bonded on Pt(111)""",
@@ -617,7 +617,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.16, 3.09, 3.5, 3.66, 3.71, 3.67, 3.65], 'cal/(mol*K)'),
-        H298=(-75.72, 'kcal/mol'),
+        H298=(-70.93, 'kcal/mol'),
         S298=(-44.7, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from NOH double-bonded on Pt(111)""",
@@ -651,7 +651,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.1, 0.6, 0.94, 1.19, 1.5, 1.68, 1.88], 'cal/(mol*K)'),
-        H298=(-23.19, 'kcal/mol'),
+        H298=(-26.81, 'kcal/mol'),
         S298=(-31.95, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2N-NH2 vdW-bonded on Pt(111)""",
@@ -682,7 +682,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.62, 3.77, 4.27, 4.45, 4.43, 4.3, 4.09], 'cal/(mol*K)'),
-        H298=(-20.58, 'kcal/mol'),
+        H298=(-24.31, 'kcal/mol'),
         S298=(-42.07, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-NH vdW-bonded on Pt(111)""",
@@ -711,7 +711,7 @@ entry(
 #    thermo=ThermoData(
 #        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #        Cpdata=([2.62, 3.77, 4.27, 4.45, 4.43, 4.3, 4.09], 'cal/(mol*K)'),
-#        H298=(-2.39, 'kcal/mol'),
+#        H298=(-6.31, 'kcal/mol'),
 #        S298=(-15.27, 'cal/(mol*K)'),
 #    ),
 #    shortDesc=u"""Came from NN vdW-bonded on Pt(111)""",
@@ -741,7 +741,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.57, 2.38, 2.87, 3.19, 3.55, 3.73, 3.91], 'cal/(mol*K)'),
-        H298=(-29.97, 'kcal/mol'),
+        H298=(-40.74, 'kcal/mol'),
         S298=(-45.43, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-NH2 single-bonded on Pt(111)""",
@@ -770,7 +770,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.42, 2.37, 2.9, 3.21, 3.47, 3.57, 3.69], 'cal/(mol*K)'),
-        H298=(-25.14, 'kcal/mol'),
+        H298=(-37.65, 'kcal/mol'),
         S298=(-43.45, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from N-NH single-bonded on Pt(111)""",
@@ -802,7 +802,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.71, 3.72, 4.13, 4.24, 4.1, 3.91, 3.71], 'cal/(mol*K)'),
-        H298=(-47.66, 'kcal/mol'),
+        H298=(-59.44, 'kcal/mol'),
         S298=(-43.17, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from N-NH2 double-bonded on Pt(111)""",
@@ -835,7 +835,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.06, 3.29, 3.9, 4.17, 4.27, 4.22, 4.08], 'cal/(mol*K)'),
-        H298=(-23.38, 'kcal/mol'),
+        H298=(-27.1, 'kcal/mol'),
         S298=(-42.53, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-NH-h bidentate, twice single-bonded on Pt(111)""",
@@ -867,7 +867,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.96, 1.81, 2.36, 2.72, 3.14, 3.36, 3.63], 'cal/(mol*K)'),
-        H298=(-43.5, 'kcal/mol'),
+        H298=(-51.48, 'kcal/mol'),
         S298=(-46.63, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-CH3 single-bonded on Pt(111)""",
@@ -897,7 +897,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.62, 2.41, 2.85, 3.12, 3.4, 3.53, 3.7], 'cal/(mol*K)'),
-        H298=(-39.08, 'kcal/mol'),
+        H298=(-50.13, 'kcal/mol'),
         S298=(-44.16, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from N-CH2 single-bonded on Pt(111)""",
@@ -930,7 +930,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.92, 1.54, 1.98, 2.29, 2.68, 2.93, 3.32], 'cal/(mol*K)'),
-        H298=(-71.1, 'kcal/mol'),
+        H298=(-84.35, 'kcal/mol'),
         S298=(-47.17, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from N-CH3 double-bonded on Pt(111)""",
@@ -963,7 +963,7 @@ entry(
 #     thermo=ThermoData(
 #         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #         Cpdata=([1.92, 2.12, 2.17, 2.17, 2.13, 2.09, 2.04], 'cal/(mol*K)'),
-#         H298=(-16.09, 'kcal/mol'),
+#         H298=(34.56, 'kcal/mol'),
 #         S298=(-33.93, 'cal/(mol*K)'),
 #     ),
 #     shortDesc=u"""Came from ON-O single-bonded on Pt(111)""",
@@ -990,7 +990,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-1.63, -0.71, -0.18, 0.14, 0.49, 0.67, 0.85], 'cal/(mol*K)'),
-        H298=(-156.9, 'kcal/mol'),
+        H298=(-158.52, 'kcal/mol'),
         S298=(-31.82, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from C quadruple-bonded on Pt(111)""",
@@ -1019,7 +1019,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.8, 1.77, 2.28, 2.56, 2.8, 2.9, 2.96], 'cal/(mol*K)'),
-        H298=(-137.32, 'kcal/mol'),
+        H298=(-148.1, 'kcal/mol'),
         S298=(-41.99, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from C-C bidentate, twice double-bonded on Pt(111)""",
@@ -1047,7 +1047,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.98, 0.54, 1.55, 2.21, 2.95, 3.32, 3.69], 'cal/(mol*K)'),
-        H298=(-93.15, 'kcal/mol'),
+        H298=(-102.06, 'kcal/mol'),
         S298=(-48.06, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from C=CH2 double-bonded on Pt(111)""",
@@ -1083,7 +1083,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.8, 1.58, 2.11, 2.48, 2.93, 3.2, 3.53], 'cal/(mol*K)'),
-        H298=(-129.74, 'kcal/mol'),
+        H298=(-141.26, 'kcal/mol'),
         S298=(-45.92, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from C-CH3 triple-bonded on Pt(111)""",
@@ -1113,7 +1113,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-1.92, -0.35, 0.62, 1.22, 1.87, 2.19, 2.56], 'cal/(mol*K)'),
-        H298=(-145.5, 'kcal/mol'),
+        H298=(-148.64, 'kcal/mol'),
         S298=(-40.0, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH triple-bonded on Pt(111)""",
@@ -1146,7 +1146,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.04, 1.3, 2.2, 2.83, 3.57, 3.92, 4.17], 'cal/(mol*K)'),
-        H298=(-47.33, 'kcal/mol'),
+        H298=(-53.12, 'kcal/mol'),
         S298=(-31.36, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH-CH bidentate, twice double-bonded on Pt(111)""",
@@ -1175,7 +1175,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-1.25, 0.39, 1.42, 2.06, 2.76, 3.1, 3.5], 'cal/(mol*K)'),
-        H298=(-85.5, 'kcal/mol'),
+        H298=(-93.47, 'kcal/mol'),
         S298=(-42.7, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH2 double-bonded on Pt(111)""",
@@ -1208,7 +1208,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.58, 2.74, 3.37, 3.72, 4.03, 4.14, 4.16], 'cal/(mol*K)'),
-        H298=(-22.63, 'kcal/mol'),
+        H298=(-27.48, 'kcal/mol'),
         S298=(-41.46, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH2-CH2 bidentate, twice single-bonded on Pt(111)""",
@@ -1237,7 +1237,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.45, 0.61, 1.42, 2.02, 2.81, 3.26, 3.73], 'cal/(mol*K)'),
-        H298=(-41.64, 'kcal/mol'),
+        H298=(-46.05, 'kcal/mol'),
         S298=(-32.73, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH3 single-bonded on Pt(111)""",
@@ -1271,7 +1271,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.01, 2.04, 2.05, 2.06, 2.07, 2.06, 2.05], 'cal/(mol*K)'),
-        H298=(-4.65, 'kcal/mol'),
+        H298=(-6.09, 'kcal/mol'),
         S298=(-15.11, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH3-CH3 vdW-bonded on Pt(111)""",
@@ -1333,7 +1333,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.44, 2.71, 2.86, 2.96, 3.05, 3.07, 3.05], 'cal/(mol*K)'),
-        H298=(-77.01, 'kcal/mol'),
+        H298=(-88.23, 'kcal/mol'),
         S298=(-34.98, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CN bidentate, double- and single-bonded on Pt(111)""",
@@ -1362,7 +1362,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.15, 2.88, 3.33, 3.62, 3.93, 4.05, 4.11], 'cal/(mol*K)'),
-        H298=(-40.56, 'kcal/mol'),
+        H298=(-48.26, 'kcal/mol'),
         S298=(-30.68, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CNH double-bonded on Pt(111)""",
@@ -1394,7 +1394,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.76, 3.37, 3.63, 3.74, 3.79, 3.77, 3.75], 'cal/(mol*K)'),
-        H298=(-94.25, 'kcal/mol'),
+        H298=(-106.38, 'kcal/mol'),
         S298=(-49.82, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CNH2 triple-bonded on Pt(111)""",
@@ -1426,7 +1426,7 @@ entry(
 #     thermo=ThermoData(
 #         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
 #         Cpdata=([1.81, 2.37, 2.68, 2.88, 3.05, 3.1, 3.08], 'cal/(mol*K)'),
-#         H298=(-34.7, 'kcal/mol'),
+#         H298=(-41.06, 'kcal/mol'),
 #         S298=(-38.09, 'cal/(mol*K)'),
 #     ),
 #     shortDesc=u"""Came from CO-f double-bonded on Pt(111)""",
@@ -1457,7 +1457,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.82, 2.68, 3.13, 3.36, 3.54, 3.6, 3.67], 'cal/(mol*K)'),
-        H298=(-99.0, 'kcal/mol'),
+        H298=(-111.88, 'kcal/mol'),
         S298=(-43.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from COH triple-bonded on Pt(111)""",
@@ -1491,7 +1491,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-1.26, 0.53, 1.67, 2.4, 3.19, 3.57, 3.9], 'cal/(mol*K)'),
-        H298=(-65.6, 'kcal/mol'),
+        H298=(-76.71, 'kcal/mol'),
         S298=(-53.04, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-CH bidentate, single- and double-bonded on Pt(111)""",
@@ -1524,7 +1524,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.61, 1.45, 2.08, 2.53, 3.11, 3.43, 3.77], 'cal/(mol*K)'),
-        H298=(-40.97, 'kcal/mol'),
+        H298=(-47.26, 'kcal/mol'),
         S298=(-42.06, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-CH3 single-bonded on Pt(111)""",
@@ -1557,7 +1557,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.5, 1.37, 1.81, 2.02, 2.14, 2.13, 2.08], 'cal/(mol*K)'),
-        H298=(-5.98, 'kcal/mol'),
+        H298=(-12.55, 'kcal/mol'),
         S298=(-33.14, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-NH vdW-bonded on Pt(111)""",
@@ -1590,7 +1590,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.1, 1.76, 2.28, 2.67, 3.19, 3.48, 3.79], 'cal/(mol*K)'),
-        H298=(-46.05, 'kcal/mol'),
+        H298=(-53.29, 'kcal/mol'),
         S298=(-39.03, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-NH2 single-bonded on Pt(111)""",
@@ -1622,7 +1622,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.91, 1.97, 2.0, 2.01, 2.02, 2.02, 2.01], 'cal/(mol*K)'),
-        H298=(-4.0, 'kcal/mol'),
+        H298=(-12.9, 'kcal/mol'),
         S298=(-20.91, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-O vdW-bonded on Pt(111)""",
@@ -1653,7 +1653,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.84, 1.62, 2.2, 2.63, 3.19, 3.51, 3.84], 'cal/(mol*K)'),
-        H298=(-55.93, 'kcal/mol'),
+        H298=(-64.35, 'kcal/mol'),
         S298=(-41.1, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2C-OH single-bonded on Pt(111)""",
@@ -1688,7 +1688,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.08, 0.64, 1.01, 1.25, 1.53, 1.68, 1.84], 'cal/(mol*K)'),
-        H298=(-20.94, 'kcal/mol'),
+        H298=(-23.1, 'kcal/mol'),
         S298=(-33.73, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H3C-NH2 vdW-bonded on Pt(111)""",
@@ -1721,7 +1721,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.38, 1.68, 1.82, 1.9, 1.96, 1.98, 2.0], 'cal/(mol*K)'),
-        H298=(-7.47, 'kcal/mol'),
+        H298=(-11.09, 'kcal/mol'),
         S298=(-28.83, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H3C-OH vdW-bonded on Pt(111)""",
@@ -1752,7 +1752,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.7, 1.83, 2.54, 2.98, 3.47, 3.7, 3.9], 'cal/(mol*K)'),
-        H298=(-95.45, 'kcal/mol'),
+        H298=(-105.88, 'kcal/mol'),
         S298=(-42.29, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HC-C bidentate, single- and double-bonded on Pt(111)""",
@@ -1783,7 +1783,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.18, 1.6, 2.46, 2.99, 3.55, 3.79, 3.99], 'cal/(mol*K)'),
-        H298=(-65.44, 'kcal/mol'),
+        H298=(-75.37, 'kcal/mol'),
         S298=(-48.91, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HC-CH2 single-bonded on Pt(111)""",
@@ -1817,7 +1817,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.9, 1.71, 2.25, 2.61, 3.03, 3.26, 3.57], 'cal/(mol*K)'),
-        H298=(-83.24, 'kcal/mol'),
+        H298=(-93.91, 'kcal/mol'),
         S298=(-44.11, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HC-CH3 double-bonded on Pt(111)""",
@@ -1848,7 +1848,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.02, 0.68, 1.15, 1.46, 1.81, 1.96, 2.06], 'cal/(mol*K)'),
-        H298=(-0.94, 'kcal/mol'),
+        H298=(-7.52, 'kcal/mol'),
         S298=(-22.92, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCN vdW-bonded on Pt(111)""",
@@ -1879,7 +1879,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.59, 1.77, 2.56, 3.08, 3.67, 3.93, 4.1], 'cal/(mol*K)'),
-        H298=(-15.96, 'kcal/mol'),
+        H298=(-22.54, 'kcal/mol'),
         S298=(-35.76, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCN-h bidentate, twice double-bonded on Pt(111)""",
@@ -1911,7 +1911,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.74, 2.48, 2.93, 3.22, 3.53, 3.67, 3.82], 'cal/(mol*K)'),
-        H298=(-51.45, 'kcal/mol'),
+        H298=(-63.07, 'kcal/mol'),
         S298=(-38.15, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCNH single-bonded on Pt(111)""",
@@ -1944,7 +1944,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.89, 2.02, 2.67, 3.07, 3.47, 3.65, 3.81], 'cal/(mol*K)'),
-        H298=(-58.44, 'kcal/mol'),
+        H298=(-70.06, 'kcal/mol'),
         S298=(-46.17, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCNH-h bidentate, double- and single-bonded on Pt(111)""",
@@ -1975,7 +1975,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.34, 3.12, 3.49, 3.66, 3.79, 3.81, 3.84], 'cal/(mol*K)'),
-        H298=(-61.91, 'kcal/mol'),
+        H298=(-69.75, 'kcal/mol'),
         S298=(-37.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCNH2 double-bonded on Pt(111)""",
@@ -2006,7 +2006,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.38, 2.19, 2.7, 3.02, 3.37, 3.53, 3.73], 'cal/(mol*K)'),
-        H298=(-51.35, 'kcal/mol'),
+        H298=(-63.82, 'kcal/mol'),
         S298=(-36.89, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCO single-bonded on Pt(111)""",
@@ -2038,7 +2038,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.99, 2.22, 2.94, 3.34, 3.67, 3.78, 3.86], 'cal/(mol*K)'),
-        H298=(-44.71, 'kcal/mol'),
+        H298=(-57.18, 'kcal/mol'),
         S298=(-45.92, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCO-h bidentate, double- and single-bonded on Pt(111)""",
@@ -2070,7 +2070,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.53, 2.45, 2.96, 3.26, 3.59, 3.75, 3.92], 'cal/(mol*K)'),
-        H298=(-68.65, 'kcal/mol'),
+        H298=(-76.64, 'kcal/mol'),
         S298=(-39.75, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HCOH double-bonded on Pt(111)""",
@@ -2135,7 +2135,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.07, 1.05, 1.77, 2.43, 2.8, 3.08, 3.39], 'cal/(mol*K)'),
-        H298=(-46.18, 'kcal/mol'),
+        H298=(-48.58, 'kcal/mol'),
         S298=(-38.17, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Average of C-*R3, N-*R2 and O-*R thermo. """,
@@ -2211,7 +2211,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.51, 2.68, 3.31, 3.65, 3.92, 4.00, 4.02], 'cal/(mol*K)'),
-        H298=(-37.29, 'kcal/mol'),
+        H298=(-45.455, 'kcal/mol'),
         S298=(-43.39, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Average of C-*R2C-*R2, C=*RN-*R, C=*RO-* and N-*RN-*R thermo. """,
@@ -2230,7 +2230,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.23, 1.71, 2.00, 2.19, 2.39, 2.50, 2.61], 'cal/(mol*K)'),
-        H298=(-7.79, 'kcal/mol'),
+        H298=(-7.937, 'kcal/mol'),
         S298=(-20.48, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Average of (CR4)*, (NR3)* and (OR2)* thermo. """,
@@ -2360,7 +2360,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([0.83, 2.02, 2.69, 3.08, 3.41, 3.53, 3.66], 'cal/(mol*K)'),
-        H298=(-30.55, 'kcal/mol'),
+        H298=(-43.06, 'kcal/mol'),
         S298=(-45.85, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-N-h bidentate, single- and double-bonded on Pt(111)""",
@@ -2390,7 +2390,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.02, 1.36, 1.56, 1.69, 1.82, 1.89, 1.95], 'cal/(mol*K)'),
-        H298=(-4.70, 'kcal/mol'),
+        H298=(-10.488, 'kcal/mol'),
         S298=(-10.33, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from CH-CH vdW-bonded on Pt(111)""",
@@ -2422,7 +2422,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.01, 2.14, 2.79, 3.16, 3.5, 3.63, 3.76], 'cal/(mol*K)'),
-        H298=(-40.44, 'kcal/mol'),
+        H298=(-51.5, 'kcal/mol'),
         S298=(-47.12, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2CN-h bidentate, single- and double-bonded on Pt(111)""",
@@ -2454,7 +2454,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([1.41, 3.0, 3.77, 4.11, 4.29, 4.28, 4.16], 'cal/(mol*K)'),
-        H298=(-18.54, 'kcal/mol'),
+        H298=(-25.1, 'kcal/mol'),
         S298=(-47.43, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2CNH-h bidentate, twice single-bonded on Pt(111)""",
@@ -2482,7 +2482,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([-0.98, 0.54, 1.55, 2.21, 2.95, 3.32, 3.69], 'cal/(mol*K)'),
-        H298=(-93.15, 'kcal/mol'),
+        H298=(-102.06, 'kcal/mol'),
         S298=(-48.06, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from C=CH2 double-bonded on Pt(111)""",
@@ -2518,7 +2518,7 @@ entry(
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
         Cpdata=([2.02, 3.22, 3.83, 4.11, 4.25, 4.22, 4.11], 'cal/(mol*K)'),
-        H298=(5.3, 'kcal/mol'),
+        H298=(-14.92, 'kcal/mol'),
         S298=(-41.48, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from H2CO-h bidentate, twice single-bonded on Pt(111)""",

--- a/input/thermo/libraries/surfaceThermoPt111.py
+++ b/input/thermo/libraries/surfaceThermoPt111.py
@@ -439,8 +439,8 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[1.08095806E+00, 1.29219267E-02, -1.33374540E-05, 7.75158679E-09, -1.92612419E-12, -8.13728821E+03, 6.08546053E-01], Tmin=(298.0,'K'), Tmax=(1000.0, 'K')),
-            NASAPolynomial(coeffs=[6.47671505E+00, -3.95793547E-03, 7.09299979E-06, -3.80627447E-09, 6.85388388E-13, -9.53610261E+03, -2.67996453E+01], Tmin=(1000.0,'K'), Tmax=(2000.0, 'K')),
+            NASAPolynomial(coeffs=[2.01921333E+00, 1.32114264E-02, -1.38865889E-05, 8.22652454E-09, -2.08098816E-12, -8.20311734E+03, -7.36585771E+00], Tmin=(298.0,'K'), Tmax=(1000.0, 'K')),
+            NASAPolynomial(coeffs=[7.47524494E+00, -3.96252296E-03, 7.10187157E-06, -3.81135483E-09, 6.86348467E-13, -9.61232525E+03, -3.50542775E+01], Tmin=(1000.0,'K'), Tmax=(2000.0, 'K')),
         ],
         Tmin = (298.0, 'K'),
         Tmax = (2000.0, 'K'),
@@ -448,8 +448,7 @@ entry(
     longDesc = u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (file: compute_NASA_for_Pt-adsorbates.ipynb). 
             Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.270 eV.
-            Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.
-            The two lowest frequencies, 36.2 and 74.0 cm-1, where replaced by the 2D gas model.""",
+            Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.""",
     metal = "Pt",
     facet = "111",
 )


### PR DESCRIPTION
The errors were due to an incorrect gas-phase reference, that assumed a liquid phase H2O in the ATcT reference of the fictitious reaction. This is corrected here, assuming gas-phase H2O which is consistent with the other reference species as well as the surface heats of formation at 0K.
Small additional fixes:
1. Fixed O, N and H adsorption corrections to that used an incorrect gas-phase reference for a different reason (missing term in fictitious reaction)
2. Fixed HNO thermo by using the harmonic oscillator approximation instead of the 2D gas model, since the binding energy of HNO is stronger than 100 kJ/mol.

Update:
Change of plans, it seems that it will be more accurate and consistent to use ATcT heats of formation for the gas-phase counterparts in calculation of the adsorption corrections, so I have switched to using that for everything in the latest commit.