### PR TITLE
Comment out CurranPentane Reaction 847

### DIFF
--- a/input/kinetics/libraries/CurranPentane/reactions.py
+++ b/input/kinetics/libraries/CurranPentane/reactions.py
@@ -14105,13 +14105,13 @@ entry(
     shortDesc = u"""""",
 )
 
-entry(
-    index = 847,
-    label = "C3H2(S) + H <=> C3H2(S) + H",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""""",
-)
+#entry(
+#    index = 847,
+#    label = "C3H2(S) + H <=> C3H2(S) + H",
+#    degeneracy = 1,
+#    kinetics = Arrhenius(A=(1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+#    shortDesc = u"""""",
+#)
 
 entry(
     index = 848,


### PR DESCRIPTION
RMG errors out if you try to load the CurranPentane library as a seed mechanism because it can't get the kinetics for reaction "C3H2(S) + H <=> C3H2(S) + H". I advocate commenting it out instead of deleting it because it's a real reaction, but it's missing the adjacency list to describe the two separate species. This is a temporary fix to issue [526](https://github.com/ReactionMechanismGenerator/RMG-database/issues/526), which has more details.