### PR TITLE
Fix labels, structures, and reactions for C:3 H:2 species in CurranPentane

### DIFF
--- a/input/kinetics/libraries/CurranPentane/dictionary.txt
+++ b/input/kinetics/libraries/CurranPentane/dictionary.txt
@@ -1220,11 +1220,11 @@ C5H9O1-3OOH-2
 18 H u0 p0 c0 {8,S}
 
 C3H2(S)
-1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u0 p0 c0 {1,D} {5,D}
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {5,S}
 3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 C u0 p1 c0 {2,D}
+4 H u0 p0 c0 {5,S}
+5 C u0 p1 c0 {2,S} {4,S}
 
 IQC3H5OTQ-I
 multiplicity 2
@@ -6526,11 +6526,11 @@ C3H6
 
 C3H2
 multiplicity 3
-1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u0 p0 c0 {1,D} {5,D}
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {5,S}
 3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 C u2 p0 c0 {2,D}
+4 H u0 p0 c0 {5,S}
+5 C u2 p0 c0 {2,S} {4,S}
 
 C3H3
 multiplicity 2
@@ -11329,3 +11329,9 @@ NC5KET25
 17 O u0 p2 c0 {5,D}
 18 H u0 p0 c0 {7,S}
 
+H2CCC(S)
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 C u0 p1 c0 {2,D}

--- a/input/kinetics/libraries/CurranPentane/reactions.py
+++ b/input/kinetics/libraries/CurranPentane/reactions.py
@@ -13925,7 +13925,7 @@ entry(
 
 entry(
     index = 837,
-    label = "C3H3 + H <=> C3H2(S) + H2",
+    label = "C3H3 + H <=> H2CCC(S) + H2",
     degeneracy = 1,
     duplicate = True,
     kinetics = PDepArrhenius(
@@ -14099,7 +14099,7 @@ entry(
 
 entry(
     index = 846,
-    label = "C3H2(S) + O2 <=> CO2 + C2H2",
+    label = "H2CCC(S) + O2 <=> CO2 + C2H2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""""",
@@ -14107,7 +14107,7 @@ entry(
 
 entry(
     index = 847,
-    label = "C3H2(S) + H <=> C3H2(S) + H",
+    label = "C3H2(S) + H <=> H2CCC(S) + H",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""""",
@@ -14699,14 +14699,7 @@ entry(
     index = 859,
     label = "C3H3 + OH <=> C3H2 + H2O",
     degeneracy = 1,
-    duplicate = True,
-    kinetics = MultiArrhenius(
-        arrhenius = [
-            Arrhenius(A=(2e+13, 'cm^3/(mol*s)'), n=0, Ea=(8000, 'cal/mol'), T0=(1, 'K')),
-            Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
-            Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
-        ],
-    ),
+    kinetics = Arrhenius(A=(2e+13, 'cm^3/(mol*s)'), n=0, Ea=(8000, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""""",
 )
 
@@ -38580,3 +38573,18 @@ entry(
     shortDesc = u"""""",
 )
 
+entry(
+    index = 3091,
+    label = "C3H3 + OH <=> C3H2(S) + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""""",
+)
+
+entry(
+    index = 3092,
+    label = "C3H3 + OH <=> H2CCC(S) + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""""",
+)

--- a/input/thermo/libraries/CurranPentane.py
+++ b/input/thermo/libraries/CurranPentane.py
@@ -23647,11 +23647,11 @@ entry(
     molecule = 
 """
 multiplicity 3
-1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u0 p0 c0 {1,D} {5,D}
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {5,S}
 3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 C u2 p0 c0 {2,D}
+4 H u0 p0 c0 {5,S}
+5 C u2 p0 c0 {2,S} {4,S}
 """,
     thermo = NASA(
         polynomials = [
@@ -23664,8 +23664,7 @@ multiplicity 3
     shortDesc = u"""""",
     longDesc = 
 u"""
-T12/00.
-[C]=C=C
+[CH]C#C
 """,
 )
 
@@ -23674,11 +23673,11 @@ entry(
     label = "C3H2(S)",
     molecule = 
 """
-1 C u0 p0 c0 {2,D} {3,S} {4,S}
-2 C u0 p0 c0 {1,D} {5,D}
+1 C u0 p0 c0 {2,T} {3,S}
+2 C u0 p0 c0 {1,T} {5,S}
 3 H u0 p0 c0 {1,S}
-4 H u0 p0 c0 {1,S}
-5 C u0 p1 c0 {2,D}
+4 H u0 p0 c0 {5,S}
+5 C u0 p1 c0 {2,S} {4,S}
 """,
     thermo = NASA(
         polynomials = [
@@ -23691,7 +23690,7 @@ entry(
     shortDesc = u"""""",
     longDesc = 
 u"""
-singlet[C]=C=C
+singlet[CH]C#C
 """,
 )
 
@@ -25118,3 +25117,29 @@ C=CCOO
 """,
 )
 
+
+entry(
+    index = 678,
+    label = "H2CCC(S)",
+    molecule = 
+"""
+1 C u0 p0 c0 {2,D} {3,S} {4,S}
+2 C u0 p0 c0 {1,D} {5,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 C u0 p1 c0 {2,D}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.7229726,9.2589854e-03,-2.3006191e-06,-1.0200808e-09,4.5374357e-13,64877.289,5.6865936], Tmin=(200,'K'), Tmax=(1500,'K')),
+            NASAPolynomial(coeffs=[6.4888762,5.3112789e-03,-1.780949e-06,2.7252642e-10,-1.561959e-14,63661.864,-10.064283], Tmin=(1500,'K'), Tmax=(5000,'K')),
+        ],
+        Tmin = (200,'K'),
+        Tmax = (5000,'K'),
+    ),
+    shortDesc = u"""""",
+    longDesc = 
+u"""
+singlet[C]=C=C
+""",
+)

--- a/trigger-rmg-tests.sh
+++ b/trigger-rmg-tests.sh
@@ -30,7 +30,7 @@ cd $TARGET_DIR
 
 # create a new branch in RMG-tests with the name equal to
 # the branch name of the tested RMG-database branch:
-if [ "$RMG_PY_BRANCH" == "master" ]
+if [ "$RMG_PY_BRANCH" == "main" ]
 then
   RMGTESTSBRANCH=rmgdb-$BRANCH
 else
@@ -42,7 +42,7 @@ git checkout $RMGTESTSBRANCH
 
 # create an empty commit with the SHA-ID of the
 # tested commit of the RMG-database branch:
-if [ "$RMG_PY_BRANCH" == "master" ]
+if [ "$RMG_PY_BRANCH" == "main" ]
 then
   git commit --allow-empty -m rmgdb-$REV
 else


### PR DESCRIPTION
Errors in label and structures for H2C3 isomers in the CurranPentane library are corrected:
- Previously omitted species H2CCC is added back
- C3H2 is updated to C#C[CH] from C=C=[C] (evolves from propargyl)
- All reactions for C3H2, C3H2(S), H2CCC(S), C3H2C (three-member ring) are checked and reassigned as needed
Closes #526 