### PR TITLE
Refit Retroene Rate Rules

### DIFF
--- a/input/kinetics/families/Retroene/groups.py
+++ b/input/kinetics/families/Retroene/groups.py
@@ -77,13 +77,13 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R",
     group = 
 """
-1 *3 C   u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
+1 *3 C   u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
 2 *4 C   u0 {1,S} {4,[S,D]}
 3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C   u0 {2,[S,D]} {6,S}
 5 *1 O   u0 {3,[D,T,B]}
 6 *6 H   u0 {4,S}
-7    R!H ux {1,[S,D,T,B]}
+7    R!H ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -94,9 +94,9 @@ entry(
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]} {7,S}
-2 *4 C u0 {1,S} {4,[S,D]}
+2 *4 C u0 {1,S} {4,S}
 3 *2 C u0 {1,[S,D]} {5,D}
-4 *5 C u0 {2,[S,D]} {6,S}
+4 *5 C u0 {2,S} {6,S}
 5 *1 O u0 {3,D}
 6 *6 H u0 {4,S}
 7    N u0 {1,S}
@@ -110,9 +110,9 @@ entry(
     group = 
 """
 1 *3 C   u0 {2,S} {3,[S,D]} {7,S}
-2 *4 C   u0 {1,S} {4,[S,D]}
+2 *4 C   u0 {1,S} {4,S}
 3 *2 C   u0 {1,[S,D]} {5,D}
-4 *5 C   u0 {2,[S,D]} {6,S} {8,S}
+4 *5 C   u0 {2,S} {6,S} {8,S}
 5 *1 O   u0 {3,D}
 6 *6 H   u0 {4,S}
 7    N   u0 {1,S}
@@ -127,9 +127,9 @@ entry(
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]} {7,S}
-2 *4 C u0 {1,S} {4,[S,D]}
+2 *4 C u0 {1,S} {4,S}
 3 *2 C u0 r0 {1,[S,D]} {5,D}
-4 *5 C u0 {2,[S,D]} {6,S} {8,S}
+4 *5 C u0 {2,S} {6,S} {8,S}
 5 *1 O u0 r0 {3,D}
 6 *6 H u0 {4,S}
 7    N u0 r0 {1,S}
@@ -143,14 +143,14 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C",
     group = 
 """
-1 *3 C             u0 {2,S} {3,[S,D]} {7,S}
-2 *4 C             u0 {1,S} {4,[S,D]}
-3 *2 C             u0 r0 {1,[S,D]} {5,D}
-4 *5 C             u0 {2,[S,D]} {6,S} {8,S}
-5 *1 O             u0 r0 {3,D}
-6 *6 H             u0 {4,S}
-7    N             u0 r0 {1,S}
-8    [S,N,Si,Cl,O] u0 r0 {4,S}
+1 *3 C                      u0 {2,S} {3,[S,D]} {7,S}
+2 *4 C                      u0 {1,S} {4,S}
+3 *2 C                      u0 r0 {1,[S,D]} {5,D}
+4 *5 C                      u0 {2,S} {6,S} {8,S}
+5 *1 O                      u0 r0 {3,D}
+6 *6 H                      u0 {4,S}
+7    N                      u0 r0 {1,S}
+8    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {4,S}
 """,
     kinetics = None,
 )
@@ -194,14 +194,14 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C",
     group = 
 """
-1 *3 C             u0 r0 {2,S} {3,S} {7,S}
-2 *4 C             u0 r0 {1,S} {4,S} {8,S}
-3 *2 C             u0 r0 {1,S} {5,D}
-4 *5 C             u0 r0 {2,S} {6,S}
-5 *1 O             u0 r0 {3,D}
-6 *6 H             u0 r0 {4,S}
-7    N             u0 r0 {1,S}
-8    [S,N,Si,Cl,O] u0 r0 {2,S}
+1 *3 C                      u0 r0 {2,S} {3,S} {7,S}
+2 *4 C                      u0 r0 {1,S} {4,S} {8,S}
+3 *2 C                      u0 r0 {1,S} {5,D}
+4 *5 C                      u0 r0 {2,S} {6,S}
+5 *1 O                      u0 r0 {3,D}
+6 *6 H                      u0 r0 {4,S}
+7    N                      u0 r0 {1,S}
+8    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {2,S}
 """,
     kinetics = None,
 )
@@ -211,13 +211,13 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N",
     group = 
 """
-1 *3 C             u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C             u0 {1,S} {4,[S,D]}
-3 *2 C             u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C             u0 {2,[S,D]} {6,S}
-5 *1 O             u0 {3,[D,T,B]}
-6 *6 H             u0 {4,S}
-7    [C,S,Si,Cl,O] ux {1,[S,D,T,B]}
+1 *3 C                      u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C                      u0 {1,S} {4,[S,D]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -227,116 +227,116 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R",
     group = 
 """
-1 *3 C             u0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C             u0 {1,S} {4,S}
-3 *2 C             u0 {1,S} {5,[D,T,B]}
-4 *5 C             u0 {2,S} {6,S} {8,[S,D,T,B]}
-5 *1 O             u0 {3,[D,T,B]}
-6 *6 H             u0 {4,S}
-7    [C,S,Si,Cl,O] ux {1,[S,D,T,B]}
-8    R!H           ux {4,[S,D,T,B]}
+1 *3 C                      u0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C                      u0 {1,S} {4,[S,D]}
+3 *2 C                      u0 {1,S} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+8    R!H                    ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 13,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C   u0 {1,S} {4,S}
+1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C   u0 {1,S} {4,[S,D]}
 3 *2 C   u0 {1,S} {5,[D,T,B]}
-4 *5 C   u0 {2,S} {6,S} {8,[S,D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O   u0 {3,[D,T,B]}
 6 *6 H   u0 {4,S}
-7    O   ux {1,[S,D,T,B]}
-8    R!H ux {4,[S,D,T,B]}
+7    O   ux {1,[S,D,T,B,Q]}
+8    R!H ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 14,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C",
     group = 
 """
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C u0 r0 {1,S} {4,S}
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
 3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,S} {6,S} {8,[S,D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 r0 {4,S}
-7    O ux {1,[S,D,T,B]}
-8    C ux {4,[S,D,T,B]}
+7    O ux {1,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 15,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C",
     group = 
 """
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C u0 r0 {1,S} {4,S}
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
 3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,S} {6,S} {8,[S,D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 r0 {4,S}
-7    O ux {1,[S,D,T,B]}
-8    N ux {4,[S,D,T,B]}
+7    O ux {1,[S,D,T,B,Q]}
+8    N ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 16,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C   u0 {1,S} {4,S}
+1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C   u0 {1,S} {4,[S,D]}
 3 *2 C   u0 {1,S} {5,[D,T,B]}
-4 *5 C   u0 {2,S} {6,S} {8,[S,D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O   u0 {3,[D,T,B]}
 6 *6 H   u0 {4,S}
-7    C   ux {1,[S,D,T,B]}
-8    R!H ux {4,[S,D,T,B]}
+7    C   ux {1,[S,D,T,B,Q]}
+8    R!H ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 17,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C",
     group = 
 """
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C u0 r0 {1,S} {4,S}
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
 3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,S} {6,S} {8,[S,D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 r0 {4,S}
-7    C ux {1,[S,D,T,B]}
-8    C ux {4,[S,D,T,B]}
+7    C ux {1,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 18,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C",
     group = 
 """
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 C u0 r0 {1,S} {4,S}
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
 3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,S} {6,S} {8,[S,D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 r0 {4,S}
-7    C ux {1,[S,D,T,B]}
-8    N ux {4,[S,D,T,B]}
+7    C ux {1,[S,D,T,B,Q]}
+8    N ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -346,14 +346,14 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R",
     group = 
 """
-1 *3 C             u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C             u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
-3 *2 C             u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C             u0 {2,[S,D]} {6,S}
-5 *1 O             u0 {3,[D,T,B]}
-6 *6 H             u0 {4,S}
-7    [C,S,Si,Cl,O] ux {1,[S,D,T,B]}
-8    R!H           ux {2,[S,D,T,B]}
+1 *3 C                      u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C                      u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+8    R!H                    ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -363,48 +363,48 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C",
     group = 
 """
-1 *3 C             u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C             u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
-3 *2 C             u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C             u0 {2,[S,D]} {6,S}
-5 *1 O             u0 {3,[D,T,B]}
-6 *6 H             u0 {4,S}
-7    [C,S,Si,Cl,O] ux {1,[S,D,T,B]}
-8    C             ux {2,[S,D,T,B]}
+1 *3 C                      u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C                      u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+8    C                      ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 21,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    O ux {1,[S,D,T,B]}
-8    C ux {2,[S,D,T,B]}
+7    O ux {1,[S,D,T,B,Q]}
+8    C ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 22,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    C ux {1,[S,D,T,B]}
-8    C ux {2,[S,D,T,B]}
+7    C ux {1,[S,D,T,B,Q]}
+8    C ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -414,80 +414,80 @@ entry(
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C",
     group = 
 """
-1 *3 C             u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C             u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
-3 *2 C             u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C             u0 {2,[S,D]} {6,S}
-5 *1 O             u0 {3,[D,T,B]}
-6 *6 H             u0 {4,S}
-7    [C,S,Si,Cl,O] ux {1,[S,D,T,B]}
-8    O             ux {2,[S,D,T,B]}
+1 *3 C                      u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C                      u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+8    O                      ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 24,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    O ux {1,[S,D,T,B]}
-8    O ux {2,[S,D,T,B]}
+7    O ux {1,[S,D,T,B,Q]}
+8    O ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 25,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
-2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B]}
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    C ux {1,[S,D,T,B]}
-8    O ux {2,[S,D,T,B]}
+7    C ux {1,[S,D,T,B,Q]}
+8    O ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 26,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
 2 *4 C u0 {1,S} {4,[S,D]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    O ux {1,[S,D,T,B]}
+7    O ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 27,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O",
     group = 
 """
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B]}
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
 2 *4 C u0 {1,S} {4,[S,D]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    C ux {1,[S,D,T,B]}
+7    C ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -544,13 +544,13 @@ entry(
     label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C",
     group = 
 """
-1 *3 C             u0 {2,S} {3,[S,D]}
-2 *4 C             u0 {1,S} {4,[S,D]} {7,S}
-3 *2 C             u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C             u0 {2,[S,D]} {6,S}
-5 *1 O             u0 {3,[D,T,B]}
-6 *6 H             u0 {4,S}
-7    [S,N,Si,Cl,O] u0 r0 {2,S}
+1 *3 C                      u0 {2,S} {3,[S,D]}
+2 *4 C                      u0 {1,S} {4,[S,D]} {7,S}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {2,S}
 """,
     kinetics = None,
 )
@@ -592,13 +592,13 @@ entry(
     label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C",
     group = 
 """
-1 *3 C             u0 r0 {2,S} {3,S}
-2 *4 C             u0 r0 {1,S} {4,S}
-3 *2 C             u0 r0 {1,S} {5,D}
-4 *5 C             u0 r0 {2,S} {6,S} {7,S}
-5 *1 O             u0 r0 {3,D}
-6 *6 H             u0 r0 {4,S}
-7    [S,N,Si,Cl,O] u0 r0 {4,S}
+1 *3 C                      u0 r0 {2,S} {3,S}
+2 *4 C                      u0 r0 {1,S} {4,S}
+3 *2 C                      u0 r0 {1,S} {5,D}
+4 *5 C                      u0 r0 {2,S} {6,S} {7,S}
+5 *1 O                      u0 r0 {3,D}
+6 *6 H                      u0 r0 {4,S}
+7    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {4,S}
 """,
     kinetics = None,
 )
@@ -626,10 +626,10 @@ entry(
 1 *3 C u0 {2,S} {3,S}
 2 *4 C u0 {1,S} {4,S}
 3 *2 C u0 {1,S} {5,D}
-4 *5 C u0 {2,S} {6,S} {7,[S,D,T,B]}
+4 *5 C u0 {2,S} {6,S} {7,[S,D,T,B,Q]}
 5 *1 C u0 {3,D}
 6 *6 H u0 {4,S}
-7    C ux {4,[S,D,T,B]}
+7    C ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -642,11 +642,11 @@ entry(
 1 *3 C   u0 {2,S} {3,S}
 2 *4 C   u0 {1,S} {4,S}
 3 *2 C   u0 {1,S} {5,D}
-4 *5 C   u0 {2,S} {6,S} {7,[S,D,T,B]}
+4 *5 C   u0 {2,S} {6,S} {7,[S,D,T,B,Q]}
 5 *1 C   u0 {3,D}
 6 *6 H   u0 {4,S}
-7    C   ux {4,[S,D,T,B]} {8,[S,D,T,B]}
-8    R!H u0 {7,[S,D,T,B]}
+7    C   ux {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    R!H u0 {7,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -659,11 +659,11 @@ entry(
 1 *3 C   u0 {2,S} {3,S}
 2 *4 C   u0 {1,S} {4,S}
 3 *2 C   u0 {1,S} {5,D}
-4 *5 C   u0 {2,S} {6,S} {7,[S,D,T,B]}
+4 *5 C   u0 {2,S} {6,S} {7,[S,D,T,B,Q]}
 5 *1 C   u0 {3,D}
 6 *6 H   u0 {4,S}
-7    C   ux {4,[S,D,T,B]} {8,[S,D,T,B]}
-8    R!H u0 {7,[S,D,T,B]} {9,S}
+7    C   ux {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    R!H u0 {7,[S,D,T,B,Q]} {9,S}
 9    R!H ux {8,S}
 """,
     kinetics = None,
@@ -677,11 +677,11 @@ entry(
 1  *3 C u0 {2,S} {3,S}
 2  *4 C u0 {1,S} {4,S}
 3  *2 C u0 {1,S} {5,D}
-4  *5 C u0 {2,S} {6,S} {7,[S,D,T,B]}
+4  *5 C u0 {2,S} {6,S} {7,[S,D,T,B,Q]}
 5  *1 C u0 {3,D}
 6  *6 H u0 {4,S}
-7     C ux {4,[S,D,T,B]} {8,[S,D,T,B]} {10,D}
-8     O u0 {7,[S,D,T,B]} {9,S}
+7     C ux {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]} {10,D}
+8     O u0 {7,[S,D,T,B,Q]} {9,S}
 9     C ux {8,S}
 10    O u0 {7,D}
 """,
@@ -696,14 +696,14 @@ entry(
 1  *3 C   u0 r0 {2,S} {3,S}
 2  *4 C   u0 r0 {1,S} {4,S}
 3  *2 C   u0 r0 {1,S} {5,D}
-4  *5 C   u0 r0 {2,S} {6,S} {7,[S,D,T,B]}
-5  *1 C   u0 r0 {3,D} {11,[S,D,T,B]}
+4  *5 C   u0 r0 {2,S} {6,S} {7,[S,D,T,B,Q]}
+5  *1 C   u0 r0 {3,D} {11,[S,D,T,B,Q]}
 6  *6 H   u0 r0 {4,S}
-7     C   ux {4,[S,D,T,B]} {8,[S,D,T,B]} {10,D}
-8     O   u0 r0 {7,[S,D,T,B]} {9,S}
+7     C   ux {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]} {10,D}
+8     O   u0 r0 {7,[S,D,T,B,Q]} {9,S}
 9     C   ux {8,S}
 10    O   u0 r0 {7,D}
-11    R!H ux {5,[S,D,T,B]}
+11    R!H ux {5,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -717,9 +717,9 @@ entry(
 2 *4 C   u0 {1,S} {4,[S,D]}
 3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 C   u0 {3,[D,T,B]} {7,[S,D,T,B]}
+5 *1 C   u0 {3,[D,T,B]} {7,[S,D,T,B,Q]}
 6 *6 H   u0 {4,S}
-7    R!H ux {5,[S,D,T,B]}
+7    R!H ux {5,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -744,13 +744,13 @@ entry(
     label = "Root_1R!H->C_N-2R!H->C_Ext-1C-R",
     group = 
 """
-1 *3 C       u0 r0 {2,S} {3,S} {7,[S,D,T,B]}
-2 *4 [O,S,N] u0 r0 {1,S} {4,S}
+1 *3 C       u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 [O,S,N] u0 r0 {1,S} {4,[S,D]}
 3 *2 C       u0 {1,S} {5,[D,T,B]}
-4 *5 C       u0 r0 {2,S} {6,S}
+4 *5 C       u0 r0 {2,[S,D]} {6,S}
 5 *1 C       u0 {3,[D,T,B]}
 6 *6 H       u0 r0 {4,S}
-7    R!H     ux {1,[S,D,T,B]}
+7    R!H     ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -820,156 +820,202 @@ entry(
     label = "Root_N-1R!H->C",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 R!H u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
+1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
+2 *4 C                      u0 {1,S} {4,[S,D]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 R!H                    u0 {2,[S,D]} {6,S}
+5 *1 R!H                    u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 49,
-    label = "Root_N-1R!H->C_Ext-2R!H-R",
+    label = "Root_N-1R!H->C_5R!H->N",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    R!H ux {2,[S,D,T,B]}
+1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
+2 *4 C                      u0 {1,S} {4,[S,D]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 R!H                    u0 {2,[S,D]} {6,S}
+5 *1 N                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 50,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B]} {8,[S,D,T,B]}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    R!H ux {2,[S,D,T,B]}
-8    R!H ux {2,[S,D,T,B]}
+1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
+2 *4 C                      u0 {1,S} {4,[S,D]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 R!H                    u0 {2,[S,D]} {6,S}
+5 *1 [O,C]                  u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 51,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B]} {8,[S,D,T,B]}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {9,[S,D,T,B]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    R!H ux {2,[S,D,T,B]}
-8    R!H ux {2,[S,D,T,B]}
-9    R!H ux {4,[S,D,T,B]}
+1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
+2 *4 C                      u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 R!H                    u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    R!H                    ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 52,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O",
     group = 
 """
-1 *3 O   u0 {2,S} {3,S}
-2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B]} {8,[S,D,T,B]}
-3 *2 C   u0 {1,S} {5,D} {9,S}
-4 *5 C   u0 {2,S} {6,S}
-5 *1 O   u0 {3,D}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S}
+5 *1 O   u0 {3,[D,T,B]}
 6 *6 H   u0 {4,S}
-7    R!H ux {2,[S,D,T,B]}
-8    R!H ux {2,[S,D,T,B]}
-9    C   u0 {3,S}
+7    R!H ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 53,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R",
     group = 
 """
-1  *3 O   u0 r0 {2,S} {3,S}
-2  *4 C   u0 r0 {1,S} {4,S} {7,[S,D,T,B]} {8,[S,D,T,B]}
-3  *2 C   u0 r0 {1,S} {5,D} {9,S}
-4  *5 C   u0 r0 {2,S} {6,S}
-5  *1 O   u0 r0 {3,D}
-6  *6 H   u0 r0 {4,S}
-7     R!H ux {2,[S,D,T,B]}
-8     R!H ux {2,[S,D,T,B]}
-9     C   u0 r0 {3,S} {10,[S,D,T,B]}
-10    R!H ux {9,[S,D,T,B]}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+3 *2 C   u0 {1,[S,D]} {5,D}
+4 *5 C   u0 {2,S} {6,S}
+5 *1 O   u0 {3,D}
+6 *6 H   u0 {4,S}
+7    R!H ux {2,[S,D,T,B,Q]}
+8    R!H ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 54,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_7R!H->O",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    O ux {2,[S,D,T,B]}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+3 *2 C   u0 r0 {1,[S,D]} {5,D}
+4 *5 C   u0 {2,S} {6,S} {9,[S,D,T,B,Q]}
+5 *1 O   u0 r0 {3,D}
+6 *6 H   u0 {4,S}
+7    R!H ux {2,[S,D,T,B,Q]}
+8    R!H ux {2,[S,D,T,B,Q]}
+9    R!H ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 55,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux {2,[S,D,T,B]}
+1 *3 O   u0 {2,S} {3,S}
+2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+3 *2 C   u0 {1,S} {5,D} {9,S}
+4 *5 C   u0 {2,S} {6,S}
+5 *1 O   u0 {3,D}
+6 *6 H   u0 {4,S}
+7    R!H ux {2,[S,D,T,B,Q]}
+8    R!H ux {2,[S,D,T,B,Q]}
+9    C   u0 {3,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 56,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux {2,[S,D,T,B]} {8,[S,D,T,B]}
-8    C ux {7,[S,D,T,B]}
+1  *3 O   u0 r0 {2,S} {3,S}
+2  *4 C   u0 r0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+3  *2 C   u0 r0 {1,S} {5,D} {9,S}
+4  *5 C   u0 r0 {2,S} {6,S}
+5  *1 O   u0 r0 {3,D}
+6  *6 H   u0 r0 {4,S}
+7     R!H ux {2,[S,D,T,B,Q]}
+8     R!H ux {2,[S,D,T,B,Q]}
+9     C   u0 r0 {3,S} {10,[S,D,T,B,Q]}
+10    R!H ux {9,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 57,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    O ux {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 58,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 59,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux {2,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    C ux {7,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 60,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -978,70 +1024,70 @@ entry(
 4 *5 C u0 {2,S} {6,S} {9,S}
 5 *1 O u0 {3,D}
 6 *6 H u0 {4,S}
-7    C u0 {2,S} {8,[S,D,T,B]}
-8    C ux {7,[S,D,T,B]}
+7    C u0 {2,S} {8,[S,D,T,B,Q]}
+8    C ux {7,[S,D,T,B,Q]}
 9    C u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 58,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing",
-    group = 
-"""
-1 *3 O u0 r0 {2,S} {3,S}
-2 *4 C u0 r0 {1,S} {4,S} {7,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S} {9,S}
-5 *1 O u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-7    C u0 r1 {2,S} {8,[S,D,T,B]}
-8    C ux {7,[S,D,T,B]}
-9    C u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 59,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
-    group = 
-"""
-1 *3 O u0 r0 {2,S} {3,S}
-2 *4 C u0 r0 {1,S} {4,S} {7,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S} {9,S}
-5 *1 O u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-7    C u0 r0 {2,S} {8,[S,D,T,B]}
-8    C ux {7,[S,D,T,B]}
-9    C u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 60,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R",
-    group = 
-"""
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    C   ux {2,[S,D,T,B]} {8,[S,D,T,B]}
-8    C   ux {7,[S,D,T,B]} {9,[S,D,T,B]}
-9    R!H ux {8,[S,D,T,B]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 61,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing",
+    group = 
+"""
+1 *3 O u0 r0 {2,S} {3,S}
+2 *4 C u0 r0 {1,S} {4,S} {7,S}
+3 *2 C u0 r0 {1,S} {5,D}
+4 *5 C u0 r0 {2,S} {6,S} {9,S}
+5 *1 O u0 r0 {3,D}
+6 *6 H u0 r0 {4,S}
+7    C u0 r1 {2,S} {8,[S,D,T,B,Q]}
+8    C ux {7,[S,D,T,B,Q]}
+9    C u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 62,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
+    group = 
+"""
+1 *3 O u0 r0 {2,S} {3,S}
+2 *4 C u0 r0 {1,S} {4,S} {7,S}
+3 *2 C u0 r0 {1,S} {5,D}
+4 *5 C u0 r0 {2,S} {6,S} {9,S}
+5 *1 O u0 r0 {3,D}
+6 *6 H u0 r0 {4,S}
+7    C u0 r0 {2,S} {8,[S,D,T,B,Q]}
+8    C ux {7,[S,D,T,B,Q]}
+9    C u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 63,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    C   ux {2,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    C   ux {7,[S,D,T,B,Q]} {9,[S,D,T,B,Q]}
+9    R!H ux {8,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 64,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
     group = 
 """
 1  *3 O   u0 r0 {2,S} {3,S}
@@ -1050,35 +1096,35 @@ entry(
 4  *5 C   u0 r0 {2,S} {6,S}
 5  *1 O   u0 r0 {3,D}
 6  *6 H   u0 r0 {4,S}
-7     C   u0 {2,S} {8,[S,D,T,B]}
-8     C   u0 {7,[S,D,T,B]} {9,[S,D,T,B]} {10,[S,D,T,B]}
-9     R!H ux {8,[S,D,T,B]}
-10    R!H ux {8,[S,D,T,B]}
+7     C   u0 {2,S} {8,[S,D,T,B,Q]}
+8     C   u0 {7,[S,D,T,B,Q]} {9,[S,D,T,B,Q]} {10,[S,D,T,B,Q]}
+9     R!H ux {8,[S,D,T,B,Q]}
+10    R!H ux {8,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 62,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
+    index = 65,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    C ux {2,[S,D,T,B]} {8,[S,D,T,B]}
-8    C ux {7,[S,D,T,B]} {9,D}
+7    C ux {2,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    C ux {7,[S,D,T,B,Q]} {9,D}
 9    C ux {8,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 63,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
+    index = 66,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1087,146 +1133,177 @@ entry(
 4 *5 C u0 {2,S} {6,S}
 5 *1 O u0 {3,D}
 6 *6 H u0 {4,S}
-7    C u0 {2,S} {8,[S,D,T,B]}
-8    C u0 {7,[S,D,T,B]} {9,[S,B]}
+7    C u0 {2,S} {8,[S,D,T,B,Q]}
+8    C u0 {7,[S,D,T,B,Q]} {9,[S,B]}
 9    C u0 {8,[S,B]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 64,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
-    group = 
-"""
-1 *3 O u0 r0 {2,S} {3,S}
-2 *4 C u0 r0 {1,S} {4,S} {7,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S}
-5 *1 O u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-7    C u0 r1 {2,S} {8,[S,D,T,B]}
-8    C u0 {7,[S,D,T,B]} {9,[S,B]}
-9    C u0 {8,[S,B]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 65,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
-    group = 
-"""
-1 *3 O u0 r0 {2,S} {3,S}
-2 *4 C u0 r0 {1,S} {4,S} {7,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S}
-5 *1 O u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-7    C u0 r0 {2,S} {8,[S,D,T,B]}
-8    C u0 {7,[S,D,T,B]} {9,[S,B]}
-9    C u0 {8,[S,B]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 66,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R",
-    group = 
-"""
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux {2,[S,D,T,B]}
-8    C ux {4,[S,D,T,B]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 67,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux {2,[S,D,T,B]}
-8    C ux {4,[S,D,T,B]} {9,[S,D,T,B]}
-9    C u0 {8,[S,D,T,B]}
+1 *3 O u0 r0 {2,S} {3,S}
+2 *4 C u0 r0 {1,S} {4,S} {7,S}
+3 *2 C u0 r0 {1,S} {5,D}
+4 *5 C u0 r0 {2,S} {6,S}
+5 *1 O u0 r0 {3,D}
+6 *6 H u0 r0 {4,S}
+7    C u0 r1 {2,S} {8,[S,D,T,B,Q]}
+8    C u0 {7,[S,D,T,B,Q]} {9,[S,B]}
+9    C u0 {8,[S,B]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 68,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux r0 {2,[S,D,T,B]}
-8    C ux {4,[S,D,T,B]} {9,S}
-9    C u0 r0 {8,S}
+1 *3 O u0 r0 {2,S} {3,S}
+2 *4 C u0 r0 {1,S} {4,S} {7,S}
+3 *2 C u0 r0 {1,S} {5,D}
+4 *5 C u0 r0 {2,S} {6,S}
+5 *1 O u0 r0 {3,D}
+6 *6 H u0 r0 {4,S}
+7    C u0 r0 {2,S} {8,[S,D,T,B,Q]}
+8    C u0 {7,[S,D,T,B,Q]} {9,[S,B]}
+9    C u0 {8,[S,B]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 69,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
 3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    C ux r0 {2,[S,D,T,B]}
-8    C ux {4,[S,D,T,B]} {9,[B,D,T]}
-9    C u0 r0 {8,[B,D,T]}
+7    C ux {2,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 70,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B]}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]} {8,[S,D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    C   ux r0 {2,[S,D,T,B]}
-8    R!H ux {3,[S,D,T,B]}
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux {2,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]} {9,[S,D,T,B,Q]}
+9    C u0 {8,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 71,
-    label = "Root_N-1R!H->C_3R!H-inRing",
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
     group = 
 """
-1 *3 O u0 {2,S} {3,S}
-2 *4 C u0 {1,S} {4,S}
-3 *2 C u0 r1 {1,S} {5,B}
-4 *5 C u0 {2,S} {6,S}
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux r0 {2,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]} {9,S}
+9    C u0 r0 {8,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 72,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux r0 {2,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]} {9,[B,D,T,Q]}
+9    C u0 r0 {8,[B,D,T,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 73,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C   u0 {1,[S,D]} {5,[D,T,B]} {8,[S,D,T,B,Q]}
+4 *5 C   u0 {2,[S,D]} {6,S}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    C   ux r0 {2,[S,D,T,B,Q]}
+8    R!H ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 74,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O",
+    group = 
+"""
+1 *3 N   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]}
+3 *2 C   u0 r0 {1,[S,D]} {5,D}
+4 *5 R!H u0 {2,S} {6,S}
+5 *1 O   u0 r0 {3,D}
+6 *6 H   u0 {4,S}
+7    R!H u0 {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 75,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O",
+    group = 
+"""
+1 *3 O     u0 {2,S} {3,[S,D]}
+2 *4 C     u0 {1,S} {4,[S,D]}
+3 *2 C     u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C     u0 {2,[S,D]} {6,S}
+5 *1 [O,C] u0 {3,[D,T,B]}
+6 *6 H     u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 76,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 r1 {1,[S,D]} {5,B}
+4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 C u0 {3,B}
 6 *6 H u0 {4,S}
 """,
@@ -1234,197 +1311,197 @@ entry(
 )
 
 entry(
-    index = 72,
-    label = "Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R",
-    group = 
-"""
-1 *3 O   u0 r0 {2,S} {3,S}
-2 *4 C   u0 r0 {1,S} {4,S}
-3 *2 C   u0 r1 {1,S} {5,B}
-4 *5 C   u0 r0 {2,S} {6,S} {7,[S,D,T,B]}
-5 *1 C   u0 r1 {3,B}
-6 *6 H   u0 r0 {4,S}
-7    R!H ux {4,[S,D,T,B]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 73,
-    label = "Root_N-1R!H->C_N-3R!H-inRing",
-    group = 
-"""
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 R!H u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 74,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R",
-    group = 
-"""
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    R!H ux {4,[S,D,T,B]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 75,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
-    group = 
-"""
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]}
-3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {7,[S,D,T,B]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux {4,[S,D,T,B]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 76,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
-    group = 
-"""
-1 *3 O u0 r0 {2,S} {3,S}
-2 *4 C u0 r0 {1,S} {4,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S} {7,[S,D,T,B]}
-5 *1 O u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-7    C ux r1 {4,[S,D,T,B]}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 77,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]}
-3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {7,[S,D,T,B]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux r0 {4,[S,D,T,B]}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r1 {1,[S,D]} {5,B}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 C   u0 r1 {3,B}
+6 *6 H   u0 {4,S}
+7    R!H ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 78,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    C   ux r0 {4,[S,D,T,B]} {8,[S,D,T,B]}
-8    R!H ux {7,[S,D,T,B]}
+1 *3 O     u0 {2,S} {3,[S,D]}
+2 *4 C     u0 {1,S} {4,[S,D]}
+3 *2 C     u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C     u0 {2,[S,D]} {6,S}
+5 *1 [O,C] u0 {3,[D,T,B]}
+6 *6 H     u0 {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 79,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R",
     group = 
 """
-1 *3 O   u0 r0 {2,S} {3,S}
-2 *4 C   u0 r0 {1,S} {4,S}
-3 *2 C   u0 r0 {1,S} {5,D}
-4 *5 C   u0 r0 {2,S} {6,S} {7,[S,D,T,B]} {9,[S,D,T,B]}
-5 *1 O   u0 r0 {3,D}
-6 *6 H   u0 r0 {4,S}
-7    C   ux r0 {4,[S,D,T,B]} {8,S}
-8    C   u0 r0 {7,S}
-9    R!H ux {4,[S,D,T,B]}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    R!H ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 80,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    C   ux r0 {4,[S,D,T,B]} {8,[S,D,T,B]} {9,[S,D,T,B]}
-8    R!H ux {7,[S,D,T,B]}
-9    R!H ux {7,[S,D,T,B]}
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 81,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    C   ux r0 {4,[S,D,T,B]} {8,[S,D,T,B]}
-8    C   ux {7,[S,D,T,B]} {9,[S,D,T,B]}
-9    R!H ux {8,[S,D,T,B]}
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 r0 {1,[S,D]} {5,D}
+4 *5 C u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O u0 r0 {3,D}
+6 *6 H u0 {4,S}
+7    C ux r1 {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 82,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B]} {8,[S,D,T,B]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    C   ux r0 {4,[S,D,T,B]}
-8    R!H ux {4,[S,D,T,B]}
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux r0 {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 83,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
     group = 
 """
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]}
-3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S} {7,S}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    C   ux r0 {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    R!H ux {7,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 84,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,D}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]} {9,[S,D,T,B,Q]}
+5 *1 O   u0 r0 {3,D}
+6 *6 H   u0 {4,S}
+7    C   ux r0 {4,[S,D,T,B,Q]} {8,S}
+8    C   u0 r0 {7,S}
+9    R!H ux {4,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 85,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    C   ux r0 {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]} {9,[S,D,T,B,Q]}
+8    R!H ux {7,[S,D,T,B,Q]}
+9    R!H ux {7,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 86,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    C   ux r0 {4,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    C   ux {7,[S,D,T,B,Q]} {9,[S,D,T,B,Q]}
+9    R!H ux {8,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 87,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    C   ux r0 {4,[S,D,T,B,Q]}
+8    R!H ux {4,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 88,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,S}
+2 *4 C u0 {1,S} {4,S}
+3 *2 C u0 r0 {1,S} {5,[D,T,B]}
+4 *5 C u0 {2,S} {6,S} {7,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
 7    O u0 {4,S}
@@ -1433,26 +1510,26 @@ entry(
 )
 
 entry(
-    index = 84,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R",
+    index = 89,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {7,S}
+1 *3 O   u0 r0 {2,S} {3,S}
+2 *4 C   u0 r0 {1,S} {4,S}
+3 *2 C   u0 r0 {1,S} {5,[D,T,B]}
+4 *5 C   u0 r0 {2,S} {6,S} {7,S}
 5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
+6 *6 H   u0 r0 {4,S}
 7    O   u0 {4,S} {8,S}
-8    C   u0 r0 {7,S} {9,[S,D,T,B]}
-9    R!H ux {8,[S,D,T,B]}
+8    C   u0 r0 {7,S} {9,[S,D,T,B,Q]}
+9    R!H ux {8,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 85,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R",
+    index = 90,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,S}
@@ -1467,8 +1544,8 @@ entry(
 )
 
 entry(
-    index = 86,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
+    index = 91,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1483,8 +1560,8 @@ entry(
 )
 
 entry(
-    index = 87,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
+    index = 92,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1500,8 +1577,8 @@ entry(
 )
 
 entry(
-    index = 88,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
+    index = 93,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
     group = 
 """
 1 *3 O   u0 r0 {2,S} {3,S}
@@ -1511,31 +1588,31 @@ entry(
 5 *1 O   u0 r0 {3,D}
 6 *6 H   u0 r0 {4,S}
 7    C   u0 r0 {3,S} {8,S}
-8    C   u0 r0 {7,S} {9,[S,D,T,B]}
-9    R!H ux {8,[S,D,T,B]}
+8    C   u0 r0 {7,S} {9,[S,D,T,B,Q]}
+9    R!H ux {8,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 89,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
+    index = 94,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
     group = 
 """
-1 *3 O             u0 r0 {2,S} {3,S}
-2 *4 C             u0 r0 {1,S} {4,S}
-3 *2 C             u0 r0 {1,S} {5,D} {7,S}
-4 *5 C             u0 r0 {2,S} {6,S}
-5 *1 O             u0 r0 {3,D}
-6 *6 H             u0 r0 {4,S}
-7    [S,N,Si,Cl,O] u0 r0 {3,S}
+1 *3 O                      u0 r0 {2,S} {3,S}
+2 *4 C                      u0 r0 {1,S} {4,S}
+3 *2 C                      u0 r0 {1,S} {5,D} {7,S}
+4 *5 C                      u0 r0 {2,S} {6,S}
+5 *1 O                      u0 r0 {3,D}
+6 *6 H                      u0 r0 {4,S}
+7    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {3,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 90,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_5R!H->O",
+    index = 95,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1549,8 +1626,8 @@ entry(
 )
 
 entry(
-    index = 91,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O",
+    index = 96,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1559,6 +1636,21 @@ entry(
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 C u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 97,
+    label = "Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O",
+    group = 
+"""
+1 *3 N     u0 {2,S} {3,[S,D]}
+2 *4 C     u0 {1,S} {4,[S,D]}
+3 *2 C     u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 R!H   u0 {2,[S,D]} {6,S}
+5 *1 [O,C] u0 {3,[D,T,B]}
+6 *6 H     u0 {4,S}
 """,
     kinetics = None,
 )
@@ -1578,21 +1670,21 @@ L1: Root
                         L7: Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
                 L5: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
                     L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C
-                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C
+                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
+                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
                     L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
                         L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
                         L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O
-                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O
-                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
+                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
+                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
             L4: Root_1R!H->C_2R!H->C_5R!H->O
                 L5: Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
                     L6: Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
@@ -1614,49 +1706,55 @@ L1: Root
                 L5: Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
                 L5: Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
     L2: Root_N-1R!H->C
-        L3: Root_N-1R!H->C_Ext-2R!H-R
-            L4: Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R
-                L5: Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R
-                L5: Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R
-                    L6: Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
-            L4: Root_N-1R!H->C_Ext-2R!H-R_7R!H->O
-            L4: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O
-                L5: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R
-                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
-                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
-                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
-                L5: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R
-                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
-                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
-                L5: Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R
-        L3: Root_N-1R!H->C_3R!H-inRing
-            L4: Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R
-        L3: Root_N-1R!H->C_N-3R!H-inRing
-            L4: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R
-                L5: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-                    L6: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
-                    L6: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-                        L7: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-                            L8: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
-                            L8: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
-                            L8: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-                        L7: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
-                L5: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-                    L6: Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R
-            L4: Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R
-                L5: Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-                    L6: Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-                        L7: Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
-                L5: Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-            L4: Root_N-1R!H->C_N-3R!H-inRing_5R!H->O
-            L4: Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O
+        L3: Root_N-1R!H->C_5R!H->N
+        L3: Root_N-1R!H->C_N-5R!H->N
+            L4: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
+                L5: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
+                    L6: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
+                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
+                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
+                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+                    L6: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+                    L6: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
+                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
+                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+                                    L10: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+                                    L10: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
+                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
+                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
+                L5: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+            L4: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
+                L5: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
+                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+                L5: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
+                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
+                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
+                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+                                L9: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+                                    L10: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+                                    L10: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+                                    L10: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
+                                L9: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
+                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
+                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
+                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+                                L9: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
+                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
+            L4: Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
 """
 )
 

--- a/input/kinetics/families/Retroene/rules.py
+++ b/input/kinetics/families/Retroene/rules.py
@@ -9,1379 +9,1469 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(3.29914e+17,'s^-1'), n=-1.73308, w0=(1.1099e+06,'J/mol'), E0=(182951,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.16692063000437535, var=8.814681701569807, Tref=1000.0, N=65, correlation='Root',), comment="""BM rule fitted to 2 training reactions at node Root
-    Total Standard Deviation in ln(k): 6.371362717619001"""),
+    kinetics = ArrheniusBM(A=(351.483,'s^-1'), n=2.72887, w0=(1.11181e+06,'J/mol'), E0=(141064,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.13055717705123002, var=19.959654271360805, Tref=1000.0, N=68, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 68 training reactions at node Root
+    Total Standard Deviation in ln(k): 9.284433424755495"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root
-Total Standard Deviation in ln(k): 6.371362717619001""",
+    shortDesc = """BM rule fitted to 68 training reactions at node Root
+Total Standard Deviation in ln(k): 9.284433424755495""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root
-Total Standard Deviation in ln(k): 6.371362717619001
+BM rule fitted to 68 training reactions at node Root
+Total Standard Deviation in ln(k): 9.284433424755495
 """,
 )
 
 entry(
     index = 2,
     label = "Root_1R!H->C",
-    kinetics = ArrheniusBM(A=(2.91917e+21,'s^-1'), n=-2.8733, w0=(1.04926e+06,'J/mol'), E0=(195358,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.2181496522400757, var=7.835807828637173, Tref=1000.0, N=31, correlation='Root_1R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C
-    Total Standard Deviation in ln(k): 6.159871971405523"""),
+    kinetics = ArrheniusBM(A=(1.75934e+14,'s^-1'), n=-0.752179, w0=(1.04926e+06,'J/mol'), E0=(177823,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09940871819346306, var=3.010161187748991, Tref=1000.0, N=31, data_mean=0.0, correlation='Root_1R!H->C',), comment="""BM rule fitted to 31 training reactions at node Root_1R!H->C
+    Total Standard Deviation in ln(k): 3.7279491413387"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C
-Total Standard Deviation in ln(k): 6.159871971405523""",
+    shortDesc = """BM rule fitted to 31 training reactions at node Root_1R!H->C
+Total Standard Deviation in ln(k): 3.7279491413387""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C
-Total Standard Deviation in ln(k): 6.159871971405523
+BM rule fitted to 31 training reactions at node Root_1R!H->C
+Total Standard Deviation in ln(k): 3.7279491413387
 """,
 )
 
 entry(
     index = 3,
     label = "Root_N-1R!H->C",
-    kinetics = ArrheniusBM(A=(1.49769e+10,'s^-1'), n=0.382551, w0=(1.16519e+06,'J/mol'), E0=(159233,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0799311574974701, var=12.366847956955514, Tref=1000.0, N=34, correlation='Root_N-1R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C
-    Total Standard Deviation in ln(k): 7.250789573970193"""),
+    kinetics = ArrheniusBM(A=(0.0523035,'s^-1'), n=3.89104, w0=(1.16422e+06,'J/mol'), E0=(117784,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.32245522758811473, var=39.144342334518626, Tref=1000.0, N=37, data_mean=0.0, correlation='Root_N-1R!H->C',), comment="""BM rule fitted to 37 training reactions at node Root_N-1R!H->C
+    Total Standard Deviation in ln(k): 13.352902155690218"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C
-Total Standard Deviation in ln(k): 7.250789573970193""",
+    shortDesc = """BM rule fitted to 37 training reactions at node Root_N-1R!H->C
+Total Standard Deviation in ln(k): 13.352902155690218""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C
-Total Standard Deviation in ln(k): 7.250789573970193
+BM rule fitted to 37 training reactions at node Root_N-1R!H->C
+Total Standard Deviation in ln(k): 13.352902155690218
 """,
 )
 
 entry(
     index = 4,
     label = "Root_1R!H->C_2R!H->C",
-    kinetics = ArrheniusBM(A=(2.02299e+20,'s^-1'), n=-2.53701, w0=(1.0543e+06,'J/mol'), E0=(190314,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.2019207829805258, var=6.004435471185692, Tref=1000.0, N=27, correlation='Root_1R!H->C_2R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C
-    Total Standard Deviation in ln(k): 5.419731385064994"""),
+    kinetics = ArrheniusBM(A=(1.13656e+14,'s^-1'), n=-0.713758, w0=(1.0543e+06,'J/mol'), E0=(175246,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09769890056487542, var=2.561580468547625, Tref=1000.0, N=27, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C',), comment="""BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
+    Total Standard Deviation in ln(k): 3.4540407270731786"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C
-Total Standard Deviation in ln(k): 5.419731385064994""",
+    shortDesc = """BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
+Total Standard Deviation in ln(k): 3.4540407270731786""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C
-Total Standard Deviation in ln(k): 5.419731385064994
+BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
+Total Standard Deviation in ln(k): 3.4540407270731786
 """,
 )
 
 entry(
     index = 5,
     label = "Root_1R!H->C_N-2R!H->C",
-    kinetics = ArrheniusBM(A=(2.60496e+13,'s^-1'), n=-0.343905, w0=(1.01525e+06,'J/mol'), E0=(242252,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=6.4548336266697035, var=111.97246879746811, Tref=1000.0, N=4, correlation='Root_1R!H->C_N-2R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C
-    Total Standard Deviation in ln(k): 37.43168900536777"""),
+    kinetics = ArrheniusBM(A=(4.66316e+09,'s^-1'), n=1.02661, w0=(1.01525e+06,'J/mol'), E0=(221066,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=3.6261064499336317, var=38.37240951049941, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
+    Total Standard Deviation in ln(k): 21.529245395988614"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C
-Total Standard Deviation in ln(k): 37.43168900536777""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
+Total Standard Deviation in ln(k): 21.529245395988614""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C
-Total Standard Deviation in ln(k): 37.43168900536777
+BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
+Total Standard Deviation in ln(k): 21.529245395988614
 """,
 )
 
 entry(
     index = 6,
-    label = "Root_N-1R!H->C_Ext-2R!H-R",
-    kinetics = ArrheniusBM(A=(1.3938e+10,'s^-1'), n=0.63614, w0=(1.183e+06,'J/mol'), E0=(153232,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.08208414286485505, var=3.1024986272172126, Tref=1000.0, N=17, correlation='Root_N-1R!H->C_Ext-2R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R
-    Total Standard Deviation in ln(k): 3.7373640995814643"""),
+    label = "Root_N-1R!H->C_5R!H->N",
+    kinetics = ArrheniusBM(A=(9.59135e+09,'s^-1'), n=0.736578, w0=(1.0955e+06,'J/mol'), E0=(70461.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R
-Total Standard Deviation in ln(k): 3.7373640995814643""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R
-Total Standard Deviation in ln(k): 3.7373640995814643
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 7,
-    label = "Root_N-1R!H->C_3R!H-inRing",
-    kinetics = ArrheniusBM(A=(8.03589e+12,'s^-1'), n=-0.810259, w0=(938500,'J/mol'), E0=(143073,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.004915336118469724, var=82.45074987938592, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_3R!H-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_3R!H-inRing
-    Total Standard Deviation in ln(k): 18.215824782958304"""),
+    label = "Root_N-1R!H->C_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(4.02942e+10,'s^-1'), n=0.375329, w0=(1.16612e+06,'J/mol'), E0=(154169,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.06684469846581474, var=24.965000021544366, Tref=1000.0, N=36, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N',), comment="""BM rule fitted to 36 training reactions at node Root_N-1R!H->C_N-5R!H->N
+    Total Standard Deviation in ln(k): 10.184607864683809"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_3R!H-inRing
-Total Standard Deviation in ln(k): 18.215824782958304""",
+    shortDesc = """BM rule fitted to 36 training reactions at node Root_N-1R!H->C_N-5R!H->N
+Total Standard Deviation in ln(k): 10.184607864683809""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_3R!H-inRing
-Total Standard Deviation in ln(k): 18.215824782958304
+BM rule fitted to 36 training reactions at node Root_N-1R!H->C_N-5R!H->N
+Total Standard Deviation in ln(k): 10.184607864683809
 """,
 )
 
 entry(
     index = 8,
-    label = "Root_N-1R!H->C_N-3R!H-inRing",
-    kinetics = ArrheniusBM(A=(5.71165e+08,'s^-1'), n=0.792569, w0=(1.17523e+06,'J/mol'), E0=(163842,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0634193157121934, var=14.689758651951971, Tref=1000.0, N=15, correlation='Root_N-1R!H->C_N-3R!H-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing
-    Total Standard Deviation in ln(k): 7.842937438650996"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(4.46238e+12,'s^-1'), n=-0.158546, w0=(1.0845e+06,'J/mol'), E0=(176009,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09120859003038287, var=2.28830828228651, Tref=1000.0, N=15, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
+    Total Standard Deviation in ln(k): 3.261761201768912"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing
-Total Standard Deviation in ln(k): 7.842937438650996""",
+    shortDesc = """BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
+Total Standard Deviation in ln(k): 3.261761201768912""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing
-Total Standard Deviation in ln(k): 7.842937438650996
+BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
+Total Standard Deviation in ln(k): 3.261761201768912
 """,
 )
 
 entry(
     index = 9,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R",
-    kinetics = ArrheniusBM(A=(5.47454e+16,'s^-1'), n=-1.36404, w0=(1.0845e+06,'J/mol'), E0=(190512,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.16017174518575955, var=4.989219283921508, Tref=1000.0, N=15, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
-    Total Standard Deviation in ln(k): 4.880330175567876"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->O",
+    kinetics = ArrheniusBM(A=(3.94505e+09,'s^-1'), n=0.601596, w0=(1.0845e+06,'J/mol'), E0=(169425,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.07591793873856297, var=4.052420941329839, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
+    Total Standard Deviation in ln(k): 4.226405752097704"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
-Total Standard Deviation in ln(k): 4.880330175567876""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
+Total Standard Deviation in ln(k): 4.226405752097704""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
-Total Standard Deviation in ln(k): 4.880330175567876
+BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
+Total Standard Deviation in ln(k): 4.226405752097704
 """,
 )
 
 entry(
     index = 10,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O",
-    kinetics = ArrheniusBM(A=(3.59298e+09,'s^-1'), n=0.614601, w0=(1.0845e+06,'J/mol'), E0=(169310,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.07280803979615884, var=3.9519504359180297, Tref=1000.0, N=5, correlation='Root_1R!H->C_2R!H->C_5R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
-    Total Standard Deviation in ln(k): 4.168250509264941"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O",
+    kinetics = ArrheniusBM(A=(1.32288e+18,'s^-1'), n=-2.21337, w0=(968000,'J/mol'), E0=(173278,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0927421085454212, var=3.278681656229481, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O',), comment="""BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
+    Total Standard Deviation in ln(k): 3.863020288060733"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
-Total Standard Deviation in ln(k): 4.168250509264941""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
+Total Standard Deviation in ln(k): 3.863020288060733""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
-Total Standard Deviation in ln(k): 4.168250509264941
+BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
+Total Standard Deviation in ln(k): 3.863020288060733
 """,
 )
 
 entry(
     index = 11,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O",
-    kinetics = ArrheniusBM(A=(5.70488e+33,'s^-1'), n=-6.74695, w0=(968000,'J/mol'), E0=(200888,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.34291747530997396, var=16.416542173868212, Tref=1000.0, N=7, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
-    Total Standard Deviation in ln(k): 8.984253428860972"""),
+    label = "Root_1R!H->C_N-2R!H->C_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(2.8e+12,'s^-1'), n=0, w0=(1.0665e+06,'J/mol'), E0=(218338,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
-Total Standard Deviation in ln(k): 8.984253428860972""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
-Total Standard Deviation in ln(k): 8.984253428860972
+BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 12,
-    label = "Root_1R!H->C_N-2R!H->C_Ext-1C-R",
-    kinetics = ArrheniusBM(A=(2.50267e+13,'s^-1'), n=-0.29146, w0=(1.0665e+06,'J/mol'), E0=(250540,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_N-2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
+    label = "Root_1R!H->C_N-2R!H->C_2NOS->S",
+    kinetics = ArrheniusBM(A=(5.6608e+10,'s^-1'), n=0, w0=(953500,'J/mol'), E0=(119669,'J/mol'), Tmin=(588,'K'), Tmax=(691,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_2NOS->S',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 13,
-    label = "Root_1R!H->C_N-2R!H->C_2NOS->S",
-    kinetics = ArrheniusBM(A=(1.43424e+08,'s^-1'), n=0.644242, w0=(953500,'J/mol'), E0=(106636,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_N-2R!H->C_2NOS->S',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S",
+    kinetics = ArrheniusBM(A=(3.11827e+11,'s^-1'), n=-0.293682, w0=(1.0205e+06,'J/mol'), E0=(160991,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.001642907944431047, var=4.049121298193099, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
+    Total Standard Deviation in ln(k): 4.03814174042697"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
+Total Standard Deviation in ln(k): 4.03814174042697""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
+Total Standard Deviation in ln(k): 4.03814174042697
 """,
 )
 
 entry(
     index = 14,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S",
-    kinetics = ArrheniusBM(A=(5.03649e+09,'s^-1'), n=0.289241, w0=(1.0205e+06,'J/mol'), E0=(165640,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.016015533849458193, var=0.027743929771675672, Tref=1000.0, N=2, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
-    Total Standard Deviation in ln(k): 0.3741589167898476"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R",
+    kinetics = ArrheniusBM(A=(4.82035e+06,'s^-1'), n=1.67734, w0=(1.17869e+06,'J/mol'), E0=(152460,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.2285837836968013, var=2.96975919141528, Tref=1000.0, N=18, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R',), comment="""BM rule fitted to 18 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
+    Total Standard Deviation in ln(k): 4.029088922385259"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
-Total Standard Deviation in ln(k): 0.3741589167898476""",
+    shortDesc = """BM rule fitted to 18 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
+Total Standard Deviation in ln(k): 4.029088922385259""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
-Total Standard Deviation in ln(k): 0.3741589167898476
+BM rule fitted to 18 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
+Total Standard Deviation in ln(k): 4.029088922385259
 """,
 )
 
 entry(
     index = 15,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R",
-    kinetics = ArrheniusBM(A=(7.30229e+08,'s^-1'), n=0.995367, w0=(1.183e+06,'J/mol'), E0=(138104,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.9718999497707853, var=2.1443634782942387, Tref=1000.0, N=4, correlation='Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R
-    Total Standard Deviation in ln(k): 5.377622613249818"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O",
+    kinetics = ArrheniusBM(A=(1.42412e+12,'s^-1'), n=-0.284057, w0=(1.1575e+06,'J/mol'), E0=(165357,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.11656939014923065, var=13.786674344573177, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O',), comment="""BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
+    Total Standard Deviation in ln(k): 7.736551688175035"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R
-Total Standard Deviation in ln(k): 5.377622613249818""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
+Total Standard Deviation in ln(k): 7.736551688175035""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R
-Total Standard Deviation in ln(k): 5.377622613249818
+BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
+Total Standard Deviation in ln(k): 7.736551688175035
 """,
 )
 
 entry(
     index = 16,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_7R!H->O",
-    kinetics = ArrheniusBM(A=(7.47098e+12,'s^-1'), n=-0.267196, w0=(1.183e+06,'J/mol'), E0=(99317.4,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_7R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_7R!H->O
+    label = "Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O",
+    kinetics = ArrheniusBM(A=(3.96843e+10,'s^-1'), n=0.78544, w0=(1.0865e+06,'J/mol'), E0=(108783,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_7R!H->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_7R!H->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 17,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O",
-    kinetics = ArrheniusBM(A=(6.01189e+09,'s^-1'), n=0.754213, w0=(1.183e+06,'J/mol'), E0=(159151,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09510814328057031, var=0.387587740300408, Tref=1000.0, N=12, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O
-    Total Standard Deviation in ln(k): 1.4870439809451415"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(1.03404e+08,'s^-1'), n=1.25673, w0=(1.0845e+06,'J/mol'), E0=(177221,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.03936081494595298, var=1.4404859165336958, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
+    Total Standard Deviation in ln(k): 2.5049844677356727"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O
-Total Standard Deviation in ln(k): 1.4870439809451415""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
+Total Standard Deviation in ln(k): 2.5049844677356727""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O
-Total Standard Deviation in ln(k): 1.4870439809451415
+BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
+Total Standard Deviation in ln(k): 2.5049844677356727
 """,
 )
 
 entry(
     index = 18,
-    label = "Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(5279.23,'s^-1'), n=1.38734, w0=(938500,'J/mol'), E0=(119664,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(1.18472e+12,'s^-1'), n=-0.0115244, w0=(1.0845e+06,'J/mol'), E0=(169271,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.07049718312528079, var=2.319532999988916, Tref=1000.0, N=10, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N',), comment="""BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 3.230342756293489"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
+Total Standard Deviation in ln(k): 3.230342756293489""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_3R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
+Total Standard Deviation in ln(k): 3.230342756293489
 """,
 )
 
 entry(
     index = 19,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(9.86671e+06,'s^-1'), n=1.56749, w0=(1.183e+06,'J/mol'), E0=(173559,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.017669080471101054, var=0.33083863833173466, Tref=1000.0, N=9, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 1.1974897084813658"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R",
+    kinetics = ArrheniusBM(A=(4.16228e+08,'s^-1'), n=0.988266, w0=(1.0845e+06,'J/mol'), E0=(162518,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0025626047091315556, var=9.251604624994211, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
+    Total Standard Deviation in ln(k): 6.104131234895419"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 1.1974897084813658""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
+Total Standard Deviation in ln(k): 6.104131234895419""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 1.1974897084813658
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
+Total Standard Deviation in ln(k): 6.104131234895419
 """,
 )
 
 entry(
     index = 20,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R",
-    kinetics = ArrheniusBM(A=(1.02018e+11,'s^-1'), n=-0.0739297, w0=(1.183e+06,'J/mol'), E0=(160258,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0038766176496688475, var=47.42603160880866, Tref=1000.0, N=4, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R
-    Total Standard Deviation in ln(k): 13.815661203148398"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(7.24523e+06,'s^-1'), n=1.35008, w0=(1.0845e+06,'J/mol'), E0=(171424,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.024461205742499107, var=5.078314475822991, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 4.579154043078822"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R
-Total Standard Deviation in ln(k): 13.815661203148398""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.579154043078822""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R
-Total Standard Deviation in ln(k): 13.815661203148398
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.579154043078822
 """,
 )
 
 entry(
     index = 21,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_5R!H->O",
-    kinetics = ArrheniusBM(A=(1.95284e+06,'s^-1'), n=1.88752, w0=(1.183e+06,'J/mol'), E0=(168117,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_5R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_5R!H->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(4.54595e+20,'s^-1'), n=-3.0326, w0=(968000,'J/mol'), E0=(170265,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.12749579816800816, var=3.8667024035834454, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 4.2624387205240515"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_5R!H->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.2624387205240515""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_5R!H->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.2624387205240515
 """,
 )
 
 entry(
     index = 22,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O",
-    kinetics = ArrheniusBM(A=(185531,'s^-1'), n=1.69565, w0=(1.0665e+06,'J/mol'), E0=(150436,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(3.23333e+11,'s^-1'), n=0, w0=(968000,'J/mol'), E0=(182946,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_N-5R!H->O
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 23,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N",
-    kinetics = ArrheniusBM(A=(7.55943e+06,'s^-1'), n=1.59729, w0=(1.0845e+06,'J/mol'), E0=(192525,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.029349407026579746, var=1.204720350666887, Tref=1000.0, N=5, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
-    Total Standard Deviation in ln(k): 2.274134509655974"""),
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O",
+    kinetics = ArrheniusBM(A=(4.1009e+10,'s^-1'), n=0, w0=(1.0665e+06,'J/mol'), E0=(167048,'J/mol'), Tmin=(725,'K'), Tmax=(810,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
-Total Standard Deviation in ln(k): 2.274134509655974""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
-Total Standard Deviation in ln(k): 2.274134509655974
+BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 24,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N",
-    kinetics = ArrheniusBM(A=(1.08743e+12,'s^-1'), n=0.000461227, w0=(1.0845e+06,'J/mol'), E0=(169161,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.06744101306807582, var=2.2494036752109094, Tref=1000.0, N=10, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
-    Total Standard Deviation in ln(k): 3.1761538801883664"""),
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O",
+    kinetics = ArrheniusBM(A=(7.8141e+10,'s^-1'), n=0, w0=(974500,'J/mol'), E0=(160561,'J/mol'), Tmin=(602,'K'), Tmax=(694,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
-Total Standard Deviation in ln(k): 3.1761538801883664""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
-Total Standard Deviation in ln(k): 3.1761538801883664
+BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 25,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R",
-    kinetics = ArrheniusBM(A=(4.16224e+08,'s^-1'), n=0.988267, w0=(1.0845e+06,'J/mol'), E0=(162518,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.00043434819943897216, var=9.21656333564786, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-    Total Standard Deviation in ln(k): 6.0872251204039465"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O",
+    kinetics = ArrheniusBM(A=(1.39378e+10,'s^-1'), n=0.636142, w0=(1.183e+06,'J/mol'), E0=(153232,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0820842374791673, var=3.1024987137828046, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O',), comment="""BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
+    Total Standard Deviation in ln(k): 3.737364386568372"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-Total Standard Deviation in ln(k): 6.0872251204039465""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
+Total Standard Deviation in ln(k): 3.737364386568372""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-Total Standard Deviation in ln(k): 6.0872251204039465
+BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
+Total Standard Deviation in ln(k): 3.737364386568372
 """,
 )
 
 entry(
     index = 26,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(8.08931e+06,'s^-1'), n=1.33845, w0=(1.0845e+06,'J/mol'), E0=(171450,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.026710218585040676, var=4.619771263908723, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 4.376019146157587"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O",
+    kinetics = ArrheniusBM(A=(1.15515e+06,'s^-1'), n=1.91844, w0=(1.1055e+06,'J/mol'), E0=(160816,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.376019146157587""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.376019146157587
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 27,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(4.83014e+38,'s^-1'), n=-8.23851, w0=(968000,'J/mol'), E0=(200906,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.41826346251888336, var=21.571226466455663, Tref=1000.0, N=5, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 10.36187210002245"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing",
+    kinetics = ArrheniusBM(A=(7.51733e+12,'s^-1'), n=-0.801522, w0=(1.0245e+06,'J/mol'), E0=(143090,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.010065863716581231, var=81.8360764684643, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
+    Total Standard Deviation in ln(k): 18.160785079462567"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 10.36187210002245""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
+Total Standard Deviation in ln(k): 18.160785079462567""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 10.36187210002245
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
+Total Standard Deviation in ln(k): 18.160785079462567
 """,
 )
 
 entry(
     index = 28,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(2.47269e+12,'s^-1'), n=-0.334211, w0=(968000,'J/mol'), E0=(180538,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing",
+    kinetics = ArrheniusBM(A=(5.71204e+08,'s^-1'), n=0.79256, w0=(1.17523e+06,'J/mol'), E0=(163842,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.06341933757336864, var=14.689759202912304, Tref=1000.0, N=15, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing',), comment="""BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
+    Total Standard Deviation in ln(k): 7.842937637670613"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
+Total Standard Deviation in ln(k): 7.842937637670613""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
+Total Standard Deviation in ln(k): 7.842937637670613
 """,
 )
 
 entry(
     index = 29,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O",
-    kinetics = ArrheniusBM(A=(2.3921e+11,'s^-1'), n=-0.284346, w0=(1.0665e+06,'J/mol'), E0=(165328,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(8.30743e+07,'s^-1'), n=1.34294, w0=(1.0845e+06,'J/mol'), E0=(186642,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.014692611028300074, var=6.989117524371048, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 5.336822036500276"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
+Total Standard Deviation in ln(k): 5.336822036500276""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
+Total Standard Deviation in ln(k): 5.336822036500276
 """,
 )
 
 entry(
     index = 30,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O",
-    kinetics = ArrheniusBM(A=(1.00939e+08,'s^-1'), n=0.86916, w0=(974500,'J/mol'), E0=(165909,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R",
+    kinetics = ArrheniusBM(A=(5.08779e+07,'s^-1'), n=1.30493, w0=(1.0845e+06,'J/mol'), E0=(168720,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.00044315246718255245, var=0.04701835067671197, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
+    Total Standard Deviation in ln(k): 0.43581449398144884"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
+Total Standard Deviation in ln(k): 0.43581449398144884""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
+Total Standard Deviation in ln(k): 0.43581449398144884
 """,
 )
 
 entry(
     index = 31,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(4.56017e+12,'s^-1'), n=-0.119702, w0=(1.183e+06,'J/mol'), E0=(135771,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(2.10319e+11,'s^-1'), n=0.204824, w0=(1.0845e+06,'J/mol'), E0=(175924,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.061353959294217005, var=3.4900972510040535, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 3.899362049801037"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
+Total Standard Deviation in ln(k): 3.899362049801037""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
+Total Standard Deviation in ln(k): 3.899362049801037
 """,
 )
 
 entry(
     index = 32,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R",
-    kinetics = ArrheniusBM(A=(7.82163e+08,'s^-1'), n=0.989298, w0=(1.183e+06,'J/mol'), E0=(138899,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.9514830544978642, var=2.010530764035632, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R
-    Total Standard Deviation in ln(k): 5.2332386811796"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R",
+    kinetics = ArrheniusBM(A=(9.59974e+09,'s^-1'), n=0.653804, w0=(1.0845e+06,'J/mol'), E0=(159613,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.006151428258272596, var=1.8383731639583567, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
+    Total Standard Deviation in ln(k): 2.7336083899052577"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R
-Total Standard Deviation in ln(k): 5.2332386811796""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
+Total Standard Deviation in ln(k): 2.7336083899052577""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R
-Total Standard Deviation in ln(k): 5.2332386811796
+BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
+Total Standard Deviation in ln(k): 2.7336083899052577
 """,
 )
 
 entry(
     index = 33,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(8.60671e+08,'s^-1'), n=0.975858, w0=(1.183e+06,'J/mol'), E0=(154165,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.8106533184083914, var=2.476564943200298, Tref=1000.0, N=7, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R
-    Total Standard Deviation in ln(k): 5.1916901547713445"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(1.2535e+06,'s^-1'), n=1.80968, w0=(1.0845e+06,'J/mol'), E0=(155867,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R
-Total Standard Deviation in ln(k): 5.1916901547713445""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R
-Total Standard Deviation in ln(k): 5.1916901547713445
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 34,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(2.0988e+10,'s^-1'), n=0.632459, w0=(1.183e+06,'J/mol'), E0=(164532,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.14086930923198027, var=0.05370774337580898, Tref=1000.0, N=3, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 0.8185389619247819"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(11.5839,'s^-1'), n=3.09547, w0=(1.0845e+06,'J/mol'), E0=(137668,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.8185389619247819""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.8185389619247819
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 35,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R",
-    kinetics = ArrheniusBM(A=(1.19613e+13,'s^-1'), n=-0.375547, w0=(1.183e+06,'J/mol'), E0=(152765,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R
+    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(21.2645,'s^-1'), n=2.97303, w0=(1.0845e+06,'J/mol'), E0=(145085,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-3R!H-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 36,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(4.72908e+06,'s^-1'), n=1.66491, w0=(1.183e+06,'J/mol'), E0=(172562,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.06209838620188961, var=0.15842678483127076, Tref=1000.0, N=7, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-    Total Standard Deviation in ln(k): 0.9539680385815258"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(3.78363e+11,'s^-1'), n=0.169307, w0=(1.0845e+06,'J/mol'), E0=(163318,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 0.9539680385815258""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 0.9539680385815258
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 37,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(5.40789e+14,'s^-1'), n=-0.823434, w0=(1.183e+06,'J/mol'), E0=(200846,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.008726972437150324, var=0.04557818763103101, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 0.44991893248605175"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(6.80655,'s^-1'), n=3.07798, w0=(1.0845e+06,'J/mol'), E0=(148263,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 0.44991893248605175""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 0.44991893248605175
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 38,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(6.72253e+12,'s^-1'), n=-0.0948638, w0=(1.183e+06,'J/mol'), E0=(172576,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0053888222478077645, var=0.5959934434744609, Tref=1000.0, N=3, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-    Total Standard Deviation in ln(k): 1.5612074955319186"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(2419.21,'s^-1'), n=2.3826, w0=(1.0845e+06,'J/mol'), E0=(171107,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 1.5612074955319186""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 1.5612074955319186
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 39,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(981181,'s^-1'), n=-0.141465, w0=(1.183e+06,'J/mol'), E0=(124049,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R",
+    kinetics = ArrheniusBM(A=(1.5405e+21,'s^-1'), n=-3.24953, w0=(968000,'J/mol'), E0=(163723,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.12977356299501228, var=2.998907670868144, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
+    Total Standard Deviation in ln(k): 3.797735031217385"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 3.797735031217385""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 3.797735031217385
 """,
 )
 
 entry(
     index = 40,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(8.93565e+06,'s^-1'), n=1.63604, w0=(1.0845e+06,'J/mol'), E0=(201748,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.01902332493336781, var=5.776135420717914, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 4.865895780841525"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R",
+    kinetics = ArrheniusBM(A=(7.30229e+08,'s^-1'), n=0.995367, w0=(1.183e+06,'J/mol'), E0=(138104,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.9718999266707798, var=2.1443634364201256, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
+    Total Standard Deviation in ln(k): 5.377622526546486"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.865895780841525""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
+Total Standard Deviation in ln(k): 5.377622526546486""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.865895780841525
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
+Total Standard Deviation in ln(k): 5.377622526546486
 """,
 )
 
 entry(
     index = 41,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R",
-    kinetics = ArrheniusBM(A=(3.99481e+07,'s^-1'), n=1.33884, w0=(1.0845e+06,'J/mol'), E0=(186501,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.01435034261978941, var=0.03782526341694205, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
-    Total Standard Deviation in ln(k): 0.42595141028386246"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O",
+    kinetics = ArrheniusBM(A=(6.63512e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(94204,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 0.42595141028386246""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 0.42595141028386246
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 42,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(2.32129e+11,'s^-1'), n=0.19464, w0=(1.0845e+06,'J/mol'), E0=(175938,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.05624842777530617, var=3.336036409379837, Tref=1000.0, N=4, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 3.802940193892467"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O",
+    kinetics = ArrheniusBM(A=(6.01185e+09,'s^-1'), n=0.754214, w0=(1.183e+06,'J/mol'), E0=(159151,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09510809546145511, var=0.3875877430471234, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O',), comment="""BM rule fitted to 12 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
+    Total Standard Deviation in ln(k): 1.4870438652189866"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 3.802940193892467""",
+    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
+Total Standard Deviation in ln(k): 1.4870438652189866""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 3.802940193892467
+BM rule fitted to 12 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
+Total Standard Deviation in ln(k): 1.4870438652189866
 """,
 )
 
 entry(
     index = 43,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R",
-    kinetics = ArrheniusBM(A=(9.59979e+09,'s^-1'), n=0.653803, w0=(1.0845e+06,'J/mol'), E0=(159613,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0061513757544572585, var=1.838372867979581, Tref=1000.0, N=4, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
-    Total Standard Deviation in ln(k): 2.7336080391743205"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(550000,'s^-1'), n=0.9, w0=(1.0245e+06,'J/mol'), E0=(131295,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 2.7336080391743205""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 2.7336080391743205
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 44,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(3.45994e+07,'s^-1'), n=1.37339, w0=(1.0845e+06,'J/mol'), E0=(158592,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(9.86666e+06,'s^-1'), n=1.56749, w0=(1.183e+06,'J/mol'), E0=(173559,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.017669062395274753, var=0.3308386397993182, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 1.1974896656222527"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 1.1974896656222527""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7CClOSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 1.1974896656222527
 """,
 )
 
 entry(
     index = 45,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(2777.82,'s^-1'), n=2.32292, w0=(1.0845e+06,'J/mol'), E0=(138850,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R",
+    kinetics = ArrheniusBM(A=(1.01976e+11,'s^-1'), n=-0.0738756, w0=(1.183e+06,'J/mol'), E0=(160257,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0038772587838617587, var=47.426029943831864, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
+    Total Standard Deviation in ln(k): 13.815662571697391"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
+Total Standard Deviation in ln(k): 13.815662571697391""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7CClOSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
+Total Standard Deviation in ln(k): 13.815662571697391
 """,
 )
 
 entry(
     index = 46,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(1871.16,'s^-1'), n=2.39873, w0=(1.0845e+06,'J/mol'), E0=(149513,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O",
+    kinetics = ArrheniusBM(A=(3.96667e+10,'s^-1'), n=0.59, w0=(1.183e+06,'J/mol'), E0=(179850,'J/mol'), Tmin=(500,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 47,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(1.20115e+13,'s^-1'), n=-0.161387, w0=(1.0845e+06,'J/mol'), E0=(173499,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O",
+    kinetics = ArrheniusBM(A=(3.33333e+07,'s^-1'), n=1.2, w0=(1.0665e+06,'J/mol'), E0=(165353,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 48,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(383.322,'s^-1'), n=2.56708, w0=(1.0845e+06,'J/mol'), E0=(152593,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C",
+    kinetics = ArrheniusBM(A=(1708.21,'s^-1'), n=2.62955, w0=(1.0845e+06,'J/mol'), E0=(162976,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 49,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(675934,'s^-1'), n=1.70582, w0=(1.0845e+06,'J/mol'), E0=(178689,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(85500.5,'s^-1'), n=2.19797, w0=(1.0845e+06,'J/mol'), E0=(186561,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 50,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R",
-    kinetics = ArrheniusBM(A=(1.3594e+40,'s^-1'), n=-8.69663, w0=(968000,'J/mol'), E0=(194614,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.44445263765859844, var=23.11680634729946, Tref=1000.0, N=4, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-    Total Standard Deviation in ln(k): 10.75546940271655"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C",
+    kinetics = ArrheniusBM(A=(111514,'s^-1'), n=2.05353, w0=(1.0845e+06,'J/mol'), E0=(161295,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 10.75546940271655""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 10.75546940271655
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 51,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
-    kinetics = ArrheniusBM(A=(1.72964e+12,'s^-1'), n=-0.154553, w0=(1.183e+06,'J/mol'), E0=(129036,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(6.3077e+06,'s^-1'), n=1.41637, w0=(1.0845e+06,'J/mol'), E0=(156860,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 52,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(3.25982e+13,'s^-1'), n=-0.459378, w0=(1.183e+06,'J/mol'), E0=(156365,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.009641817806757116, var=0.05092668070555705, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 0.47663304654519345"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(2.01084e+12,'s^-1'), n=0.0883205, w0=(1.0845e+06,'J/mol'), E0=(183925,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.021492990850914453, var=5.303057773824753, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 4.670580394351897"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.47663304654519345""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 4.670580394351897""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.47663304654519345
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 4.670580394351897
 """,
 )
 
 entry(
     index = 53,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.26982e+13,'s^-1'), n=-0.442684, w0=(1.183e+06,'J/mol'), E0=(141988,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.008973802109952855, var=1.7601356034708961, Tref=1000.0, N=4, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 2.6822313187810094"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(9.58447e+09,'s^-1'), n=0.427548, w0=(1.0845e+06,'J/mol'), E0=(167154,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.023199101818381307, var=14.082287951603485, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 7.581333161482922"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 2.6822313187810094""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 7.581333161482922""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 2.6822313187810094
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 7.581333161482922
 """,
 )
 
 entry(
     index = 54,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(2.41068e+13,'s^-1'), n=-0.43239, w0=(1.183e+06,'J/mol'), E0=(160784,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.008055355569653555, var=0.1636224322977239, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 0.8311603334693084"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C",
+    kinetics = ArrheniusBM(A=(2.6009e+07,'s^-1'), n=1.28561, w0=(1.0845e+06,'J/mol'), E0=(152714,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0072034781886713035, var=1.112822940211039, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
+    Total Standard Deviation in ln(k): 2.1329027100545948"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 0.8311603334693084""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
+Total Standard Deviation in ln(k): 2.1329027100545948""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 0.8311603334693084
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
+Total Standard Deviation in ln(k): 2.1329027100545948
 """,
 )
 
 entry(
     index = 55,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
-    kinetics = ArrheniusBM(A=(1.18223e+12,'s^-1'), n=-0.0806669, w0=(1.183e+06,'J/mol'), E0=(164116,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(5.01614e+11,'s^-1'), n=0.272082, w0=(1.0845e+06,'J/mol'), E0=(164653,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0004677404420120619, var=2.2953718575893025, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
+    Total Standard Deviation in ln(k): 3.038446033140682"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 3.038446033140682""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 3.038446033140682
 """,
 )
 
 entry(
     index = 56,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
-    kinetics = ArrheniusBM(A=(3.93467e+06,'s^-1'), n=1.69077, w0=(1.183e+06,'J/mol'), E0=(172691,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.047593991409819986, var=0.10410275539571957, Tref=1000.0, N=6, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-    Total Standard Deviation in ln(k): 0.766409835904944"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(1.84364e+21,'s^-1'), n=-3.37687, w0=(968000,'J/mol'), E0=(155107,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.12158036022019265, var=4.26315521405602, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 4.4447369115914395"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-Total Standard Deviation in ln(k): 0.766409835904944""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 4.4447369115914395""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-Total Standard Deviation in ln(k): 0.766409835904944
+BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 4.4447369115914395
 """,
 )
 
 entry(
     index = 57,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(5.41006e+14,'s^-1'), n=-0.823484, w0=(1.183e+06,'J/mol'), E0=(200218,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(4.45626e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(142579,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7ClNOSSi-R_Ext-8R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 58,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(6.26347e+11,'s^-1'), n=0.219786, w0=(1.183e+06,'J/mol'), E0=(170925,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0058163353471268765, var=2.1167643769249636, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-    Total Standard Deviation in ln(k): 2.931323893522042"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R",
+    kinetics = ArrheniusBM(A=(7.82163e+08,'s^-1'), n=0.989298, w0=(1.183e+06,'J/mol'), E0=(138899,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.9397855924827363, var=2.0052075611816607, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
+    Total Standard Deviation in ln(k): 5.200082488575585"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-Total Standard Deviation in ln(k): 2.931323893522042""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
+Total Standard Deviation in ln(k): 5.200082488575585""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-Total Standard Deviation in ln(k): 2.931323893522042
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
+Total Standard Deviation in ln(k): 5.200082488575585
 """,
 )
 
 entry(
     index = 59,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C",
-    kinetics = ArrheniusBM(A=(86311.7,'s^-1'), n=2.17939, w0=(1.0845e+06,'J/mol'), E0=(187331,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(8.60674e+08,'s^-1'), n=0.975857, w0=(1.183e+06,'J/mol'), E0=(154165,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.810653195545372, var=2.4765646224643563, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R',), comment="""BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
+    Total Standard Deviation in ln(k): 5.191689641779036"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
+Total Standard Deviation in ln(k): 5.191689641779036""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
+Total Standard Deviation in ln(k): 5.191689641779036
 """,
 )
 
 entry(
     index = 60,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(1.87591e+07,'s^-1'), n=1.59301, w0=(1.0845e+06,'J/mol'), E0=(212642,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(2.09881e+10,'s^-1'), n=0.632458, w0=(1.183e+06,'J/mol'), E0=(164532,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.140869378589362, var=0.05370776408169411, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 0.8185392257471298"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.8185392257471298""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.8185392257471298
 """,
 )
 
 entry(
     index = 61,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C",
-    kinetics = ArrheniusBM(A=(8.32843e+06,'s^-1'), n=1.5484, w0=(1.0845e+06,'J/mol'), E0=(186060,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R",
+    kinetics = ArrheniusBM(A=(1.32388e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(156130,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 62,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(1.89761e+08,'s^-1'), n=1.1305, w0=(1.0845e+06,'J/mol'), E0=(186932,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(4.72908e+06,'s^-1'), n=1.66491, w0=(1.183e+06,'J/mol'), E0=(172562,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.062098400931787215, var=0.15842678078199102, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 0.9539680653938947"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 0.9539680653938947""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 0.9539680653938947
 """,
 )
 
 entry(
     index = 63,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(2.30347e+12,'s^-1'), n=0.0733742, w0=(1.0845e+06,'J/mol'), E0=(183974,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.015266294096436867, var=4.881791266034793, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O
-    Total Standard Deviation in ln(k): 4.4677747708059945"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(5.40789e+14,'s^-1'), n=-0.823434, w0=(1.183e+06,'J/mol'), E0=(200846,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-5.3172441301014085e-15, var=0.04558127893527205, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 0.4280063799185306"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O
-Total Standard Deviation in ln(k): 4.4677747708059945""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 0.4280063799185306""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O
-Total Standard Deviation in ln(k): 4.4677747708059945
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 0.4280063799185306
 """,
 )
 
 entry(
     index = 64,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(1.00713e+10,'s^-1'), n=0.423656, w0=(1.0845e+06,'J/mol'), E0=(167123,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.03324198521787133, var=13.418124712865499, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O
-    Total Standard Deviation in ln(k): 7.42701923178722"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(6.72258e+12,'s^-1'), n=-0.0948649, w0=(1.183e+06,'J/mol'), E0=(172576,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0053888710926292245, var=0.5959934258564467, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 1.5612075953824893"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O
-Total Standard Deviation in ln(k): 7.42701923178722""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.5612075953824893""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O
-Total Standard Deviation in ln(k): 7.42701923178722
+BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.5612075953824893
 """,
 )
 
 entry(
     index = 65,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C",
-    kinetics = ArrheniusBM(A=(2.60089e+07,'s^-1'), n=1.28561, w0=(1.0845e+06,'J/mol'), E0=(152714,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.004127634385233546, var=1.0888059594189994, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
-    Total Standard Deviation in ln(k): 2.1022291030877542"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(58002.5,'s^-1'), n=0.286, w0=(1.183e+06,'J/mol'), E0=(125149,'J/mol'), Tmin=(500,'K'), Tmax=(1300,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
-Total Standard Deviation in ln(k): 2.1022291030877542""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
-Total Standard Deviation in ln(k): 2.1022291030877542
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 66,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(5.01584e+11,'s^-1'), n=0.27209, w0=(1.0845e+06,'J/mol'), E0=(164653,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0017558494266727738, var=2.344475790003672, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-    Total Standard Deviation in ln(k): 3.073998107322022"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C",
+    kinetics = ArrheniusBM(A=(6.1395e+07,'s^-1'), n=1.36832, w0=(1.0845e+06,'J/mol'), E0=(163924,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-Total Standard Deviation in ln(k): 3.073998107322022""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-Total Standard Deviation in ln(k): 3.073998107322022
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 67,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.31787e+40,'s^-1'), n=-8.74581, w0=(968000,'J/mol'), E0=(182985,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.5644001667961636, var=32.38162431418706, Tref=1000.0, N=3, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 12.82600660003687"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(2.87851e+08,'s^-1'), n=1.30992, w0=(1.0845e+06,'J/mol'), E0=(187582,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 12.82600660003687""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 12.82600660003687
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 68,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing",
-    kinetics = ArrheniusBM(A=(1.75623e+14,'s^-1'), n=-0.68222, w0=(1.183e+06,'J/mol'), E0=(156891,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C",
+    kinetics = ArrheniusBM(A=(459.236,'s^-1'), n=2.68918, w0=(1.0845e+06,'J/mol'), E0=(145855,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 69,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
-    kinetics = ArrheniusBM(A=(7.16993e+12,'s^-1'), n=-0.258319, w0=(1.183e+06,'J/mol'), E0=(155989,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(6552.1,'s^-1'), n=2.29082, w0=(1.0845e+06,'J/mol'), E0=(167773,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 70,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.01133e+12,'s^-1'), n=-0.317664, w0=(1.183e+06,'J/mol'), E0=(115676,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(1.65185e+07,'s^-1'), n=1.51788, w0=(1.0845e+06,'J/mol'), E0=(159604,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 71,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
-    kinetics = ArrheniusBM(A=(5.77584e+12,'s^-1'), n=-0.330794, w0=(1.183e+06,'J/mol'), E0=(148158,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(1017.11,'s^-1'), n=2.55399, w0=(1.0845e+06,'J/mol'), E0=(143955,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 72,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
-    kinetics = ArrheniusBM(A=(8.84721e+12,'s^-1'), n=-0.302094, w0=(1.183e+06,'J/mol'), E0=(150154,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.006801173647055783, var=0.016504986209969107, Tref=1000.0, N=2, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-    Total Standard Deviation in ln(k): 0.2746401658299856"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(8.27867e+08,'s^-1'), n=1.04991, w0=(1.0845e+06,'J/mol'), E0=(160247,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-Total Standard Deviation in ln(k): 0.2746401658299856""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-Total Standard Deviation in ln(k): 0.2746401658299856
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 73,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
-    kinetics = ArrheniusBM(A=(4.04251e+12,'s^-1'), n=-0.258404, w0=(1.183e+06,'J/mol'), E0=(154724,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(2.0173e+12,'s^-1'), n=0.0499164, w0=(1.0845e+06,'J/mol'), E0=(158672,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 74,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
-    kinetics = ArrheniusBM(A=(7.65417e+13,'s^-1'), n=-0.52566, w0=(1.183e+06,'J/mol'), E0=(166257,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R",
+    kinetics = ArrheniusBM(A=(1.34275e+16,'s^-1'), n=-2.11924, w0=(968000,'J/mol'), E0=(122130,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0013608568101268583, var=1.6674726433047609, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+    Total Standard Deviation in ln(k): 2.5921468035711666"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 2.5921468035711666""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 2.5921468035711666
 """,
 )
 
 entry(
     index = 75,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(139248,'s^-1'), n=2.06526, w0=(1.183e+06,'J/mol'), E0=(165686,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.6647699906393877, var=1.1672292739411867, Tref=1000.0, N=4, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-    Total Standard Deviation in ln(k): 3.836159769370438"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
+    kinetics = ArrheniusBM(A=(1.39881e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(136330,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-Total Standard Deviation in ln(k): 3.836159769370438""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-Total Standard Deviation in ln(k): 3.836159769370438
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 76,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(7.0786e+07,'s^-1'), n=1.38493, w0=(1.183e+06,'J/mol'), E0=(180119,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(3.2598e+13,'s^-1'), n=-0.459377, w0=(1.183e+06,'J/mol'), E0=(156365,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0006121978434024415, var=0.049410262461096775, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 0.4471591044090268"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.4471591044090268""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.4471591044090268
 """,
 )
 
 entry(
     index = 77,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.08466e+14,'s^-1'), n=-0.414807, w0=(1.183e+06,'J/mol'), E0=(173074,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(1.2699e+13,'s^-1'), n=-0.442692, w0=(1.183e+06,'J/mol'), E0=(141989,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.008973758145679172, var=1.7601354275190648, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 2.682231075380441"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 2.682231075380441""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 2.682231075380441
 """,
 )
 
 entry(
     index = 78,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C",
-    kinetics = ArrheniusBM(A=(1.18304e+09,'s^-1'), n=0.953965, w0=(1.0845e+06,'J/mol'), E0=(164806,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(2.4107e+13,'s^-1'), n=-0.432391, w0=(1.183e+06,'J/mol'), E0=(160784,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0010628098785811556, var=0.16224599752348345, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 0.8101730807390738"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 0.8101730807390738""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 0.8101730807390738
 """,
 )
 
 entry(
     index = 79,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(3.04101e+10,'s^-1'), n=0.719247, w0=(1.0845e+06,'J/mol'), E0=(192037,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(165471,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7CClOSSi->O_N-8R!H->C
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 80,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C",
-    kinetics = ArrheniusBM(A=(69952.6,'s^-1'), n=1.95219, w0=(1.0845e+06,'J/mol'), E0=(145203,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
+    kinetics = ArrheniusBM(A=(3.93467e+06,'s^-1'), n=1.69077, w0=(1.183e+06,'J/mol'), E0=(172691,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.047594001962377265, var=0.10410275187919844, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing',), comment="""BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+    Total Standard Deviation in ln(k): 0.7664098514942174"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+Total Standard Deviation in ln(k): 0.7664098514942174""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+Total Standard Deviation in ln(k): 0.7664098514942174
 """,
 )
 
 entry(
     index = 81,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(4.82682e+06,'s^-1'), n=1.39789, w0=(1.0845e+06,'J/mol'), E0=(170872,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(193178,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7CClOSSi->O_N-8R!H->C
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 82,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(4.85334e+08,'s^-1'), n=1.04262, w0=(1.0845e+06,'J/mol'), E0=(160490,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(6.26357e+11,'s^-1'), n=0.219784, w0=(1.183e+06,'J/mol'), E0=(170925,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-1.6694644050553874e-15, var=2.116729755416145, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+    Total Standard Deviation in ln(k): 2.9166861328622327"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+Total Standard Deviation in ln(k): 2.9166861328622327""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7CClOSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+Total Standard Deviation in ln(k): 2.9166861328622327
 """,
 )
 
 entry(
     index = 83,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(237214,'s^-1'), n=1.7551, w0=(1.0845e+06,'J/mol'), E0=(143269,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(6.5e+10,'s^-1'), n=0, w0=(968000,'J/mol'), E0=(139431,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7CClOSSi->O
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 84,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(1.01292e+10,'s^-1'), n=0.801049, w0=(1.0845e+06,'J/mol'), E0=(167172,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing",
+    kinetics = ArrheniusBM(A=(1.25594e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(155092,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7CClOSSi->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 85,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O",
-    kinetics = ArrheniusBM(A=(1.9784e+14,'s^-1'), n=-0.523303, w0=(1.0845e+06,'J/mol'), E0=(164051,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
+    kinetics = ArrheniusBM(A=(1.98582e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(160232,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7CClOSSi->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 86,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R",
-    kinetics = ArrheniusBM(A=(6.33177e+16,'s^-1'), n=-2.0239, w0=(968000,'J/mol'), E0=(100618,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.023344927135838273, var=2.623167713233261, Tref=1000.0, N=2, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-    Total Standard Deviation in ln(k): 3.305563859910207"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(1.32702e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(116943,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 3.305563859910207""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 3.305563859910207
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 87,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
-    kinetics = ArrheniusBM(A=(8.29948e+12,'s^-1'), n=-0.271204, w0=(1.183e+06,'J/mol'), E0=(151786,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
+    kinetics = ArrheniusBM(A=(8.37297e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(151179,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 88,
-    label = "Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
-    kinetics = ArrheniusBM(A=(8.55485e+12,'s^-1'), n=-0.320523, w0=(1.183e+06,'J/mol'), E0=(148430,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
+    kinetics = ArrheniusBM(A=(8.84721e+12,'s^-1'), n=-0.302094, w0=(1.183e+06,'J/mol'), E0=(150154,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=3.255606157999161e-05, var=0.017017844750293856, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+    Total Standard Deviation in ln(k): 0.2616044249499389"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+Total Standard Deviation in ln(k): 0.2616044249499389""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+Total Standard Deviation in ln(k): 0.2616044249499389
 """,
 )
 
 entry(
     index = 89,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(1.43227e+13,'s^-1'), n=-0.435883, w0=(1.183e+06,'J/mol'), E0=(171149,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
+    kinetics = ArrheniusBM(A=(1.11936e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(158970,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 90,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(7.42317e+12,'s^-1'), n=-0.355627, w0=(1.183e+06,'J/mol'), E0=(168309,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
+    kinetics = ArrheniusBM(A=(1.99054e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(166153,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 91,
-    label = "Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(7.07376e+12,'s^-1'), n=-0.349886, w0=(1.183e+06,'J/mol'), E0=(167015,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(139248,'s^-1'), n=2.06526, w0=(1.183e+06,'J/mol'), E0=(165686,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.6647699949854299, var=1.1672292911792304, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+    Total Standard Deviation in ln(k): 3.8361597962833978"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+Total Standard Deviation in ln(k): 3.8361597962833978""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+Total Standard Deviation in ln(k): 3.8361597962833978
 """,
 )
 
 entry(
     index = 92,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(4.77467e+13,'s^-1'), n=-1.06001, w0=(968000,'J/mol'), E0=(89904,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(3.16053e+06,'s^-1'), n=1.87467, w0=(1.183e+06,'J/mol'), E0=(182477,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 93,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(6.96433e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(174127,'J/mol'), Tmin=(900,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 94,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
+    kinetics = ArrheniusBM(A=(1.32702e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(152192,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 95,
+    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
+    kinetics = ArrheniusBM(A=(1.32702e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(151418,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 96,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(7.94328e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(172170,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 97,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(170162,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 98,
+    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(168938,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/Retroene/training/dictionary.txt
+++ b/input/kinetics/families/Retroene/training/dictionary.txt
@@ -1934,3 +1934,65 @@ C4H9NO2-2
 15    H u0 p0 c0 {7,S}
 16    H u0 p0 c0 {1,S}
 
+C2H4N2O2
+1     O u0 p2 c0 {5,D}
+2  *1 O u0 p2 c0 {6,D}
+3  *3 N u0 p1 c0 {5,S} {6,S} {7,S}
+4  *5 N u0 p1 c0 {5,S} {9,S} {10,S}
+5  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {8,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {6,S}
+9  *6 H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+
+CH3NO
+1 *1 O u0 p2 c0 {3,S} {6,S}
+2 *3 N u0 p1 c0 {3,D} {5,S}
+3 *2 C u0 p0 c0 {1,S} {2,D} {4,S}
+4    H u0 p0 c0 {3,S}
+5    H u0 p0 c0 {2,S}
+6 *6 H u0 p0 c0 {1,S}
+
+CHNO
+1    O u0 p2 c0 {3,D}
+2 *5 N u0 p1 c0 {3,D} {4,S}
+3 *4 C u0 p0 c0 {1,D} {2,D}
+4    H u0 p0 c0 {2,S}
+
+C2H4N2O2-2
+1  *3 O u0 p2 c0 {5,S} {6,S}
+2     O u0 p2 c0 {5,D}
+3  *5 N u0 p1 c0 {5,S} {8,S} {9,S}
+4  *1 N u0 p1 c0 {6,D} {10,S}
+5  *4 C u0 p0 c0 {1,S} {2,D} {3,S}
+6  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+7     H u0 p0 c0 {6,S}
+8  *6 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+
+CH3NO-2
+1 *3 O u0 p2 c0 {3,D}
+2 *1 N u0 p1 c0 {3,S} {4,S} {5,S}
+3 *2 C u0 p0 c0 {1,D} {2,S} {6,S}
+4    H u0 p0 c0 {2,S}
+5 *6 H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {3,S}
+
+C2H4N2O
+1 *1 O u0 p2 c0 {5,D}
+2 *3 N u0 p1 c0 {4,S} {5,S} {6,S}
+3 *5 N u0 p1 c0 {4,D} {9,S}
+4 *4 C u0 p0 c0 {2,S} {3,D} {7,S}
+5 *2 C u0 p0 c0 {1,D} {2,S} {8,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {5,S}
+9 *6 H u0 p0 c0 {3,S}
+
+CHN
+1 *5 N u0 p1 c0 {2,T}
+2 *4 C u0 p0 c0 {1,T} {3,S}
+3    H u0 p0 c0 {2,S}
+

--- a/input/kinetics/families/Retroene/training/reactions.py
+++ b/input/kinetics/families/Retroene/training/reactions.py
@@ -851,3 +851,54 @@ Calculated at CBS-QB3 using TST + 1DSHR approximation by Jeffrey Herron, Xiaorui
 """,
 )
 
+entry(
+    index = 65,
+    label = "C2H4N2O2 <=> CH3NO + CHNO",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(2.3103e+06,'s^-1'), n=1.91844, Ea=(215.344,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 2.14216, dn = +|- 0.101085, dEa = +|- 0.521248 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indicies that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001091 <=> p001091_0 + p001091_1
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 66,
+    label = "C2H4N2O2-2 <=> CH3NO-2 + CHNO",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(1.91827e+10,'s^-1'), n=0.736578, Ea=(60.3985,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.14366, dn = +|- 0.0178114, dEa = +|- 0.0918447 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indicies that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001689 <=> p001689_0 + p001689_1
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 67,
+    label = "C2H4N2O <=> CH3NO + CHN",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.96843e+10,'s^-1'), n=0.78544, Ea=(151.759,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.12608, dn = +|- 0.0157564, dEa = +|- 0.0812481 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indicies that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005591 <=> p005591_0 + p005591_1
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+


### PR DESCRIPTION
This PR adds 3 training reactions to the retroene family. All calculations were done at `CCSD(T)-F12/cc-pVDZ-F12//ωB97X-D3/def2-TZVP`. The rate tree was then refit using Matt's notebook (#490).

The long description includes the indices that label these species in the dataset paper I'm working on. These indices can be used to find the raw log files from the QM calculations. 

Do we normally store the results from running [kinetics_library_to_training.ipynb](https://github.com/ReactionMechanismGenerator/RMG-Py/blob/master/ipython/kinetics_library_to_training.ipynb) or the tree generation notebook somewhere on RMG server?


