### PR TITLE
Add forbidden group to ban thermally forbidden 2pi + 2pi cycloaddition

### DIFF
--- a/input/kinetics/families/2+2_cycloaddition/groups.py
+++ b/input/kinetics/families/2+2_cycloaddition/groups.py
@@ -162,3 +162,18 @@ Banning the doublebond within Benzene from reacting in 2+2 cycloaddition.
 """,
 )
 
+forbidden(
+    label = "2+2_cycloaddition_CdCd",
+    group = 
+"""
+1  *4 C u0 p0 c0 {2,S} {3,S}
+2  *3 C u0 p0 c0 {1,S} {4,S}
+3  *2 C u0 p0 c0 {1,S} {4,S}
+4  *1 C u0 p0 c0 {2,S} {3,S}
+""",
+    shortDesc = """2+2_cycloaddition_CdCd""",
+    longDesc = 
+"""
+Banning the 2pi + 2pi cycloaddition, as it is thermally forbidden
+"""
+)


### PR DESCRIPTION
As mentioned in https://github.com/ReactionMechanismGenerator/RMG-Py/issues/1761, the 2pi + 2pi cycloaddition was thermally forbidden. The definition of current root node prevents the generation of such reaction from the forward direction, but nothing stops RMG to try creating this reaction from the reverse direction (luckily this doesn't appear commonly, as I just encounter the first ever of such case). 

Currently, if one runs the following code, one would get `UndeterminableKineticsError`. This is because RMG labels the four ring structure in the product and tries to use the forward reaction to find the kinetics, but the root node is defined in the way to prevent a 2pi + 2pi cycloaddition.

```
from rmgpy import settings
from rmgpy.data.rmg import RMGDatabase
from rmgpy.molecule.molecule import Molecule

dbdir = settings['database.directory']
database = RMGDatabase()
database.load(
    path=dbdir,
    thermo_libraries=['Klippenstein_Glarborg2016', 'BurkeH2O2', 'thermo_DFT_CCSDTF12_BAC', 'DFT_QCI_thermo',
                     'primaryThermoLibrary', 'primaryNS', 'NitrogenCurran', 'NOx2018', 'FFCM1(-)',
                     'SulfurLibrary', 'SulfurGlarborgH2S', 'SABIC_aromatics'],
    transport_libraries=[],
    reaction_libraries=[],
    seed_mechanisms=[],
    kinetics_families=["2+2_cycloaddition"],
    kinetics_depositories=['training'],
)

database.kinetics.families["2+2_cycloaddition"]._generate_reactions([Molecule().from_smiles("C=CC1CCC1C=C")],forward=False)

---------------------------------------------------------------------------
UndeterminableKineticsError               Traceback (most recent call last)
<ipython-input-28-06cf9a989f51> in <module>
----> 1 rmg.database.kinetics.families["2+2_cycloaddition"]._generate_reactions([Molecule().from_smiles("C=CC1CCC1C=C")],forward=False)

~/Software/RMG-Py/rmgpy/data/kinetics/family.py in _generate_reactions(self, reactants, products, forward, prod_resonance, react_non_reactive)
   2379             # Generate metadata about the reaction that we will need later
   2380             reaction.pairs = self.get_reaction_pairs(reaction)
-> 2381             reaction.template = self.get_reaction_template_labels(reaction)
   2382 
   2383             # Unlabel the atoms for both reactants and products

~/Software/RMG-Py/rmgpy/data/kinetics/family.py in get_reaction_template_labels(self, reaction)
   2743         groups in the template.
   2744         """
-> 2745         template = self.get_reaction_template(reaction)
   2746 
   2747         template_labels = []

~/Software/RMG-Py/rmgpy/data/kinetics/family.py in get_reaction_template(self, reaction)
   2564         describe the reaction.
   2565         """
-> 2566         return self.groups.get_reaction_template(reaction)
   2567 
   2568     def get_kinetics_for_template(self, template, degeneracy=1, method='rate rules'):

~/Software/RMG-Py/rmgpy/data/kinetics/groups.py in get_reaction_template(self, reaction)
    196                                                                                                      str(self))
    197             msg += 'Trying to match {0} but matched {1}'.format(str(forward_template), str(template))
--> 198             raise UndeterminableKineticsError(reaction, message=msg)
    199 
    200         return template

UndeterminableKineticsError: (TemplateReaction(reactants=[Molecule(smiles="C=CC=CC=C"), Molecule(smiles="C=C")], products=[Molecule(smiles="C=CC1CCC1C=C")], pairs=[[Molecule(smiles="C=CC=CC=C"), Molecule(smiles="C=CC1CCC1C=C")], [Molecule(smiles="C=C"), Molecule(smiles="C=CC1CCC1C=C")]], family='2+2_cycloaddition'), 'Kinetics could not be determined. Unable to find matching template for reaction <Molecule "C=CC=CC=C"> + <Molecule "C=C"> <=> <Molecule "C=CC1CCC1C=C"> in reaction family <KineticsGroups "2+2_cycloaddition/groups">.Trying to match [<Entry index=0 label="Root">] but matched []')
```

With the newly added forbidden group, one gets `[]` instead.

