### PR TITLE
Rotor scans

### DIFF
--- a/input/kinetics/families/1,3_sigmatropic_rearrangement/groups.py
+++ b/input/kinetics/families/1,3_sigmatropic_rearrangement/groups.py
@@ -81,29 +81,29 @@ entry(
 
 entry(
     index = 3,
-    label = "Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R",
+    label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 N   u0 r1 {1,S} {4,S} {5,[S,D,T,B,Q]}
+1 *2 C   u0 {2,S} {3,D}
+2 *3 N   u0 {1,S} {4,S} {5,[S,D,T,B,Q]}
 3 *1 R!H u0 {1,D}
-4 *4 R!H u0 r1 {2,S}
-5    C   ux r1 {2,[S,D,T,B,Q]}
-6    R!H ux {1,[S,D,T,B,Q]}
+4 *4 C   u0 {2,S}
+5    C   ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 4,
-    label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C",
+    label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D}
-2 *3 N   u0 {1,S} {4,S} {5,S}
-3 *1 R!H u0 {1,D}
-4 *4 C   u0 {2,S}
-5    C   u0 {2,S}
+1 *2 C   u0 r0 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 N   u0 r1 {1,S} {4,S} {5,S}
+3 *1 R!H u0 r0 {1,D}
+4 *4 C   u0 r1 {2,S}
+5    C   u0 r1 {2,S}
+6    R!H ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -113,11 +113,11 @@ entry(
     label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N",
     group = 
 """
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 N u0 r1 {1,S} {4,S} {5,S}
-3 *1 N u0 r0 {1,D}
+1 *2 C u0 {2,S} {3,D}
+2 *3 N u0 r1 {1,S} {4,S} {5,[S,D,T,B,Q]}
+3 *1 N u0 {1,D}
 4 *4 C u0 r1 {2,S}
-5    C u0 r1 {2,S}
+5    C ux r1 {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -127,11 +127,11 @@ entry(
     label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N",
     group = 
 """
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 N u0 r1 {1,S} {4,S} {5,S}
-3 *1 O u0 r0 {1,D}
+1 *2 C u0 {2,S} {3,D}
+2 *3 N u0 r1 {1,S} {4,S} {5,[S,D,T,B,Q]}
+3 *1 O u0 {1,D}
 4 *4 C u0 r1 {2,S}
-5    C u0 r1 {2,S}
+5    C ux r1 {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -269,7 +269,7 @@ entry(
 2 *3 N                      u0 r1 {1,S} {4,S}
 3 *1 N                      u0 r1 {1,D}
 4 *4 C                      u0 r1 {2,S} {5,D}
-5    [F,I,N,Br,Cl,O,P,S,Si] u0 r1 {4,D}
+5    [I,P,Br,Cl,O,F,N,S,Si] u0 r1 {4,D}
 """,
     kinetics = None,
 )
@@ -350,7 +350,7 @@ entry(
 2 *3 O                      u0 r1 {1,S} {4,S}
 3 *1 N                      u0 r1 {1,D}
 4 *4 C                      u0 r1 {2,S} {5,D}
-5    [F,I,N,Br,Cl,O,P,S,Si] u0 r1 {4,D}
+5    [I,P,Br,Cl,O,F,N,S,Si] u0 r1 {4,D}
 """,
     kinetics = None,
 )
@@ -390,7 +390,7 @@ entry(
 2 *3 R!H u0 {1,S} {4,S}
 3 *1 R!H u0 {1,D}
 4 *4 C   u0 {2,S} {5,[S,D,T,B,Q]}
-5    R!H ux {4,[S,D,T,B,Q]}
+5    O   ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -398,20 +398,6 @@ entry(
 entry(
     index = 26,
     label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N",
-    group = 
-"""
-1 *2 C   u0 r0 {2,S} {3,D}
-2 *3 N   u0 {1,S} {4,S}
-3 *1 O   u0 {1,D}
-4 *4 C   u0 {2,S} {5,[S,D,T,B,Q]}
-5    R!H ux {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 27,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D}
@@ -424,29 +410,43 @@ entry(
 )
 
 entry(
-    index = 28,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R",
+    index = 27,
+    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D}
-2 *3 N   u0 {1,S} {4,S}
-3 *1 O   u0 {1,D}
-4 *4 C   u0 {2,S} {5,D} {6,[S,D,T,B,Q]}
-5    O   u0 r0 {4,D}
-6    R!H ux {4,[S,D,T,B,Q]}
+1 *2 C   u0 r0 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 N   u0 r0 {1,S} {4,S}
+3 *1 O   u0 r0 {1,D}
+4 *4 C   u0 r0 {2,S} {5,[S,D,T,B,Q]}
+5    O   ux {4,[S,D,T,B,Q]}
+6    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 28,
+    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 C u0 {2,S} {5,[S,D,T,B,Q]}
+5    O ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 29,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R",
+    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R",
     group = 
 """
 1 *2 C   u0 r0 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 N   u0 {1,S} {4,S}
-3 *1 O   u0 {1,D}
-4 *4 C   u0 {2,S} {5,[S,D,T,B,Q]}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 N   u0 r0 {1,D}
+4 *4 C   u0 r0 {2,S} {5,[S,D,T,B,Q]}
 5    O   ux {4,[S,D,T,B,Q]}
 6    R!H ux {1,[S,D,T,B,Q]}
 """,
@@ -455,92 +455,6 @@ entry(
 
 entry(
     index = 30,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O",
-    group = 
-"""
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 N u0 r0 {1,S} {4,S}
-3 *1 O u0 r0 {1,D}
-4 *4 C u0 r0 {2,S} {5,D}
-5    N ux {4,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 31,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N",
-    group = 
-"""
-1 *2 C   u0 r0 {2,S} {3,D}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
-4 *4 C   u0 {2,S} {5,[S,D,T,B,Q]}
-5    R!H u0 {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 32,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N",
-    group = 
-"""
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 {1,D}
-4 *4 C u0 {2,S} {5,[S,D,T,B,Q]}
-5    N u0 {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 33,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R",
-    group = 
-"""
-1 *2 C   u0 r0 {2,S} {3,D}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
-4 *4 C   u0 {2,S} {5,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-5    N   u0 r0 {4,[S,D,T,B,Q]}
-6    R!H ux {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 34,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N",
-    group = 
-"""
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 {1,D}
-4 *4 C u0 {2,S} {5,D}
-5    O u0 {4,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 35,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R",
-    group = 
-"""
-1 *2 C   u0 r0 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
-4 *4 C   u0 {2,S} {5,D}
-5    O   u0 r0 {4,D}
-6    R!H ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 36,
     label = "Root_N-1R!H-inRing_2R!H->C",
     group = 
 """
@@ -553,7 +467,7 @@ entry(
 )
 
 entry(
-    index = 37,
+    index = 31,
     label = "Root_N-1R!H-inRing_N-2R!H->C",
     group = 
 """
@@ -570,8 +484,8 @@ tree(
 L1: Root
     L2: Root_Ext-2R!H-R
         L3: Root_Ext-2R!H-R_5R!H->C
-            L4: Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R
             L4: Root_Ext-2R!H-R_5R!H->C_4R!H->C
+                L5: Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R
                 L5: Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N
                 L5: Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N
             L4: Root_Ext-2R!H-R_5R!H->C_N-4R!H->C
@@ -594,15 +508,9 @@ L1: Root
     L2: Root_N-1R!H-inRing
         L3: Root_N-1R!H-inRing_Ext-4R!H-R
             L4: Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
-                L5: Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O
-                    L6: Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R
-                    L6: Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R
-                L5: Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O
+                L5: Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R
             L4: Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
-                L5: Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N
-                    L6: Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R
-                L5: Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N
-                    L6: Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R
+                L5: Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R
         L3: Root_N-1R!H-inRing_2R!H->C
         L3: Root_N-1R!H-inRing_N-2R!H->C
 """

--- a/input/kinetics/families/1,3_sigmatropic_rearrangement/rules.py
+++ b/input/kinetics/families/1,3_sigmatropic_rearrangement/rules.py
@@ -9,135 +9,135 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(3.11403e+20,'s^-1'), n=-1.91643, w0=(671167,'J/mol'), E0=(227910,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.2489853322397734, var=103.35155747037187, Tref=1000.0, N=24, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 24 training reactions at node Root
-    Total Standard Deviation in ln(k): 21.006122624958927"""),
+    kinetics = ArrheniusBM(A=(2.30449e+26,'s^-1'), n=-3.67965, w0=(664000,'J/mol'), E0=(247186,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.41637278281289714, var=128.17786304001615, Tref=1000.0, N=20, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 20 training reactions at node Root
+    Total Standard Deviation in ln(k): 23.74290382411667"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 24 training reactions at node Root
-Total Standard Deviation in ln(k): 21.006122624958927""",
+    shortDesc = """BM rule fitted to 20 training reactions at node Root
+Total Standard Deviation in ln(k): 23.74290382411667""",
     longDesc = 
 """
-BM rule fitted to 24 training reactions at node Root
-Total Standard Deviation in ln(k): 21.006122624958927
+BM rule fitted to 20 training reactions at node Root
+Total Standard Deviation in ln(k): 23.74290382411667
 """,
 )
 
 entry(
     index = 2,
     label = "Root_Ext-2R!H-R",
-    kinetics = ArrheniusBM(A=(1.26563e-22,'s^-1'), n=10.0023, w0=(636417,'J/mol'), E0=(45254.6,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.4448894413899516, var=25.919851613271362, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_Ext-2R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_Ext-2R!H-R
-    Total Standard Deviation in ln(k): 13.836790993424374"""),
+    kinetics = ArrheniusBM(A=(1.07986e-21,'s^-1'), n=9.62589, w0=(636417,'J/mol'), E0=(33022,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.3571800124903484, var=28.092031200167057, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_Ext-2R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_Ext-2R!H-R
+    Total Standard Deviation in ln(k): 14.035480087290036"""),
     rank = 11,
     shortDesc = """BM rule fitted to 6 training reactions at node Root_Ext-2R!H-R
-Total Standard Deviation in ln(k): 13.836790993424374""",
+Total Standard Deviation in ln(k): 14.035480087290036""",
     longDesc = 
 """
 BM rule fitted to 6 training reactions at node Root_Ext-2R!H-R
-Total Standard Deviation in ln(k): 13.836790993424374
+Total Standard Deviation in ln(k): 14.035480087290036
 """,
 )
 
 entry(
     index = 3,
     label = "Root_1R!H-inRing",
-    kinetics = ArrheniusBM(A=(1.047e+66,'s^-1'), n=-14.5812, w0=(654062,'J/mol'), E0=(401059,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=1.5126184551256572, var=267.3876986170645, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_1R!H-inRing',), comment="""BM rule fitted to 8 training reactions at node Root_1R!H-inRing
-    Total Standard Deviation in ln(k): 36.58196427792415"""),
+    kinetics = ArrheniusBM(A=(5.95588e+67,'s^-1'), n=-15.1817, w0=(654062,'J/mol'), E0=(403939,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=1.5544159323717395, var=269.88167642966965, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_1R!H-inRing',), comment="""BM rule fitted to 8 training reactions at node Root_1R!H-inRing
+    Total Standard Deviation in ln(k): 36.83950759794208"""),
     rank = 11,
     shortDesc = """BM rule fitted to 8 training reactions at node Root_1R!H-inRing
-Total Standard Deviation in ln(k): 36.58196427792415""",
+Total Standard Deviation in ln(k): 36.83950759794208""",
     longDesc = 
 """
 BM rule fitted to 8 training reactions at node Root_1R!H-inRing
-Total Standard Deviation in ln(k): 36.58196427792415
+Total Standard Deviation in ln(k): 36.83950759794208
 """,
 )
 
 entry(
     index = 4,
     label = "Root_N-1R!H-inRing",
-    kinetics = ArrheniusBM(A=(1.42921e+12,'s^-1'), n=0.272588, w0=(705700,'J/mol'), E0=(162073,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0169552558958688, var=18.84203515518181, Tref=1000.0, N=10, data_mean=0.0, correlation='Root_N-1R!H-inRing',), comment="""BM rule fitted to 10 training reactions at node Root_N-1R!H-inRing
-    Total Standard Deviation in ln(k): 8.744637519563351"""),
+    kinetics = ArrheniusBM(A=(1.714e+12,'s^-1'), n=0.0344252, w0=(704833,'J/mol'), E0=(136687,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.06088719902891068, var=8.841028141402564, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-1R!H-inRing',), comment="""BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing
+    Total Standard Deviation in ln(k): 6.113835418268561"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 10 training reactions at node Root_N-1R!H-inRing
-Total Standard Deviation in ln(k): 8.744637519563351""",
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing
+Total Standard Deviation in ln(k): 6.113835418268561""",
     longDesc = 
 """
-BM rule fitted to 10 training reactions at node Root_N-1R!H-inRing
-Total Standard Deviation in ln(k): 8.744637519563351
+BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing
+Total Standard Deviation in ln(k): 6.113835418268561
 """,
 )
 
 entry(
     index = 5,
     label = "Root_Ext-2R!H-R_5R!H->C",
-    kinetics = ArrheniusBM(A=(1.95709e-15,'s^-1'), n=7.94274, w0=(624125,'J/mol'), E0=(36543.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.8896120741680805, var=1.6673814255816741, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_Ext-2R!H-R_5R!H->C
-    Total Standard Deviation in ln(k): 4.823862973780159"""),
+    kinetics = ArrheniusBM(A=(2.91531e-14,'s^-1'), n=7.49565, w0=(624125,'J/mol'), E0=(13825.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.8129505795286808, var=3.6728302512857196, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_Ext-2R!H-R_5R!H->C
+    Total Standard Deviation in ln(k): 5.88458990276278"""),
     rank = 11,
     shortDesc = """BM rule fitted to 4 training reactions at node Root_Ext-2R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 4.823862973780159""",
+Total Standard Deviation in ln(k): 5.88458990276278""",
     longDesc = 
 """
 BM rule fitted to 4 training reactions at node Root_Ext-2R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 4.823862973780159
+Total Standard Deviation in ln(k): 5.88458990276278
 """,
 )
 
 entry(
     index = 6,
     label = "Root_Ext-2R!H-R_N-5R!H->C",
-    kinetics = ArrheniusBM(A=(5.29289e-37,'s^-1'), n=14.1215, w0=(661000,'J/mol'), E0=(16586.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=8.725930562005685, var=31.20912802912534, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_Ext-2R!H-R_N-5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_N-5R!H->C
-    Total Standard Deviation in ln(k): 33.12392731476194"""),
+    kinetics = ArrheniusBM(A=(1.48161e-36,'s^-1'), n=13.8864, w0=(661000,'J/mol'), E0=(11036.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=8.649252153480784, var=28.6187499376758, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_Ext-2R!H-R_N-5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_N-5R!H->C
+    Total Standard Deviation in ln(k): 32.45641936565119"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_N-5R!H->C
-Total Standard Deviation in ln(k): 33.12392731476194""",
+Total Standard Deviation in ln(k): 32.45641936565119""",
     longDesc = 
 """
 BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_N-5R!H->C
-Total Standard Deviation in ln(k): 33.12392731476194
+Total Standard Deviation in ln(k): 32.45641936565119
 """,
 )
 
 entry(
     index = 7,
     label = "Root_1R!H-inRing_2R!H->N",
-    kinetics = ArrheniusBM(A=(4.83039e+87,'s^-1'), n=-20.7641, w0=(638000,'J/mol'), E0=(482767,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=4.129184246830301, var=422.90828088074545, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_2R!H->N
-    Total Standard Deviation in ln(k): 51.60167822215132"""),
+    kinetics = ArrheniusBM(A=(2.50818e+88,'s^-1'), n=-21.0628, w0=(638000,'J/mol'), E0=(484196,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=4.168561953451146, var=422.3137326737107, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_2R!H->N
+    Total Standard Deviation in ln(k): 51.671627485424715"""),
     rank = 11,
     shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_2R!H->N
-Total Standard Deviation in ln(k): 51.60167822215132""",
+Total Standard Deviation in ln(k): 51.671627485424715""",
     longDesc = 
 """
 BM rule fitted to 4 training reactions at node Root_1R!H-inRing_2R!H->N
-Total Standard Deviation in ln(k): 51.60167822215132
+Total Standard Deviation in ln(k): 51.671627485424715
 """,
 )
 
 entry(
     index = 8,
     label = "Root_1R!H-inRing_N-2R!H->N",
-    kinetics = ArrheniusBM(A=(3.57104e+57,'s^-1'), n=-12.1805, w0=(670125,'J/mol'), E0=(355647,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=1.427142357120706, var=535.1560083290228, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_N-2R!H->N
-    Total Standard Deviation in ln(k): 49.96220180328063"""),
+    kinetics = ArrheniusBM(A=(4.09681e+60,'s^-1'), n=-13.1585, w0=(670125,'J/mol'), E0=(360582,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=1.5668157718817215, var=547.8562761169217, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_N-2R!H->N
+    Total Standard Deviation in ln(k): 50.860213488451016"""),
     rank = 11,
     shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_N-2R!H->N
-Total Standard Deviation in ln(k): 49.96220180328063""",
+Total Standard Deviation in ln(k): 50.860213488451016""",
     longDesc = 
 """
 BM rule fitted to 4 training reactions at node Root_1R!H-inRing_N-2R!H->N
-Total Standard Deviation in ln(k): 49.96220180328063
+Total Standard Deviation in ln(k): 50.860213488451016
 """,
 )
 
 entry(
     index = 9,
     label = "Root_N-1R!H-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(1.17409e+12,'s^-1'), n=0.297212, w0=(707000,'J/mol'), E0=(161155,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.025396941674194665, var=16.021570096630306, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 8 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 8.088155191452177"""),
+    kinetics = ArrheniusBM(A=(7.50839e+11,'s^-1'), n=0.136197, w0=(707000,'J/mol'), E0=(134212,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.01703312323488117, var=1.3519057502930525, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 2.373731974677581"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 8 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 8.088155191452177""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 2.373731974677581""",
     longDesc = 
 """
-BM rule fitted to 8 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 8.088155191452177
+BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 2.373731974677581
 """,
 )
 
@@ -173,38 +173,23 @@ Total Standard Deviation in ln(k): 11.540182761524994
 
 entry(
     index = 12,
-    label = "Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(7.98007e+11,'s^-1'), n=0.338845, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C",
+    kinetics = ArrheniusBM(A=(1.84746e-16,'s^-1'), n=8.14258, w0=(645667,'J/mol'), E0=(64566.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.7487509793916722, var=1.4587138791120244, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C
+    Total Standard Deviation in ln(k): 4.3025473220224155"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C
+Total Standard Deviation in ln(k): 4.3025473220224155""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C
+Total Standard Deviation in ln(k): 4.3025473220224155
 """,
 )
 
 entry(
     index = 13,
-    label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C",
-    kinetics = ArrheniusBM(A=(1.5457e-15,'s^-1'), n=7.99283, w0=(661000,'J/mol'), E0=(66100,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=7.92545895214582, var=0.05532539280288581, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C
-    Total Standard Deviation in ln(k): 20.384754211192494"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C
-Total Standard Deviation in ln(k): 20.384754211192494""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C
-Total Standard Deviation in ln(k): 20.384754211192494
-""",
-)
-
-entry(
-    index = 14,
     label = "Root_Ext-2R!H-R_5R!H->C_N-4R!H->C",
-    kinetics = ArrheniusBM(A=(7.5809e+11,'s^-1'), n=0.263048, w0=(559500,'J/mol'), E0=(131897,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_N-4R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_N-4R!H->C
+    kinetics = ArrheniusBM(A=(7.88104e+10,'s^-1'), n=0.444174, w0=(559500,'J/mol'), E0=(121694,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_N-4R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_N-4R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_N-4R!H->C
@@ -217,9 +202,9 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 15,
+    index = 14,
     label = "Root_Ext-2R!H-R_N-5R!H->C_3R!H->N",
-    kinetics = ArrheniusBM(A=(3.90941e+10,'s^-1'), n=0.721594, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_N-5R!H->C_3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_N-5R!H->C_3R!H->N
+    kinetics = ArrheniusBM(A=(3.19239e+10,'s^-1'), n=0.633646, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_N-5R!H->C_3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_N-5R!H->C_3R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_N-5R!H->C_3R!H->N
@@ -232,9 +217,9 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 16,
+    index = 15,
     label = "Root_Ext-2R!H-R_N-5R!H->C_N-3R!H->N",
-    kinetics = ArrheniusBM(A=(9.08391e+10,'s^-1'), n=0.559605, w0=(707000,'J/mol'), E0=(197781,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_N-5R!H->C_N-3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_N-5R!H->C_N-3R!H->N
+    kinetics = ArrheniusBM(A=(7.16673e+09,'s^-1'), n=0.77465, w0=(707000,'J/mol'), E0=(194100,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_N-5R!H->C_N-3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_N-5R!H->C_N-3R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_N-5R!H->C_N-3R!H->N
@@ -247,24 +232,24 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 17,
+    index = 16,
     label = "Root_1R!H-inRing_2R!H->N_3R!H->N",
-    kinetics = ArrheniusBM(A=(2.5627e-25,'s^-1'), n=11.532, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.0471320207033354, var=37.83890763345716, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N
-    Total Standard Deviation in ln(k): 14.96277963690898"""),
+    kinetics = ArrheniusBM(A=(7.79562e-25,'s^-1'), n=11.2893, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.0768327727097848, var=36.91907930296372, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N
+    Total Standard Deviation in ln(k): 14.886595318028107"""),
     rank = 11,
     shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N
-Total Standard Deviation in ln(k): 14.96277963690898""",
+Total Standard Deviation in ln(k): 14.886595318028107""",
     longDesc = 
 """
 BM rule fitted to 3 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N
-Total Standard Deviation in ln(k): 14.96277963690898
+Total Standard Deviation in ln(k): 14.886595318028107
 """,
 )
 
 entry(
-    index = 18,
+    index = 17,
     label = "Root_1R!H-inRing_2R!H->N_N-3R!H->N",
-    kinetics = ArrheniusBM(A=(1.5373e+10,'s^-1'), n=1.12018, w0=(707000,'J/mol'), E0=(429584,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_N-3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_N-3R!H->N
+    kinetics = ArrheniusBM(A=(1.14287e+10,'s^-1'), n=1.07105, w0=(707000,'J/mol'), E0=(428529,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_N-3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_N-3R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_N-3R!H->N
@@ -277,24 +262,24 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 19,
+    index = 18,
     label = "Root_1R!H-inRing_N-2R!H->N_4R!H->C",
-    kinetics = ArrheniusBM(A=(4.83275e+67,'s^-1'), n=-15.104, w0=(707000,'J/mol'), E0=(416393,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=1.5423715033712326, var=749.7290753599457, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C
-    Total Standard Deviation in ln(k): 58.76731938407889"""),
+    kinetics = ArrheniusBM(A=(5.17463e+69,'s^-1'), n=-15.7846, w0=(707000,'J/mol'), E0=(419904,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=1.6020204647519467, var=752.2013288923092, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C
+    Total Standard Deviation in ln(k): 59.0076206693908"""),
     rank = 11,
     shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C
-Total Standard Deviation in ln(k): 58.76731938407889""",
+Total Standard Deviation in ln(k): 59.0076206693908""",
     longDesc = 
 """
 BM rule fitted to 3 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C
-Total Standard Deviation in ln(k): 58.76731938407889
+Total Standard Deviation in ln(k): 59.0076206693908
 """,
 )
 
 entry(
-    index = 20,
+    index = 19,
     label = "Root_1R!H-inRing_N-2R!H->N_N-4R!H->C",
-    kinetics = ArrheniusBM(A=(4.0435e+11,'s^-1'), n=1.01704, w0=(559500,'J/mol'), E0=(124536,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_N-4R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_N-4R!H->C
+    kinetics = ArrheniusBM(A=(3.23202e+11,'s^-1'), n=0.959257, w0=(559500,'J/mol'), E0=(116309,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_N-4R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_N-4R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_N-4R!H->C
@@ -307,39 +292,54 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 21,
+    index = 20,
     label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N",
-    kinetics = ArrheniusBM(A=(4.6152e+12,'s^-1'), n=0.237708, w0=(707000,'J/mol'), E0=(162124,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.026486858660185405, var=26.778014476754585, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
-    Total Standard Deviation in ln(k): 10.44054826608419"""),
+    kinetics = ArrheniusBM(A=(7.42118e+12,'s^-1'), n=-0.057127, w0=(707000,'J/mol'), E0=(136643,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.010222737318967457, var=0.4833412136116934, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
+    Total Standard Deviation in ln(k): 1.4194321346238945"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
-Total Standard Deviation in ln(k): 10.44054826608419""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
+Total Standard Deviation in ln(k): 1.4194321346238945""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
-Total Standard Deviation in ln(k): 10.44054826608419
+BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N
+Total Standard Deviation in ln(k): 1.4194321346238945
+""",
+)
+
+entry(
+    index = 21,
+    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N",
+    kinetics = ArrheniusBM(A=(7.42131e+10,'s^-1'), n=0.332427, w0=(707000,'J/mol'), E0=(131754,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0006044627176402661, var=1.3355604139234127, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
+    Total Standard Deviation in ln(k): 2.318319891761889"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
+Total Standard Deviation in ln(k): 2.318319891761889""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
+Total Standard Deviation in ln(k): 2.318319891761889
 """,
 )
 
 entry(
     index = 22,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N",
-    kinetics = ArrheniusBM(A=(2.94384e+11,'s^-1'), n=0.35852, w0=(707000,'J/mol'), E0=(160169,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.016746619657169413, var=20.83377532884782, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
-    Total Standard Deviation in ln(k): 9.19249586318171"""),
+    label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(9.35695e+11,'s^-1'), n=0.214198, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
-Total Standard Deviation in ln(k): 9.19249586318171""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N
-Total Standard Deviation in ln(k): 9.19249586318171
+BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 23,
     label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N",
-    kinetics = ArrheniusBM(A=(1.00046e+12,'s^-1'), n=0.355217, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N
+    kinetics = ArrheniusBM(A=(9.61405e+11,'s^-1'), n=0.233577, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_3R!H->N
@@ -354,7 +354,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 entry(
     index = 24,
     label = "Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N",
-    kinetics = ArrheniusBM(A=(7.58556e+11,'s^-1'), n=0.301396, w0=(707000,'J/mol'), E0=(70700,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N
+    kinetics = ArrheniusBM(A=(3.83567e+11,'s^-1'), n=0.27432, w0=(707000,'J/mol'), E0=(70700,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_Ext-2R!H-R_5R!H->C_4R!H->C_N-3R!H->N
@@ -369,22 +369,22 @@ Total Standard Deviation in ln(k): 11.540182761524994
 entry(
     index = 25,
     label = "Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C",
-    kinetics = ArrheniusBM(A=(1.08157e-17,'s^-1'), n=9.35044, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=7.803854354883043, var=0.32490167187561364, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C
-    Total Standard Deviation in ln(k): 20.75037619267036"""),
+    kinetics = ArrheniusBM(A=(2.55603e-17,'s^-1'), n=9.13956, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=7.73338536715972, var=0.32655979383658124, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C
+    Total Standard Deviation in ln(k): 20.576230589316168"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 20.75037619267036""",
+Total Standard Deviation in ln(k): 20.576230589316168""",
     longDesc = 
 """
 BM rule fitted to 2 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 20.75037619267036
+Total Standard Deviation in ln(k): 20.576230589316168
 """,
 )
 
 entry(
     index = 26,
     label = "Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_N-5R!H->C",
-    kinetics = ArrheniusBM(A=(6.1544e+10,'s^-1'), n=1.34775, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_N-5R!H->C
+    kinetics = ArrheniusBM(A=(3.92014e+10,'s^-1'), n=1.31782, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_N-5R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_N-5R!H->C
@@ -399,7 +399,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 entry(
     index = 27,
     label = "Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(2.1761e+10,'s^-1'), n=0.996245, w0=(707000,'J/mol'), E0=(430709,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-1R!H-R
+    kinetics = ArrheniusBM(A=(1.61854e+10,'s^-1'), n=0.947053, w0=(707000,'J/mol'), E0=(429654,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-1R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-1R!H-R
@@ -414,7 +414,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 entry(
     index = 28,
     label = "Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_5R!H->C",
-    kinetics = ArrheniusBM(A=(1.6259e+11,'s^-1'), n=1.19107, w0=(707000,'J/mol'), E0=(70700,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_5R!H->C
+    kinetics = ArrheniusBM(A=(1.42792e+11,'s^-1'), n=1.12171, w0=(707000,'J/mol'), E0=(70700,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_5R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_5R!H->C
@@ -429,7 +429,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 entry(
     index = 29,
     label = "Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_N-5R!H->C",
-    kinetics = ArrheniusBM(A=(1.23586e+11,'s^-1'), n=1.27308, w0=(707000,'J/mol'), E0=(191263,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_N-5R!H->C
+    kinetics = ArrheniusBM(A=(7.48935e+10,'s^-1'), n=1.24936, w0=(707000,'J/mol'), E0=(189635,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_N-5R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_N-2R!H->N_4R!H->C_Ext-4C-R_N-5R!H->C
@@ -443,68 +443,38 @@ Total Standard Deviation in ln(k): 11.540182761524994
 
 entry(
     index = 30,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O",
-    kinetics = ArrheniusBM(A=(1.4157e+13,'s^-1'), n=0.116469, w0=(707000,'J/mol'), E0=(150200,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.024797229953593753, var=12.258043364057169, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O
-    Total Standard Deviation in ln(k): 7.08118053561588"""),
+    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(1.00957e+13,'s^-1'), n=-0.120785, w0=(707000,'J/mol'), E0=(137481,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O
-Total Standard Deviation in ln(k): 7.08118053561588""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O
-Total Standard Deviation in ln(k): 7.08118053561588
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 31,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O",
-    kinetics = ArrheniusBM(A=(2.30252e+10,'s^-1'), n=0.837267, w0=(707000,'J/mol'), E0=(195266,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O
+    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(1.84315e+12,'s^-1'), n=-0.0912511, w0=(707000,'J/mol'), E0=(137560,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_N-5R!H->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_Ext-1R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 32,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N",
-    kinetics = ArrheniusBM(A=(1.50036e+10,'s^-1'), n=0.759237, w0=(707000,'J/mol'), E0=(181473,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0031826932391024877, var=21.29156289472698, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N
-    Total Standard Deviation in ln(k): 9.258401991518488"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N
-Total Standard Deviation in ln(k): 9.258401991518488""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N
-Total Standard Deviation in ln(k): 9.258401991518488
-""",
-)
-
-entry(
-    index = 33,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N",
-    kinetics = ArrheniusBM(A=(8.99356e+09,'s^-1'), n=0.762386, w0=(707000,'J/mol'), E0=(131558,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0013555408842965467, var=1.8883622591608438, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N
-    Total Standard Deviation in ln(k): 2.758266593399976"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N
-Total Standard Deviation in ln(k): 2.758266593399976""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N
-Total Standard Deviation in ln(k): 2.758266593399976
-""",
-)
-
-entry(
-    index = 34,
     label = "Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(1.04679e+11,'s^-1'), n=1.26667, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R
+    kinetics = ArrheniusBM(A=(8.04681e+10,'s^-1'), n=1.21369, w0=(615000,'J/mol'), E0=(61500,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R
@@ -512,66 +482,6 @@ Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
 BM rule fitted to 1 training reactions at node Root_1R!H-inRing_2R!H->N_3R!H->N_Ext-4R!H-R_5R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 35,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(1.88231e+11,'s^-1'), n=0.661449, w0=(707000,'J/mol'), E0=(168563,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 36,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(3.57015e+11,'s^-1'), n=0.576299, w0=(707000,'J/mol'), E0=(133711,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_2R!H->N_5R!H->O_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 37,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(1.10312e+11,'s^-1'), n=0.507696, w0=(707000,'J/mol'), E0=(169853,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_5R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 38,
-    label = "Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(1.85823e+11,'s^-1'), n=0.331305, w0=(707000,'J/mol'), E0=(135901,'J/mol'), Tmin=(303.03,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_Ext-4R!H-R_N-2R!H->N_N-5R!H->N_Ext-1R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/1,3_sigmatropic_rearrangement/training/dictionary.txt
+++ b/input/kinetics/families/1,3_sigmatropic_rearrangement/training/dictionary.txt
@@ -23,42 +23,18 @@ C3H6O-2
 10    H u0 p0 c0 {4,S}
 
 C2H4N2O2
-1     O u0 p2 c0 {5,D}
-2  *1 O u0 p2 c0 {6,D}
-3  *3 N u0 p1 c0 {5,S} {6,S} {7,S}
-4     N u0 p1 c0 {5,S} {8,S} {9,S}
-5  *4 C u0 p0 c0 {1,D} {3,S} {4,S}
-6  *2 C u0 p0 c0 {2,D} {3,S} {10,S}
-7     H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {4,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {6,S}
-
-C2H4N2O2-2
-1  *1 O u0 p2 c0 {5,S} {6,S}
-2     O u0 p2 c0 {5,D}
-3     N u0 p1 c0 {5,S} {7,S} {8,S}
-4  *3 N u0 p1 c0 {6,D} {10,S}
-5  *4 C u0 p0 c0 {1,S} {2,D} {3,S}
-6  *2 C u0 p0 c0 {1,S} {4,D} {9,S}
-7     H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {6,S}
-10    H u0 p0 c0 {4,S}
-
-C2H4N2O2-3
 1  *1 O u0 p2 c0 {5,D}
 2     O u0 p2 c0 {6,D}
 3  *3 N u0 p1 c0 {5,S} {6,S} {7,S}
-4     N u0 p1 c0 {5,S} {8,S} {9,S}
+4     N u0 p1 c0 {5,S} {9,S} {10,S}
 5  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
-6  *4 C u0 p0 c0 {2,D} {3,S} {10,S}
+6  *4 C u0 p0 c0 {2,D} {3,S} {8,S}
 7     H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {6,S}
 9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {4,S}
 
-C2H4N2O2-4
+C2H4N2O2-2
 1  *1 O u0 p2 c0 {5,S} {6,S}
 2     O u0 p2 c0 {6,D}
 3     N u0 p1 c0 {5,S} {7,S} {8,S}
@@ -167,28 +143,6 @@ C2H2N2O-4
 5 *2 C u0 p0 c0 {1,D} {2,S} {7,S}
 6    H u0 p0 c0 {4,S}
 7    H u0 p0 c0 {5,S}
-
-C2H4N2O
-1 *1 O u0 p2 c0 {5,D}
-2 *3 N u0 p1 c0 {4,S} {5,S} {6,S}
-3    N u0 p1 c0 {4,D} {9,S}
-4 *4 C u0 p0 c0 {2,S} {3,D} {7,S}
-5 *2 C u0 p0 c0 {1,D} {2,S} {8,S}
-6    H u0 p0 c0 {2,S}
-7    H u0 p0 c0 {4,S}
-8    H u0 p0 c0 {5,S}
-9    H u0 p0 c0 {3,S}
-
-C2H4N2O-2
-1 *1 O u0 p2 c0 {4,S} {5,S}
-2 *3 N u0 p1 c0 {5,D} {8,S}
-3    N u0 p1 c0 {4,D} {9,S}
-4 *4 C u0 p0 c0 {1,S} {3,D} {6,S}
-5 *2 C u0 p0 c0 {1,S} {2,D} {7,S}
-6    H u0 p0 c0 {4,S}
-7    H u0 p0 c0 {5,S}
-8    H u0 p0 c0 {2,S}
-9    H u0 p0 c0 {3,S}
 
 C3H3NO
 1 *3 O u0 p2 c0 {3,S} {5,S}

--- a/input/kinetics/families/1,3_sigmatropic_rearrangement/training/reactions.py
+++ b/input/kinetics/families/1,3_sigmatropic_rearrangement/training/reactions.py
@@ -26,41 +26,24 @@ entry(
     index = 1,
     label = "C2H4N2O2 <=> C2H4N2O2-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.88231e+11,'s^-1'), n=0.661449, Ea=(208.054,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.1914, dn = +|- 0.0232376, dEa = +|- 0.119825 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.00957e+13,'s^-1'), n=-0.120785, Ea=(192.666,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.17679, dn = +|- 0.0216006, dEa = +|- 0.111384 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
-Original entry: r001084 <=> p001086
+Original entry: r001085 <=> p001088
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
     index = 2,
-    label = "C2H4N2O2-3 <=> C2H4N2O2-4",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(3.57015e+11,'s^-1'), n=0.576299, Ea=(192.369,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.15438, dn = +|- 0.0190497, dEa = +|- 0.0982302 kJ/mol"""),
-    rank = 4,
-    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
-    longDesc = 
-"""
-Original entry: r001084 <=> p001088
-Calculated by Kevin Spiekermann
-opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
-""",
-)
-
-entry(
-    index = 3,
     label = "C2H3N3 <=> C2H3N3-2",
     degeneracy = 2.0,
-    kinetics = Arrhenius(A=(1.23088e+11,'s^-1'), n=1.34775, Ea=(406.598,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.46535, dn = +|- 0.0507003, dEa = +|- 0.261437 kJ/mol"""),
+    kinetics = Arrhenius(A=(7.84027e+10,'s^-1'), n=1.31782, Ea=(406.92,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.44696, dn = +|- 0.0490241, dEa = +|- 0.252794 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -69,15 +52,15 @@ Original entry: r001235 <=> p001235
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 4,
+    index = 3,
     label = "C2H3NO2 <=> C2H3NO2-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(2.38947e+11,'s^-1'), n=0.419069, Ea=(103.611,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.11238, dn = +|- 0.0141317, dEa = +|- 0.0728703 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.90422e+13,'s^-1'), n=-0.320329, Ea=(105.293,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.07354, dn = +|- 0.00941532, dEa = +|- 0.0485503 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -86,15 +69,15 @@ Original entry: r001958 <=> p001958
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 5,
+    index = 4,
     label = "C2H2N2O <=> C2H2N2O-2",
     degeneracy = 2.0,
-    kinetics = Arrhenius(A=(2.47172e+11,'s^-1'), n=1.27308, Ea=(321.43,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.45225, dn = +|- 0.0495083, dEa = +|- 0.25529 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.49787e+11,'s^-1'), n=1.24936, Ea=(321.691,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.43847, dn = +|- 0.0482433, dEa = +|- 0.248768 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -103,15 +86,15 @@ Original entry: r002774 <=> p002774
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 6,
+    index = 5,
     label = "C3H4N2 <=> C3H4N2-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.47516e+11,'s^-1'), n=1.23379, Ea=(439.575,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.38946, dn = +|- 0.0436439, dEa = +|- 0.225051 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.07396e+11,'s^-1'), n=1.18751, Ea=(440.095,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.3651, dn = +|- 0.0412969, dEa = +|- 0.212948 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -120,15 +103,15 @@ Original entry: r004142 <=> p004142
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 7,
+    index = 6,
     label = "C2H2N2O-3 <=> C2H2N2O-4",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(4.0435e+11,'s^-1'), n=1.01704, Ea=(242.812,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.32691, dn = +|- 0.0375319, dEa = +|- 0.193534 kJ/mol"""),
+    kinetics = Arrhenius(A=(3.23202e+11,'s^-1'), n=0.959257, Ea=(243.463,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.29772, dn = +|- 0.0345798, dEa = +|- 0.178312 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -137,32 +120,15 @@ Original entry: r004202 <=> p002774
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 8,
-    label = "C2H4N2O <=> C2H4N2O-2",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(2.30252e+10,'s^-1'), n=0.837267, Ea=(238.019,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.22417, dn = +|- 0.0268381, dEa = +|- 0.138391 kJ/mol"""),
-    rank = 4,
-    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
-    longDesc = 
-"""
-Original entry: r005588 <=> p005593
-Calculated by Kevin Spiekermann
-opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
-""",
-)
-
-entry(
-    index = 9,
+    index = 7,
     label = "C3H3NO <=> C3H3NO-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.6259e+11,'s^-1'), n=1.19107, Ea=(359.894,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.39462, dn = +|- 0.0441353, dEa = +|- 0.227585 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.42792e+11,'s^-1'), n=1.12171, Ea=(360.677,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.35846, dn = +|- 0.0406495, dEa = +|- 0.20961 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -171,15 +137,15 @@ Original entry: r005763 <=> p005763
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 10,
+    index = 8,
     label = "C4H3N3 <=> C4H3N3-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.04679e+11,'s^-1'), n=1.26667, Ea=(446.512,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.39754, dn = +|- 0.0444136, dEa = +|- 0.22902 kJ/mol"""),
+    kinetics = Arrhenius(A=(8.04681e+10,'s^-1'), n=1.21369, Ea=(447.107,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.36962, dn = +|- 0.0417358, dEa = +|- 0.215211 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -188,15 +154,15 @@ Original entry: r007269 <=> p007269
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 11,
+    index = 9,
     label = "C4H4N2O <=> C4H4N2O-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(2.1761e+10,'s^-1'), n=0.996245, Ea=(380.451,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.27748, dn = +|- 0.0324947, dEa = +|- 0.16756 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.61854e+10,'s^-1'), n=0.947053, Ea=(380.965,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.24984, dn = +|- 0.0295922, dEa = +|- 0.152593 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -205,7 +171,7 @@ Original entry: r011506 <=> p011506
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 

--- a/input/kinetics/families/Ketoenol/groups.py
+++ b/input/kinetics/families/Ketoenol/groups.py
@@ -83,7 +83,7 @@ entry(
 """
 1 *2 C                      u0 {2,S} {3,D}
 2 *3 O                      u0 {1,S} {4,S}
-3 *1 [I,N,Br,F,Cl,O,P,S,Si] u0 {1,D}
+3 *1 [I,Br,Cl,O,P,S,F,N,Si] u0 {1,D}
 4 *4 H                      u0 {2,S}
 """,
     kinetics = None,
@@ -104,81 +104,20 @@ entry(
 
 entry(
     index = 5,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R",
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R",
     group = 
 """
-1 *2 C u0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 {1,D} {5,S}
-4 *4 H u0 {2,S}
-5    C u0 {3,S}
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
     index = 6,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R",
-    group = 
-"""
-1 *2 C   u0 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D} {5,S}
-4 *4 H   u0 {2,S}
-5    C   u0 r0 {3,S}
-6    R!H ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 7,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
-    group = 
-"""
-1 *2 C   u0 r0 {2,S} {3,D}
-2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 N   u0 r0 {1,D} {5,S}
-4 *4 H   u0 r0 {2,S}
-5    C   u0 r0 {3,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-6    R!H ux {5,[S,D,T,B,Q]}
-7    R!H ux {5,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 8,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N",
-    group = 
-"""
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 O u0 r0 {1,S} {4,S}
-3 *1 N u0 r0 {1,D} {5,S}
-4 *4 H u0 r0 {2,S}
-5    C u0 r0 {3,S} {6,D}
-6    N u0 r0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 9,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
-    group = 
-"""
-1 *2 C                      u0 r0 {2,S} {3,D}
-2 *3 O                      u0 r0 {1,S} {4,S}
-3 *1 N                      u0 r0 {1,D} {5,S}
-4 *4 H                      u0 r0 {2,S}
-5    C                      u0 r0 {3,S} {6,D}
-6    [I,Br,F,Cl,O,P,S,C,Si] u0 r0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 10,
     label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
     group = 
 """
@@ -193,30 +132,137 @@ entry(
 )
 
 entry(
-    index = 11,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C",
+    index = 7,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {5,S}
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 N   u0 r0 {1,D}
+4 *4 H   u0 r0 {2,S}
+5    R!H ux r1 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H u0 {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 8,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 {1,D}
 4 *4 H   u0 {2,S}
-5    C   u0 {1,S} {6,[S,D,T,B,Q]}
+5    R!H ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
 6    R!H ux {5,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 12,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R",
+    index = 9,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H ux r0 {1,[S,D,T,B,Q]} {6,S}
+6    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 10,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 r0 {1,S} {4,S}
 3 *1 N   u0 r0 {1,D}
 4 *4 H   u0 r0 {2,S}
-5    C   u0 r0 {1,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+5    C   ux r0 {1,[S,D,T,B,Q]} {6,S}
+6    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 11,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    N ux r0 {1,[S,D,T,B,Q]} {6,S}
+6    C u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 12,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D}
+4 *4 H u0 r0 {2,S}
+5    N ux r0 {1,[S,D,T,B,Q]} {6,S}
+6    C u0 {5,S} {7,D}
+7    N u0 r0 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 13,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r0 {1,D}
+4 *4 H                      u0 r0 {2,S}
+5    N                      ux r0 {1,[S,D,T,B,Q]} {6,S}
+6    C                      u0 {5,S} {7,D}
+7    [I,Br,Cl,O,P,S,F,C,Si] u0 r0 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {5,S}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H u0 r0 {1,S} {6,[D,T]}
+6    R!H ux r0 {5,[D,T]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
 6    R!H ux {5,[S,D,T,B,Q]}
 7    R!H ux {5,[S,D,T,B,Q]}
 """,
@@ -224,118 +270,37 @@ entry(
 )
 
 entry(
-    index = 13,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C",
-    group = 
-"""
-1 *2 C     u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O     u0 {1,S} {4,S}
-3 *1 N     u0 {1,D}
-4 *4 H     u0 {2,S}
-5    [N,O] ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    C     ux {5,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 14,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O",
-    group = 
-"""
-1 *2 C     u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O     u0 {1,S} {4,S}
-3 *1 N     u0 {1,D}
-4 *4 H     u0 {2,S}
-5    [N,O] ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    C     u0 {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    O     u0 {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 15,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O",
-    group = 
-"""
-1 *2 C                      u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D}
-4 *4 H                      u0 {2,S}
-5    [N,O]                  ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    C                      ux {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    [I,N,Br,F,Cl,P,S,C,Si] ux {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 16,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N",
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N",
     group = 
 """
-1 *2 C                      u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D}
-4 *4 H                      u0 {2,S}
-5    N                      ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    C                      u0 {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    [I,N,Br,F,Cl,P,S,C,Si] u0 {6,[S,D,T,B,Q]}
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux {3,[S,D,T,B,Q]} {6,D}
+6    N u0 r0 {5,D}
 """,
     kinetics = None,
 )
 
 entry(
     index = 17,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing",
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
     group = 
 """
-1 *2 C                      u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C                      u0 {2,S} {3,D}
 2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D}
+3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H                      u0 {2,S}
-5    N                      ux r1 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    C                      u0 {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    [I,N,Br,F,Cl,P,S,C,Si] u0 {6,[S,D,T,B,Q]}
+5    C                      ux {3,[S,D,T,B,Q]} {6,D}
+6    [I,Br,Cl,O,P,S,F,C,Si] u0 r0 {5,D}
 """,
     kinetics = None,
 )
 
 entry(
     index = 18,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing",
-    group = 
-"""
-1 *2 C                      u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D}
-4 *4 H                      u0 {2,S}
-5    N                      ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    C                      u0 {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    [I,N,Br,F,Cl,P,S,C,Si] u0 {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 19,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N",
-    group = 
-"""
-1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
-2 *3 O                      u0 r0 {1,S} {4,S}
-3 *1 N                      u0 r0 {1,D}
-4 *4 H                      u0 r0 {2,S}
-5    O                      u0 {1,S} {6,S}
-6    C                      ux {5,S} {7,[S,D,T,B,Q]}
-7    [I,N,Br,F,Cl,P,S,C,Si] ux {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 20,
     label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N",
     group = 
 """
@@ -348,7 +313,7 @@ entry(
 )
 
 entry(
-    index = 21,
+    index = 19,
     label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R",
     group = 
 """
@@ -362,7 +327,7 @@ entry(
 )
 
 entry(
-    index = 22,
+    index = 20,
     label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
     group = 
 """
@@ -383,21 +348,19 @@ L1: Root
         L3: Root_3R!H->C_Ext-1R!H-R
     L2: Root_N-3R!H->C
         L3: Root_N-3R!H->C_3BrClFINOPSSi->N
-            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C
-                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C
-                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O
-                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O
-                        L7: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N
-                            L8: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing
-                            L8: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing
-                        L7: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N
+            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
+                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
+                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
+                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+                        L7: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+                            L8: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
+                            L8: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
+                                L9: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+                                L9: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
+                        L7: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
         L3: Root_N-3R!H->C_N-3BrClFINOPSSi->N
             L4: Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R
                 L5: Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R

--- a/input/kinetics/families/Ketoenol/rules.py
+++ b/input/kinetics/families/Ketoenol/rules.py
@@ -9,15 +9,15 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(4.70715e-12,'s^-1'), n=7.18941, w0=(792618,'J/mol'), E0=(96849.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.048623136096174725, var=7.38275188734163, Tref=1000.0, N=17, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 17 training reactions at node Root
-    Total Standard Deviation in ln(k): 5.569278438749864"""),
+    kinetics = ArrheniusBM(A=(3.64543e-12,'s^-1'), n=7.0342, w0=(791900,'J/mol'), E0=(96088.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.025591830299650252, var=3.209136248979107, Tref=1000.0, N=15, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 15 training reactions at node Root
+    Total Standard Deviation in ln(k): 3.6555959704468117"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 17 training reactions at node Root
-Total Standard Deviation in ln(k): 5.569278438749864""",
+    shortDesc = """BM rule fitted to 15 training reactions at node Root
+Total Standard Deviation in ln(k): 3.6555959704468117""",
     longDesc = 
 """
-BM rule fitted to 17 training reactions at node Root
-Total Standard Deviation in ln(k): 5.569278438749864
+BM rule fitted to 15 training reactions at node Root
+Total Standard Deviation in ln(k): 3.6555959704468117
 """,
 )
 
@@ -39,15 +39,15 @@ Total Standard Deviation in ln(k): 5.140513384866411
 entry(
     index = 3,
     label = "Root_N-3R!H->C",
-    kinetics = ArrheniusBM(A=(2.87617e-12,'s^-1'), n=7.25159, w0=(794571,'J/mol'), E0=(96067.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.05095623138621764, var=6.9856901089733165, Tref=1000.0, N=14, data_mean=0.0, correlation='Root_N-3R!H->C',), comment="""BM rule fitted to 14 training reactions at node Root_N-3R!H->C
-    Total Standard Deviation in ln(k): 5.4266369823609475"""),
+    kinetics = ArrheniusBM(A=(2.14216e-12,'s^-1'), n=7.10076, w0=(794000,'J/mol'), E0=(95211.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.027300955354671547, var=2.809838899397277, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-3R!H->C',), comment="""BM rule fitted to 12 training reactions at node Root_N-3R!H->C
+    Total Standard Deviation in ln(k): 3.4290473906824763"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 14 training reactions at node Root_N-3R!H->C
-Total Standard Deviation in ln(k): 5.4266369823609475""",
+    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-3R!H->C
+Total Standard Deviation in ln(k): 3.4290473906824763""",
     longDesc = 
 """
-BM rule fitted to 14 training reactions at node Root_N-3R!H->C
-Total Standard Deviation in ln(k): 5.4266369823609475
+BM rule fitted to 12 training reactions at node Root_N-3R!H->C
+Total Standard Deviation in ln(k): 3.4290473906824763
 """,
 )
 
@@ -69,15 +69,15 @@ Total Standard Deviation in ln(k): 11.540182761524994
 entry(
     index = 5,
     label = "Root_N-3R!H->C_3BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(7.04228e-12,'s^-1'), n=7.149, w0=(798000,'J/mol'), E0=(99279.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.037889180917409476, var=6.328452360267048, Tref=1000.0, N=11, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N',), comment="""BM rule fitted to 11 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 5.138393785410001"""),
+    kinetics = ArrheniusBM(A=(1.30473e-11,'s^-1'), n=6.87514, w0=(798000,'J/mol'), E0=(99876.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0117411635116814, var=0.6446492092925814, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N',), comment="""BM rule fitted to 9 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 1.6391032023367265"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 11 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 5.138393785410001""",
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 1.6391032023367265""",
     longDesc = 
 """
-BM rule fitted to 11 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 5.138393785410001
+BM rule fitted to 9 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 1.6391032023367265
 """,
 )
 
@@ -98,36 +98,66 @@ Total Standard Deviation in ln(k): 1.0724628112272296
 
 entry(
     index = 7,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R",
-    kinetics = ArrheniusBM(A=(4.42102e-08,'s^-1'), n=6.02684, w0=(798000,'J/mol'), E0=(100291,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.04644471083794055, var=26.35201393188678, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R
-    Total Standard Deviation in ln(k): 10.407844939707589"""),
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(1.09806e-11,'s^-1'), n=6.89792, w0=(798000,'J/mol'), E0=(99858.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0190200390037195, var=1.0964123289271033, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 2.1469413209668056"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R
-Total Standard Deviation in ln(k): 10.407844939707589""",
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
+Total Standard Deviation in ln(k): 2.1469413209668056""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R
-Total Standard Deviation in ln(k): 10.407844939707589
+BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
+Total Standard Deviation in ln(k): 2.1469413209668056
 """,
 )
 
 entry(
     index = 8,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(9.59297e-14,'s^-1'), n=7.69658, w0=(798000,'J/mol'), E0=(100978,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.008127373484941138, var=0.13233644987650478, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 0.749704609952026"""),
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(6.24893e-09,'s^-1'), n=6.18216, w0=(798000,'J/mol'), E0=(107861,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 0.749704609952026""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 0.749704609952026
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 9,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    kinetics = ArrheniusBM(A=(3.10725e-11,'s^-1'), n=6.76455, w0=(798000,'J/mol'), E0=(102204,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 10,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(6.36022e-11,'s^-1'), n=6.62861, w0=(798000,'J/mol'), E0=(100596,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 11,
     label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R",
     kinetics = ArrheniusBM(A=(2857.3,'s^-1'), n=2.79065, w0=(782000,'J/mol'), E0=(88663.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-2.015825826525184e-07, var=0.0007766175206250726, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R
     Total Standard Deviation in ln(k): 0.05586817935319939"""),
@@ -142,97 +172,22 @@ Total Standard Deviation in ln(k): 0.05586817935319939
 )
 
 entry(
-    index = 10,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(8.00037e+12,'s^-1'), n=0.391734, w0=(798000,'J/mol'), E0=(115905,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 11,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(3.63498e-12,'s^-1'), n=7.20509, w0=(798000,'J/mol'), E0=(105249,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
     index = 12,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N",
-    kinetics = ArrheniusBM(A=(2.13103e-12,'s^-1'), n=7.21352, w0=(798000,'J/mol'), E0=(101137,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(2.87238e-12,'s^-1'), n=7.05581, w0=(798000,'J/mol'), E0=(99707.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.02252736485366013, var=0.8629404088644341, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 1.9188917676717938"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 1.9188917676717938""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 5 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 1.9188917676717938
 """,
 )
 
 entry(
     index = 13,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
-    kinetics = ArrheniusBM(A=(6.18181e-12,'s^-1'), n=7.01339, w0=(798000,'J/mol'), E0=(99403.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 14,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C",
-    kinetics = ArrheniusBM(A=(3.52889e-15,'s^-1'), n=8.14889, w0=(798000,'J/mol'), E0=(98709.2,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0060049628157933235, var=0.37717516496187486, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C
-    Total Standard Deviation in ln(k): 1.246287639507079"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 1.246287639507079""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 1.246287639507079
-""",
-)
-
-entry(
-    index = 15,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C",
-    kinetics = ArrheniusBM(A=(7.43586e-13,'s^-1'), n=7.42108, w0=(798000,'J/mol'), E0=(102563,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004210953566892827, var=0.20127748890718947, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C
-    Total Standard Deviation in ln(k): 0.9099838245929136"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C
-Total Standard Deviation in ln(k): 0.9099838245929136""",
-    longDesc = 
-"""
-BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C
-Total Standard Deviation in ln(k): 0.9099838245929136
-""",
-)
-
-entry(
-    index = 16,
     label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
     kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(85014.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
@@ -247,106 +202,121 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 17,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(2.24517e-15,'s^-1'), n=8.2595, w0=(798000,'J/mol'), E0=(103171,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R
+    index = 14,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
+    kinetics = ArrheniusBM(A=(1.68509e-11,'s^-1'), n=6.88807, w0=(798000,'J/mol'), E0=(102832,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H->C_Ext-5C-R
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 15,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
+    kinetics = ArrheniusBM(A=(2.36128e-12,'s^-1'), n=7.07296, w0=(798000,'J/mol'), E0=(99585.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.029593247978928896, var=1.2653129163997325, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+    Total Standard Deviation in ln(k): 2.3294037749260914"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+Total Standard Deviation in ln(k): 2.3294037749260914""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+Total Standard Deviation in ln(k): 2.3294037749260914
+""",
+)
+
+entry(
+    index = 16,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
+    kinetics = ArrheniusBM(A=(7.93116e-11,'s^-1'), n=6.59023, w0=(798000,'J/mol'), E0=(104253,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004083326014350255, var=0.36678964389307633, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+    Total Standard Deviation in ln(k): 1.2243905404532403"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 1.2243905404532403""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 1.2243905404532403
+""",
+)
+
+entry(
+    index = 17,
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
+    kinetics = ArrheniusBM(A=(3.02789e-13,'s^-1'), n=7.48219, w0=(798000,'J/mol'), E0=(95953.2,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 18,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O",
-    kinetics = ArrheniusBM(A=(9.26244e-13,'s^-1'), n=7.34559, w0=(798000,'J/mol'), E0=(102159,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C",
+    kinetics = ArrheniusBM(A=(1.30511e-12,'s^-1'), n=7.26372, w0=(798000,'J/mol'), E0=(105105,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_7R!H->O
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 19,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O",
-    kinetics = ArrheniusBM(A=(6.99061e-13,'s^-1'), n=7.44526, w0=(798000,'J/mol'), E0=(102738,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004731463438640534, var=0.28391442034031983, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O
-    Total Standard Deviation in ln(k): 1.0800835278451721"""),
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(8.42992e-10,'s^-1'), n=6.22192, w0=(798000,'J/mol'), E0=(104542,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-3.0517082806578122e-05, var=0.15820189146844285, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
+    Total Standard Deviation in ln(k): 0.7974520617821278"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O
-Total Standard Deviation in ln(k): 1.0800835278451721""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
+Total Standard Deviation in ln(k): 0.7974520617821278""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O
-Total Standard Deviation in ln(k): 1.0800835278451721
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
+Total Standard Deviation in ln(k): 0.7974520617821278
 """,
 )
 
 entry(
     index = 20,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N",
-    kinetics = ArrheniusBM(A=(2.42473e-12,'s^-1'), n=7.26154, w0=(798000,'J/mol'), E0=(100991,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0010131706773348554, var=0.27551282913717107, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N
-    Total Standard Deviation in ln(k): 1.0548173841742803"""),
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(1.95577e-10,'s^-1'), n=6.41822, w0=(798000,'J/mol'), E0=(102434,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N
-Total Standard Deviation in ln(k): 1.0548173841742803""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N
-Total Standard Deviation in ln(k): 1.0548173841742803
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 21,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N",
-    kinetics = ArrheniusBM(A=(1.40253e-13,'s^-1'), n=7.701, w0=(798000,'J/mol'), E0=(107078,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N
+    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(5.58698e-10,'s^-1'), n=6.27942, w0=(798000,'J/mol'), E0=(105618,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_N-5NO->N
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 22,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing",
-    kinetics = ArrheniusBM(A=(4.47903e-12,'s^-1'), n=7.22226, w0=(798000,'J/mol'), E0=(102310,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_5N-inRing
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 23,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing",
-    kinetics = ArrheniusBM(A=(1.70268e-12,'s^-1'), n=7.27027, w0=(798000,'J/mol'), E0=(100050,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H->C_Ext-6R!H-R_N-7R!H->O_5NO->N_N-5N-inRing
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/Ketoenol/training/dictionary.txt
+++ b/input/kinetics/families/Ketoenol/training/dictionary.txt
@@ -107,42 +107,18 @@ C3H6OS-2
 11 *4 H u0 p0 c0 {1,S}
 
 C2H4N2O2
-1  *3 O u0 p2 c0 {5,S} {10,S}
-2     O u0 p2 c0 {6,D}
-3     N u0 p1 c0 {5,S} {7,S} {8,S}
-4  *1 N u0 p1 c0 {5,D} {6,S}
-5  *2 C u0 p0 c0 {1,S} {3,S} {4,D}
-6     C u0 p0 c0 {2,D} {4,S} {9,S}
-7     H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {6,S}
-10 *4 H u0 p0 c0 {1,S}
-
-C2H4N2O2-2
-1  *3 O u0 p2 c0 {5,D}
-2     O u0 p2 c0 {6,D}
-3  *1 N u0 p1 c0 {5,S} {6,S} {7,S}
-4     N u0 p1 c0 {5,S} {8,S} {9,S}
-5  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
-6     C u0 p0 c0 {2,D} {3,S} {10,S}
-7  *4 H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {4,S}
-9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {6,S}
-
-C2H4N2O2-3
-1  *3 O u0 p2 c0 {5,S} {10,S}
+1  *3 O u0 p2 c0 {5,S} {9,S}
 2     O u0 p2 c0 {6,D}
 3     N u0 p1 c0 {5,S} {6,S} {7,S}
-4  *1 N u0 p1 c0 {5,D} {9,S}
+4  *1 N u0 p1 c0 {5,D} {10,S}
 5  *2 C u0 p0 c0 {1,S} {3,S} {4,D}
 6     C u0 p0 c0 {2,D} {3,S} {8,S}
 7     H u0 p0 c0 {3,S}
 8     H u0 p0 c0 {6,S}
-9     H u0 p0 c0 {4,S}
-10 *4 H u0 p0 c0 {1,S}
+9  *4 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {4,S}
 
-C2H4N2O2-4
+C2H4N2O2-2
 1  *3 O u0 p2 c0 {5,D}
 2     O u0 p2 c0 {6,D}
 3     N u0 p1 c0 {5,S} {6,S} {7,S}
@@ -151,65 +127,41 @@ C2H4N2O2-4
 6     C u0 p0 c0 {2,D} {3,S} {8,S}
 7     H u0 p0 c0 {3,S}
 8     H u0 p0 c0 {6,S}
-9     H u0 p0 c0 {4,S}
-10 *4 H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
 
-C2H4N2O2-5
+C2H4N2O2-3
 1  *3 O u0 p2 c0 {6,S} {10,S}
 2     O u0 p2 c0 {5,D}
-3     N u0 p1 c0 {5,S} {7,S} {8,S}
+3     N u0 p1 c0 {5,S} {8,S} {9,S}
 4  *1 N u0 p1 c0 {5,S} {6,D}
 5     C u0 p0 c0 {2,D} {3,S} {4,S}
-6  *2 C u0 p0 c0 {1,S} {4,D} {9,S}
-7     H u0 p0 c0 {3,S}
+6  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+7     H u0 p0 c0 {6,S}
 8     H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {3,S}
 10 *4 H u0 p0 c0 {1,S}
 
-C2H4N2O2-6
+C2H4N2O2-4
 1     O u0 p2 c0 {5,D}
 2  *3 O u0 p2 c0 {6,D}
 3  *1 N u0 p1 c0 {5,S} {6,S} {7,S}
-4     N u0 p1 c0 {5,S} {8,S} {9,S}
+4     N u0 p1 c0 {5,S} {9,S} {10,S}
 5     C u0 p0 c0 {1,D} {3,S} {4,S}
-6  *2 C u0 p0 c0 {2,D} {3,S} {10,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {8,S}
 7  *4 H u0 p0 c0 {3,S}
-8     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {6,S}
 9     H u0 p0 c0 {4,S}
-10    H u0 p0 c0 {6,S}
-
-C2H4N2O2-7
-1     O u0 p2 c0 {5,S} {6,S}
-2  *3 O u0 p2 c0 {5,S} {8,S}
-3  *1 N u0 p1 c0 {5,D} {9,S}
-4     N u0 p1 c0 {6,D} {10,S}
-5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
-6     C u0 p0 c0 {1,S} {4,D} {7,S}
-7     H u0 p0 c0 {6,S}
-8  *4 H u0 p0 c0 {2,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {4,S}
-
-C2H4N2O2-8
-1     O u0 p2 c0 {5,S} {6,S}
-2  *3 O u0 p2 c0 {5,D}
-3  *1 N u0 p1 c0 {5,S} {8,S} {9,S}
-4     N u0 p1 c0 {6,D} {10,S}
-5  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
-6     C u0 p0 c0 {1,S} {4,D} {7,S}
-7     H u0 p0 c0 {6,S}
-8  *4 H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {3,S}
 10    H u0 p0 c0 {4,S}
 
 C3H3NO
-1 *3 O u0 p2 c0 {3,S} {7,S}
-2 *1 N u0 p1 c0 {3,D} {6,S}
+1 *3 O u0 p2 c0 {3,S} {6,S}
+2 *1 N u0 p1 c0 {3,D} {7,S}
 3 *2 C u0 p0 c0 {1,S} {2,D} {4,S}
 4    C u0 p0 c0 {3,S} {5,T}
 5    C u0 p0 c0 {4,T} {8,S}
-6    H u0 p0 c0 {2,S}
-7 *4 H u0 p0 c0 {1,S}
+6 *4 H u0 p0 c0 {1,S}
+7    H u0 p0 c0 {2,S}
 8    H u0 p0 c0 {5,S}
 
 C3H3NO-2
@@ -218,8 +170,8 @@ C3H3NO-2
 3 *2 C u0 p0 c0 {1,D} {2,S} {4,S}
 4    C u0 p0 c0 {3,S} {5,T}
 5    C u0 p0 c0 {4,T} {8,S}
-6    H u0 p0 c0 {2,S}
-7 *4 H u0 p0 c0 {2,S}
+6 *4 H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
 8    H u0 p0 c0 {5,S}
 
 C3H6N2O
@@ -253,15 +205,15 @@ C3H6N2O-2
 C2H5N3O
 1  *3 O u0 p2 c0 {5,S} {9,S}
 2     N u0 p1 c0 {5,S} {6,S} {7,S}
-3  *1 N u0 p1 c0 {5,D} {10,S}
-4     N u0 p1 c0 {6,D} {11,S}
+3  *1 N u0 p1 c0 {5,D} {11,S}
+4     N u0 p1 c0 {6,D} {10,S}
 5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
 6     C u0 p0 c0 {2,S} {4,D} {8,S}
 7     H u0 p0 c0 {2,S}
 8     H u0 p0 c0 {6,S}
 9  *4 H u0 p0 c0 {1,S}
-10    H u0 p0 c0 {3,S}
-11    H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {3,S}
 
 C2H5N3O-2
 1  *3 O u0 p2 c0 {5,D}
@@ -296,7 +248,7 @@ C2H3NO2-2
 7    H u0 p0 c0 {4,S}
 8    H u0 p0 c0 {5,S}
 
-C2H4N2O2-9
+C2H4N2O2-5
 1  *3 O u0 p2 c0 {6,S} {9,S}
 2     O u0 p2 c0 {5,D}
 3     N u0 p1 c0 {5,S} {7,S} {8,S}
@@ -308,7 +260,7 @@ C2H4N2O2-9
 9  *4 H u0 p0 c0 {1,S}
 10    H u0 p0 c0 {4,S}
 
-C2H4N2O2-10
+C2H4N2O2-6
 1  *3 O u0 p2 c0 {6,D}
 2     O u0 p2 c0 {5,D}
 3     N u0 p1 c0 {5,S} {7,S} {8,S}
@@ -321,15 +273,15 @@ C2H4N2O2-10
 10    H u0 p0 c0 {4,S}
 
 C2H4N2O
-1 *3 O u0 p2 c0 {5,S} {9,S}
+1 *3 O u0 p2 c0 {5,S} {8,S}
 2 *1 N u0 p1 c0 {4,S} {5,D}
-3    N u0 p1 c0 {4,D} {8,S}
-4    C u0 p0 c0 {2,S} {3,D} {6,S}
-5 *2 C u0 p0 c0 {1,S} {2,D} {7,S}
-6    H u0 p0 c0 {4,S}
-7    H u0 p0 c0 {5,S}
-8    H u0 p0 c0 {3,S}
-9 *4 H u0 p0 c0 {1,S}
+3    N u0 p1 c0 {4,D} {9,S}
+4    C u0 p0 c0 {2,S} {3,D} {7,S}
+5 *2 C u0 p0 c0 {1,S} {2,D} {6,S}
+6    H u0 p0 c0 {5,S}
+7    H u0 p0 c0 {4,S}
+8 *4 H u0 p0 c0 {1,S}
+9    H u0 p0 c0 {3,S}
 
 C2H4N2O-2
 1 *3 O u0 p2 c0 {5,D}
@@ -343,14 +295,14 @@ C2H4N2O-2
 9    H u0 p0 c0 {3,S}
 
 CH4N2O
-1 *3 O u0 p2 c0 {4,S} {8,S}
+1 *3 O u0 p2 c0 {4,S} {7,S}
 2    N u0 p1 c0 {4,S} {5,S} {6,S}
-3 *1 N u0 p1 c0 {4,D} {7,S}
+3 *1 N u0 p1 c0 {4,D} {8,S}
 4 *2 C u0 p0 c0 {1,S} {2,S} {3,D}
 5    H u0 p0 c0 {2,S}
 6    H u0 p0 c0 {2,S}
-7    H u0 p0 c0 {3,S}
-8 *4 H u0 p0 c0 {1,S}
+7 *4 H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {3,S}
 
 CH4N2O-2
 1 *3 O u0 p2 c0 {4,D}
@@ -359,6 +311,6 @@ CH4N2O-2
 4 *2 C u0 p0 c0 {1,D} {2,S} {3,S}
 5    H u0 p0 c0 {2,S}
 6    H u0 p0 c0 {2,S}
-7    H u0 p0 c0 {3,S}
-8 *4 H u0 p0 c0 {3,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
 

--- a/input/kinetics/families/Ketoenol/training/reactions.py
+++ b/input/kinetics/families/Ketoenol/training/reactions.py
@@ -89,16 +89,16 @@ entry(
     index = 6,
     label = "C2H4N2O2 <=> C2H4N2O2-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(8.00037e+12,'s^-1'), n=0.391734, Ea=(94.5149,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.18377, dn = +|- 0.0223855, dEa = +|- 0.115431 kJ/mol"""),
+    kinetics = Arrhenius(A=(5.58698e-10,'s^-1'), n=6.27942, Ea=(73.9697,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 105.212, dn = +|- 0.617802, dEa = +|- 3.18571 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
-Original entry: p001084 <=> r001084
+Original entry: p001085 <=> r001085
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
@@ -106,58 +106,24 @@ entry(
     index = 7,
     label = "C2H4N2O2-3 <=> C2H4N2O2-4",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(9.26244e-13,'s^-1'), n=7.34559, Ea=(70.152,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 109.399, dn = +|- 0.62298, dEa = +|- 3.21241 kJ/mol"""),
+    kinetics = Arrhenius(A=(6.24893e-09,'s^-1'), n=6.18216, Ea=(82.1219,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 110.839, dn = +|- 0.624715, dEa = +|- 3.22135 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
-Original entry: p001085 <=> r001084
+Original entry: p001089 <=> r001085
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
     index = 8,
-    label = "C2H4N2O2-5 <=> C2H4N2O2-6",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(3.63498e-12,'s^-1'), n=7.20509, Ea=(79.6963,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 110.489, dn = +|- 0.624295, dEa = +|- 3.21919 kJ/mol"""),
-    rank = 4,
-    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
-    longDesc = 
-"""
-Original entry: p001089 <=> r001084
-Calculated by Kevin Spiekermann
-opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
-""",
-)
-
-entry(
-    index = 9,
-    label = "C2H4N2O2-7 <=> C2H4N2O2-8",
-    degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.40253e-13,'s^-1'), n=7.701, Ea=(72.7924,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 138.963, dn = +|- 0.65472, dEa = +|- 3.37608 kJ/mol"""),
-    rank = 4,
-    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
-    longDesc = 
-"""
-Original entry: p001691 <=> r001691
-Calculated by Kevin Spiekermann
-opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
-""",
-)
-
-entry(
-    index = 10,
     label = "C3H3NO <=> C3H3NO-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(7.48602e-15,'s^-1'), n=8.00071, Ea=(73.8737,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 162.648, dn = +|- 0.675603, dEa = +|- 3.48376 kJ/mol"""),
+    kinetics = Arrhenius(A=(3.02789e-13,'s^-1'), n=7.48219, Ea=(75.5303,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 172.661, dn = +|- 0.68353, dEa = +|- 3.52464 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -166,15 +132,15 @@ Original entry: p003183 <=> r003183
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 11,
+    index = 9,
     label = "C3H6N2O <=> C3H6N2O-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(4.47903e-12,'s^-1'), n=7.22226, Ea=(73.9821,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 103.905, dn = +|- 0.616142, dEa = +|- 3.17715 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.68509e-11,'s^-1'), n=6.88807, Ea=(73.4794,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 117.433, dn = +|- 0.632383, dEa = +|- 3.26089 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -183,15 +149,15 @@ Original entry: p003454 <=> r003454
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 12,
+    index = 10,
     label = "C2H5N3O <=> C2H5N3O-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(1.70268e-12,'s^-1'), n=7.27027, Ea=(68.0463,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 100.019, dn = +|- 0.611086, dEa = +|- 3.15108 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.95577e-10,'s^-1'), n=6.41822, Ea=(70.956,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 97.9173, dn = +|- 0.608267, dEa = +|- 3.13654 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -200,32 +166,32 @@ Original entry: p004749 <=> r004749
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 13,
+    index = 11,
     label = "C2H3NO2 <=> C2H3NO2-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(6.18181e-12,'s^-1'), n=7.01339, Ea=(72.1949,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 88.831, dn = +|- 0.595345, dEa = +|- 3.06991 kJ/mol"""),
+    kinetics = Arrhenius(A=(6.36022e-11,'s^-1'), n=6.62861, Ea=(72.851,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 88.4737, dn = +|- 0.59481, dEa = +|- 3.06715 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
-Original entry: p005032 <=> r005032
+Original entry: p005032 <=> p001958
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 14,
-    label = "C2H4N2O2-9 <=> C2H4N2O2-10",
+    index = 12,
+    label = "C2H4N2O2-5 <=> C2H4N2O2-6",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(2.24517e-15,'s^-1'), n=8.2595, Ea=(75.0964,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 203.941, dn = +|- 0.705623, dEa = +|- 3.63856 kJ/mol"""),
+    kinetics = Arrhenius(A=(1.30511e-12,'s^-1'), n=7.26372, Ea=(77.7584,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 210.811, dn = +|- 0.710019, dEa = +|- 3.66123 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -234,15 +200,15 @@ Original entry: p005432 <=> r005432
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 15,
+    index = 13,
     label = "C2H4N2O <=> C2H4N2O-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(2.13103e-12,'s^-1'), n=7.21352, Ea=(75.026,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 104.624, dn = +|- 0.617057, dEa = +|- 3.18187 kJ/mol"""),
+    kinetics = Arrhenius(A=(3.10725e-11,'s^-1'), n=6.76455, Ea=(75.3833,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 107.635, dn = +|- 0.620823, dEa = +|- 3.20129 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -251,15 +217,15 @@ Original entry: p005588 <=> r005588
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
-    index = 16,
+    index = 14,
     label = "CH4N2O <=> CH4N2O-2",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(6.67535e-10,'s^-1'), n=6.6431, Ea=(72.3053,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 68.373, dn = +|- 0.560612, dEa = +|- 2.89081 kJ/mol"""),
+    kinetics = Arrhenius(A=(3.08033e-09,'s^-1'), n=6.26751, Ea=(72.9112,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 71.0635, dn = +|- 0.565734, dEa = +|- 2.91722 kJ/mol"""),
     rank = 4,
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
@@ -268,7 +234,7 @@ Original entry: p005826 <=> r005826
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12
-Systematic conformer search was done with ACS
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 

--- a/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
+++ b/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
@@ -9,7 +9,7 @@ Spiekermann, K. A.; Pattanaik, L.; Green, W. H.
 Refining elementary reactions with a highly accurate quantum method. 
 Sci. data. (In preparation)
 
-This published work reports nearly 12,000 reactions, with about 1,500 reactions matching RMG templates. 
+This published work reports nearly 12,000 reactions, with over 1,000 reactions matching RMG templates. 
 The species included in this file represent a subset of the species participating in these RMG reactions.
 All species were calculated with multiplicity 1 and charge 0 using CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP i.e.
 Optimization and frequency calculations were done at wB97X-D3/def2-TZVP with QChem.
@@ -32,21 +32,15 @@ n_point_each_torsion: 30
 n_rotors_to_couple: 2
 vdw_collision_threshold: 0.3
 
+1D Hindered Rotors were calculated for steps of 10 degrees up to the full 360 degree cycle, with geometry optimization on each step.
+
 The frequency scaling factor at ωB97X-D3/def2-TZVP was calculated as 0.984 using the method from Alecu et al. (https://pubs.acs.org/doi/abs/10.1021/ct100326h)
-It was added to RMG-database in PR #459: https://github.com/ReactionMechanismGenerator/RMG-database/pull/459/commits/e2e93fb51dad93fa9d8271209cfbb50641a84c58
-
 All values include atom energy corrections, which were fit to the single point energies of experimental geometries for 16 small molecules (no geometry optimization was performed).
-The ωB97X-D3/def2-TZVP AEC values were added in RMG-database PR #459: https://github.com/ReactionMechanismGenerator/RMG-database/pull/459
-The CCSD(T)-F12a/cc-pVDZ-F12 AEC values were added in RMG-database PR #508: https://github.com/ReactionMechanismGenerator/RMG-database/pull/508
-
 All values also include bond additivity corrections.
 BACs were fit using about 400 species from our reference set using the procedure from Petersson et al. 1998 (http://aip.scitation.org/doi/10.1063/1.477794)
-The ωB97X-D3/def2-TZVP BAC values were added in RMG-database PR #459: https://github.com/ReactionMechanismGenerator/RMG-database/pull/459
-The CCSD(T)-F12a/cc-pVDZ-F12 BAC values were added in RMG-database PR #508: https://github.com/ReactionMechanismGenerator/RMG-database/pull/508
 
 Disclaimer: The number of significant figures displayed does not reflect the accuracy of the thermochemistry values.
-As described in RMG-database PR #508, after fitting the Petersson BACs, the enthalpy values at the coupled cluster level have an MAE (RMSE) of 0.517 (0.826) kcal/mol relative to our reference set. 
-As described in the publication from Spiekermann et al., the enthalpy values have an MAE (RMSE) of 0.995 (1.246) kcal/mol relative to an external test set from Pedley: Pedley, J. Thermochemical data and structures of organic compounds, vol. 1 (CRC Press, 1994).
+After fitting the Petersson BACs, the enthalpy values at the coupled cluster level have an MAE (RMSE) of 0.52 (0.83) kcal/mol relative to our reference set.
 These values are similar to those from other published works:
 - Bischoff, F. A., Wolfsegger, S., Tew, D. P. & Klopper, W. Assessment of basis sets for f12 explicitly-correlated molecular electronic-structure methodfs. Mol. Phys. 107, 963–975 (2009).
 - Knizia, G., Adler, T. B. & Werner, H.-J. Simplified ccsd (t)-f12 methods: Theory and benchmarks. The J. chemical physics 130, 054104 (2009). 
@@ -56,30 +50,30 @@ These values are similar to those from other published works:
 """
 entry(
     index = 0,
-    label = "p001084",
+    label = "p001085",
     molecule = 
 """
-1  O u0 p2 c0 {5,S} {10,S}
+1  O u0 p2 c0 {5,S} {9,S}
 2  O u0 p2 c0 {6,D}
-3  N u0 p1 c0 {5,S} {7,S} {8,S}
-4  N u0 p1 c0 {5,D} {6,S}
+3  N u0 p1 c0 {5,S} {6,S} {7,S}
+4  N u0 p1 c0 {5,D} {10,S}
 5  C u0 p0 c0 {1,S} {3,S} {4,D}
-6  C u0 p0 c0 {2,D} {4,S} {9,S}
+6  C u0 p0 c0 {2,D} {3,S} {8,S}
 7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {6,S}
-10 H u0 p0 c0 {1,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {4,S}
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.90453,0.0068491,0.000125755,-2.92973e-07,2.12971e-10,-45444.2,10.0669], Tmin=(10,'K'), Tmax=(433.425,'K')),
-            NASAPolynomial(coeffs=[2.09778,0.0367646,-2.36023e-05,7.24527e-09,-8.51275e-13,-45412,15.8381], Tmin=(433.425,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.74528,0.0199317,4.9871e-05,-1.20506e-07,8.0885e-11,-40053.6,10.9897], Tmin=(10,'K'), Tmax=(391.235,'K')),
+            NASAPolynomial(coeffs=[1.83109,0.0395023,-2.51626e-05,7.35157e-09,-8.1563e-13,-39903.8,18.4281], Tmin=(391.235,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-377.851,'kJ/mol'),
+        E0 = (-333.065,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -90,108 +84,6 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 
 entry(
     index = 1,
-    label = "r001084",
-    molecule = 
-"""
-1  O u0 p2 c0 {5,D}
-2  O u0 p2 c0 {6,D}
-3  N u0 p1 c0 {5,S} {6,S} {7,S}
-4  N u0 p1 c0 {5,S} {8,S} {9,S}
-5  C u0 p0 c0 {1,D} {3,S} {4,S}
-6  C u0 p0 c0 {2,D} {3,S} {10,S}
-7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {4,S}
-9  H u0 p0 c0 {4,S}
-10 H u0 p0 c0 {6,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.88423,0.00825528,0.000133399,-3.31802e-07,2.52823e-10,-51045.1,10.3937], Tmin=(10,'K'), Tmax=(428.701,'K')),
-            NASAPolynomial(coeffs=[2.89294,0.0351772,-2.26349e-05,7.00331e-09,-8.2982e-13,-51122.5,12.4424], Tmin=(428.701,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-424.419,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 2,
-    label = "p001085",
-    molecule = 
-"""
-1  O u0 p2 c0 {5,S} {10,S}
-2  O u0 p2 c0 {6,D}
-3  N u0 p1 c0 {5,S} {6,S} {7,S}
-4  N u0 p1 c0 {5,D} {9,S}
-5  C u0 p0 c0 {1,S} {3,S} {4,D}
-6  C u0 p0 c0 {2,D} {3,S} {8,S}
-7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {6,S}
-9  H u0 p0 c0 {4,S}
-10 H u0 p0 c0 {1,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.89676,0.0069668,0.00013048,-3.0221e-07,2.14699e-10,-42491.9,10.4941], Tmin=(10,'K'), Tmax=(458.393,'K')),
-            NASAPolynomial(coeffs=[2.64332,0.0359324,-2.32967e-05,7.23252e-09,-8.575e-13,-42566.4,13.4975], Tmin=(458.393,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-353.313,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 3,
-    label = "p001086",
-    molecule = 
-"""
-1  O u0 p2 c0 {5,S} {6,S}
-2  O u0 p2 c0 {5,D}
-3  N u0 p1 c0 {5,S} {7,S} {8,S}
-4  N u0 p1 c0 {6,D} {10,S}
-5  C u0 p0 c0 {1,S} {2,D} {3,S}
-6  C u0 p0 c0 {1,S} {4,D} {9,S}
-7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {6,S}
-10 H u0 p0 c0 {4,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.66393,0.0292743,-2.15322e-06,-2.1046e-08,1.21524e-11,-42414,10.6522], Tmin=(10,'K'), Tmax=(757.562,'K')),
-            NASAPolynomial(coeffs=[4.9002,0.0298984,-1.75495e-05,4.96452e-09,-5.43608e-13,-42806.5,3.67671], Tmin=(757.562,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-352.685,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 4,
     label = "p001088",
     molecule = 
 """
@@ -208,14 +100,14 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.82631,0.0162512,0.000125687,-4.39385e-07,4.659e-10,-38718.2,11.4505], Tmin=(10,'K'), Tmax=(302.995,'K')),
-            NASAPolynomial(coeffs=[3.20335,0.0354034,-2.32286e-05,7.3043e-09,-8.77305e-13,-38730.7,12.8843], Tmin=(302.995,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.72242,0.0294883,1.41007e-06,-2.49661e-08,1.24941e-11,-36583,10.6782], Tmin=(10,'K'), Tmax=(876.419,'K')),
+            NASAPolynomial(coeffs=[6.76815,0.0278153,-1.66549e-05,4.69481e-09,-5.07772e-13,-37586.5,-6.29309], Tmin=(876.419,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-321.895,'kJ/mol'),
+        E0 = (-304.168,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -225,31 +117,31 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 5,
+    index = 2,
     label = "p001089",
     molecule = 
 """
 1  O u0 p2 c0 {6,S} {10,S}
 2  O u0 p2 c0 {5,D}
-3  N u0 p1 c0 {5,S} {7,S} {8,S}
+3  N u0 p1 c0 {5,S} {8,S} {9,S}
 4  N u0 p1 c0 {5,S} {6,D}
 5  C u0 p0 c0 {2,D} {3,S} {4,S}
-6  C u0 p0 c0 {1,S} {4,D} {9,S}
-7  H u0 p0 c0 {3,S}
+6  C u0 p0 c0 {1,S} {4,D} {7,S}
+7  H u0 p0 c0 {6,S}
 8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {3,S}
 10 H u0 p0 c0 {1,S}
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.85067,0.0143143,0.000141804,-5.0958e-07,5.7187e-10,-44659.9,10.5534], Tmin=(10,'K'), Tmax=(279.306,'K')),
-            NASAPolynomial(coeffs=[3.04532,0.0354442,-2.32093e-05,7.29584e-09,-8.76641e-13,-44652.3,12.7415], Tmin=(279.306,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.73273,0.0255802,2.61114e-05,-6.5876e-08,3.38022e-11,-42219.2,9.69998], Tmin=(10,'K'), Tmax=(735.919,'K')),
+            NASAPolynomial(coeffs=[5.35014,0.0327411,-2.09989e-05,6.25594e-09,-7.07968e-13,-42889.3,-0.541993], Tmin=(735.919,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-371.297,'kJ/mol'),
+        E0 = (-351.052,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -259,127 +151,29 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 6,
+    index = 3,
     label = "p001235",
     molecule = 
 """
 1 N u0 p1 c0 {2,S} {4,S} {5,S}
 2 N u0 p1 c0 {1,S} {4,D}
 3 N u0 p1 c0 {5,D} {8,S}
-4 C u0 p0 c0 {1,S} {2,D} {7,S}
-5 C u0 p0 c0 {1,S} {3,D} {6,S}
-6 H u0 p0 c0 {5,S}
-7 H u0 p0 c0 {4,S}
-8 H u0 p0 c0 {3,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.9412,0.00367745,8.97937e-05,-1.83545e-07,1.16062e-10,55343.3,9.94177], Tmin=(10,'K'), Tmax=(504.787,'K')),
-            NASAPolynomial(coeffs=[2.34563,0.028174,-1.82207e-05,5.62546e-09,-6.6405e-13,55353.3,15.0529], Tmin=(504.787,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (460.132,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 7,
-    label = "r001235",
-    molecule = 
-"""
-1 N u0 p1 c0 {4,S} {5,S} {6,S}
-2 N u0 p1 c0 {3,S} {4,D}
-3 N u0 p1 c0 {2,S} {5,D}
-4 C u0 p0 c0 {1,S} {2,D} {7,S}
-5 C u0 p0 c0 {1,S} {3,D} {8,S}
-6 H u0 p0 c0 {1,S}
-7 H u0 p0 c0 {4,S}
-8 H u0 p0 c0 {5,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[4.19196,-0.0148682,0.000135852,-2.02053e-07,9.69878e-11,22059.2,7.94616], Tmin=(10,'K'), Tmax=(665.053,'K')),
-            NASAPolynomial(coeffs=[0.275364,0.0315389,-2.03558e-05,6.19759e-09,-7.1627e-13,22074.8,21.4447], Tmin=(665.053,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (183.426,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 8,
-    label = "p001691",
-    molecule = 
-"""
-1  O u0 p2 c0 {5,S} {6,S}
-2  O u0 p2 c0 {5,S} {8,S}
-3  N u0 p1 c0 {5,D} {9,S}
-4  N u0 p1 c0 {6,D} {10,S}
-5  C u0 p0 c0 {1,S} {2,S} {3,D}
-6  C u0 p0 c0 {1,S} {4,D} {7,S}
-7  H u0 p0 c0 {6,S}
-8  H u0 p0 c0 {2,S}
-9  H u0 p0 c0 {3,S}
-10 H u0 p0 c0 {4,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.90256,0.00616103,0.000124812,-2.67251e-07,1.74325e-10,-32914,10.7644], Tmin=(10,'K'), Tmax=(502.975,'K')),
-            NASAPolynomial(coeffs=[2.59734,0.0362399,-2.36378e-05,7.37722e-09,-8.78888e-13,-33031.9,13.6874], Tmin=(502.975,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-273.69,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 9,
-    label = "r001958",
-    molecule = 
-"""
-1 O u0 p2 c0 {4,S} {5,S}
-2 O u0 p2 c0 {5,D}
-3 N u0 p1 c0 {4,D} {8,S}
-4 C u0 p0 c0 {1,S} {3,D} {6,S}
-5 C u0 p0 c0 {1,S} {2,D} {7,S}
+4 C u0 p0 c0 {1,S} {2,D} {6,S}
+5 C u0 p0 c0 {1,S} {3,D} {7,S}
 6 H u0 p0 c0 {4,S}
 7 H u0 p0 c0 {5,S}
 8 H u0 p0 c0 {3,S}
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.92559,0.0149988,1.20319e-05,-2.22577e-08,8.39575e-12,-34102,9.23015], Tmin=(10,'K'), Tmax=(1007.89,'K')),
-            NASAPolynomial(coeffs=[5.16881,0.0201742,-1.07157e-05,2.74036e-09,-2.73287e-13,-34866.1,0.67534], Tmin=(1007.89,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.90417,0.00687764,9.87203e-05,-2.47877e-07,1.88703e-10,58261.1,9.18629], Tmin=(10,'K'), Tmax=(433.032,'K')),
+            NASAPolynomial(coeffs=[3.31187,0.026356,-1.7272e-05,5.39569e-09,-6.42742e-13,58181,10.0317], Tmin=(433.032,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-283.507,'kJ/mol'),
+        E0 = (484.404,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -389,7 +183,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 10,
+    index = 4,
     label = "p001958",
     molecule = 
 """
@@ -404,14 +198,14 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.83419,0.0137275,2.22867e-05,-4.30261e-08,2.07116e-11,-42139.6,8.49502], Tmin=(10,'K'), Tmax=(688.898,'K')),
-            NASAPolynomial(coeffs=[2.66155,0.0257622,-1.52963e-05,4.35569e-09,-4.79311e-13,-42102,12.8153], Tmin=(688.898,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.66855,0.0286017,-5.31907e-05,8.57569e-08,-5.31814e-11,-40063.3,8.52118], Tmin=(10,'K'), Tmax=(555.319,'K')),
+            NASAPolynomial(coeffs=[2.60947,0.0252908,-1.4698e-05,4.07179e-09,-4.37269e-13,-39777,14.5264], Tmin=(555.319,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-350.389,'kJ/mol'),
+        E0 = (-333.124,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -421,38 +215,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 11,
-    label = "r002774",
-    molecule = 
-"""
-1 O u0 p2 c0 {4,S} {5,S}
-2 N u0 p1 c0 {3,S} {4,D}
-3 N u0 p1 c0 {2,S} {5,D}
-4 C u0 p0 c0 {1,S} {2,D} {6,S}
-5 C u0 p0 c0 {1,S} {3,D} {7,S}
-6 H u0 p0 c0 {4,S}
-7 H u0 p0 c0 {5,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[4.18171,-0.0135628,0.000115446,-1.65192e-07,7.60827e-11,4321.24,7.92826], Tmin=(10,'K'), Tmax=(694.897,'K')),
-            NASAPolynomial(coeffs=[0.550232,0.0278611,-1.82656e-05,5.58285e-09,-6.44488e-13,4330.5,20.5614], Tmin=(694.897,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (35.9504,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (157.975,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 12,
+    index = 5,
     label = "p002774",
     molecule = 
 """
@@ -466,14 +229,14 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.87984,0.0117384,2.85566e-05,-5.71836e-08,2.93799e-11,29991.5,9.75096], Tmin=(10,'K'), Tmax=(680.825,'K')),
-            NASAPolynomial(coeffs=[3.8194,0.0214159,-1.33042e-05,3.91873e-09,-4.42129e-13,29783.7,8.43258], Tmin=(680.825,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.896,0.0161115,2.88027e-06,-1.34886e-08,5.73028e-12,32730.1,9.54122], Tmin=(10,'K'), Tmax=(998.201,'K')),
+            NASAPolynomial(coeffs=[5.95965,0.0158419,-8.7362e-06,2.29845e-09,-2.34419e-13,31919.6,-2.40737], Tmin=(998.201,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (249.351,'kJ/mol'),
+        E0 = (272.157,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (157.975,'J/(mol*K)'),
+        CpInf = (153.818,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -483,29 +246,29 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 13,
-    label = "r003183",
+    index = 6,
+    label = "p003183",
     molecule = 
 """
-1 O u0 p2 c0 {3,D}
-2 N u0 p1 c0 {3,S} {6,S} {7,S}
-3 C u0 p0 c0 {1,D} {2,S} {4,S}
+1 O u0 p2 c0 {3,S} {6,S}
+2 N u0 p1 c0 {3,D} {7,S}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
 4 C u0 p0 c0 {3,S} {5,T}
 5 C u0 p0 c0 {4,T} {8,S}
-6 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {1,S}
 7 H u0 p0 c0 {2,S}
 8 H u0 p0 c0 {5,S}
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.87783,0.00807989,0.000106218,-2.66769e-07,1.94606e-10,2643.25,9.21739], Tmin=(10,'K'), Tmax=(480.43,'K')),
-            NASAPolynomial(coeffs=[4.97716,0.0228572,-1.46347e-05,4.60813e-09,-5.60578e-13,2261.45,1.84547], Tmin=(480.43,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.92139,0.00449384,9.2293e-05,-1.75513e-07,9.92664e-11,10875.7,8.99332], Tmin=(10,'K'), Tmax=(589.697,'K')),
+            NASAPolynomial(coeffs=[2.76273,0.0309312,-2.22119e-05,7.36225e-09,-9.1209e-13,10689.4,11.2324], Tmin=(589.697,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (21.9533,'kJ/mol'),
+        E0 = (90.3914,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -515,39 +278,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 14,
-    label = "p003183",
-    molecule = 
-"""
-1 O u0 p2 c0 {3,S} {7,S}
-2 N u0 p1 c0 {3,D} {6,S}
-3 C u0 p0 c0 {1,S} {2,D} {4,S}
-4 C u0 p0 c0 {3,S} {5,T}
-5 C u0 p0 c0 {4,T} {8,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {1,S}
-8 H u0 p0 c0 {5,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.91038,0.00533575,9.19269e-05,-1.89724e-07,1.1583e-10,8195.7,9.02564], Tmin=(10,'K'), Tmax=(558.847,'K')),
-            NASAPolynomial(coeffs=[3.92299,0.0256042,-1.71204e-05,5.54909e-09,-6.87347e-13,7876.38,6.1278], Tmin=(558.847,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (68.1082,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 15,
+    index = 7,
     label = "p003454",
     molecule = 
 """
@@ -566,14 +297,279 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.92982,0.00414922,0.00013109,-2.39364e-07,1.36465e-10,-5592.01,11.2179], Tmin=(10,'K'), Tmax=(541.878,'K')),
-            NASAPolynomial(coeffs=[-0.123429,0.0484905,-3.15733e-05,9.87276e-09,-1.18128e-12,-5364.46,26.3353], Tmin=(541.878,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.93071,0.00400401,0.000134186,-2.37377e-07,1.30188e-10,-2213.4,11.1003], Tmin=(10,'K'), Tmax=(559.016,'K')),
+            NASAPolynomial(coeffs=[-1.05604,0.0537607,-3.70905e-05,1.19213e-08,-1.44314e-12,-1875.78,30.2914], Tmin=(559.016,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-46.5227,'kJ/mol'),
+        E0 = (-18.4335,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (282.692,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 8,
+    label = "p004142",
+    molecule = 
+"""
+1 N u0 p1 c0 {3,S} {4,S} {5,S}
+2 N u0 p1 c0 {5,D} {9,S}
+3 C u0 p0 c0 {1,S} {4,D} {6,S}
+4 C u0 p0 c0 {1,S} {3,D} {7,S}
+5 C u0 p0 c0 {1,S} {2,D} {8,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {5,S}
+9 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91383,0.00502838,0.000100635,-1.96294e-07,1.14637e-10,58617,9.64666], Tmin=(10,'K'), Tmax=(571.872,'K')),
+            NASAPolynomial(coeffs=[2.962,0.031621,-2.14053e-05,6.93266e-09,-8.53688e-13,58399.8,10.8567], Tmin=(571.872,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (487.333,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 9,
+    label = "p004749",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {9,S}
+2  N u0 p1 c0 {5,S} {6,S} {7,S}
+3  N u0 p1 c0 {5,D} {11,S}
+4  N u0 p1 c0 {6,D} {10,S}
+5  C u0 p0 c0 {1,S} {2,S} {3,D}
+6  C u0 p0 c0 {2,S} {4,D} {8,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85255,0.0124039,0.000146465,-4.60037e-07,4.79632e-10,-13024.5,10.9216], Tmin=(10,'K'), Tmax=(242.729,'K')),
+            NASAPolynomial(coeffs=[2.18536,0.0398779,-2.33156e-05,6.27326e-09,-6.44719e-13,-12943.6,16.6044], Tmin=(242.729,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-108.299,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 10,
+    label = "p005032",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {8,S}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {4,D} {5,S}
+4 C u0 p0 c0 {1,S} {3,D} {6,S}
+5 C u0 p0 c0 {2,D} {3,S} {7,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.8329,0.013903,2.66783e-05,-4.93548e-08,2.27189e-11,-33074.4,10.1698], Tmin=(10,'K'), Tmax=(750.443,'K')),
+            NASAPolynomial(coeffs=[3.02057,0.0269852,-1.69647e-05,4.95729e-09,-5.51773e-13,-33198.9,12.2136], Tmin=(750.443,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-275.014,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 11,
+    label = "p005432",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {9,S}
+2  O u0 p2 c0 {5,D}
+3  N u0 p1 c0 {5,S} {7,S} {8,S}
+4  N u0 p1 c0 {6,D} {10,S}
+5  C u0 p0 c0 {2,D} {3,S} {6,S}
+6  C u0 p0 c0 {1,S} {4,D} {5,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86365,0.00994296,0.000147869,-3.79219e-07,2.95985e-10,-41907,9.78703], Tmin=(10,'K'), Tmax=(417.404,'K')),
+            NASAPolynomial(coeffs=[2.70624,0.039861,-2.73019e-05,8.61777e-09,-1.02703e-12,-41974.4,12.395], Tmin=(417.404,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-348.437,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 12,
+    label = "p005588",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,S} {8,S}
+2 N u0 p1 c0 {4,S} {5,D}
+3 N u0 p1 c0 {4,D} {9,S}
+4 C u0 p0 c0 {2,S} {3,D} {7,S}
+5 C u0 p0 c0 {1,S} {2,D} {6,S}
+6 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {1,S}
+9 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94254,0.00372339,0.00010797,-2.24256e-07,1.465e-10,-7163.48,10.2253], Tmin=(10,'K'), Tmax=(470.028,'K')),
+            NASAPolynomial(coeffs=[1.49205,0.0346629,-2.29529e-05,7.091e-09,-8.30501e-13,-7044.53,19.0124], Tmin=(470.028,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-59.5727,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (199.547,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 13,
+    label = "p005763",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,D}
+2 N u0 p1 c0 {3,S} {4,S} {5,S}
+3 C u0 p0 c0 {2,S} {4,D} {6,S}
+4 C u0 p0 c0 {2,S} {3,D} {7,S}
+5 C u0 p0 c0 {1,D} {2,S} {8,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.90764,0.00573914,9.62134e-05,-2.1046e-07,1.36691e-10,32479.2,9.82126], Tmin=(10,'K'), Tmax=(523.227,'K')),
+            NASAPolynomial(coeffs=[3.86584,0.0256532,-1.70506e-05,5.42837e-09,-6.5961e-13,32215.4,7.43276], Tmin=(523.227,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (270.018,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 14,
+    label = "p005826",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {7,S}
+2 N u0 p1 c0 {4,S} {5,S} {6,S}
+3 N u0 p1 c0 {4,D} {8,S}
+4 C u0 p0 c0 {1,S} {2,S} {3,D}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {1,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94959,0.00376692,9.10792e-05,-2.08913e-07,1.5705e-10,-22676.2,8.53103], Tmin=(10,'K'), Tmax=(339.914,'K')),
+            NASAPolynomial(coeffs=[1.8449,0.028535,-1.82232e-05,5.46623e-09,-6.267e-13,-22533.2,16.4138], Tmin=(339.914,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-188.542,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 15,
+    label = "p007269",
+    molecule = 
+"""
+1  N u0 p1 c0 {4,S} {5,S} {6,S}
+2  N u0 p1 c0 {6,D} {10,S}
+3  N u0 p1 c0 {7,T}
+4  C u0 p0 c0 {1,S} {5,D} {8,S}
+5  C u0 p0 c0 {1,S} {4,D} {9,S}
+6  C u0 p0 c0 {1,S} {2,D} {7,S}
+7  C u0 p0 c0 {3,T} {6,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.81129,0.0125028,0.000153033,-3.89114e-07,2.84008e-10,76163.2,11.8603], Tmin=(10,'K'), Tmax=(482.416,'K')),
+            NASAPolynomial(coeffs=[5.57357,0.0335342,-2.31887e-05,7.56972e-09,-9.33021e-13,75578.4,0.34418], Tmin=(482.416,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (633.219,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -584,6 +580,202 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 
 entry(
     index = 16,
+    label = "p011506",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  N u0 p1 c0 {4,S} {5,S} {8,S}
+3  N u0 p1 c0 {6,D} {7,S}
+4  C u0 p0 c0 {1,D} {2,S} {6,S}
+5  C u0 p0 c0 {2,S} {7,D} {9,S}
+6  C u0 p0 c0 {3,D} {4,S} {10,S}
+7  C u0 p0 c0 {3,S} {5,D} {11,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.07209,-0.00749772,0.000179243,-3.16872e-07,1.77511e-10,-1165.4,10.5595], Tmin=(10,'K'), Tmax=(572.918,'K')),
+            NASAPolynomial(coeffs=[0.511141,0.0447271,-2.91313e-05,8.9634e-09,-1.04859e-12,-1206.45,21.8363], Tmin=(572.918,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-9.71276,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (257.749,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 17,
+    label = "r001085",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {5,S} {6,S} {7,S}
+4  N u0 p1 c0 {5,S} {9,S} {10,S}
+5  C u0 p0 c0 {1,D} {3,S} {4,S}
+6  C u0 p0 c0 {2,D} {3,S} {8,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88928,0.0103767,0.000212721,-8.26685e-07,1.02496e-09,-48518.4,9.69993], Tmin=(10,'K'), Tmax=(257.92,'K')),
+            NASAPolynomial(coeffs=[3.20526,0.0359325,-2.28358e-05,6.87388e-09,-7.95667e-13,-48532.8,11.1092], Tmin=(257.92,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-403.385,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 18,
+    label = "r001235",
+    molecule = 
+"""
+1 N u0 p1 c0 {4,S} {5,S} {6,S}
+2 N u0 p1 c0 {3,S} {4,D}
+3 N u0 p1 c0 {2,S} {5,D}
+4 C u0 p0 c0 {1,S} {2,D} {7,S}
+5 C u0 p0 c0 {1,S} {3,D} {8,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.19196,-0.0148682,0.000135852,-2.02053e-07,9.6988e-11,24989.6,7.94616], Tmin=(10,'K'), Tmax=(665.052,'K')),
+            NASAPolynomial(coeffs=[0.275355,0.0315389,-2.03558e-05,6.1976e-09,-7.16272e-13,25005.3,21.4448], Tmin=(665.052,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (207.791,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (182.918,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 19,
+    label = "r001958",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {4,D} {8,S}
+4 C u0 p0 c0 {1,S} {3,D} {6,S}
+5 C u0 p0 c0 {1,S} {2,D} {7,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93348,0.00416331,9.65262e-05,-1.99086e-07,1.25771e-10,-32358.3,9.91543], Tmin=(10,'K'), Tmax=(506.733,'K')),
+            NASAPolynomial(coeffs=[2.18116,0.031008,-2.14561e-05,6.80901e-09,-8.1008e-13,-32347.7,15.5298], Tmin=(506.733,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-269.062,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 20,
+    label = "r002774",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {5,S}
+2 N u0 p1 c0 {3,S} {4,D}
+3 N u0 p1 c0 {2,S} {5,D}
+4 C u0 p0 c0 {1,S} {2,D} {6,S}
+5 C u0 p0 c0 {1,S} {3,D} {7,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.18172,-0.0135629,0.000115447,-1.65195e-07,7.60845e-11,6657.02,7.92825], Tmin=(10,'K'), Tmax=(694.888,'K')),
+            NASAPolynomial(coeffs=[0.550055,0.0278615,-1.8266e-05,5.58302e-09,-6.44511e-13,6666.33,20.5623], Tmin=(694.888,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (55.3711,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (157.975,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 21,
+    label = "r003183",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,D}
+2 N u0 p1 c0 {3,S} {6,S} {7,S}
+3 C u0 p0 c0 {1,D} {2,S} {4,S}
+4 C u0 p0 c0 {3,S} {5,T}
+5 C u0 p0 c0 {4,T} {8,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84781,0.0102147,0.000114565,-3.08304e-07,2.3458e-10,5414.55,8.43127], Tmin=(10,'K'), Tmax=(472.718,'K')),
+            NASAPolynomial(coeffs=[6.0474,0.0210911,-1.3519e-05,4.29341e-09,-5.29079e-13,4877.11,-4.01742], Tmin=(472.718,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (44.9935,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 22,
     label = "r003454",
     molecule = 
 """
@@ -602,14 +794,14 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.91708,0.00519553,0.000141656,-2.84791e-07,1.79102e-10,-13149.5,11.6965], Tmin=(10,'K'), Tmax=(498.878,'K')),
-            NASAPolynomial(coeffs=[0.943721,0.0454404,-2.86746e-05,8.74058e-09,-1.02535e-12,-13057,21.9276], Tmin=(498.878,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.81214,0.019999,4.45235e-05,-7.70682e-08,3.44587e-11,-9708.75,10.6531], Tmin=(10,'K'), Tmax=(771.048,'K')),
+            NASAPolynomial(coeffs=[2.75441,0.0402387,-2.35502e-05,6.60407e-09,-7.16305e-13,-9984.16,12.6374], Tmin=(771.048,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-109.355,'kJ/mol'),
+        E0 = (-80.7251,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (282.692,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -619,40 +811,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 17,
-    label = "p004142",
-    molecule = 
-"""
-1 N u0 p1 c0 {3,S} {4,S} {5,S}
-2 N u0 p1 c0 {5,D} {9,S}
-3 C u0 p0 c0 {1,S} {4,D} {6,S}
-4 C u0 p0 c0 {1,S} {3,D} {7,S}
-5 C u0 p0 c0 {1,S} {2,D} {8,S}
-6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {4,S}
-8 H u0 p0 c0 {5,S}
-9 H u0 p0 c0 {2,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.92814,0.00424912,9.85243e-05,-1.8956e-07,1.11209e-10,55412.4,9.7156], Tmin=(10,'K'), Tmax=(554.554,'K')),
-            NASAPolynomial(coeffs=[2.23392,0.0325191,-2.13545e-05,6.74321e-09,-8.14556e-13,55353.5,14.6652], Tmin=(554.554,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (460.696,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (207.862,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 18,
+    index = 23,
     label = "r004142",
     molecule = 
 """
@@ -668,12 +827,12 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[4.21464,-0.0168371,0.000155578,-2.33813e-07,1.13789e-10,11267.3,8.67808], Tmin=(10,'K'), Tmax=(653.143,'K')),
-            NASAPolynomial(coeffs=[-0.293321,0.0357942,-2.27634e-05,6.87882e-09,-7.92183e-13,11322.5,24.4202], Tmin=(653.143,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[4.21464,-0.0168371,0.000155578,-2.33813e-07,1.13789e-10,14473.2,8.67808], Tmin=(10,'K'), Tmax=(653.143,'K')),
+            NASAPolynomial(coeffs=[-0.29332,0.0357942,-2.27634e-05,6.87882e-09,-7.92183e-13,14528.3,24.4202], Tmin=(653.143,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (93.6961,'kJ/mol'),
+        E0 = (120.351,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
         CpInf = (207.862,'J/(mol*K)'),
     ),
@@ -685,7 +844,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 19,
+    index = 24,
     label = "r004202",
     molecule = 
 """
@@ -699,12 +858,12 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[4.18045,-0.0133194,0.000112508,-1.58903e-07,7.22193e-11,7844.5,8.62328], Tmin=(10,'K'), Tmax=(703.312,'K')),
-            NASAPolynomial(coeffs=[0.444753,0.0279626,-1.82684e-05,5.56371e-09,-6.40191e-13,7874.44,21.8082], Tmin=(703.312,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[4.18044,-0.0133193,0.000112507,-1.58902e-07,7.22187e-11,9260.36,8.62329], Tmin=(10,'K'), Tmax=(703.315,'K')),
+            NASAPolynomial(coeffs=[0.444821,0.0279624,-1.82683e-05,5.56364e-09,-6.40182e-13,9290.28,21.8079], Tmin=(703.315,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (65.2464,'kJ/mol'),
+        E0 = (77.0185,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
         CpInf = (157.975,'J/(mol*K)'),
     ),
@@ -716,42 +875,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 20,
-    label = "p004749",
-    molecule = 
-"""
-1  O u0 p2 c0 {5,S} {9,S}
-2  N u0 p1 c0 {5,S} {6,S} {7,S}
-3  N u0 p1 c0 {5,D} {10,S}
-4  N u0 p1 c0 {6,D} {11,S}
-5  C u0 p0 c0 {1,S} {2,S} {3,D}
-6  C u0 p0 c0 {2,S} {4,D} {8,S}
-7  H u0 p0 c0 {2,S}
-8  H u0 p0 c0 {6,S}
-9  H u0 p0 c0 {1,S}
-10 H u0 p0 c0 {3,S}
-11 H u0 p0 c0 {4,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.89437,0.00667872,0.000136356,-2.91615e-07,1.90382e-10,-15654.2,10.5049], Tmin=(10,'K'), Tmax=(502.61,'K')),
-            NASAPolynomial(coeffs=[2.50709,0.0392486,-2.50987e-05,7.7663e-09,-9.23056e-13,-15786.7,13.5381], Tmin=(502.61,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-130.186,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (257.749,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 21,
+    index = 25,
     label = "r004749",
     molecule = 
 """
@@ -769,14 +893,14 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.88963,0.0071797,0.000140299,-3.13164e-07,2.13624e-10,-24203.6,10.4972], Tmin=(10,'K'), Tmax=(481.856,'K')),
-            NASAPolynomial(coeffs=[2.70714,0.0385412,-2.4398e-05,7.49517e-09,-8.86622e-13,-24339.8,12.7432], Tmin=(481.856,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.87779,0.0117495,0.000176459,-6.10491e-07,7.05557e-10,-21489.2,9.96896], Tmin=(10,'K'), Tmax=(218.929,'K')),
+            NASAPolynomial(coeffs=[2.25484,0.0414026,-2.67143e-05,8.20996e-09,-9.66753e-13,-21418.2,15.3334], Tmin=(218.929,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-201.264,'kJ/mol'),
+        E0 = (-178.644,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (257.749,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -786,97 +910,31 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 22,
-    label = "p005032",
-    molecule = 
-"""
-1 O u0 p2 c0 {4,S} {8,S}
-2 O u0 p2 c0 {5,D}
-3 N u0 p1 c0 {4,D} {5,S}
-4 C u0 p0 c0 {1,S} {3,D} {6,S}
-5 C u0 p0 c0 {2,D} {3,S} {7,S}
-6 H u0 p0 c0 {4,S}
-7 H u0 p0 c0 {5,S}
-8 H u0 p0 c0 {1,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.85265,0.0142526,1.9194e-05,-3.6021e-08,1.58841e-11,-35075.3,9.93557], Tmin=(10,'K'), Tmax=(801.355,'K')),
-            NASAPolynomial(coeffs=[3.49583,0.0239762,-1.38743e-05,3.85765e-09,-4.15466e-13,-35273.1,9.9868], Tmin=(801.355,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-291.638,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 23,
-    label = "p005432",
-    molecule = 
-"""
-1  O u0 p2 c0 {6,S} {9,S}
-2  O u0 p2 c0 {5,D}
-3  N u0 p1 c0 {5,S} {7,S} {8,S}
-4  N u0 p1 c0 {6,D} {10,S}
-5  C u0 p0 c0 {2,D} {3,S} {6,S}
-6  C u0 p0 c0 {1,S} {4,D} {5,S}
-7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {1,S}
-10 H u0 p0 c0 {4,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.86738,0.00842115,0.000132184,-3.01176e-07,2.03049e-10,-44204.8,10.5243], Tmin=(10,'K'), Tmax=(507.624,'K')),
-            NASAPolynomial(coeffs=[4.18501,0.0332134,-2.17311e-05,6.88788e-09,-8.36332e-13,-44588.7,5.74335], Tmin=(507.624,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-367.576,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 24,
+    index = 26,
     label = "r005432",
     molecule = 
 """
 1  O u0 p2 c0 {5,D}
 2  O u0 p2 c0 {6,D}
-3  N u0 p1 c0 {5,S} {7,S} {8,S}
-4  N u0 p1 c0 {6,S} {9,S} {10,S}
+3  N u0 p1 c0 {5,S} {9,S} {10,S}
+4  N u0 p1 c0 {6,S} {7,S} {8,S}
 5  C u0 p0 c0 {1,D} {3,S} {6,S}
 6  C u0 p0 c0 {2,D} {4,S} {5,S}
-7  H u0 p0 c0 {3,S}
-8  H u0 p0 c0 {3,S}
-9  H u0 p0 c0 {4,S}
-10 H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.85473,0.00947281,0.00013695,-3.28904e-07,2.32268e-10,-51635.8,9.66211], Tmin=(10,'K'), Tmax=(489.046,'K')),
-            NASAPolynomial(coeffs=[4.61323,0.0320794,-2.07566e-05,6.54296e-09,-7.9293e-13,-52054.5,3.0229], Tmin=(489.046,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.79706,0.013989,0.00016029,-4.45182e-07,3.51927e-10,-49253.4,8.13997], Tmin=(10,'K'), Tmax=(452.195,'K')),
+            NASAPolynomial(coeffs=[6.32438,0.0298284,-1.89509e-05,5.86282e-09,-7.06145e-13,-49872.5,-6.36501], Tmin=(452.195,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-429.357,'kJ/mol'),
+        E0 = (-409.539,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -886,7 +944,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 25,
+    index = 27,
     label = "r005588",
     molecule = 
 """
@@ -902,80 +960,14 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.86718,0.0122449,3.89079e-05,-6.79101e-08,3.26697e-11,-16154.8,9.29021], Tmin=(10,'K'), Tmax=(683.636,'K')),
-            NASAPolynomial(coeffs=[2.36025,0.0294686,-1.73287e-05,4.91801e-09,-5.40737e-13,-16145.2,14.5503], Tmin=(683.636,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.7722,0.0165499,2.0681e-05,-4.14136e-08,2.04212e-11,-13864.7,9.9967], Tmin=(10,'K'), Tmax=(551.161,'K')),
+            NASAPolynomial(coeffs=[1.84299,0.0305509,-1.74231e-05,4.67605e-09,-4.84479e-13,-13652.1,18.1547], Tmin=(551.161,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-134.333,'kJ/mol'),
+        E0 = (-115.324,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (207.862,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 26,
-    label = "p005588",
-    molecule = 
-"""
-1 O u0 p2 c0 {5,S} {9,S}
-2 N u0 p1 c0 {4,S} {5,D}
-3 N u0 p1 c0 {4,D} {8,S}
-4 C u0 p0 c0 {2,S} {3,D} {6,S}
-5 C u0 p0 c0 {1,S} {2,D} {7,S}
-6 H u0 p0 c0 {4,S}
-7 H u0 p0 c0 {5,S}
-8 H u0 p0 c0 {3,S}
-9 H u0 p0 c0 {1,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.89148,0.00928569,5.89762e-05,-1.09647e-07,6.0365e-11,-9375.62,9.94308], Tmin=(10,'K'), Tmax=(573.894,'K')),
-            NASAPolynomial(coeffs=[1.97725,0.0308188,-1.87146e-05,5.47283e-09,-6.17596e-13,-9290.8,16.9399], Tmin=(573.894,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-77.9714,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (207.862,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 27,
-    label = "p005593",
-    molecule = 
-"""
-1 O u0 p2 c0 {4,S} {5,S}
-2 N u0 p1 c0 {4,D} {8,S}
-3 N u0 p1 c0 {5,D} {9,S}
-4 C u0 p0 c0 {1,S} {2,D} {6,S}
-5 C u0 p0 c0 {1,S} {3,D} {7,S}
-6 H u0 p0 c0 {4,S}
-7 H u0 p0 c0 {5,S}
-8 H u0 p0 c0 {2,S}
-9 H u0 p0 c0 {3,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.9237,0.0155513,1.84862e-05,-3.04153e-08,1.14421e-11,-6556.28,9.49339], Tmin=(10,'K'), Tmax=(977.812,'K')),
-            NASAPolynomial(coeffs=[4.65854,0.0243097,-1.29968e-05,3.35413e-09,-3.37727e-13,-7262.4,3.08884], Tmin=(977.812,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-54.4747,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (207.862,'J/(mol*K)'),
+        CpInf = (199.547,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -1000,12 +992,12 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[4.20556,-0.0156206,0.000135691,-1.97337e-07,9.27042e-11,-6008.9,8.66008], Tmin=(10,'K'), Tmax=(678.476,'K')),
-            NASAPolynomial(coeffs=[0.00143082,0.0321485,-2.07317e-05,6.29117e-09,-7.24355e-13,-5967.41,23.4134], Tmin=(678.476,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[4.20556,-0.0156206,0.000135691,-1.97337e-07,9.27042e-11,-3397.72,8.66008], Tmin=(10,'K'), Tmax=(678.475,'K')),
+            NASAPolynomial(coeffs=[0.00143003,0.0321485,-2.07317e-05,6.29117e-09,-7.24355e-13,-3356.23,23.4134], Tmin=(678.475,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (-49.9403,'kJ/mol'),
+        E0 = (-28.2297,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
         CpInf = (182.918,'J/(mol*K)'),
     ),
@@ -1018,28 +1010,28 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 
 entry(
     index = 29,
-    label = "p005763",
+    label = "r005826",
     molecule = 
 """
-1 O u0 p2 c0 {5,D}
-2 N u0 p1 c0 {3,S} {4,S} {5,S}
-3 C u0 p0 c0 {2,S} {4,D} {6,S}
-4 C u0 p0 c0 {2,S} {3,D} {7,S}
-5 C u0 p0 c0 {1,D} {2,S} {8,S}
+1 O u0 p2 c0 {4,D}
+2 N u0 p1 c0 {4,S} {7,S} {8,S}
+3 N u0 p1 c0 {4,S} {5,S} {6,S}
+4 C u0 p0 c0 {1,D} {2,S} {3,S}
+5 H u0 p0 c0 {3,S}
 6 H u0 p0 c0 {3,S}
-7 H u0 p0 c0 {4,S}
-8 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.92614,0.00459907,9.36823e-05,-1.96966e-07,1.25816e-10,29470.8,9.9431], Tmin=(10,'K'), Tmax=(515.053,'K')),
-            NASAPolynomial(coeffs=[2.94794,0.0275793,-1.80449e-05,5.63866e-09,-6.73193e-13,29367.5,12.0325], Tmin=(515.053,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.91818,0.00509993,8.79711e-05,-1.91958e-07,1.25285e-10,-29936.1,8.61375], Tmin=(10,'K'), Tmax=(519.461,'K')),
+            NASAPolynomial(coeffs=[3.87025,0.0230136,-1.44185e-05,4.46514e-09,-5.38442e-13,-30167.8,6.53517], Tmin=(519.461,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (245.011,'kJ/mol'),
+        E0 = (-248.928,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 
@@ -1050,70 +1042,6 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 
 entry(
     index = 30,
-    label = "p005826",
-    molecule = 
-"""
-1 O u0 p2 c0 {4,S} {8,S}
-2 N u0 p1 c0 {4,S} {5,S} {6,S}
-3 N u0 p1 c0 {4,D} {7,S}
-4 C u0 p0 c0 {1,S} {2,S} {3,D}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {1,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.94131,0.00334279,7.65673e-05,-1.40641e-07,7.83088e-11,-24364.4,8.41878], Tmin=(10,'K'), Tmax=(589.47,'K')),
-            NASAPolynomial(coeffs=[2.60078,0.0263478,-1.73647e-05,5.61951e-09,-6.97619e-13,-24448.1,12.1279], Tmin=(589.47,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-202.604,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 31,
-    label = "r005826",
-    molecule = 
-"""
-1 O u0 p2 c0 {4,D}
-2 N u0 p1 c0 {4,S} {5,S} {6,S}
-3 N u0 p1 c0 {4,S} {7,S} {8,S}
-4 C u0 p0 c0 {1,D} {2,S} {3,S}
-5 H u0 p0 c0 {2,S}
-6 H u0 p0 c0 {2,S}
-7 H u0 p0 c0 {3,S}
-8 H u0 p0 c0 {3,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.93687,0.00367548,7.83773e-05,-1.49834e-07,8.6724e-11,-31705,7.74707], Tmin=(10,'K'), Tmax=(571.929,'K')),
-            NASAPolynomial(coeffs=[2.99134,0.0249769,-1.60134e-05,5.09724e-09,-6.27524e-13,-31837.1,9.6802], Tmin=(571.929,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-263.637,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (182.918,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 32,
     label = "r007269",
     molecule = 
 """
@@ -1130,12 +1058,12 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.92299,0.00445513,0.000113709,-2.09901e-07,1.18235e-10,27155,10.421], Tmin=(10,'K'), Tmax=(570.325,'K')),
-            NASAPolynomial(coeffs=[1.20078,0.0409092,-2.78311e-05,8.92399e-09,-1.08345e-12,27183.2,19.55], Tmin=(570.325,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.923,0.00445466,0.000113713,-2.09913e-07,1.18244e-10,31729.6,10.421], Tmin=(10,'K'), Tmax=(570.304,'K')),
+            NASAPolynomial(coeffs=[1.20052,0.04091,-2.78318e-05,8.92428e-09,-1.08349e-12,31757.8,19.5513], Tmin=(570.304,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (225.747,'kJ/mol'),
+        E0 = (263.782,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
         CpInf = (232.805,'J/(mol*K)'),
     ),
@@ -1147,76 +1075,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 33,
-    label = "p007269",
-    molecule = 
-"""
-1  N u0 p1 c0 {4,S} {5,S} {6,S}
-2  N u0 p1 c0 {6,D} {10,S}
-3  N u0 p1 c0 {7,T}
-4  C u0 p0 c0 {1,S} {5,D} {8,S}
-5  C u0 p0 c0 {1,S} {4,D} {9,S}
-6  C u0 p0 c0 {1,S} {2,D} {7,S}
-7  C u0 p0 c0 {3,T} {6,S}
-8  H u0 p0 c0 {4,S}
-9  H u0 p0 c0 {5,S}
-10 H u0 p0 c0 {2,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[3.81607,0.0130338,0.000148737,-3.98101e-07,3.1032e-10,71581.9,11.9623], Tmin=(10,'K'), Tmax=(442.945,'K')),
-            NASAPolynomial(coeffs=[4.48889,0.0355277,-2.41865e-05,7.77793e-09,-9.46038e-13,71242,6.10048], Tmin=(442.945,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (595.15,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (232.805,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 34,
-    label = "p011506",
-    molecule = 
-"""
-1  O u0 p2 c0 {4,D}
-2  N u0 p1 c0 {4,S} {5,S} {8,S}
-3  N u0 p1 c0 {6,D} {7,S}
-4  C u0 p0 c0 {1,D} {2,S} {6,S}
-5  C u0 p0 c0 {2,S} {7,D} {9,S}
-6  C u0 p0 c0 {3,D} {4,S} {10,S}
-7  C u0 p0 c0 {3,S} {5,D} {11,S}
-8  H u0 p0 c0 {2,S}
-9  H u0 p0 c0 {5,S}
-10 H u0 p0 c0 {6,S}
-11 H u0 p0 c0 {7,S}
-""",
-    thermo = NASA(
-        polynomials = [
-            NASAPolynomial(coeffs=[4.07209,-0.0074976,0.000179242,-3.1687e-07,1.77508e-10,-5051.56,10.5595], Tmin=(10,'K'), Tmax=(572.922,'K')),
-            NASAPolynomial(coeffs=[0.511206,0.0447269,-2.91311e-05,8.96333e-09,-1.04858e-12,-5092.62,21.836], Tmin=(572.922,'K'), Tmax=(3000,'K')),
-        ],
-        Tmin = (10,'K'),
-        Tmax = (3000,'K'),
-        E0 = (-42.0241,'kJ/mol'),
-        Cp0 = (33.2579,'J/(mol*K)'),
-        CpInf = (257.749,'J/(mol*K)'),
-    ),
-    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
-    longDesc = 
-"""
-Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
-""",
-)
-
-entry(
-    index = 35,
+    index = 31,
     label = "r011506",
     molecule = 
 """
@@ -1234,12 +1093,12 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[3.93833,0.00353767,0.00012055,-2.1048e-07,1.14013e-10,7208.85,10.3105], Tmin=(10,'K'), Tmax=(565.219,'K')),
-            NASAPolynomial(coeffs=[-0.717119,0.0490743,-3.37099e-05,1.08778e-08,-1.32602e-12,7534,28.3352], Tmin=(565.219,'K'), Tmax=(3000,'K')),
+            NASAPolynomial(coeffs=[3.9387,0.00352108,0.000120697,-2.10886e-07,1.14353e-10,10695.2,10.3098], Tmin=(10,'K'), Tmax=(564.202,'K')),
+            NASAPolynomial(coeffs=[-0.725958,0.0491002,-3.37353e-05,1.0888e-08,-1.32744e-12,11022.5,28.38], Tmin=(564.202,'K'), Tmax=(3000,'K')),
         ],
         Tmin = (10,'K'),
         Tmax = (3000,'K'),
-        E0 = (59.9102,'kJ/mol'),
+        E0 = (88.8977,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
         CpInf = (257.749,'J/(mol*K)'),
     ),


### PR DESCRIPTION
The previous PR (#550) added a thermo library for species involved in training reactions for the ketoenol and 1,3 sigmatropic rearrangement families. This current PR performed 1D rotor scans on the reactants and products to improve the estimations from the thermo library. Scans are also done on the TS to improve A-factors for the training reactions used to fit the rate trees.
