### PR TITLE
Add Nitrogen groups to transport 

### DIFF
--- a/input/transport/groups/nonring.py
+++ b/input/transport/groups/nonring.py
@@ -11,6 +11,8 @@ PhD Thesis, Massachusetts Institute of Technology: Cambridge, MA, 1984.
 
 Note the Pc contributions are all the negative of what is in Table 3 of Joback's thesis.
 The Tb contributions are from table 13.
+
+`structureIndex` is 0 if linear, 1 if makes molecule nonlinear
 """
 entry(
     index = 0,
@@ -748,6 +750,122 @@ entry(
     longDesc = u"""Tb from https://doi.org/10.1021/ie00008a029""",
 )
 
+entry(
+    index = 36,
+    label = "N_centered",
+    group =
+"""
+1 * N ux
+""",
+    transportGroup = None,
+    shortDesc = u"""Dummy node for head of tree""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 37,
+    label = "NsH2R",
+    group =
+"""
+1 * N   u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S}
+3   H   u0 {1,S}
+4   H   u0 {1,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0243,
+        Pc = 0.0109,
+        Vc = 38,
+        Tb = 73.23,
+        structureIndex = 1,
+    ),
+    shortDesc = u"""nonring_library value for NsH2R""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 38,
+    label = "NsHR2",
+    group =
+"""
+1 * N   u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S}
+3   R!H u0 {1,S}
+4   H   u0 {1,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0295,
+        Pc = 0.0077,
+        Vc = 35,
+        Tb = 50.17,
+        structureIndex = 1,
+    ),
+    shortDesc = u"""nonring_library value for NsHR2""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 39,
+    label = "NsR3",
+    group =
+"""
+1 * N   u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S}
+3   R!H u0 {1,S}
+4   R!H u0 {1,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0169,
+        Pc = 0.0074,
+        Vc = 9,
+        Tb = 11.74,
+        structureIndex = 1,
+    ),
+    shortDesc = u"""nonring_library value for NsR3""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 40,
+    label = "Nt-CtR",
+    group =
+"""
+1 * N3t u0 p1 {2,T}
+2   Ct  u0 {1,T} {3,S}
+3   R!H u0 {2,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0496,
+        Pc = -0.0101,
+        Vc = 91,
+        Tb = 125.66,
+        structureIndex = 0,
+    ),
+    shortDesc = u"""nonring_library value for Nt-CtR""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 41,
+    label = "NsOs2R",
+    group =
+"""
+1 * N   u0 {2,S} {3,S} {4,S}
+2   O   u0 {1,S}
+3   O   u0 {1,S}
+4   R!H u0 {1,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0437,
+        Pc = 0.0064,
+        Vc = 91,
+        Tb = 152.54,
+        structureIndex = 1,
+    ),
+    shortDesc = u"""nonring_library value for NsOs2R""",
+    longDesc = u"""""",
+)
+
 tree(
 """
 L1: R
@@ -787,6 +905,12 @@ L1: R
         L3: F-Cs
     L2: Cl
     L2: Br
+    L2: N_centered
+        L3: NsH2R
+        L3: NsHR2
+        L3: NsR3
+            L4: NsOs2R
+        L3: Nt-CtR
 """
 )
 

--- a/input/transport/groups/ring.py
+++ b/input/transport/groups/ring.py
@@ -280,6 +280,59 @@ entry(
     longDesc = u"""""",
 )
 
+entry(
+    index = 0,
+    label = "N_centered_ring",
+    group =
+"""
+1 * N ux
+""",
+    transportGroup = None,
+    shortDesc = u"""Dummy node for head of tree""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 9,
+    label = "NsringHR2",
+    group =
+"""
+1 * N   u0 {2,S} {3,S} {4,S}
+2   R!H u0 {1,S}
+3   R!H u0 {1,S}
+4   H   u0 {1,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0130,
+        Pc = 0.0114,
+        Vc = 29,
+        Tb = 52.82,
+        structureIndex = 1,
+    ),
+    shortDesc = u"""ring_library value for NsringHR2""",
+    longDesc = u"""""",
+)
+
+entry(
+    index = 10,
+    label = "NdringR2",
+    group =
+"""
+1 * N   u0 {2,D} {3,S}
+2   R!H u0 {1,D}
+3   R!H u0 {1,S}
+""",
+    transportGroup = CriticalPointGroupContribution(
+        Tc = 0.0085,
+        Pc = 0.0076,
+        Vc = 34,
+        Tb = 57.55,
+        structureIndex = 1,
+    ),
+    shortDesc = u"""ring_library value for NdringR2""",
+    longDesc = u"""""",
+)
+
 tree(
 """
 L1: R_ring
@@ -296,6 +349,9 @@ L1: R_ring
         L3: Ether_ring
     L2: S_centered_ring
         L3: Thioether_ring
+    L2: N_centered_ring
+        L3: NsringHR2
+        L3: NdringR2
 """
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

### Motivation or Problem
The transport groups were previously missing nitrogen. The nitrogen groups for the transport GAV have been added to the RMG-database. Two nitrogen molecules have been added to the `transportTest.py`.

Note that this PR needs simultaneous update of RMG-Py and RMG-database. (Twin RMG-Py PR is: [ #2274](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2274))

### Description of Changes
Several nonring and ring nitrogen groups are added to `RMG-database/input/transport/groups/`.
These group values are obtained from Joback's Ph.D. thesis Table 3 and Table 13. These values can be also found [here](https://en.wikipedia.org/wiki/Joback_method#Critical_temperature). The nitrogen groups with any missing values were not added to the RMG-database. 

### Testing
Two molecules with SMILES `CNC` and `c1ncc[nH]1` have been added to the `transportTest.py`. 

### Reviewer Tips
You can run the unittests to check.

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->
