### PR TITLE
Refit Ketoenol Rate Rules

### DIFF
--- a/input/kinetics/families/Retroene/training/reactions.py
+++ b/input/kinetics/families/Retroene/training/reactions.py
@@ -861,7 +861,7 @@ entry(
     longDesc = 
 """
 Calculated by Kevin Spiekermann
-Reaction indicies that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001091 <=> p001091_0 + p001091_1
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001091 <=> p001091_0 + p001091_1
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12/cc-pVDZ-F12
 Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
@@ -878,7 +878,7 @@ entry(
     longDesc = 
 """
 Calculated by Kevin Spiekermann
-Reaction indicies that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001689 <=> p001689_0 + p001689_1
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001689 <=> p001689_0 + p001689_1
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12/cc-pVDZ-F12
 Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
@@ -895,7 +895,7 @@ entry(
     longDesc = 
 """
 Calculated by Kevin Spiekermann
-Reaction indicies that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005591 <=> p005591_0 + p005591_1
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005591 <=> p005591_0 + p005591_1
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12/cc-pVDZ-F12
 Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)

--- a/input/kinetics/families/ketoenol/groups.py
+++ b/input/kinetics/families/ketoenol/groups.py
@@ -44,33 +44,59 @@ entry(
 
 entry(
     index = 1,
-    label = "Root_3R!H->C",
+    label = "Root_4R->C",
     group = 
 """
-1 *2 C u0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 C u0 {1,D}
-4 *4 R u0 {2,S}
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 R!H u0 {1,D}
+4 *4 C   u0 {2,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 2,
-    label = "Root_3R!H->C_4R->C",
+    label = "Root_4R->C_1R!H-inRing",
     group = 
 """
-1 *2 C u0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 C u0 {1,D}
-4 *4 C u0 {2,S}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 R!H u0 {1,D}
+4 *4 C   u0 {2,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 3,
-    label = "Root_3R!H->C_N-4R->C",
+    label = "Root_4R->C_N-1R!H-inRing",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 R!H u0 {1,D}
+4 *4 C   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 4,
+    label = "Root_N-4R->C",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 R!H u0 {1,D}
+4 *4 H   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
+    label = "Root_N-4R->C_3R!H->C",
     group = 
 """
 1 *2 C u0 {2,S} {3,D}
@@ -82,22 +108,35 @@ entry(
 )
 
 entry(
-    index = 4,
-    label = "Root_3R!H->C_N-4R->C_Ext-1R!H-R",
+    index = 6,
+    label = "Root_N-4R->C_3R!H->C_Ext-1R!H-R",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B]}
-2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 C   u0 r0 {1,D}
-4 *4 H   u0 r0 {2,S}
-5    R!H ux {1,[S,D,T,B]}
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 5,
-    label = "Root_N-3R!H->C",
+    index = 7,
+    label = "Root_N-4R->C_N-3R!H->C",
+    group = 
+"""
+1 *2 C     u0 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 [S,N] u0 {1,D}
+4 *4 H     u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 8,
+    label = "Root_N-4R->C_N-3R!H->C_3NS->S",
     group = 
 """
 1 *2 C u0 {2,S} {3,D}
@@ -109,8 +148,8 @@ entry(
 )
 
 entry(
-    index = 6,
-    label = "Root_N-3R!H->C_Ext-1R!H-R",
+    index = 9,
+    label = "Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R",
     group = 
 """
 1 *2 C u0 {2,S} {3,D} {5,S}
@@ -123,16 +162,255 @@ entry(
 )
 
 entry(
-    index = 7,
-    label = "Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R",
+    index = 10,
+    label = "Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+1 *2 C   u0 {2,S} {3,D} {5,S}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 S   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    C   u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 11,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 12,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    C u0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 13,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    C   u0 r0 {3,S}
+6    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
 2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 S   u0 r0 {1,D}
+3 *1 N   u0 r0 {1,D} {5,S}
 4 *4 H   u0 r0 {2,S}
-5    C   u0 r0 {1,S} {6,[S,D,T,B]}
-6    R!H ux {5,[S,D,T,B]}
+5    C   u0 r0 {3,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+7    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,D}
+6    N u0 r0 {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r0 {1,D} {5,S}
+4 *4 H                      u0 r0 {2,S}
+5    C                      u0 r0 {3,S} {6,D}
+6    [S,C,P,Si,F,I,Cl,Br,O] u0 r0 {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    N ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 18,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    N ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 19,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    N ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    N u0 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 20,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D}
+4 *4 H                      u0 {2,S}
+5    N                      u0 {1,S} {6,S}
+6    C                      u0 {5,S} {7,[S,D,T,B,Q]}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 21,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r0 {1,D}
+4 *4 H                      u0 r0 {2,S}
+5    N                      u0 r1 {1,S} {6,S}
+6    C                      u0 {5,S} {7,[S,D,T,B,Q]}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 22,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r0 {1,D}
+4 *4 H                      u0 r0 {2,S}
+5    N                      u0 r0 {1,S} {6,S}
+6    C                      u0 {5,S} {7,[S,D,T,B,Q]}
+7    [S,C,P,Si,F,I,Cl,Br,O] ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 23,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D}
+4 *4 H                      u0 {2,S}
+5    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 24,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r0 {1,D}
+4 *4 H                      u0 r0 {2,S}
+5    [S,C,P,Si,F,I,Cl,Br,O] u0 {1,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    R!H                    ux {5,[S,D,T,B,Q]}
+7    R!H                    ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 25,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    O ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 26,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -140,13 +418,32 @@ entry(
 tree(
 """
 L1: Root
-    L2: Root_3R!H->C
-        L3: Root_3R!H->C_4R->C
-        L3: Root_3R!H->C_N-4R->C
-            L4: Root_3R!H->C_N-4R->C_Ext-1R!H-R
-    L2: Root_N-3R!H->C
-        L3: Root_N-3R!H->C_Ext-1R!H-R
-            L4: Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R
+    L2: Root_4R->C
+        L3: Root_4R->C_1R!H-inRing
+        L3: Root_4R->C_N-1R!H-inRing
+    L2: Root_N-4R->C
+        L3: Root_N-4R->C_3R!H->C
+            L4: Root_N-4R->C_3R!H->C_Ext-1R!H-R
+        L3: Root_N-4R->C_N-3R!H->C
+            L4: Root_N-4R->C_N-3R!H->C_3NS->S
+                L5: Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R
+                    L6: Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+            L4: Root_N-4R->C_N-3R!H->C_N-3NS->S
+                L5: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+                L5: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R
+                        L7: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+                        L7: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+                            L8: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing
+                            L8: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing
+                L5: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O
+                    L6: Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O
 """
 )
 

--- a/input/kinetics/families/ketoenol/rules.py
+++ b/input/kinetics/families/ketoenol/rules.py
@@ -9,119 +9,404 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(4.11746e-45,'s^-1'), n=16.9026, w0=(771000,'J/mol'), E0=(-859.303,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-1.5745173911872379, var=52.09733235475162, Tref=1000.0, N=7, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 7 training reactions at node Root
-    Total Standard Deviation in ln(k): 18.425947277680763"""),
+    kinetics = ArrheniusBM(A=(0.000244134,'s^-1'), n=4.98481, w0=(783263,'J/mol'), E0=(116784,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.036954718624156536, var=4.143630220325711, Tref=1000.0, N=19, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 19 training reactions at node Root
+    Total Standard Deviation in ln(k): 4.173671487051275"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 7 training reactions at node Root
-Total Standard Deviation in ln(k): 18.425947277680763""",
+    shortDesc = """BM rule fitted to 19 training reactions at node Root
+Total Standard Deviation in ln(k): 4.173671487051275""",
     longDesc = 
 """
-BM rule fitted to 7 training reactions at node Root
-Total Standard Deviation in ln(k): 18.425947277680763
+BM rule fitted to 19 training reactions at node Root
+Total Standard Deviation in ln(k): 4.173671487051275
 """,
 )
 
 entry(
     index = 2,
-    label = "Root_3R!H->C",
-    kinetics = ArrheniusBM(A=(0.0954007,'s^-1'), n=3.97882, w0=(762750,'J/mol'), E0=(250868,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.05104117971660031, var=160.05464641490252, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_3R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_3R!H->C
-    Total Standard Deviation in ln(k): 25.490690006267023"""),
+    label = "Root_4R->C",
+    kinetics = ArrheniusBM(A=(7.88579e+21,'s^-1'), n=-1.81416, w0=(703750,'J/mol'), E0=(216779,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-29.470976721039033, var=1852.2904403864713, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_4R->C',), comment="""BM rule fitted to 2 training reactions at node Root_4R->C
+    Total Standard Deviation in ln(k): 160.32795747506685"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_3R!H->C
-Total Standard Deviation in ln(k): 25.490690006267023""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_4R->C
+Total Standard Deviation in ln(k): 160.32795747506685""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_3R!H->C
-Total Standard Deviation in ln(k): 25.490690006267023
+BM rule fitted to 2 training reactions at node Root_4R->C
+Total Standard Deviation in ln(k): 160.32795747506685
 """,
 )
 
 entry(
     index = 3,
-    label = "Root_N-3R!H->C",
-    kinetics = ArrheniusBM(A=(2628.85,'s^-1'), n=2.78353, w0=(782000,'J/mol'), E0=(89057.2,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.004857179637508415, var=0.25064116944332687, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C
-    Total Standard Deviation in ln(k): 1.0158560594211685"""),
+    label = "Root_N-4R->C",
+    kinetics = ArrheniusBM(A=(1.62985e-08,'s^-1'), n=6.15131, w0=(792618,'J/mol'), E0=(104854,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.03619485067575475, var=3.8346489698107864, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-4R->C',), comment="""BM rule fitted to 17 training reactions at node Root_N-4R->C
+    Total Standard Deviation in ln(k): 4.016666137746275"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C
-Total Standard Deviation in ln(k): 1.0158560594211685""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-4R->C
+Total Standard Deviation in ln(k): 4.016666137746275""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-3R!H->C
-Total Standard Deviation in ln(k): 1.0158560594211685
+BM rule fitted to 17 training reactions at node Root_N-4R->C
+Total Standard Deviation in ln(k): 4.016666137746275
 """,
 )
 
 entry(
     index = 4,
-    label = "Root_3R!H->C_4R->C",
-    kinetics = ArrheniusBM(A=(7040,'s^-1'), n=2.66, w0=(700500,'J/mol'), E0=(384026,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_4R->C',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_4R->C
+    label = "Root_4R->C_1R!H-inRing",
+    kinetics = ArrheniusBM(A=(1.23584e+11,'s^-1'), n=1.27308, w0=(707000,'J/mol'), E0=(183610,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_4R->C_1R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_4R->C_1R!H-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_4R->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_4R->C_1R!H-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_3R!H->C_4R->C
+BM rule fitted to 1 training reactions at node Root_4R->C_1R!H-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 5,
-    label = "Root_3R!H->C_N-4R->C",
-    kinetics = ArrheniusBM(A=(635.413,'s^-1'), n=2.83859, w0=(783500,'J/mol'), E0=(219488,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0012207818220425905, var=12.527101437509526, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_3R!H->C_N-4R->C',), comment="""BM rule fitted to 3 training reactions at node Root_3R!H->C_N-4R->C
-    Total Standard Deviation in ln(k): 7.098555561663242"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_3R!H->C_N-4R->C
-Total Standard Deviation in ln(k): 7.098555561663242""",
-    longDesc = 
-"""
-BM rule fitted to 3 training reactions at node Root_3R!H->C_N-4R->C
-Total Standard Deviation in ln(k): 7.098555561663242
-""",
-)
-
-entry(
-    index = 6,
-    label = "Root_N-3R!H->C_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(4909.53,'s^-1'), n=2.71698, w0=(782000,'J/mol'), E0=(88826.1,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-1.1408662726283667e-06, var=3.5438674360202764e-06, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 0.003776812860711284"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 0.003776812860711284""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-3R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 0.003776812860711284
-""",
-)
-
-entry(
-    index = 7,
-    label = "Root_3R!H->C_N-4R->C_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(205000,'s^-1'), n=2.37, w0=(783500,'J/mol'), E0=(221387,'J/mol'), Tmin=(600,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-4R->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-4R->C_Ext-1R!H-R
+    label = "Root_4R->C_N-1R!H-inRing",
+    kinetics = ArrheniusBM(A=(7040,'s^-1'), n=2.66, w0=(700500,'J/mol'), E0=(384026,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_4R->C_N-1R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_4R->C_N-1R!H-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-4R->C_Ext-1R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_4R->C_N-1R!H-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_3R!H->C_N-4R->C_Ext-1R!H-R
+BM rule fitted to 1 training reactions at node Root_4R->C_N-1R!H-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
+    index = 6,
+    label = "Root_N-4R->C_3R!H->C",
+    kinetics = ArrheniusBM(A=(635.413,'s^-1'), n=2.83859, w0=(783500,'J/mol'), E0=(219488,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0012207818220425905, var=12.527101437509526, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-4R->C_3R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-4R->C_3R!H->C
+    Total Standard Deviation in ln(k): 7.098555561663242"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-4R->C_3R!H->C
+Total Standard Deviation in ln(k): 7.098555561663242""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-4R->C_3R!H->C
+Total Standard Deviation in ln(k): 7.098555561663242
+""",
+)
+
+entry(
+    index = 7,
+    label = "Root_N-4R->C_N-3R!H->C",
+    kinetics = ArrheniusBM(A=(1.36227e-08,'s^-1'), n=6.17457, w0=(794571,'J/mol'), E0=(104564,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.036663879476713866, var=3.6167730030024967, Tref=1000.0, N=14, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C',), comment="""BM rule fitted to 14 training reactions at node Root_N-4R->C_N-3R!H->C
+    Total Standard Deviation in ln(k): 3.9046884509108764"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 14 training reactions at node Root_N-4R->C_N-3R!H->C
+Total Standard Deviation in ln(k): 3.9046884509108764""",
+    longDesc = 
+"""
+BM rule fitted to 14 training reactions at node Root_N-4R->C_N-3R!H->C
+Total Standard Deviation in ln(k): 3.9046884509108764
+""",
+)
+
+entry(
     index = 8,
-    label = "Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(84839.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R
+    label = "Root_N-4R->C_3R!H->C_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(205000,'s^-1'), n=2.37, w0=(783500,'J/mol'), E0=(221387,'J/mol'), Tmin=(600,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_3R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_3R!H->C_Ext-1R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_3R!H->C_Ext-1R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_Ext-1R!H-R_Ext-5R!H-R
+BM rule fitted to 1 training reactions at node Root_N-4R->C_3R!H->C_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 9,
+    label = "Root_N-4R->C_N-3R!H->C_3NS->S",
+    kinetics = ArrheniusBM(A=(2628.85,'s^-1'), n=2.78353, w0=(782000,'J/mol'), E0=(89057.2,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.004857179637508415, var=0.25064116944332687, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_3NS->S',), comment="""BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S
+    Total Standard Deviation in ln(k): 1.0158560594211685"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S
+Total Standard Deviation in ln(k): 1.0158560594211685""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S
+Total Standard Deviation in ln(k): 1.0158560594211685
+""",
+)
+
+entry(
+    index = 10,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S",
+    kinetics = ArrheniusBM(A=(4.71117e-08,'s^-1'), n=6.01657, w0=(798000,'J/mol'), E0=(106563,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.042885526969415354, var=3.2069381670551236, Tref=1000.0, N=11, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S',), comment="""BM rule fitted to 11 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S
+    Total Standard Deviation in ln(k): 3.697817339145407"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 11 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S
+Total Standard Deviation in ln(k): 3.697817339145407""",
+    longDesc = 
+"""
+BM rule fitted to 11 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S
+Total Standard Deviation in ln(k): 3.697817339145407
+""",
+)
+
+entry(
+    index = 11,
+    label = "Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(4909.53,'s^-1'), n=2.71698, w0=(782000,'J/mol'), E0=(88826.1,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-1.1408662726283667e-06, var=3.5438674360202764e-06, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 0.003776812860711284"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 0.003776812860711284""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 0.003776812860711284
+""",
+)
+
+entry(
+    index = 12,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R",
+    kinetics = ArrheniusBM(A=(2.92444,'s^-1'), n=3.72909, w0=(798000,'J/mol'), E0=(116830,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.06573990524748347, var=12.669811692818818, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R
+    Total Standard Deviation in ln(k): 7.300965786524997"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R
+Total Standard Deviation in ln(k): 7.300965786524997""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R
+Total Standard Deviation in ln(k): 7.300965786524997
+""",
+)
+
+entry(
+    index = 13,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N",
+    kinetics = ArrheniusBM(A=(7.72033e-12,'s^-1'), n=7.13865, w0=(798000,'J/mol'), E0=(101332,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.000940629431949834, var=0.10603351980903279, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N
+    Total Standard Deviation in ln(k): 0.6551610347530803"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N
+Total Standard Deviation in ln(k): 0.6551610347530803""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N
+Total Standard Deviation in ln(k): 0.6551610347530803
+""",
+)
+
+entry(
+    index = 14,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(8.46062e-15,'s^-1'), n=7.98481, w0=(798000,'J/mol'), E0=(96853.6,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0026338346337519743, var=0.43967595157844896, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N
+    Total Standard Deviation in ln(k): 1.3359187179535994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N
+Total Standard Deviation in ln(k): 1.3359187179535994""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N
+Total Standard Deviation in ln(k): 1.3359187179535994
+""",
+)
+
+entry(
+    index = 15,
+    label = "Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(84839.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 16,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(8.00067e+12,'s^-1'), n=0.391729, w0=(798000,'J/mol'), E0=(133048,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 17,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(1.20077e-11,'s^-1'), n=7.05311, w0=(798000,'J/mol'), E0=(100604,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 18,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    kinetics = ArrheniusBM(A=(7.35011e-13,'s^-1'), n=7.36802, w0=(798000,'J/mol'), E0=(90879,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 19,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(1.29627e-12,'s^-1'), n=7.28519, w0=(798000,'J/mol'), E0=(101095,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 20,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R",
+    kinetics = ArrheniusBM(A=(2.19963e-11,'s^-1'), n=6.98648, w0=(798000,'J/mol'), E0=(100797,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0060992050567732995, var=0.1675474541205485, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R',), comment="""BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R
+    Total Standard Deviation in ln(k): 0.8359140421055807"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R
+Total Standard Deviation in ln(k): 0.8359140421055807""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R
+Total Standard Deviation in ln(k): 0.8359140421055807
+""",
+)
+
+entry(
+    index = 21,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R",
+    kinetics = ArrheniusBM(A=(2.24517e-15,'s^-1'), n=8.2595, w0=(798000,'J/mol'), E0=(97485.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_Ext-5BrCClFIOPSSi-R_Ext-5BrCClFIOPSSi-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 22,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(3.21561e-15,'s^-1'), n=8.08717, w0=(798000,'J/mol'), E0=(97688.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_5BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 23,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(7.48602e-15,'s^-1'), n=8.00071, w0=(798000,'J/mol'), E0=(97935.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_N-5R!H->N_N-5BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 24,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(9.61654e-11,'s^-1'), n=6.78703, w0=(798000,'J/mol'), E0=(99834.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 25,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(1.1358e-11,'s^-1'), n=7.08342, w0=(798000,'J/mol'), E0=(101820,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-3.774397504038806e-05, var=0.31280538790524537, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 1.1213232657408565"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+Total Standard Deviation in ln(k): 1.1213232657408565""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+Total Standard Deviation in ln(k): 1.1213232657408565
+""",
+)
+
+entry(
+    index = 26,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing",
+    kinetics = ArrheniusBM(A=(4.38421e-12,'s^-1'), n=7.22006, w0=(798000,'J/mol'), E0=(103463,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_5N-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 27,
+    label = "Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing",
+    kinetics = ArrheniusBM(A=(7.07407e-11,'s^-1'), n=6.82872, w0=(798000,'J/mol'), E0=(100753,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-4R->C_N-3R!H->C_N-3NS->S_Ext-1R!H-R_5R!H->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N_N-5N-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/ketoenol/training/dictionary.txt
+++ b/input/kinetics/families/ketoenol/training/dictionary.txt
@@ -130,3 +130,277 @@ C3H6O-2
 9     H u0 p0 c0 {3,S}
 10    H u0 p0 c0 {4,S}
 
+C2H4N2O2
+1  *3 O u0 p2 c0 {5,S} {10,S}
+2     O u0 p2 c0 {6,D}
+3     N u0 p1 c0 {5,S} {7,S} {8,S}
+4  *1 N u0 p1 c0 {5,D} {6,S}
+5  *2 C u0 p0 c0 {1,S} {3,S} {4,D}
+6     C u0 p0 c0 {2,D} {4,S} {9,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {6,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C2H4N2O2-2
+1  *3 O u0 p2 c0 {5,D}
+2     O u0 p2 c0 {6,D}
+3  *1 N u0 p1 c0 {5,S} {6,S} {7,S}
+4     N u0 p1 c0 {5,S} {8,S} {9,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+6     C u0 p0 c0 {2,D} {3,S} {10,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {6,S}
+
+C2H4N2O2-3
+1  *3 O u0 p2 c0 {5,S} {9,S}
+2     O u0 p2 c0 {6,D}
+3     N u0 p1 c0 {5,S} {6,S} {7,S}
+4  *1 N u0 p1 c0 {5,D} {10,S}
+5  *2 C u0 p0 c0 {1,S} {3,S} {4,D}
+6     C u0 p0 c0 {2,D} {3,S} {8,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {6,S}
+9  *4 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+
+C2H4N2O2-4
+1  *3 O u0 p2 c0 {5,D}
+2     O u0 p2 c0 {6,D}
+3     N u0 p1 c0 {5,S} {6,S} {7,S}
+4  *1 N u0 p1 c0 {5,S} {9,S} {10,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+6     C u0 p0 c0 {2,D} {3,S} {8,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {6,S}
+9  *4 H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+
+C2H4N2O2-5
+1  *3 O u0 p2 c0 {6,S} {10,S}
+2     O u0 p2 c0 {5,D}
+3     N u0 p1 c0 {5,S} {8,S} {9,S}
+4  *1 N u0 p1 c0 {5,S} {6,D}
+5     C u0 p0 c0 {2,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C2H4N2O2-6
+1     O u0 p2 c0 {5,D}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 N u0 p1 c0 {5,S} {6,S} {7,S}
+4     N u0 p1 c0 {5,S} {9,S} {10,S}
+5     C u0 p0 c0 {1,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {8,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+
+C2H4N2O2-7
+1     O u0 p2 c0 {5,S} {6,S}
+2  *3 O u0 p2 c0 {5,S} {8,S}
+3  *1 N u0 p1 c0 {5,D} {10,S}
+4     N u0 p1 c0 {6,D} {9,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6     C u0 p0 c0 {1,S} {4,D} {7,S}
+7     H u0 p0 c0 {6,S}
+8  *4 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {3,S}
+
+C2H4N2O2-8
+1     O u0 p2 c0 {5,S} {6,S}
+2  *3 O u0 p2 c0 {5,D}
+3  *1 N u0 p1 c0 {5,S} {8,S} {9,S}
+4     N u0 p1 c0 {6,D} {10,S}
+5  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+6     C u0 p0 c0 {1,S} {4,D} {7,S}
+7     H u0 p0 c0 {6,S}
+8  *4 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+
+C2H2N2O
+1 *3 O u0 p2 c0 {4,S} {5,S}
+2 *1 N u0 p1 c0 {3,S} {4,D}
+3    N u0 p1 c0 {2,S} {5,D}
+4 *2 C u0 p0 c0 {1,S} {2,D} {6,S}
+5 *4 C u0 p0 c0 {1,S} {3,D} {7,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {5,S}
+
+C2H2N2O-2
+1 *3 O u0 p2 c0 {5,D}
+2 *1 N u0 p1 c0 {3,S} {4,S} {5,S}
+3    N u0 p1 c0 {2,S} {4,D}
+4 *4 C u0 p0 c0 {2,S} {3,D} {6,S}
+5 *2 C u0 p0 c0 {1,D} {2,S} {7,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {5,S}
+
+C3H3NO
+1 *3 O u0 p2 c0 {3,S} {6,S}
+2 *1 N u0 p1 c0 {3,D} {7,S}
+3 *2 C u0 p0 c0 {1,S} {2,D} {4,S}
+4    C u0 p0 c0 {3,S} {5,T}
+5    C u0 p0 c0 {4,T} {8,S}
+6 *4 H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {5,S}
+
+C3H3NO-2
+1 *3 O u0 p2 c0 {3,D}
+2 *1 N u0 p1 c0 {3,S} {6,S} {7,S}
+3 *2 C u0 p0 c0 {1,D} {2,S} {4,S}
+4    C u0 p0 c0 {3,S} {5,T}
+5    C u0 p0 c0 {4,T} {8,S}
+6 *4 H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {5,S}
+
+C3H6N2O
+1  *3 O u0 p2 c0 {6,S} {11,S}
+2     N u0 p1 c0 {4,S} {5,S} {6,S}
+3  *1 N u0 p1 c0 {6,D} {12,S}
+4     C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11 *4 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {3,S}
+
+C3H6N2O-2
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {4,S} {5,S} {6,S}
+3  *1 N u0 p1 c0 {6,S} {11,S} {12,S}
+4     C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+5     C u0 p0 c0 {2,S} {4,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11 *4 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+
+C2H5N3O
+1  *3 O u0 p2 c0 {5,S} {9,S}
+2     N u0 p1 c0 {5,S} {6,S} {7,S}
+3  *1 N u0 p1 c0 {5,D} {11,S}
+4     N u0 p1 c0 {6,D} {10,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6     C u0 p0 c0 {2,S} {4,D} {8,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {6,S}
+9  *4 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
+
+C2H5N3O-2
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {5,S} {6,S} {7,S}
+3  *1 N u0 p1 c0 {5,S} {9,S} {10,S}
+4     N u0 p1 c0 {6,D} {11,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+6     C u0 p0 c0 {2,S} {4,D} {8,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {6,S}
+9  *4 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+
+C2H3NO2
+1 *3 O u0 p2 c0 {4,S} {8,S}
+2    O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {4,D} {5,S}
+4 *2 C u0 p0 c0 {1,S} {3,D} {6,S}
+5    C u0 p0 c0 {2,D} {3,S} {7,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {5,S}
+8 *4 H u0 p0 c0 {1,S}
+
+C2H3NO2-2
+1 *3 O u0 p2 c0 {4,D}
+2    O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {4,S} {5,S} {6,S}
+4 *2 C u0 p0 c0 {1,D} {3,S} {7,S}
+5    C u0 p0 c0 {2,D} {3,S} {8,S}
+6 *4 H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {5,S}
+
+C2H4N2O2-9
+1  *3 O u0 p2 c0 {6,S} {9,S}
+2     O u0 p2 c0 {5,D}
+3     N u0 p1 c0 {5,S} {7,S} {8,S}
+4  *1 N u0 p1 c0 {6,D} {10,S}
+5     C u0 p0 c0 {2,D} {3,S} {6,S}
+6  *2 C u0 p0 c0 {1,S} {4,D} {5,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9  *4 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
+
+C2H4N2O2-10
+1  *3 O u0 p2 c0 {6,D}
+2     O u0 p2 c0 {5,D}
+3     N u0 p1 c0 {5,S} {7,S} {8,S}
+4  *1 N u0 p1 c0 {6,S} {9,S} {10,S}
+5     C u0 p0 c0 {2,D} {3,S} {6,S}
+6  *2 C u0 p0 c0 {1,D} {4,S} {5,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9  *4 H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+
+C2H4N2O
+1 *3 O u0 p2 c0 {5,S} {8,S}
+2 *1 N u0 p1 c0 {4,S} {5,D}
+3    N u0 p1 c0 {4,D} {9,S}
+4    C u0 p0 c0 {2,S} {3,D} {7,S}
+5 *2 C u0 p0 c0 {1,S} {2,D} {6,S}
+6    H u0 p0 c0 {5,S}
+7    H u0 p0 c0 {4,S}
+8 *4 H u0 p0 c0 {1,S}
+9    H u0 p0 c0 {3,S}
+
+C2H4N2O-2
+1 *3 O u0 p2 c0 {5,D}
+2 *1 N u0 p1 c0 {4,S} {5,S} {6,S}
+3    N u0 p1 c0 {4,D} {9,S}
+4    C u0 p0 c0 {2,S} {3,D} {7,S}
+5 *2 C u0 p0 c0 {1,D} {2,S} {8,S}
+6 *4 H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {5,S}
+9    H u0 p0 c0 {3,S}
+
+CH4N2O
+1 *3 O u0 p2 c0 {4,S} {7,S}
+2    N u0 p1 c0 {4,S} {5,S} {6,S}
+3 *1 N u0 p1 c0 {4,D} {8,S}
+4 *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7 *4 H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {3,S}
+
+CH4N2O-2
+1 *3 O u0 p2 c0 {4,D}
+2    N u0 p1 c0 {4,S} {5,S} {6,S}
+3 *1 N u0 p1 c0 {4,S} {7,S} {8,S}
+4 *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+5    H u0 p0 c0 {2,S}
+6    H u0 p0 c0 {2,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+

--- a/input/kinetics/families/ketoenol/training/reactions.py
+++ b/input/kinetics/families/ketoenol/training/reactions.py
@@ -100,3 +100,207 @@ Converted to training reaction from rate rule: R_ROR;R1_doublebond_CH2;R2_double
 """,
 )
 
+entry(
+    index = 7,
+    label = "C2H4N2O2 <=> C2H4N2O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(8.00067e+12,'s^-1'), n=0.391729, Ea=(94.5147,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.18377, dn = +|- 0.0223852, dEa = +|- 0.11543 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001084 <=> p001084_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 8,
+    label = "C2H4N2O2-3 <=> C2H4N2O2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.07407e-11,'s^-1'), n=6.82872, Ea=(71.4835,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 77.9277, dn = +|- 0.577969, dEa = +|- 2.98031 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001085 <=> p001085_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 9,
+    label = "C2H4N2O2-5 <=> C2H4N2O2-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.20077e-11,'s^-1'), n=7.05311, Ea=(80.7907,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 97.3371, dn = +|- 0.607479, dEa = +|- 3.13248 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001089 <=> p001089_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 10,
+    label = "C2H4N2O2-7 <=> C2H4N2O2-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.21561e-15,'s^-1'), n=8.08717, Ea=(70.5685,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 173.347, dn = +|- 0.684056, dEa = +|- 3.52735 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r001691 <=> p001691_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 11,
+    label = "C2H2N2O <=> C2H2N2O-2",
+    degeneracy = 2.0,
+    kinetics = Arrhenius(A=(2.47167e+11,'s^-1'), n=1.27308, Ea=(321.43,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.45225, dn = +|- 0.0495084, dEa = +|- 0.255291 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r002774 <=> p002774_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 12,
+    label = "C3H3NO <=> C3H3NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.48602e-15,'s^-1'), n=8.00071, Ea=(73.8737,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 162.648, dn = +|- 0.675603, dEa = +|- 3.48376 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r003183 <=> p003183_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 13,
+    label = "C3H6N2O <=> C3H6N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.38421e-12,'s^-1'), n=7.22006, Ea=(74.0025,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 104.123, dn = +|- 0.616422, dEa = +|- 3.17859 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r003454 <=> p003454_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 14,
+    label = "C2H5N3O <=> C2H5N3O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.61654e-11,'s^-1'), n=6.78703, Ea=(67.979,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 72.1251, dn = +|- 0.567701, dEa = +|- 2.92736 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r004749 <=> p004749_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 15,
+    label = "C2H3NO2 <=> C2H3NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.29627e-12,'s^-1'), n=7.28519, Ea=(72.1644,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 108.246, dn = +|- 0.621573, dEa = +|- 3.20516 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005032 <=> p005032_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 16,
+    label = "C2H4N2O2-9 <=> C2H4N2O2-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.24517e-15,'s^-1'), n=8.2595, Ea=(75.0964,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 203.941, dn = +|- 0.705623, dEa = +|- 3.63856 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005432 <=> p005432_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 17,
+    label = "C2H4N2O <=> C2H4N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.35011e-13,'s^-1'), n=7.36802, Ea=(73.0838,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 115.182, dn = +|- 0.629815, dEa = +|- 3.24765 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005588 <=> p005588_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+
+entry(
+    index = 18,
+    label = "CH4N2O <=> CH4N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.56778e-11,'s^-1'), n=7.05561, Ea=(68.9016,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 84.7858, dn = +|- 0.589161, dEa = +|- 3.03802 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Calculated by Kevin Spiekermann
+Reaction indices that correspond to the raw QM log files from the kinetics dataset from Spiekermann et al.: r005826 <=> p005826_0
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12/cc-pVDZ-F12
+Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+""",
+)
+


### PR DESCRIPTION
This PR adds 3 training reactions to the keto-enol family. All calculations were done at `CCSD(T)-F12/cc-pVDZ-F12//ωB97X-D3/def2-TZVP`. The rate tree was then refit using Matt's notebook (#490).

The long description includes the indices that label these species in the dataset paper I'm working on. These indices can be used to find the raw log files from the QM calculations.