### PR TITLE
More ketoenol training rxns

### DIFF
--- a/input/kinetics/families/Ketoenol/groups.py
+++ b/input/kinetics/families/Ketoenol/groups.py
@@ -51,50 +51,10 @@ entry(
 
 entry(
     index = 1,
-    label = "Root_3R!H->C",
+    label = "Root_1R!H-inRing",
     group = 
 """
-1 *2 C u0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 C u0 {1,D}
-4 *4 H u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 2,
-    label = "Root_3R!H->C_Ext-1R!H-R",
-    group = 
-"""
-1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 C   u0 {1,D}
-4 *4 H   u0 {2,S}
-5    R!H ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 3,
-    label = "Root_N-3R!H->C",
-    group = 
-"""
-1 *2 C                      u0 {2,S} {3,D}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 [I,Br,Cl,O,P,S,F,N,Si] u0 {1,D}
-4 *4 H                      u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 4,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N",
-    group = 
-"""
-1 *2 C u0 {2,S} {3,D}
+1 *2 C u0 r1 {2,S} {3,D}
 2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 {1,D}
 4 *4 H u0 {2,S}
@@ -103,11 +63,602 @@ entry(
 )
 
 entry(
-    index = 5,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R",
+    index = 2,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    C ux {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 4,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    C ux r1 {3,S}
+6    C u0 r1 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,S}
+4 *4 H                      u0 {2,S}
+5    C                      u0 {3,S}
+6    [Si,S,N,P,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 6,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,S}
+4 *4 H                      u0 {2,S}
+5    C                      u0 {3,S}
+6    [Si,S,N,P,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C                      ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 7,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    C u0 {3,S}
+6    N ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 8,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    C   u0 {3,S} {8,S}
+6    N   ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C   ux {6,[S,D,T,B,Q]}
+8    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 9,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r1 {3,S} {8,S}
+6    N ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C ux r1 {6,[S,D,T,B,Q]}
+8    C u0 r0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 10,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r1 {1,D} {5,S}
+4 *4 H                      u0 r0 {2,S}
+5    C                      u0 r1 {3,S} {8,S}
+6    N                      ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C                      ux r1 {6,[S,D,T,B,Q]}
+8    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 11,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r1 {3,S}
+6    O ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C ux r1 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 12,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    C u0 {3,S}
+6    N ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    N ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 13,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 N   u0 r1 {1,D} {5,S}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r1 {3,S} {8,[S,D,T,B,Q]}
+6    N   ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    N   ux r1 {6,[S,D,T,B,Q]}
+8    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,D}
+4 *4 H u0 {2,S}
+5    C ux r1 {3,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
+6    C                      ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
+6    C                      ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C                      ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 18,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    N u0 {3,[S,D,T,B,Q]}
+6    C u0 {1,S} {7,D}
+7    C u0 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 19,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D} {6,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 N   u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 r0 {2,S}
+5    N   u0 r1 {3,[S,D,T,B,Q]}
+6    C   u0 r1 {1,S} {7,D}
+7    C   u0 r1 {6,D} {8,[S,D,T,B,Q]}
+8    R!H ux {7,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 20,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    O ux r1 {3,S}
+6    C ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C ux r1 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 21,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 r0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] u0 r1 {3,[S,D,T,B,Q]}
+6    C                      u0 r1 {1,S} {7,D}
+7    [Si,S,N,P,F,I,Br,Cl,O] u0 r1 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 22,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] u0 {3,[S,D,T,B,Q]}
+6    N                      u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 23,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] u0 {3,[S,D,T,B,Q]} {7,S}
+6    N                      u0 {1,S}
+7    R!H                    u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 24,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D} {5,S}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] u0 {3,S} {7,S}
+6    N                      u0 {1,S}
+7    C                      u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 25,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    N u0 r1 {3,S} {7,S}
+6    N u0 r1 {1,S}
+7    C u0 r1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 26,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D} {6,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    O u0 r1 {3,S} {7,S}
+6    N u0 r1 {1,S}
+7    C u0 r1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 27,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D} {6,S}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H     u0 {2,S}
+5    N     u0 {3,[S,D,T,B,Q]} {7,S}
+6    N     u0 {1,S}
+7    [N,O] u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 28,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D} {6,S}
+2 *3 O     u0 r0 {1,S} {4,S}
+3 *1 N     u0 r1 {1,D} {5,S}
+4 *4 H     u0 r0 {2,S}
+5    N     u0 r1 {3,S} {7,S}
+6    N     u0 r1 {1,S}
+7    [N,O] u0 r1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 29,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D} {6,S}
+2 *3 O     u0 r0 {1,S} {4,S}
+3 *1 N     u0 r1 {1,D} {5,D}
+4 *4 H     u0 r0 {2,S}
+5    N     u0 r1 {3,D} {7,S}
+6    N     u0 r1 {1,S}
+7    [N,O] u0 r1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 30,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 r0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] u0 r1 {3,[S,D,T,B,Q]} {7,[B,D,T,Q]}
+6    N                      u0 r1 {1,S}
+7    R!H                    u0 r1 {5,[B,D,T,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 31,
+    label = "Root_N-1R!H-inRing",
+    group = 
+"""
+1 *2 R!H u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 R!H u0 {1,D}
+4 *4 H   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 32,
+    label = "Root_N-1R!H-inRing_3R!H->C",
+    group = 
+"""
+1 *2 R!H u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 {1,D}
+4 *4 H   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 33,
+    label = "Root_N-1R!H-inRing_3R!H->C_1R!H->N",
+    group = 
+"""
+1 *2 N u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 {1,D}
+4 *4 H u0 r0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 34,
+    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 {1,D}
+4 *4 H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 35,
+    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 36,
+    label = "Root_N-1R!H-inRing_N-3R!H->C",
+    group = 
+"""
+1 *2 C     u0 r0 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 [S,N] u0 {1,D}
+4 *4 H     u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 37,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 S u0 {1,D}
+4 *4 H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 38,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 S u0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 39,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 S   u0 {1,D}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 40,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 41,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 {1,D}
 4 *4 H   u0 {2,S}
@@ -117,11 +668,11 @@ entry(
 )
 
 entry(
-    index = 6,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
+    index = 42,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 {1,D}
 4 *4 H   u0 {2,S}
@@ -132,14 +683,14 @@ entry(
 )
 
 entry(
-    index = 7,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
+    index = 43,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
     group = 
 """
 1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 r0 {1,S} {4,S}
+2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 r0 {1,D}
-4 *4 H   u0 r0 {2,S}
+4 *4 H   u0 {2,S}
 5    R!H ux r1 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
 6    R!H u0 {5,[S,D,T,B,Q]}
 """,
@@ -147,11 +698,11 @@ entry(
 )
 
 entry(
-    index = 8,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
+    index = 44,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 {1,D}
 4 *4 H   u0 {2,S}
@@ -162,11 +713,11 @@ entry(
 )
 
 entry(
-    index = 9,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
+    index = 45,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 {1,D}
 4 *4 H   u0 {2,S}
@@ -177,26 +728,11 @@ entry(
 )
 
 entry(
-    index = 10,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C",
+    index = 46,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 N   u0 r0 {1,D}
-4 *4 H   u0 r0 {2,S}
-5    C   ux r0 {1,[S,D,T,B,Q]} {6,S}
-6    R!H u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 11,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C",
-    group = 
-"""
-1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 {1,D}
 4 *4 H u0 {2,S}
@@ -207,14 +743,14 @@ entry(
 )
 
 entry(
-    index = 12,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N",
+    index = 47,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O u0 r0 {1,S} {4,S}
+2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 r0 {1,D}
-4 *4 H u0 r0 {2,S}
+4 *4 H u0 {2,S}
 5    N ux r0 {1,[S,D,T,B,Q]} {6,S}
 6    C u0 {5,S} {7,D}
 7    N u0 r0 {6,D}
@@ -223,30 +759,45 @@ entry(
 )
 
 entry(
-    index = 13,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N",
+    index = 48,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N",
     group = 
 """
 1 *2 C                      u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O                      u0 r0 {1,S} {4,S}
+2 *3 O                      u0 {1,S} {4,S}
 3 *1 N                      u0 r0 {1,D}
-4 *4 H                      u0 r0 {2,S}
+4 *4 H                      u0 {2,S}
 5    N                      ux r0 {1,[S,D,T,B,Q]} {6,S}
 6    C                      u0 {5,S} {7,D}
-7    [I,Br,Cl,O,P,S,F,C,Si] u0 r0 {6,D}
+7    [Si,S,P,C,F,I,Br,Cl,O] u0 r0 {6,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 14,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
+    index = 49,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D} {5,S}
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
+3 *1 N   u0 r0 {1,D}
 4 *4 H   u0 {2,S}
+5    C   ux r0 {1,[S,D,T,B,Q]} {6,S}
+6    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 50,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 r0 {2,S}
 5    R!H u0 r0 {1,S} {6,[D,T]}
 6    R!H ux r0 {5,[D,T]}
 """,
@@ -254,11 +805,11 @@ entry(
 )
 
 entry(
-    index = 15,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    index = 51,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
     group = 
 """
-1 *2 C   u0 {2,S} {3,D}
+1 *2 C   u0 r0 {2,S} {3,D}
 2 *3 O   u0 {1,S} {4,S}
 3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H   u0 {2,S}
@@ -270,11 +821,11 @@ entry(
 )
 
 entry(
-    index = 16,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    index = 52,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
     group = 
 """
-1 *2 C u0 {2,S} {3,D}
+1 *2 C u0 r0 {2,S} {3,D}
 2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H u0 {2,S}
@@ -285,58 +836,16 @@ entry(
 )
 
 entry(
-    index = 17,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    index = 53,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
     group = 
 """
-1 *2 C                      u0 {2,S} {3,D}
+1 *2 C                      u0 r0 {2,S} {3,D}
 2 *3 O                      u0 {1,S} {4,S}
 3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H                      u0 {2,S}
 5    C                      ux {3,[S,D,T,B,Q]} {6,D}
-6    [I,Br,Cl,O,P,S,F,C,Si] u0 r0 {5,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 18,
-    label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N",
-    group = 
-"""
-1 *2 C u0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 S u0 {1,D}
-4 *4 H u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 19,
-    label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R",
-    group = 
-"""
-1 *2 C u0 {2,S} {3,D} {5,S}
-2 *3 O u0 {1,S} {4,S}
-3 *1 S u0 {1,D}
-4 *4 H u0 {2,S}
-5    C u0 {1,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 20,
-    label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
-    group = 
-"""
-1 *2 C   u0 {2,S} {3,D} {5,S}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 S   u0 {1,D}
-4 *4 H   u0 {2,S}
-5    C   u0 r0 {1,S} {6,[S,D,T,B,Q]}
-6    R!H ux {5,[S,D,T,B,Q]}
+6    [Si,S,P,C,F,I,Br,Cl,O] u0 r0 {5,D}
 """,
     kinetics = None,
 )
@@ -344,26 +853,59 @@ entry(
 tree(
 """
 L1: Root
-    L2: Root_3R!H->C
-        L3: Root_3R!H->C_Ext-1R!H-R
-    L2: Root_N-3R!H->C
-        L3: Root_N-3R!H->C_3BrClFINOPSSi->N
-            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
-                L5: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-                    L6: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-                        L7: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-                            L8: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
-                            L8: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
-                                L9: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
-                                L9: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
-                        L7: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
-            L4: Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-        L3: Root_N-3R!H->C_N-3BrClFINOPSSi->N
-            L4: Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R
-                L5: Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
+    L2: Root_1R!H-inRing
+        L3: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
+            L4: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
+                L5: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
+                L5: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
+                    L6: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
+                            L8: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
+                                L9: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
+                                L9: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
+                    L6: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
+            L4: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
+        L3: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
+            L4: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
+                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
+                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
+                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
+                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
+            L4: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
+                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
+                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
+                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
+                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
+    L2: Root_N-1R!H-inRing
+        L3: Root_N-1R!H-inRing_3R!H->C
+            L4: Root_N-1R!H-inRing_3R!H->C_1R!H->N
+            L4: Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
+                L5: Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+        L3: Root_N-1R!H-inRing_N-3R!H->C
+            L4: Root_N-1R!H-inRing_N-3R!H->C_3NS->S
+                L5: Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
+                    L6: Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+            L4: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
+                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
+                    L6: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
+                        L7: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
+                        L7: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+                            L8: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+                                L9: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
+                                    L10: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+                                    L10: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
+                                L9: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+                            L8: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
 """
 )
 

--- a/input/kinetics/families/Ketoenol/rules.py
+++ b/input/kinetics/families/Ketoenol/rules.py
@@ -9,314 +9,809 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(3.64543e-12,'s^-1'), n=7.0342, w0=(791900,'J/mol'), E0=(96088.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.025591830299650252, var=3.209136248979107, Tref=1000.0, N=15, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 15 training reactions at node Root
-    Total Standard Deviation in ln(k): 3.6555959704468117"""),
+    kinetics = ArrheniusBM(A=(6.10397e-09,'s^-1'), n=6.18187, w0=(795076,'J/mol'), E0=(134685,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.2195681169559809, var=20.961761804484684, Tref=1000.0, N=33, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 33 training reactions at node Root
+    Total Standard Deviation in ln(k): 9.730161101696131"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 15 training reactions at node Root
-Total Standard Deviation in ln(k): 3.6555959704468117""",
+    shortDesc = """BM rule fitted to 33 training reactions at node Root
+Total Standard Deviation in ln(k): 9.730161101696131""",
     longDesc = 
 """
-BM rule fitted to 15 training reactions at node Root
-Total Standard Deviation in ln(k): 3.6555959704468117
+BM rule fitted to 33 training reactions at node Root
+Total Standard Deviation in ln(k): 9.730161101696131
 """,
 )
 
 entry(
     index = 2,
-    label = "Root_3R!H->C",
-    kinetics = ArrheniusBM(A=(75.1006,'s^-1'), n=3.11041, w0=(783500,'J/mol'), E0=(209076,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.00848789959541425, var=6.520606768146176, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_3R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_3R!H->C
-    Total Standard Deviation in ln(k): 5.140513384866411"""),
+    label = "Root_1R!H-inRing",
+    kinetics = ArrheniusBM(A=(5.26108e-07,'s^-1'), n=5.66028, w0=(798000,'J/mol'), E0=(149674,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.2986016055903136, var=12.008348340526611, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_1R!H-inRing',), comment="""BM rule fitted to 17 training reactions at node Root_1R!H-inRing
+    Total Standard Deviation in ln(k): 7.697276553951726"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_3R!H->C
-Total Standard Deviation in ln(k): 5.140513384866411""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_1R!H-inRing
+Total Standard Deviation in ln(k): 7.697276553951726""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_3R!H->C
-Total Standard Deviation in ln(k): 5.140513384866411
+BM rule fitted to 17 training reactions at node Root_1R!H-inRing
+Total Standard Deviation in ln(k): 7.697276553951726
 """,
 )
 
 entry(
     index = 3,
-    label = "Root_N-3R!H->C",
-    kinetics = ArrheniusBM(A=(2.14216e-12,'s^-1'), n=7.10076, w0=(794000,'J/mol'), E0=(95211.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.027300955354671547, var=2.809838899397277, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-3R!H->C',), comment="""BM rule fitted to 12 training reactions at node Root_N-3R!H->C
-    Total Standard Deviation in ln(k): 3.4290473906824763"""),
+    label = "Root_N-1R!H-inRing",
+    kinetics = ArrheniusBM(A=(1.08943e-18,'s^-1'), n=8.92199, w0=(791969,'J/mol'), E0=(93809.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.08893667560245318, var=37.94025194284002, Tref=1000.0, N=16, data_mean=0.0, correlation='Root_N-1R!H-inRing',), comment="""BM rule fitted to 16 training reactions at node Root_N-1R!H-inRing
+    Total Standard Deviation in ln(k): 12.571756783434886"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-3R!H->C
-Total Standard Deviation in ln(k): 3.4290473906824763""",
+    shortDesc = """BM rule fitted to 16 training reactions at node Root_N-1R!H-inRing
+Total Standard Deviation in ln(k): 12.571756783434886""",
     longDesc = 
 """
-BM rule fitted to 12 training reactions at node Root_N-3R!H->C
-Total Standard Deviation in ln(k): 3.4290473906824763
+BM rule fitted to 16 training reactions at node Root_N-1R!H-inRing
+Total Standard Deviation in ln(k): 12.571756783434886
 """,
 )
 
 entry(
     index = 4,
-    label = "Root_3R!H->C_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(205000,'s^-1'), n=2.37, w0=(783500,'J/mol'), E0=(221387,'J/mol'), Tmin=(600,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C",
+    kinetics = ArrheniusBM(A=(3.63777e-17,'s^-1'), n=8.55003, w0=(798000,'J/mol'), E0=(118646,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0028809451405216774, var=3.403124387745618, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C',), comment="""BM rule fitted to 8 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
+    Total Standard Deviation in ln(k): 3.705485448648163"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 8 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
+Total Standard Deviation in ln(k): 3.705485448648163""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_3R!H->C_Ext-1R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 8 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
+Total Standard Deviation in ln(k): 3.705485448648163
 """,
 )
 
 entry(
     index = 5,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(1.30473e-11,'s^-1'), n=6.87514, w0=(798000,'J/mol'), E0=(99876.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0117411635116814, var=0.6446492092925814, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N',), comment="""BM rule fitted to 9 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 1.6391032023367265"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(0.12949,'s^-1'), n=4.13415, w0=(798000,'J/mol'), E0=(168423,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.4467128617852155, var=23.288738414217875, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C',), comment="""BM rule fitted to 9 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
+    Total Standard Deviation in ln(k): 10.79692624441642"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 1.6391032023367265""",
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
+Total Standard Deviation in ln(k): 10.79692624441642""",
     longDesc = 
 """
-BM rule fitted to 9 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 1.6391032023367265
+BM rule fitted to 9 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
+Total Standard Deviation in ln(k): 10.79692624441642
 """,
 )
 
 entry(
     index = 6,
-    label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(1583.91,'s^-1'), n=2.85161, w0=(782000,'J/mol'), E0=(88955.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003045184023974304, var=0.28211849898893376, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_N-3BrClFINOPSSi->N',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 1.0724628112272296"""),
+    label = "Root_N-1R!H-inRing_3R!H->C",
+    kinetics = ArrheniusBM(A=(1.80789e-52,'s^-1'), n=18.7686, w0=(785875,'J/mol'), E0=(142261,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=7.096700906046526, var=111.32985920057283, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_3R!H->C
+    Total Standard Deviation in ln(k): 38.98346113476485"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 1.0724628112272296""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_3R!H->C
+Total Standard Deviation in ln(k): 38.98346113476485""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 1.0724628112272296
+BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_3R!H->C
+Total Standard Deviation in ln(k): 38.98346113476485
 """,
 )
 
 entry(
     index = 7,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(1.09806e-11,'s^-1'), n=6.89792, w0=(798000,'J/mol'), E0=(99858.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0190200390037195, var=1.0964123289271033, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 2.1469413209668056"""),
+    label = "Root_N-1R!H-inRing_N-3R!H->C",
+    kinetics = ArrheniusBM(A=(2.14216e-12,'s^-1'), n=7.10076, w0=(794000,'J/mol'), E0=(95211.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.027300955354671547, var=2.809838899397277, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C',), comment="""BM rule fitted to 12 training reactions at node Root_N-1R!H-inRing_N-3R!H->C
+    Total Standard Deviation in ln(k): 3.4290473906824763"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
-Total Standard Deviation in ln(k): 2.1469413209668056""",
+    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-1R!H-inRing_N-3R!H->C
+Total Standard Deviation in ln(k): 3.4290473906824763""",
     longDesc = 
 """
-BM rule fitted to 6 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R
-Total Standard Deviation in ln(k): 2.1469413209668056
+BM rule fitted to 12 training reactions at node Root_N-1R!H-inRing_N-3R!H->C
+Total Standard Deviation in ln(k): 3.4290473906824763
 """,
 )
 
 entry(
     index = 8,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(6.24893e-09,'s^-1'), n=6.18216, w0=(798000,'J/mol'), E0=(107861,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H",
+    kinetics = ArrheniusBM(A=(6.35117e-18,'s^-1'), n=8.76855, w0=(798000,'J/mol'), E0=(117401,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.008743366414696061, var=4.057942970727891, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H',), comment="""BM rule fitted to 7 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
+    Total Standard Deviation in ln(k): 4.0603740767018035"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
+Total Standard Deviation in ln(k): 4.0603740767018035""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 7 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
+Total Standard Deviation in ln(k): 4.0603740767018035
 """,
 )
 
 entry(
     index = 9,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N",
-    kinetics = ArrheniusBM(A=(3.10725e-11,'s^-1'), n=6.76455, w0=(798000,'J/mol'), E0=(102204,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H",
+    kinetics = ArrheniusBM(A=(6.87223e-13,'s^-1'), n=7.30388, w0=(798000,'J/mol'), E0=(124360,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_6R!H->N
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 10,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
-    kinetics = ArrheniusBM(A=(6.36022e-11,'s^-1'), n=6.62861, w0=(798000,'J/mol'), E0=(100596,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C",
+    kinetics = ArrheniusBM(A=(1.50083e-19,'s^-1'), n=9.25255, w0=(798000,'J/mol'), E0=(127699,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0006427823284157327, var=0.5967826247970905, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
+    Total Standard Deviation in ln(k): 1.5503071008497333"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
+Total Standard Deviation in ln(k): 1.5503071008497333""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
+Total Standard Deviation in ln(k): 1.5503071008497333
 """,
 )
 
 entry(
     index = 11,
-    label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(2857.3,'s^-1'), n=2.79065, w0=(782000,'J/mol'), E0=(88663.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-2.015825826525184e-07, var=0.0007766175206250726, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 0.05586817935319939"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(3.15335e+06,'s^-1'), n=2.03333, w0=(798000,'J/mol'), E0=(184034,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.5800252121262526, var=55.895560511264364, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
+    Total Standard Deviation in ln(k): 16.44541751648541"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R
-Total Standard Deviation in ln(k): 0.05586817935319939""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
+Total Standard Deviation in ln(k): 16.44541751648541""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R
-Total Standard Deviation in ln(k): 0.05586817935319939
+BM rule fitted to 5 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
+Total Standard Deviation in ln(k): 16.44541751648541
 """,
 )
 
 entry(
     index = 12,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(2.87238e-12,'s^-1'), n=7.05581, w0=(798000,'J/mol'), E0=(99707.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.02252736485366013, var=0.8629404088644341, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 1.9188917676717938"""),
+    label = "Root_N-1R!H-inRing_3R!H->C_1R!H->N",
+    kinetics = ArrheniusBM(A=(9.27692e-54,'s^-1'), n=19.1913, w0=(793000,'J/mol'), E0=(143942,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C_1R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_1R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 1.9188917676717938""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_1R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 5 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 1.9188917676717938
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_1R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 13,
-    label = "Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(85014.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N",
+    kinetics = ArrheniusBM(A=(75.1006,'s^-1'), n=3.11041, w0=(783500,'J/mol'), E0=(209076,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.00848789959541425, var=6.520606768146176, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C_N-1R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
+    Total Standard Deviation in ln(k): 5.140513384866411"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
+Total Standard Deviation in ln(k): 5.140513384866411""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
+Total Standard Deviation in ln(k): 5.140513384866411
 """,
 )
 
 entry(
     index = 14,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
-    kinetics = ArrheniusBM(A=(1.68509e-11,'s^-1'), n=6.88807, w0=(798000,'J/mol'), E0=(102832,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S",
+    kinetics = ArrheniusBM(A=(1583.91,'s^-1'), n=2.85161, w0=(782000,'J/mol'), E0=(88955.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003045184023974304, var=0.28211849898893376, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_3NS->S',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S
+    Total Standard Deviation in ln(k): 1.0724628112272296"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S
+Total Standard Deviation in ln(k): 1.0724628112272296""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S
+Total Standard Deviation in ln(k): 1.0724628112272296
 """,
 )
 
 entry(
     index = 15,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
-    kinetics = ArrheniusBM(A=(2.36128e-12,'s^-1'), n=7.07296, w0=(798000,'J/mol'), E0=(99585.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.029593247978928896, var=1.2653129163997325, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-    Total Standard Deviation in ln(k): 2.3294037749260914"""),
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S",
+    kinetics = ArrheniusBM(A=(1.30473e-11,'s^-1'), n=6.87514, w0=(798000,'J/mol'), E0=(99876.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0117411635116814, var=0.6446492092925814, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S',), comment="""BM rule fitted to 9 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
+    Total Standard Deviation in ln(k): 1.6391032023367265"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-Total Standard Deviation in ln(k): 2.3294037749260914""",
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
+Total Standard Deviation in ln(k): 1.6391032023367265""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-Total Standard Deviation in ln(k): 2.3294037749260914
+BM rule fitted to 9 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
+Total Standard Deviation in ln(k): 1.6391032023367265
 """,
 )
 
 entry(
     index = 16,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
-    kinetics = ArrheniusBM(A=(7.93116e-11,'s^-1'), n=6.59023, w0=(798000,'J/mol'), E0=(104253,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004083326014350255, var=0.36678964389307633, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-    Total Standard Deviation in ln(k): 1.2243905404532403"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C",
+    kinetics = ArrheniusBM(A=(1.03729e-10,'s^-1'), n=6.68631, w0=(798000,'J/mol'), E0=(105099,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 1.2243905404532403""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 1.2243905404532403
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 17,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
-    kinetics = ArrheniusBM(A=(3.02789e-13,'s^-1'), n=7.48219, w0=(798000,'J/mol'), E0=(95953.2,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(1.69363e-18,'s^-1'), n=8.94137, w0=(798000,'J/mol'), E0=(121373,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0038084715549368104, var=0.5842399037789903, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C',), comment="""BM rule fitted to 6 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
+    Total Standard Deviation in ln(k): 1.5419000584052351"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
+Total Standard Deviation in ln(k): 1.5419000584052351""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 6 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
+Total Standard Deviation in ln(k): 1.5419000584052351
 """,
 )
 
 entry(
     index = 18,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C",
-    kinetics = ArrheniusBM(A=(1.30511e-12,'s^-1'), n=7.26372, w0=(798000,'J/mol'), E0=(105105,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(1.2013e-18,'s^-1'), n=8.97925, w0=(798000,'J/mol'), E0=(126845,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.007503612341907746, var=0.008054470110497336, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
+    Total Standard Deviation in ln(k): 0.1987716543490167"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
+Total Standard Deviation in ln(k): 0.1987716543490167""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
+Total Standard Deviation in ln(k): 0.1987716543490167
 """,
 )
 
 entry(
     index = 19,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C",
-    kinetics = ArrheniusBM(A=(8.42992e-10,'s^-1'), n=6.22192, w0=(798000,'J/mol'), E0=(104542,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-3.0517082806578122e-05, var=0.15820189146844285, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
-    Total Standard Deviation in ln(k): 0.7974520617821278"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
-Total Standard Deviation in ln(k): 0.7974520617821278""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C
-Total Standard Deviation in ln(k): 0.7974520617821278
-""",
-)
-
-entry(
-    index = 20,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N",
-    kinetics = ArrheniusBM(A=(1.95577e-10,'s^-1'), n=6.41822, w0=(798000,'J/mol'), E0=(102434,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(1.18952e-19,'s^-1'), n=9.32392, w0=(798000,'J/mol'), E0=(137103,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_7R!H->N
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
+    index = 20,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi",
+    kinetics = ArrheniusBM(A=(3.33668e-20,'s^-1'), n=9.45072, w0=(798000,'J/mol'), E0=(138622,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.025999023929210666, var=2.2367127697893783, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
+    Total Standard Deviation in ln(k): 3.0635345236969505"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
+Total Standard Deviation in ln(k): 3.0635345236969505""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
+Total Standard Deviation in ln(k): 3.0635345236969505
+""",
+)
+
+entry(
     index = 21,
-    label = "Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N",
-    kinetics = ArrheniusBM(A=(5.58698e-10,'s^-1'), n=6.27942, w0=(798000,'J/mol'), E0=(105618,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi",
+    kinetics = ArrheniusBM(A=(7.03103e-17,'s^-1'), n=8.43292, w0=(798000,'J/mol'), E0=(45092.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-3R!H->C_3BrClFINOPSSi->N_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->C_Ext-6R!H-R_N-7R!H->N
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 22,
+    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(205000,'s^-1'), n=2.37, w0=(783500,'J/mol'), E0=(221387,'J/mol'), Tmin=(600,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 23,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(2857.3,'s^-1'), n=2.79065, w0=(782000,'J/mol'), E0=(88663.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-2.015825826525184e-07, var=0.0007766175206250726, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 0.05586817935319939"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 0.05586817935319939""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 0.05586817935319939
+""",
+)
+
+entry(
+    index = 24,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(1.09806e-11,'s^-1'), n=6.89792, w0=(798000,'J/mol'), E0=(99858.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0190200390037195, var=1.0964123289271033, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 2.1469413209668056"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 2.1469413209668056""",
+    longDesc = 
+"""
+BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 2.1469413209668056
+""",
+)
+
+entry(
+    index = 25,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(6.24893e-09,'s^-1'), n=6.18216, w0=(798000,'J/mol'), E0=(107861,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 26,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    kinetics = ArrheniusBM(A=(3.10725e-11,'s^-1'), n=6.76455, w0=(798000,'J/mol'), E0=(102204,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 27,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(6.36022e-11,'s^-1'), n=6.62861, w0=(798000,'J/mol'), E0=(100596,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 28,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(1.05792e-18,'s^-1'), n=9.0012, w0=(798000,'J/mol'), E0=(119968,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0011076788615978056, var=1.099229330440946, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
+    Total Standard Deviation in ln(k): 2.104630326801545"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
+Total Standard Deviation in ln(k): 2.104630326801545""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
+Total Standard Deviation in ln(k): 2.104630326801545
+""",
+)
+
+entry(
+    index = 29,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(3.10141e-18,'s^-1'), n=8.86353, w0=(798000,'J/mol'), E0=(123814,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-7.630684147407905e-05, var=0.07260338773725893, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 0.5403679094229893"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
+Total Standard Deviation in ln(k): 0.5403679094229893""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
+Total Standard Deviation in ln(k): 0.5403679094229893
+""",
+)
+
+entry(
+    index = 30,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(2.9852e-20,'s^-1'), n=9.42069, w0=(798000,'J/mol'), E0=(121194,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00033558131741877046, var=0.002267350901758185, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 0.09630205437896223"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 0.09630205437896223""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 0.09630205437896223
+""",
+)
+
+entry(
+    index = 31,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(2.95366e-14,'s^-1'), n=7.77475, w0=(798000,'J/mol'), E0=(142358,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 32,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C",
+    kinetics = ArrheniusBM(A=(5.35193e-22,'s^-1'), n=9.96064, w0=(798000,'J/mol'), E0=(136695,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0025574536717999116, var=2.4594978159443808, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
+    Total Standard Deviation in ln(k): 3.1504089146845984"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
+Total Standard Deviation in ln(k): 3.1504089146845984""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
+Total Standard Deviation in ln(k): 3.1504089146845984
+""",
+)
+
+entry(
+    index = 33,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(2.27189e-19,'s^-1'), n=9.21636, w0=(798000,'J/mol'), E0=(138167,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0005520236756471257, var=10.279324647875598, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
+    Total Standard Deviation in ln(k): 6.428845485264807"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
+Total Standard Deviation in ln(k): 6.428845485264807""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
+Total Standard Deviation in ln(k): 6.428845485264807
+""",
+)
+
+entry(
+    index = 34,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(85014.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 35,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(2.87238e-12,'s^-1'), n=7.05581, w0=(798000,'J/mol'), E0=(99707.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.02252736485366013, var=0.8629404088644341, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 1.9188917676717938"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 1.9188917676717938""",
+    longDesc = 
+"""
+BM rule fitted to 5 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 1.9188917676717938
+""",
+)
+
+entry(
+    index = 36,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(1.02008e-17,'s^-1'), n=8.71849, w0=(798000,'J/mol'), E0=(119287,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003881804765101457, var=0.009199804740706677, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 0.20203867135609896"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 0.20203867135609896""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 0.20203867135609896
+""",
+)
+
+entry(
+    index = 37,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(5.23245e-20,'s^-1'), n=9.38178, w0=(798000,'J/mol'), E0=(126650,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 38,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(9.00746e-18,'s^-1'), n=8.75254, w0=(798000,'J/mol'), E0=(125562,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 39,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(3.57404e-19,'s^-1'), n=9.1193, w0=(798000,'J/mol'), E0=(124449,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 40,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(2.52338e-22,'s^-1'), n=10.05, w0=(798000,'J/mol'), E0=(131010,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 41,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(1.62343e-20,'s^-1'), n=9.5285, w0=(798000,'J/mol'), E0=(144945,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 42,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H",
+    kinetics = ArrheniusBM(A=(4.58562e-24,'s^-1'), n=10.6226, w0=(798000,'J/mol'), E0=(138683,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 43,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H",
+    kinetics = ArrheniusBM(A=(2.02819e-14,'s^-1'), n=7.71417, w0=(798000,'J/mol'), E0=(137432,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 44,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
+    kinetics = ArrheniusBM(A=(1.68509e-11,'s^-1'), n=6.88807, w0=(798000,'J/mol'), E0=(102832,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 45,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
+    kinetics = ArrheniusBM(A=(2.36128e-12,'s^-1'), n=7.07296, w0=(798000,'J/mol'), E0=(99585.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.029593247978928896, var=1.2653129163997325, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+    Total Standard Deviation in ln(k): 2.3294037749260914"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+Total Standard Deviation in ln(k): 2.3294037749260914""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
+Total Standard Deviation in ln(k): 2.3294037749260914
+""",
+)
+
+entry(
+    index = 46,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(1.36428e-17,'s^-1'), n=8.68106, w0=(798000,'J/mol'), E0=(119355,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=9.875757718463376e-05, var=0.019447819937148978, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
+    Total Standard Deviation in ln(k): 0.2798193482943225"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
+Total Standard Deviation in ln(k): 0.2798193482943225""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
+Total Standard Deviation in ln(k): 0.2798193482943225
+""",
+)
+
+entry(
+    index = 47,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
+    kinetics = ArrheniusBM(A=(7.93116e-11,'s^-1'), n=6.59023, w0=(798000,'J/mol'), E0=(104253,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004083326014350255, var=0.36678964389307633, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+    Total Standard Deviation in ln(k): 1.2243905404532403"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 1.2243905404532403""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 1.2243905404532403
+""",
+)
+
+entry(
+    index = 48,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
+    kinetics = ArrheniusBM(A=(3.02789e-13,'s^-1'), n=7.48219, w0=(798000,'J/mol'), E0=(95953.2,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 49,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C",
+    kinetics = ArrheniusBM(A=(9.14825e-17,'s^-1'), n=8.45574, w0=(798000,'J/mol'), E0=(121877,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 50,
+    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(4.10787e-17,'s^-1'), n=8.57309, w0=(798000,'J/mol'), E0=(122784,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 51,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N",
+    kinetics = ArrheniusBM(A=(8.42992e-10,'s^-1'), n=6.22192, w0=(798000,'J/mol'), E0=(104542,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-3.0517082806578122e-05, var=0.15820189146844285, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
+    Total Standard Deviation in ln(k): 0.7974520617821278"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
+Total Standard Deviation in ln(k): 0.7974520617821278""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
+Total Standard Deviation in ln(k): 0.7974520617821278
+""",
+)
+
+entry(
+    index = 52,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(1.30511e-12,'s^-1'), n=7.26372, w0=(798000,'J/mol'), E0=(105105,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 53,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(1.95577e-10,'s^-1'), n=6.41822, w0=(798000,'J/mol'), E0=(102434,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 54,
+    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(5.58698e-10,'s^-1'), n=6.27942, w0=(798000,'J/mol'), E0=(105618,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/Ketoenol/training/dictionary.txt
+++ b/input/kinetics/families/Ketoenol/training/dictionary.txt
@@ -314,3 +314,431 @@ CH4N2O-2
 7 *4 H u0 p0 c0 {3,S}
 8    H u0 p0 c0 {3,S}
 
+C2H3N3O
+1 *3 O u0 p2 c0 {5,S} {9,S}
+2    N u0 p1 c0 {4,S} {5,S} {7,S}
+3 *1 N u0 p1 c0 {5,D} {6,S}
+4    N u0 p1 c0 {2,S} {6,D}
+5 *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6    C u0 p0 c0 {3,S} {4,D} {8,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {1,S}
+
+C2H3N3O-2
+1 *3 O u0 p2 c0 {5,D}
+2 *1 N u0 p1 c0 {5,S} {6,S} {7,S}
+3    N u0 p1 c0 {4,S} {5,S} {8,S}
+4    N u0 p1 c0 {3,S} {6,D}
+5 *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+6    C u0 p0 c0 {2,S} {4,D} {9,S}
+7 *4 H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {6,S}
+
+C3H3NO2
+1    O u0 p2 c0 {3,S} {6,S}
+2 *3 O u0 p2 c0 {4,S} {9,S}
+3 *1 N u0 p1 c0 {1,S} {4,D}
+4 *2 C u0 p0 c0 {2,S} {3,D} {5,S}
+5    C u0 p0 c0 {4,S} {6,D} {7,S}
+6    C u0 p0 c0 {1,S} {5,D} {8,S}
+7    H u0 p0 c0 {5,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {2,S}
+
+C3H3NO2-2
+1    O u0 p2 c0 {3,S} {6,S}
+2 *3 O u0 p2 c0 {4,D}
+3 *1 N u0 p1 c0 {1,S} {4,S} {9,S}
+4 *2 C u0 p0 c0 {2,D} {3,S} {5,S}
+5    C u0 p0 c0 {4,S} {6,D} {7,S}
+6    C u0 p0 c0 {1,S} {5,D} {8,S}
+7    H u0 p0 c0 {5,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {3,S}
+
+C2H3N3O-3
+1 *3 O u0 p2 c0 {5,S} {9,S}
+2    N u0 p1 c0 {3,S} {6,S} {7,S}
+3 *1 N u0 p1 c0 {2,S} {5,D}
+4    N u0 p1 c0 {5,S} {6,D}
+5 *2 C u0 p0 c0 {1,S} {3,D} {4,S}
+6    C u0 p0 c0 {2,S} {4,D} {8,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {1,S}
+
+C2H3N3O-4
+1 *3 O u0 p2 c0 {5,D}
+2    N u0 p1 c0 {3,S} {6,S} {7,S}
+3 *1 N u0 p1 c0 {2,S} {5,S} {8,S}
+4    N u0 p1 c0 {5,S} {6,D}
+5 *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+6    C u0 p0 c0 {2,S} {4,D} {9,S}
+7    H u0 p0 c0 {2,S}
+8 *4 H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {6,S}
+
+C3H7NO
+1  *3 O u0 p2 c0 {2,S} {12,S}
+2  *2 N u0 p1 c0 {1,S} {5,D}
+3     C u0 p0 c0 {5,S} {9,S} {10,S} {11,S}
+4     C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  *1 C u0 p0 c0 {2,D} {3,S} {4,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C3H7NO-2
+1  *3 O u0 p2 c0 {2,D}
+2  *2 N u0 p1 c0 {1,D} {3,S}
+3  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5     C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+6  *4 H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+
+CHN3O2
+1    O u0 p2 c0 {3,S} {5,S}
+2 *3 O u0 p2 c0 {6,S} {7,S}
+3    N u0 p2 c-1 {1,S} {6,S}
+4 *1 N u0 p0 c+1 {5,D} {6,D}
+5    N u0 p1 c0 {1,S} {4,D}
+6 *2 C u0 p0 c0 {2,S} {3,S} {4,D}
+7 *4 H u0 p0 c0 {2,S}
+
+CHN3O2-2
+1    O u0 p2 c0 {4,S} {5,S}
+2 *3 O u0 p2 c0 {6,D}
+3 *1 N u0 p0 c+1 {5,D} {6,S} {7,S}
+4    N u0 p2 c-1 {1,S} {6,S}
+5    N u0 p1 c0 {1,S} {3,D}
+6 *2 C u0 p0 c0 {2,D} {3,S} {4,S}
+7 *4 H u0 p0 c0 {3,S}
+
+CH2N4O
+1 *3 O u0 p2 c0 {6,S} {8,S}
+2    N u0 p0 c+1 {3,S} {5,D} {7,S}
+3    N u0 p2 c-1 {2,S} {6,S}
+4 *1 N u0 p1 c0 {5,S} {6,D}
+5    N u0 p1 c0 {2,D} {4,S}
+6 *2 C u0 p0 c0 {1,S} {3,S} {4,D}
+7    H u0 p0 c0 {2,S}
+8 *4 H u0 p0 c0 {1,S}
+
+CH2N4O-2
+1 *3 O u0 p2 c0 {6,D}
+2 *1 N u0 p1 c0 {5,S} {6,S} {7,S}
+3    N u0 p0 c+1 {4,S} {5,D} {8,S}
+4    N u0 p2 c-1 {3,S} {6,S}
+5    N u0 p1 c0 {2,S} {3,D}
+6 *2 C u0 p0 c0 {1,D} {2,S} {4,S}
+7 *4 H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+
+CH2N4O-3
+1 *3 O u0 p2 c0 {6,S} {8,S}
+2    N u0 p1 c0 {3,S} {5,S} {7,S}
+3 *1 N u0 p1 c0 {2,S} {6,D}
+4    N u0 p1 c0 {5,D} {6,S}
+5    N u0 p1 c0 {2,S} {4,D}
+6 *2 C u0 p0 c0 {1,S} {3,D} {4,S}
+7    H u0 p0 c0 {2,S}
+8 *4 H u0 p0 c0 {1,S}
+
+CH2N4O-4
+1 *3 O u0 p2 c0 {6,D}
+2 *1 N u0 p1 c0 {3,S} {6,S} {7,S}
+3    N u0 p1 c0 {2,S} {5,S} {8,S}
+4    N u0 p1 c0 {5,D} {6,S}
+5    N u0 p1 c0 {3,S} {4,D}
+6 *2 C u0 p0 c0 {1,D} {2,S} {4,S}
+7 *4 H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {3,S}
+
+C3H4N2O
+1  *3 O u0 p2 c0 {4,S} {10,S}
+2     N u0 p1 c0 {4,S} {5,S} {8,S}
+3  *1 N u0 p1 c0 {4,D} {6,S}
+4  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+5     C u0 p0 c0 {2,S} {6,D} {7,S}
+6     C u0 p0 c0 {3,S} {5,D} {9,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {6,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C3H4N2O-2
+1  *3 O u0 p2 c0 {4,D}
+2     N u0 p1 c0 {4,S} {5,S} {8,S}
+3  *1 N u0 p1 c0 {4,S} {6,S} {10,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+5     C u0 p0 c0 {2,S} {6,D} {7,S}
+6     C u0 p0 c0 {3,S} {5,D} {9,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {6,S}
+10 *4 H u0 p0 c0 {3,S}
+
+C2H2N2O2
+1    O u0 p2 c0 {4,S} {6,S}
+2 *3 O u0 p2 c0 {5,S} {8,S}
+3    N u0 p1 c0 {5,S} {6,D}
+4 *1 N u0 p1 c0 {1,S} {5,D}
+5 *2 C u0 p0 c0 {2,S} {3,S} {4,D}
+6    C u0 p0 c0 {1,S} {3,D} {7,S}
+7    H u0 p0 c0 {6,S}
+8 *4 H u0 p0 c0 {2,S}
+
+C2H2N2O2-2
+1    O u0 p2 c0 {3,S} {6,S}
+2 *3 O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {1,S} {5,S} {7,S}
+4    N u0 p1 c0 {5,S} {6,D}
+5 *2 C u0 p0 c0 {2,D} {3,S} {4,S}
+6    C u0 p0 c0 {1,S} {4,D} {8,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {6,S}
+
+C2H2N2O2-3
+1    O u0 p2 c0 {4,S} {6,S}
+2 *3 O u0 p2 c0 {5,S} {8,S}
+3 *1 N u0 p0 c+1 {5,D} {6,D}
+4    N u0 p2 c-1 {1,S} {5,S}
+5 *2 C u0 p0 c0 {2,S} {3,D} {4,S}
+6    C u0 p0 c0 {1,S} {3,D} {7,S}
+7    H u0 p0 c0 {6,S}
+8 *4 H u0 p0 c0 {2,S}
+
+C2H2N2O2-4
+1    O u0 p2 c0 {4,S} {6,S}
+2 *3 O u0 p2 c0 {5,D}
+3 *1 N u0 p0 c+1 {5,S} {6,D} {7,S}
+4    N u0 p2 c-1 {1,S} {5,S}
+5 *2 C u0 p0 c0 {2,D} {3,S} {4,S}
+6    C u0 p0 c0 {1,S} {3,D} {8,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {6,S}
+
+C2H3N3O-5
+1 *3 O u0 p2 c0 {5,S} {9,S}
+2    N u0 p1 c0 {3,S} {4,S} {8,S}
+3 *1 N u0 p1 c0 {2,S} {5,D}
+4    N u0 p1 c0 {2,S} {6,D}
+5 *2 C u0 p0 c0 {1,S} {3,D} {6,S}
+6    C u0 p0 c0 {4,D} {5,S} {7,S}
+7    H u0 p0 c0 {6,S}
+8    H u0 p0 c0 {2,S}
+9 *4 H u0 p0 c0 {1,S}
+
+C2H3N3O-6
+1 *3 O u0 p2 c0 {5,D}
+2 *1 N u0 p1 c0 {3,S} {5,S} {7,S}
+3    N u0 p1 c0 {2,S} {4,S} {9,S}
+4    N u0 p1 c0 {3,S} {6,D}
+5 *2 C u0 p0 c0 {1,D} {2,S} {6,S}
+6    C u0 p0 c0 {4,D} {5,S} {8,S}
+7 *4 H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {6,S}
+9    H u0 p0 c0 {3,S}
+
+C3H4N2O-3
+1  *3 O u0 p2 c0 {4,S} {10,S}
+2     N u0 p1 c0 {3,S} {6,S} {9,S}
+3  *1 N u0 p1 c0 {2,S} {4,D}
+4  *2 C u0 p0 c0 {1,S} {3,D} {5,S}
+5     C u0 p0 c0 {4,S} {6,D} {8,S}
+6     C u0 p0 c0 {2,S} {5,D} {7,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {2,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C3H4N2O-4
+1  *3 O u0 p2 c0 {4,D}
+2     N u0 p1 c0 {3,S} {6,S} {9,S}
+3  *1 N u0 p1 c0 {2,S} {4,S} {10,S}
+4  *2 C u0 p0 c0 {1,D} {3,S} {5,S}
+5     C u0 p0 c0 {4,S} {6,D} {8,S}
+6     C u0 p0 c0 {2,S} {5,D} {7,S}
+7     H u0 p0 c0 {6,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {2,S}
+10 *4 H u0 p0 c0 {3,S}
+
+C3H3N3O
+1  *3 O u0 p2 c0 {5,S} {10,S}
+2  *1 N u0 p1 c0 {5,D} {7,S}
+3     N u0 p1 c0 {4,S} {6,D}
+4     N u0 p1 c0 {3,S} {7,D}
+5  *2 C u0 p0 c0 {1,S} {2,D} {6,S}
+6     C u0 p0 c0 {3,D} {5,S} {8,S}
+7     C u0 p0 c0 {2,S} {4,D} {9,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {7,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C3H3N3O-2
+1  *3 O u0 p2 c0 {5,D}
+2  *1 N u0 p1 c0 {5,S} {7,S} {8,S}
+3     N u0 p1 c0 {4,S} {6,D}
+4     N u0 p1 c0 {3,S} {7,D}
+5  *2 C u0 p0 c0 {1,D} {2,S} {6,S}
+6     C u0 p0 c0 {3,D} {5,S} {9,S}
+7     C u0 p0 c0 {2,S} {4,D} {10,S}
+8  *4 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {7,S}
+
+C4H6N2O
+1  *3 O u0 p2 c0 {7,S} {13,S}
+2     N u0 p1 c0 {3,S} {5,S} {12,S}
+3  *1 N u0 p1 c0 {2,S} {7,D}
+4     C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5     C u0 p0 c0 {2,S} {4,S} {6,D}
+6     C u0 p0 c0 {5,D} {7,S} {11,S}
+7  *2 C u0 p0 c0 {1,S} {3,D} {6,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {2,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H6N2O-2
+1  *3 O u0 p2 c0 {7,D}
+2     N u0 p1 c0 {3,S} {5,S} {12,S}
+3  *1 N u0 p1 c0 {2,S} {7,S} {13,S}
+4     C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5     C u0 p0 c0 {2,S} {4,S} {6,D}
+6     C u0 p0 c0 {5,D} {7,S} {11,S}
+7  *2 C u0 p0 c0 {1,D} {3,S} {6,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {2,S}
+13 *4 H u0 p0 c0 {3,S}
+
+C4H5NO2
+1     O u0 p2 c0 {6,S} {7,S}
+2  *3 O u0 p2 c0 {7,S} {12,S}
+3  *1 N u0 p1 c0 {5,S} {7,D}
+4     C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5     C u0 p0 c0 {3,S} {4,S} {6,D}
+6     C u0 p0 c0 {1,S} {5,D} {11,S}
+7  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12 *4 H u0 p0 c0 {2,S}
+
+C4H5NO2-2
+1     O u0 p2 c0 {6,S} {7,S}
+2  *3 O u0 p2 c0 {7,D}
+3  *1 N u0 p1 c0 {5,S} {7,S} {11,S}
+4     C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5     C u0 p0 c0 {3,S} {4,S} {6,D}
+6     C u0 p0 c0 {1,S} {5,D} {12,S}
+7  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11 *4 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+
+C4H6N2O-3
+1  *3 O u0 p2 c0 {7,S} {13,S}
+2     N u0 p1 c0 {6,S} {7,S} {12,S}
+3  *1 N u0 p1 c0 {5,S} {7,D}
+4     C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5     C u0 p0 c0 {3,S} {4,S} {6,D}
+6     C u0 p0 c0 {2,S} {5,D} {11,S}
+7  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {2,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H6N2O-4
+1  *3 O u0 p2 c0 {7,D}
+2  *1 N u0 p1 c0 {5,S} {7,S} {13,S}
+3     N u0 p1 c0 {6,S} {7,S} {12,S}
+4     C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5     C u0 p0 c0 {2,S} {4,S} {6,D}
+6     C u0 p0 c0 {3,S} {5,D} {11,S}
+7  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {3,S}
+13 *4 H u0 p0 c0 {2,S}
+
+C2H4N4O
+1  *3 O u0 p2 c0 {7,S} {11,S}
+2     N u0 p1 c0 {5,S} {7,S} {8,S}
+3     N u0 p1 c0 {6,S} {9,S} {10,S}
+4  *1 N u0 p1 c0 {6,S} {7,D}
+5     N u0 p1 c0 {2,S} {6,D}
+6     C u0 p0 c0 {3,S} {4,S} {5,D}
+7  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C2H4N4O-2
+1  *3 O u0 p2 c0 {7,D}
+2  *1 N u0 p1 c0 {6,S} {7,S} {8,S}
+3     N u0 p1 c0 {5,S} {7,S} {9,S}
+4     N u0 p1 c0 {6,S} {10,S} {11,S}
+5     N u0 p1 c0 {3,S} {6,D}
+6     C u0 p0 c0 {2,S} {4,S} {5,D}
+7  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+8  *4 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+
+C3H5N3O
+1  *3 O u0 p2 c0 {7,S} {12,S}
+2     N u0 p1 c0 {6,S} {7,S} {9,S}
+3     N u0 p1 c0 {5,S} {10,S} {11,S}
+4  *1 N u0 p1 c0 {5,S} {7,D}
+5     C u0 p0 c0 {3,S} {4,S} {6,D}
+6     C u0 p0 c0 {2,S} {5,D} {8,S}
+7  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C3H5N3O-2
+1  *3 O u0 p2 c0 {7,D}
+2  *1 N u0 p1 c0 {5,S} {7,S} {10,S}
+3     N u0 p1 c0 {6,S} {7,S} {9,S}
+4     N u0 p1 c0 {5,S} {11,S} {12,S}
+5     C u0 p0 c0 {2,S} {4,S} {6,D}
+6     C u0 p0 c0 {3,S} {5,D} {8,S}
+7  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {3,S}
+10 *4 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/Ketoenol/training/reactions.py
+++ b/input/kinetics/families/Ketoenol/training/reactions.py
@@ -238,3 +238,310 @@ All species include systematic conformer search and 1D rotor scans
 """,
 )
 
+entry(
+    index = 15,
+    label = "C2H3N3O <=> C2H3N3O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(8.50659e-18,'s^-1'), n=8.75863, Ea=(114.547,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 530.44, dn = +|- 0.832458, dEa = +|- 4.29259 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r000017 <=> p000017
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 16,
+    label = "C3H3NO2 <=> C3H3NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.95366e-14,'s^-1'), n=7.77475, Ea=(152.142,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 337.834, dn = +|- 0.772595, dEa = +|- 3.9839 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r000314 <=> p000314
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 17,
+    label = "C2H3N3O-3 <=> C2H3N3O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.52338e-22,'s^-1'), n=10.05, Ea=(150.418,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 865.769, dn = +|- 0.897465, dEa = +|- 4.6278 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r000399 <=> p000401
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 18,
+    label = "C3H7NO <=> C3H7NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.27692e-54,'s^-1'), n=19.1913, Ea=(180.189,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 21678.5, dn = +|- 1.32479, dEa = +|- 6.83129 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Training reaction from kinetics library: 20220318_ketoenol_tmp
+Original entry: r000842 <=> p000842
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 19,
+    label = "CHN3O2 <=> CHN3O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.02819e-14,'s^-1'), n=7.71417, Ea=(180.621,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 199.221, dn = +|- 0.702516, dEa = +|- 3.62254 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r002513 <=> p002513
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 20,
+    label = "CH2N4O <=> CH2N4O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.03103e-17,'s^-1'), n=8.43292, Ea=(153.029,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 354.367, dn = +|- 0.778935, dEa = +|- 4.01659 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r004006 <=> p004006
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 21,
+    label = "CH2N4O-3 <=> CH2N4O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.58562e-24,'s^-1'), n=10.6226, Ea=(173.215,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1192.35, dn = +|- 0.939933, dEa = +|- 4.84679 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r004006 <=> p004007
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 22,
+    label = "C3H4N2O <=> C3H4N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.02325e-17,'s^-1'), n=8.65259, Ea=(104.52,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 465.629, dn = +|- 0.815167, dEa = +|- 4.20342 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r004295 <=> p004295
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 23,
+    label = "C2H2N2O2 <=> C2H2N2O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.62343e-20,'s^-1'), n=9.5285, Ea=(156.362,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 787.027, dn = +|- 0.884812, dEa = +|- 4.56255 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r004717 <=> p004717
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 24,
+    label = "C2H2N2O2-3 <=> C2H2N2O2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.87223e-13,'s^-1'), n=7.30388, Ea=(159.322,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 138.752, dn = +|- 0.654518, dEa = +|- 3.37504 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r004717 <=> p004719
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 25,
+    label = "C2H3N3O-5 <=> C2H3N3O-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.18952e-19,'s^-1'), n=9.32392, Ea=(161.52,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 641.618, dn = +|- 0.857707, dEa = +|- 4.42279 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r005102 <=> p005102
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 26,
+    label = "C3H4N2O-3 <=> C3H4N2O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.23784e-18,'s^-1'), n=8.74837, Ea=(143.184,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 474.17, dn = +|- 0.817578, dEa = +|- 4.21586 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r005546 <=> p005546
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 27,
+    label = "C3H3N3O <=> C3H3N3O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.03729e-10,'s^-1'), n=6.68631, Ea=(102.806,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 132.44, dn = +|- 0.64834, dEa = +|- 3.34318 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r007945 <=> p007945
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 28,
+    label = "C4H6N2O <=> C4H6N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.57404e-19,'s^-1'), n=9.1193, Ea=(135.561,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 579.205, dn = +|- 0.844128, dEa = +|- 4.35277 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r008828 <=> p008828
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 29,
+    label = "C4H5NO2 <=> C4H5NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.23245e-20,'s^-1'), n=9.38178, Ea=(107.208,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 667.354, dn = +|- 0.862926, dEa = +|- 4.4497 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r009513 <=> p009513
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 30,
+    label = "C4H6N2O-3 <=> C4H6N2O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.14825e-17,'s^-1'), n=8.45574, Ea=(104.82,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 419.583, dn = +|- 0.80135, dEa = +|- 4.13218 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r010419 <=> p010419
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 31,
+    label = "C2H4N4O <=> C2H4N4O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.00746e-18,'s^-1'), n=8.75254, Ea=(115.264,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 546.354, dn = +|- 0.836381, dEa = +|- 4.31281 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r011443 <=> p011443
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 32,
+    label = "C3H5N3O <=> C3H5N3O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.10787e-17,'s^-1'), n=8.57309, Ea=(108.743,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 474.691, dn = +|- 0.817724, dEa = +|- 4.21661 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: r011937 <=> p011937
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+

--- a/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
+++ b/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
@@ -50,6 +50,174 @@ These values are similar to those from other published works:
 """
 entry(
     index = 0,
+    label = "p000017",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,D}
+2 N u0 p1 c0 {5,S} {6,S} {7,S}
+3 N u0 p1 c0 {4,S} {5,S} {9,S}
+4 N u0 p1 c0 {3,S} {6,D}
+5 C u0 p0 c0 {1,D} {2,S} {3,S}
+6 C u0 p0 c0 {2,S} {4,D} {8,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {6,S}
+9 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.08315,-0.00834958,0.00015685,-2.81708e-07,1.60589e-10,-3863.8,9.73083], Tmin=(10,'K'), Tmax=(568.266,'K')),
+            NASAPolynomial(coeffs=[1.5925,0.0344212,-2.26705e-05,7.0561e-09,-8.33299e-13,-3988.25,16.7535], Tmin=(568.266,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-32.1451,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (207.862,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 1,
+    label = "p000314",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {6,S}
+2 O u0 p2 c0 {4,D}
+3 N u0 p1 c0 {1,S} {4,S} {8,S}
+4 C u0 p0 c0 {2,D} {3,S} {5,S}
+5 C u0 p0 c0 {4,S} {6,D} {7,S}
+6 C u0 p0 c0 {1,S} {5,D} {9,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {3,S}
+9 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.10247,-0.0101348,0.000168818,-3.04704e-07,1.75036e-10,-11128.5,9.78109], Tmin=(10,'K'), Tmax=(564.253,'K')),
+            NASAPolynomial(coeffs=[1.54673,0.0350531,-2.32712e-05,7.27411e-09,-8.61354e-13,-11271,16.8299], Tmin=(564.253,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-92.548,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (207.862,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 2,
+    label = "p000399",
+    molecule = 
+"""
+1 O u0 p3 c-1 {6,S}
+2 N u0 p0 c+1 {5,D} {6,S} {8,S}
+3 N u0 p1 c0 {4,S} {5,S} {9,S}
+4 N u0 p1 c0 {3,S} {6,D}
+5 C u0 p0 c0 {2,D} {3,S} {7,S}
+6 C u0 p0 c0 {1,S} {2,S} {4,D}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {2,S}
+9 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.13164,-0.0124889,0.000177785,-3.16891e-07,1.80337e-10,5043.18,9.73761], Tmin=(10,'K'), Tmax=(570.396,'K')),
+            NASAPolynomial(coeffs=[1.51597,0.0348951,-2.31945e-05,7.2699e-09,-8.62857e-13,4869.14,16.747], Tmin=(570.396,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (41.9129,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (207.862,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 3,
+    label = "p000401",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,D}
+2 N u0 p1 c0 {3,S} {5,S} {7,S}
+3 N u0 p1 c0 {2,S} {6,S} {8,S}
+4 N u0 p1 c0 {5,S} {6,D}
+5 C u0 p0 c0 {1,D} {2,S} {4,S}
+6 C u0 p0 c0 {3,S} {4,D} {9,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {3,S}
+9 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.1036,-0.00984831,0.000159384,-2.79814e-07,1.56573e-10,4040.08,9.73985], Tmin=(10,'K'), Tmax=(576.554,'K')),
+            NASAPolynomial(coeffs=[1.29232,0.0349484,-2.29648e-05,7.12335e-09,-8.38528e-13,3943.87,18.1088], Tmin=(576.554,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (33.5744,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (207.862,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 4,
+    label = "p000842",
+    molecule = 
+"""
+1  O u0 p2 c0 {2,D}
+2  N u0 p1 c0 {1,D} {3,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4  C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {5,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93846,0.00746404,0.000362497,-2.43626e-06,5.88578e-09,-1497.43,9.00632], Tmin=(10,'K'), Tmax=(103.642,'K')),
+            NASAPolynomial(coeffs=[3.25927,0.0336765,-1.68703e-05,3.96667e-09,-3.52153e-13,-1483.36,10.7434], Tmin=(103.642,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-9.71827,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 5,
     label = "p001085",
     molecule = 
 """
@@ -83,7 +251,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 1,
+    index = 6,
     label = "p001088",
     molecule = 
 """
@@ -117,7 +285,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 2,
+    index = 7,
     label = "p001089",
     molecule = 
 """
@@ -151,7 +319,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 3,
+    index = 8,
     label = "p001235",
     molecule = 
 """
@@ -183,7 +351,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 4,
+    index = 9,
     label = "p001958",
     molecule = 
 """
@@ -215,7 +383,38 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 5,
+    index = 10,
+    label = "p002513",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u0 p2 c0 {6,D}
+3 N u0 p0 c+1 {5,D} {6,S} {7,S}
+4 N u0 p2 c-1 {1,S} {6,S}
+5 N u0 p1 c0 {1,S} {3,D}
+6 C u0 p0 c0 {2,D} {3,S} {4,S}
+7 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.09657,-0.00907939,0.000135813,-2.38726e-07,1.32296e-10,19122.4,9.71784], Tmin=(10,'K'), Tmax=(593.188,'K')),
+            NASAPolynomial(coeffs=[2.40613,0.0272365,-1.9027e-05,6.10616e-09,-7.33056e-13,18884.5,13.2953], Tmin=(593.188,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (158.977,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (157.975,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 11,
     label = "p002774",
     molecule = 
 """
@@ -246,7 +445,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 6,
+    index = 12,
     label = "p003183",
     molecule = 
 """
@@ -278,7 +477,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 7,
+    index = 13,
     label = "p003454",
     molecule = 
 """
@@ -314,7 +513,71 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 8,
+    index = 14,
+    label = "p004006",
+    molecule = 
+"""
+1 O u0 p3 c-1 {6,S}
+2 N u0 p0 c+1 {5,D} {6,S} {7,S}
+3 N u0 p1 c0 {4,S} {5,S} {8,S}
+4 N u0 p1 c0 {3,S} {6,D}
+5 N u0 p1 c0 {2,D} {3,S}
+6 C u0 p0 c0 {1,S} {2,S} {4,D}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.10691,-0.00968671,0.000141912,-2.42133e-07,1.31199e-10,21199.9,9.69375], Tmin=(10,'K'), Tmax=(598.956,'K')),
+            NASAPolynomial(coeffs=[1.63057,0.0310738,-2.083e-05,6.52701e-09,-7.71966e-13,21062,16.7443], Tmin=(598.956,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (176.254,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (182.918,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 15,
+    label = "p004007",
+    molecule = 
+"""
+1 O u0 p2 c0 {6,D}
+2 N u0 p1 c0 {3,S} {6,S} {7,S}
+3 N u0 p1 c0 {2,S} {4,S} {8,S}
+4 N u0 p1 c0 {3,S} {5,D}
+5 N u0 p1 c0 {4,D} {6,S}
+6 C u0 p0 c0 {1,D} {2,S} {5,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.08633,-0.00876052,0.000151467,-2.77042e-07,1.60533e-10,24999.5,9.7236], Tmin=(10,'K'), Tmax=(563.232,'K')),
+            NASAPolynomial(coeffs=[2.12198,0.0305244,-2.06272e-05,6.51774e-09,-7.77103e-13,24819,14.5055], Tmin=(563.232,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (207.838,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (182.918,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 16,
     label = "p004142",
     molecule = 
 """
@@ -347,7 +610,105 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 9,
+    index = 17,
+    label = "p004295",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  N u0 p1 c0 {4,S} {5,S} {7,S}
+3  N u0 p1 c0 {4,S} {6,S} {10,S}
+4  C u0 p0 c0 {1,D} {2,S} {3,S}
+5  C u0 p0 c0 {2,S} {6,D} {8,S}
+6  C u0 p0 c0 {3,S} {5,D} {9,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {6,S}
+10 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94212,0.00327142,0.000103808,-1.79634e-07,9.58448e-11,-12872.5,8.41273], Tmin=(10,'K'), Tmax=(582.737,'K')),
+            NASAPolynomial(coeffs=[0.0763484,0.0423709,-2.91775e-05,9.50459e-09,-1.17035e-12,-12635.3,23.1448], Tmin=(582.737,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-107.054,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (232.805,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 18,
+    label = "p004717",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {6,S}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {1,S} {5,S} {7,S}
+4 N u0 p1 c0 {5,S} {6,D}
+5 C u0 p0 c0 {2,D} {3,S} {4,S}
+6 C u0 p0 c0 {1,S} {4,D} {8,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.08042,-0.00779049,0.000138331,-2.43168e-07,1.3531e-10,-10427.9,9.73178], Tmin=(10,'K'), Tmax=(583.22,'K')),
+            NASAPolynomial(coeffs=[1.78109,0.0310328,-2.08113e-05,6.51853e-09,-7.71045e-13,-10551.8,16.2237], Tmin=(583.22,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-86.7186,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (182.918,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 19,
+    label = "p004719",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {6,S}
+2 O u0 p3 c-1 {5,S}
+3 N u0 p0 c+1 {5,S} {6,D} {7,S}
+4 N u0 p1 c0 {1,S} {5,D}
+5 C u0 p0 c0 {2,S} {3,S} {4,D}
+6 C u0 p0 c0 {1,S} {3,D} {8,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.11098,-0.0107656,0.000160722,-2.8983e-07,1.65966e-10,-5405.64,9.752], Tmin=(10,'K'), Tmax=(570.433,'K')),
+            NASAPolynomial(coeffs=[2.04089,0.0310762,-2.11601e-05,6.71421e-09,-8.02345e-13,-5614.05,14.68], Tmin=(570.433,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-44.964,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (182.918,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 20,
     label = "p004749",
     molecule = 
 """
@@ -382,7 +743,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 10,
+    index = 21,
     label = "p005032",
     molecule = 
 """
@@ -414,7 +775,40 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 11,
+    index = 22,
+    label = "p005102",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,D}
+2 N u0 p1 c0 {3,S} {5,S} {7,S}
+3 N u0 p1 c0 {2,S} {4,S} {8,S}
+4 N u0 p1 c0 {3,S} {6,D}
+5 C u0 p0 c0 {1,D} {2,S} {6,S}
+6 C u0 p0 c0 {4,D} {5,S} {9,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {3,S}
+9 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.10625,-0.010297,0.000165783,-2.95888e-07,1.68331e-10,14198.6,9.76357], Tmin=(10,'K'), Tmax=(568.519,'K')),
+            NASAPolynomial(coeffs=[1.43938,0.0348626,-2.30121e-05,7.16751e-09,-8.46661e-13,14075.2,17.372], Tmin=(568.519,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (118.035,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (207.862,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 23,
     label = "p005432",
     molecule = 
 """
@@ -448,7 +842,41 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 12,
+    index = 24,
+    label = "p005546",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  N u0 p1 c0 {3,S} {4,S} {7,S}
+3  N u0 p1 c0 {2,S} {5,S} {8,S}
+4  C u0 p0 c0 {1,D} {2,S} {6,S}
+5  C u0 p0 c0 {3,S} {6,D} {9,S}
+6  C u0 p0 c0 {4,S} {5,D} {10,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.13036,-0.0123963,0.000187244,-3.31879e-07,1.88303e-10,2393.39,9.79119], Tmin=(10,'K'), Tmax=(567.709,'K')),
+            NASAPolynomial(coeffs=[0.931998,0.0391285,-2.54905e-05,7.8851e-09,-9.27888e-13,2289.38,19.2963], Tmin=(567.709,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (19.8809,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (232.805,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 25,
     label = "p005588",
     molecule = 
 """
@@ -481,7 +909,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 13,
+    index = 26,
     label = "p005763",
     molecule = 
 """
@@ -513,7 +941,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 14,
+    index = 27,
     label = "p005826",
     molecule = 
 """
@@ -545,7 +973,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 15,
+    index = 28,
     label = "p007269",
     molecule = 
 """
@@ -579,7 +1007,186 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 16,
+    index = 29,
+    label = "p007945",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {5,S} {7,S} {8,S}
+3  N u0 p1 c0 {4,S} {6,D}
+4  N u0 p1 c0 {3,S} {7,D}
+5  C u0 p0 c0 {1,D} {2,S} {6,S}
+6  C u0 p0 c0 {3,D} {5,S} {9,S}
+7  C u0 p0 c0 {2,S} {4,D} {10,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {6,S}
+10 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94087,0.00338192,0.000109386,-1.91888e-07,1.03994e-10,12268.1,10.164], Tmin=(10,'K'), Tmax=(570.3,'K')),
+            NASAPolynomial(coeffs=[-0.0951325,0.0441247,-3.04821e-05,9.8469e-09,-1.19947e-12,12526.3,25.5959], Tmin=(570.3,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (101.976,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (232.805,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 30,
+    label = "p008828",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,D}
+2  N u0 p1 c0 {3,S} {5,S} {13,S}
+3  N u0 p1 c0 {2,S} {7,S} {12,S}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {4,S} {6,D}
+6  C u0 p0 c0 {5,D} {7,S} {11,S}
+7  C u0 p0 c0 {1,D} {3,S} {6,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.9144,0.0053403,0.000153976,-3.05374e-07,1.89912e-10,-3569.97,11.3176], Tmin=(10,'K'), Tmax=(500.057,'K')),
+            NASAPolynomial(coeffs=[0.338625,0.0506842,-3.22579e-05,9.85772e-09,-1.15629e-12,-3421.66,23.9977], Tmin=(500.057,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-29.7079,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (303.478,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 31,
+    label = "p009513",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {7,S}
+2  O u0 p2 c0 {7,D}
+3  N u0 p1 c0 {5,S} {7,S} {11,S}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  C u0 p0 c0 {1,S} {2,D} {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.87221,0.0095011,0.000138178,-3.05118e-07,2.07869e-10,-36800.1,10.6838], Tmin=(10,'K'), Tmax=(464.216,'K')),
+            NASAPolynomial(coeffs=[1.56818,0.0452889,-2.89505e-05,8.8418e-09,-1.03376e-12,-36757.9,18.182], Tmin=(464.216,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-305.991,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (278.535,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 32,
+    label = "p010419",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,D}
+2  N u0 p1 c0 {5,S} {7,S} {13,S}
+3  N u0 p1 c0 {6,S} {7,S} {12,S}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {4,S} {6,D}
+6  C u0 p0 c0 {3,S} {5,D} {11,S}
+7  C u0 p0 c0 {1,D} {2,S} {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.8763,0.00907103,0.000167954,-3.96278e-07,2.93654e-10,-18030.6,10.6775], Tmin=(10,'K'), Tmax=(421.203,'K')),
+            NASAPolynomial(coeffs=[1.39064,0.0488014,-3.09602e-05,9.44747e-09,-1.10672e-12,-17964.3,18.8222], Tmin=(421.203,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-149.919,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (303.478,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 33,
+    label = "p011443",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,D}
+2  N u0 p1 c0 {6,S} {7,S} {8,S}
+3  N u0 p1 c0 {5,S} {7,S} {9,S}
+4  N u0 p1 c0 {6,S} {10,S} {11,S}
+5  N u0 p1 c0 {3,S} {6,D}
+6  C u0 p0 c0 {2,S} {4,S} {5,D}
+7  C u0 p0 c0 {1,D} {2,S} {3,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85954,0.00890907,0.000147401,-3.30894e-07,2.2109e-10,-5241.36,11.1283], Tmin=(10,'K'), Tmax=(507.172,'K')),
+            NASAPolynomial(coeffs=[3.70601,0.0387889,-2.5762e-05,8.18029e-09,-9.89393e-13,-5594.5,8.12972], Tmin=(507.172,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-43.6181,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (253.591,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 34,
     label = "p011506",
     molecule = 
 """
@@ -614,7 +1221,178 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 17,
+    index = 35,
+    label = "p011937",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,D}
+2  N u0 p1 c0 {5,S} {7,S} {10,S}
+3  N u0 p1 c0 {6,S} {7,S} {9,S}
+4  N u0 p1 c0 {5,S} {11,S} {12,S}
+5  C u0 p0 c0 {2,S} {4,S} {6,D}
+6  C u0 p0 c0 {3,S} {5,D} {8,S}
+7  C u0 p0 c0 {1,D} {2,S} {3,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85694,0.00927896,0.000160381,-3.65786e-07,2.51062e-10,-11389.5,11.5195], Tmin=(10,'K'), Tmax=(488.227,'K')),
+            NASAPolynomial(coeffs=[3.26256,0.0422679,-2.73641e-05,8.54373e-09,-1.02191e-12,-11666.6,10.5288], Tmin=(488.227,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-94.7307,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (278.535,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 36,
+    label = "r000017",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,S} {9,S}
+2 N u0 p1 c0 {4,S} {5,S} {7,S}
+3 N u0 p1 c0 {5,D} {6,S}
+4 N u0 p1 c0 {2,S} {6,D}
+5 C u0 p0 c0 {1,S} {2,S} {3,D}
+6 C u0 p0 c0 {3,S} {4,D} {8,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {6,S}
+9 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.0803,-0.00732929,0.000143859,-2.38332e-07,1.23504e-10,-1052.96,9.63266], Tmin=(10,'K'), Tmax=(629.654,'K')),
+            NASAPolynomial(coeffs=[1.2622,0.0371665,-2.54934e-05,8.0517e-09,-9.53182e-13,-1225.24,17.7386], Tmin=(629.654,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-8.76833,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 37,
+    label = "r000314",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {6,S}
+2 O u0 p2 c0 {4,S} {9,S}
+3 N u0 p1 c0 {1,S} {4,D}
+4 C u0 p0 c0 {2,S} {3,D} {5,S}
+5 C u0 p0 c0 {4,S} {6,D} {7,S}
+6 C u0 p0 c0 {1,S} {5,D} {8,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {6,S}
+9 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.14314,-0.012772,0.000180682,-3.07049e-07,1.63711e-10,-13839.9,9.74514], Tmin=(10,'K'), Tmax=(620.774,'K')),
+            NASAPolynomial(coeffs=[2.06582,0.0366733,-2.59275e-05,8.40936e-09,-1.01588e-12,-14276.8,13.1803], Tmin=(620.774,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-115.088,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 38,
+    label = "r000399",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,S} {9,S}
+2 N u0 p1 c0 {3,S} {6,S} {7,S}
+3 N u0 p1 c0 {2,S} {5,D}
+4 N u0 p1 c0 {5,S} {6,D}
+5 C u0 p0 c0 {1,S} {3,D} {4,S}
+6 C u0 p0 c0 {2,S} {4,D} {8,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {6,S}
+9 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94235,0.00320109,9.25409e-05,-1.59438e-07,8.37365e-11,-701.018,9.51065], Tmin=(10,'K'), Tmax=(601.582,'K')),
+            NASAPolynomial(coeffs=[0.616382,0.0382592,-2.71471e-05,8.96348e-09,-1.10926e-12,-535.058,21.9197], Tmin=(601.582,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-5.85576,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 39,
+    label = "r000842",
+    molecule = 
+"""
+1  O u0 p2 c0 {2,S} {12,S}
+2  N u0 p1 c0 {1,S} {5,D}
+3  C u0 p0 c0 {5,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {2,D} {3,S} {4,S}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.78182,0.0200174,3.34314e-05,-5.56058e-08,2.29537e-11,-9877.45,10.0198], Tmin=(10,'K'), Tmax=(836.558,'K')),
+            NASAPolynomial(coeffs=[2.29376,0.0391789,-2.25263e-05,6.20113e-09,-6.61012e-13,-10050,14.4139], Tmin=(836.558,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-82.1344,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 40,
     label = "r001085",
     molecule = 
 """
@@ -648,7 +1426,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 18,
+    index = 41,
     label = "r001235",
     molecule = 
 """
@@ -680,7 +1458,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 19,
+    index = 42,
     label = "r001958",
     molecule = 
 """
@@ -712,7 +1490,38 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 20,
+    index = 43,
+    label = "r002513",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {6,S} {7,S}
+3 N u0 p1 c0 {1,S} {6,D}
+4 N u0 p1 c0 {5,D} {6,S}
+5 N u0 p1 c0 {1,S} {4,D}
+6 C u0 p0 c0 {2,S} {3,D} {4,S}
+7 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94217,0.00316915,7.51695e-05,-1.32801e-07,6.98018e-11,9290.77,9.79178], Tmin=(10,'K'), Tmax=(624.801,'K')),
+            NASAPolynomial(coeffs=[2.05328,0.0294963,-2.2209e-05,7.56521e-09,-9.52665e-13,9248.97,15.7928], Tmin=(624.801,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (77.2205,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (153.818,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 44,
     label = "r002774",
     molecule = 
 """
@@ -743,7 +1552,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 21,
+    index = 45,
     label = "r003183",
     molecule = 
 """
@@ -775,7 +1584,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 22,
+    index = 46,
     label = "r003454",
     molecule = 
 """
@@ -811,7 +1620,39 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 23,
+    index = 47,
+    label = "r004006",
+    molecule = 
+"""
+1 O u0 p2 c0 {6,S} {8,S}
+2 N u0 p1 c0 {3,S} {5,S} {7,S}
+3 N u0 p1 c0 {2,S} {6,D}
+4 N u0 p1 c0 {5,D} {6,S}
+5 N u0 p1 c0 {2,S} {4,D}
+6 C u0 p0 c0 {1,S} {3,D} {4,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93535,0.00361396,8.57411e-05,-1.54366e-07,8.34006e-11,17018.1,9.28743], Tmin=(10,'K'), Tmax=(605.304,'K')),
+            NASAPolynomial(coeffs=[1.96967,0.0320645,-2.30753e-05,7.6792e-09,-9.54767e-13,16972.8,15.4443], Tmin=(605.304,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (141.467,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 48,
     label = "r004142",
     molecule = 
 """
@@ -844,7 +1685,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 24,
+    index = 49,
     label = "r004202",
     molecule = 
 """
@@ -875,7 +1716,73 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 25,
+    index = 50,
+    label = "r004295",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {10,S}
+2  N u0 p1 c0 {4,S} {5,S} {8,S}
+3  N u0 p1 c0 {4,D} {6,S}
+4  C u0 p0 c0 {1,S} {2,S} {3,D}
+5  C u0 p0 c0 {2,S} {6,D} {7,S}
+6  C u0 p0 c0 {3,S} {5,D} {9,S}
+7  H u0 p0 c0 {5,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {6,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.10371,-0.00995022,0.000179042,-3.1189e-07,1.71401e-10,-8788.3,9.67848], Tmin=(10,'K'), Tmax=(592.645,'K')),
+            NASAPolynomial(coeffs=[1.1941,0.0406697,-2.7494e-05,8.65291e-09,-1.02607e-12,-8987.51,17.6032], Tmin=(592.645,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-73.0911,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 51,
+    label = "r004717",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {6,S}
+2 O u0 p2 c0 {5,S} {8,S}
+3 N u0 p1 c0 {5,S} {6,D}
+4 N u0 p1 c0 {1,S} {5,D}
+5 C u0 p0 c0 {2,S} {3,S} {4,D}
+6 C u0 p0 c0 {1,S} {3,D} {7,S}
+7 H u0 p0 c0 {6,S}
+8 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.05867,-0.00575043,0.000127057,-2.17279e-07,1.15784e-10,-13240,10.1523], Tmin=(10,'K'), Tmax=(616.588,'K')),
+            NASAPolynomial(coeffs=[2.07328,0.0312434,-2.16031e-05,6.88285e-09,-8.20981e-13,-13453.5,15.0535], Tmin=(616.588,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-110.1,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 52,
     label = "r004749",
     molecule = 
 """
@@ -910,7 +1817,40 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 26,
+    index = 53,
+    label = "r005102",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,S} {9,S}
+2 N u0 p1 c0 {3,S} {4,S} {8,S}
+3 N u0 p1 c0 {2,S} {5,D}
+4 N u0 p1 c0 {2,S} {6,D}
+5 C u0 p0 c0 {1,S} {3,D} {6,S}
+6 C u0 p0 c0 {4,D} {5,S} {7,S}
+7 H u0 p0 c0 {6,S}
+8 H u0 p0 c0 {2,S}
+9 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.92648,0.00402319,9.66004e-05,-1.69272e-07,8.86746e-11,8097.7,8.94156], Tmin=(10,'K'), Tmax=(626.05,'K')),
+            NASAPolynomial(coeffs=[1.50069,0.0376978,-2.76315e-05,9.39358e-09,-1.19e-12,8045.25,16.6638], Tmin=(626.05,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (67.2932,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 54,
     label = "r005432",
     molecule = 
 """
@@ -944,7 +1884,41 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 27,
+    index = 55,
+    label = "r005546",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {10,S}
+2  N u0 p1 c0 {3,S} {6,S} {9,S}
+3  N u0 p1 c0 {2,S} {4,D}
+4  C u0 p0 c0 {1,S} {3,D} {5,S}
+5  C u0 p0 c0 {4,S} {6,D} {8,S}
+6  C u0 p0 c0 {2,S} {5,D} {7,S}
+7  H u0 p0 c0 {6,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.1478,-0.0144462,0.00021733,-3.96703e-07,2.28328e-10,-1593.28,9.76824], Tmin=(10,'K'), Tmax=(575.688,'K')),
+            NASAPolynomial(coeffs=[2.40645,0.0383892,-2.6478e-05,8.55121e-09,-1.03673e-12,-2067.81,11.3449], Tmin=(575.688,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-13.276,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 56,
     label = "r005588",
     molecule = 
 """
@@ -977,7 +1951,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 28,
+    index = 57,
     label = "r005763",
     molecule = 
 """
@@ -1009,7 +1983,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 29,
+    index = 58,
     label = "r005826",
     molecule = 
 """
@@ -1041,7 +2015,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 30,
+    index = 59,
     label = "r007269",
     molecule = 
 """
@@ -1075,7 +2049,186 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 31,
+    index = 60,
+    label = "r007945",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {10,S}
+2  N u0 p1 c0 {5,D} {7,S}
+3  N u0 p1 c0 {4,S} {6,D}
+4  N u0 p1 c0 {3,S} {7,D}
+5  C u0 p0 c0 {1,S} {2,D} {6,S}
+6  C u0 p0 c0 {3,D} {5,S} {8,S}
+7  C u0 p0 c0 {2,S} {4,D} {9,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {7,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.05946,-0.00587327,0.000156843,-2.60839e-07,1.35022e-10,12448.8,10.4065], Tmin=(10,'K'), Tmax=(627.735,'K')),
+            NASAPolynomial(coeffs=[0.5839,0.0444161,-3.05737e-05,9.62021e-09,-1.13378e-12,12330.7,21.1391], Tmin=(627.735,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (103.487,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 61,
+    label = "r008828",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {13,S}
+2  N u0 p1 c0 {3,S} {5,S} {12,S}
+3  N u0 p1 c0 {2,S} {7,D}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {4,S} {6,D}
+6  C u0 p0 c0 {5,D} {7,S} {11,S}
+7  C u0 p0 c0 {1,S} {3,D} {6,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88411,0.0066883,0.000151633,-2.84874e-07,1.61745e-10,-6689.67,11.4162], Tmin=(10,'K'), Tmax=(577.29,'K')),
+            NASAPolynomial(coeffs=[1.24109,0.0518102,-3.52678e-05,1.14056e-08,-1.39788e-12,-6831.23,18.846], Tmin=(577.29,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-55.671,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 62,
+    label = "r009513",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {7,S}
+2  O u0 p2 c0 {7,S} {12,S}
+3  N u0 p1 c0 {5,S} {7,D}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {1,S} {5,D} {11,S}
+7  C u0 p0 c0 {1,S} {2,S} {3,D}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.87493,0.00750804,0.000149483,-3.02275e-07,1.83747e-10,-32247.6,10.7883], Tmin=(10,'K'), Tmax=(546.719,'K')),
+            NASAPolynomial(coeffs=[2.44098,0.0455985,-3.07462e-05,9.8305e-09,-1.19268e-12,-32503.3,13.0682], Tmin=(546.719,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-268.168,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 63,
+    label = "r010419",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {13,S}
+2  N u0 p1 c0 {6,S} {7,S} {12,S}
+3  N u0 p1 c0 {5,S} {7,D}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {2,S} {5,D} {11,S}
+7  C u0 p0 c0 {1,S} {2,S} {3,D}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.89746,0.00662895,0.00016815,-3.54398e-07,2.32905e-10,-13964.6,10.9654], Tmin=(10,'K'), Tmax=(477.67,'K')),
+            NASAPolynomial(coeffs=[0.681258,0.0523493,-3.44211e-05,1.06664e-08,-1.25531e-12,-13871.7,21.8618], Tmin=(477.67,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-116.132,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 64,
+    label = "r011443",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {11,S}
+2  N u0 p1 c0 {5,S} {7,S} {8,S}
+3  N u0 p1 c0 {6,S} {9,S} {10,S}
+4  N u0 p1 c0 {6,S} {7,D}
+5  N u0 p1 c0 {2,S} {6,D}
+6  C u0 p0 c0 {3,S} {4,S} {5,D}
+7  C u0 p0 c0 {1,S} {2,S} {4,D}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88601,0.0066499,0.000138399,-2.68846e-07,1.56178e-10,-2924.99,11.4773], Tmin=(10,'K'), Tmax=(570.545,'K')),
+            NASAPolynomial(coeffs=[2.05084,0.0455458,-3.22948e-05,1.05687e-08,-1.29351e-12,-3139.24,15.5883], Tmin=(570.545,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-24.3672,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 65,
     label = "r011506",
     molecule = 
 """
@@ -1101,6 +2254,42 @@ entry(
         E0 = (88.8977,'kJ/mol'),
         Cp0 = (33.2579,'J/(mol*K)'),
         CpInf = (257.749,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 66,
+    label = "r011937",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {12,S}
+2  N u0 p1 c0 {6,S} {7,S} {9,S}
+3  N u0 p1 c0 {5,S} {10,S} {11,S}
+4  N u0 p1 c0 {5,S} {7,D}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {2,S} {5,D} {8,S}
+7  C u0 p0 c0 {1,S} {2,S} {4,D}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85666,0.00880064,0.00015955,-3.37865e-07,2.13526e-10,-8362.51,11.2149], Tmin=(10,'K'), Tmax=(530.936,'K')),
+            NASAPolynomial(coeffs=[2.96574,0.0459772,-3.15492e-05,1.01596e-08,-1.23353e-12,-8697.3,10.9054], Tmin=(530.936,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-69.5783,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
     ),
     shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
     longDesc = 


### PR DESCRIPTION
This PR adds 18 training reactions to the ketoenol family and refits the rate tree. All species are calculated at `CCSD(T)-F12a/cc-pVDZ-F12//ωB97X-D3/def2-TZVP`. A thorough conformer search was done with ACS on the reactant, TS, and product. 1D rotor scans were also done on the reactant, TS, and product. All scans start and end in the same place and have the lowest energy well at 0 degrees, which makes sense since a conformer search was done for each species. The notebook below has `assert glog.success` which was True for all species. 
[visualize_scans.ipynb.zip](https://github.com/ReactionMechanismGenerator/RMG-database/files/8307710/visualize_scans.ipynb.zip)
