### PR TITLE
Use forbidden group instead of defining non-symmetric head node to avoid UndeterminableKineticsError

### DIFF
--- a/input/kinetics/families/2+2_cycloaddition/groups.py
+++ b/input/kinetics/families/2+2_cycloaddition/groups.py
@@ -31,7 +31,7 @@ entry(
 1 *1 [Cd,Cdd,CO,CS]         u0 {2,D}
 2 *2 [Cd,Cdd,CO,CS,O2d,S2d] u0 {1,D}
 3 *3 [Cd,Cdd,CO,CS]         u0 {4,D}
-4 *4 [Cdd,CO,CS,O2d,S2d]    u0 {3,D}
+4 *4 [Cd,Cdd,CO,CS,O2d,S2d]    u0 {3,D}
 """,
     kinetics = None,
 )
@@ -163,13 +163,29 @@ Banning the doublebond within Benzene from reacting in 2+2 cycloaddition.
 )
 
 forbidden(
-    label = "2+2_cycloaddition_CdCd",
+    label = "2+2_cycloaddition_CdCd_product",
     group = 
 """
 1  *4 C u0 p0 c0 {2,S} {3,S}
 2  *3 C u0 p0 c0 {1,S} {4,S}
 3  *2 C u0 p0 c0 {1,S} {4,S}
 4  *1 C u0 p0 c0 {2,S} {3,S}
+""",
+    shortDesc = """2+2_cycloaddition_CdCd""",
+    longDesc = 
+"""
+Banning the 2pi + 2pi cycloaddition, as it is thermally forbidden
+"""
+)
+
+forbidden(
+    label = "2+2_cycloaddition_CdCd_reactant",
+    group = 
+"""
+1  *4 Cd u0 p0 c0 {2,D}
+2  *3 Cd u0 p0 c0 {1,D}
+3  *2 Cd u0 p0 c0 {4,D}
+4  *1 Cd u0 p0 c0 {3,D}
 """,
     shortDesc = """2+2_cycloaddition_CdCd""",
     longDesc = 

--- a/input/kinetics/families/Diels_alder_addition/groups.py
+++ b/input/kinetics/families/Diels_alder_addition/groups.py
@@ -416,19 +416,6 @@ L1: Root
 )
 
 forbidden(
-    label = "allene_avoid_doublecounting",
-    group = 
-"""
-1 *2 Cdd u0
-""",
-    shortDesc = """""",
-    longDesc = 
-"""
-
-""",
-)
-
-forbidden(
     label = "benzene_diene1",
     group = 
 """

--- a/input/kinetics/families/Diels_alder_addition/groups.py
+++ b/input/kinetics/families/Diels_alder_addition/groups.py
@@ -37,7 +37,7 @@ entry(
 3 *3 Cd                                                                    u0 {1,D}
 4 *6 Cd                                                                    u0 {2,D}
 5 *1 [Cd,Cdd,CO,CS,O2d,S2d,S4d,S6d,N3d,N5dc,Ct,S4t,S6t,S6td,S6tt,N3t,N5tc] u0 {6,[D,T]}
-6 *2 [Cd,CO,CS,O2d,S2d,S4d,S6d,N3d,N5dc,Ct,S4t,S6t,S6td,S6tt,N3t,N5tc]     u0 {5,[D,T]}
+6 *2 [Cd,Cdd,CO,CS,O2d,S2d,S4d,S6d,N3d,N5dc,Ct,S4t,S6t,S6td,S6tt,N3t,N5tc] u0 {5,[D,T]}
 """,
     kinetics = None,
 )


### PR DESCRIPTION
I found two families that have this problem. The one in `2+2_cycloaddition` was introduced by my old PR (oops). There could be more undiscovered bugs like these.

Currently, these pairs of reactants/products can be generated from the forward direction, but would encounter `UndeterminableKineticsError` while generated from the reverse direction. See below for example. This is caused by developer writing the head node in a way that hopes to avoid certain reactions from being generated. In these two families, the developer tried to avoid generating C=C + C=C cycloaddition in 2+2_cycloaddition and  avoiding double counting allene in Diels_alder_addition. This works fine when generating in the forward direction.

However, this would cause problem when generating from the reverse direction. Take the 2+2_cycloaddition case for example. With the unsymmetric head node, the forward direction would make sure to map C=C as *1 *2 or *2 *1 and C=O as *3 *4. But when mapping from the reverse direction, C-O in C1CCO1 can be mapped as either *4 *3 or *3 *4. The former would give `UndeterminableKineticsError` as RMG tries to find the rate from the forward direction.

This PR resumes the symmetry in the head node and instead uses forbidden group to avoid generating C=C + C=C cycloaddition or double counting allene.

```
from rmgpy import settings
from rmgpy.data.rmg import RMGDatabase
from rmgpy.molecule.molecule import Molecule

database = RMGDatabase()
database.load(
    path=settings['database.directory'],
    thermo_libraries=['primaryThermoLibrary'],
    transport_libraries=[],
    reaction_libraries=[],
    seed_mechanisms=[],
    kinetics_families="default",
    kinetics_depositories=['training'],
)

mol1 = Molecule()
mol1.from_smiles("C=C")

mol2 = Molecule()
mol2.from_smiles("C=O")

mol3 = Molecule()
mol3.from_smiles("C1CCO1")

database.kinetics.generate_reactions_from_families(reactants=[mol1,mol2],products=[mol3],only_families=["2+2_cycloaddition"])
>>> [TemplateReaction(reactants=[Species(label="", molecule=[Molecule(smiles="C=C")], molecular_weight=(28.0532,'amu')), Species(label="", molecule=[Molecule(smiles="C=O")], molecular_weight=(30.026,'amu'))], products=[Species(label="", molecule=[Molecule(smiles="C1COC1")], molecular_weight=(58.0792,'amu'))], degeneracy=2.0, pairs=[[Species(label="", molecule=[Molecule(smiles="C=C")], molecular_weight=(28.0532,'amu')), Species(label="", molecule=[Molecule(smiles="C1COC1")], molecular_weight=(58.0792,'amu'))], [Species(label="", molecule=[Molecule(smiles="C=O")], molecular_weight=(30.026,'amu')), Species(label="", molecule=[Molecule(smiles="C1COC1")], molecular_weight=(58.0792,'amu'))]], family='2+2_cycloaddition', template=['Root_1COCSCdCdd->Cd_3COCSCdCdd->CO'])]

database.kinetics.generate_reactions_from_families(reactants=[mol3],products=[mol1,mol2])
>>> UndeterminableKineticsError: (TemplateReaction(reactants=[Molecule(smiles="C=O"), Molecule(smiles="C=C")], products=[Molecule(smiles="C1COC1")], pairs=[[Molecule(smiles="C=O"), Molecule(smiles="C1COC1")], [Molecule(smiles="C=C"), Molecule(smiles="C1COC1")]], family='2+2_cycloaddition'), 'Kinetics could not be determined. Unable to find matching template for reaction <Molecule "C=O"> + <Molecule "C=C"> <=> <Molecule "C1COC1"> in reaction family <KineticsGroups "2+2_cycloaddition/groups">.Trying to match [<Entry index=0 label="Root">] but matched []')


mol1 = Molecule()
mol1.from_smiles("C=C=C")

mol2 = Molecule()
mol2.from_smiles("C=CC=C")

mol3 = Molecule()
mol3.from_smiles("C=C1CC=CCC1")

database.kinetics.generate_reactions_from_families(reactants=[mol1,mol2],products=[mol3],only_families=["Diels_alder_addition"])
>>> [TemplateReaction(reactants=[Species(label="", molecule=[Molecule(smiles="C=CC=C")], molecular_weight=(54.0904,'amu')), Species(label="", molecule=[Molecule(smiles="C=C=C")], molecular_weight=(40.0638,'amu'))], products=[Species(label="", molecule=[Molecule(smiles="C=C1CC=CCC1")], molecular_weight=(94.1542,'amu'))], degeneracy=4.0, pairs=[[Species(label="", molecule=[Molecule(smiles="C=CC=C")], molecular_weight=(54.0904,'amu')), Species(label="", molecule=[Molecule(smiles="C=C1CC=CCC1")], molecular_weight=(94.1542,'amu'))], [Species(label="", molecule=[Molecule(smiles="C=C=C")], molecular_weight=(40.0638,'amu')), Species(label="", molecule=[Molecule(smiles="C=C1CC=CCC1")], molecular_weight=(94.1542,'amu'))]], family='Diels_alder_addition', template=['Root_N-5COCSCdCddCtN3dN3tN5dcN5tcO2dS2dS4dS4tS6dS6tS6tdS6tt->Cd_N-5COCSCddCtN3dN3tN5dcN5tcO2dS2dS4dS4tS6dS6tS6tdS6tt->Ct'])]

database.kinetics.generate_reactions_from_families(reactants=[mol3],products=[mol1,mol2],only_families=["Diels_alder_addition"])
>>> UndeterminableKineticsError: (TemplateReaction(reactants=[Molecule(smiles="C=C=C"), Molecule(smiles="C=CC=C")], products=[Molecule(smiles="C=C1CC=CCC1")], pairs=[[Molecule(smiles="C=C=C"), Molecule(smiles="C=C1CC=CCC1")], [Molecule(smiles="C=CC=C"), Molecule(smiles="C=C1CC=CCC1")]], family='Diels_alder_addition'), 'Kinetics could not be determined. Unable to find matching template for reaction <Molecule "C=C=C"> + <Molecule "C=CC=C"> <=> <Molecule "C=C1CC=CCC1"> in reaction family <KineticsGroups "Diels_alder_addition/groups">.Trying to match [<Entry index=0 label="Root">] but matched []')
```

