### PR TITLE
Retroene rotor scans

### DIFF
--- a/input/kinetics/families/Ketoenol/groups.py
+++ b/input/kinetics/families/Ketoenol/groups.py
@@ -51,7 +51,1079 @@ entry(
 
 entry(
     index = 1,
-    label = "Root_1R!H-inRing",
+    label = "Root_3R!H->C",
+    group = 
+"""
+1 *2 R!H u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 {1,D}
+4 *4 H   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 2,
+    label = "Root_3R!H->C_3C-inRing",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D}
+4 *4 H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 3,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r1 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 4,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D}
+4 *4 H u0 {2,S}
+5    C ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 5,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {6,S}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S}
+6    N u0 r1 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 6,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 C                      u0 r1 {1,D} {6,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    C                      ux {1,[S,D,T,B,Q]}
+6    [Si,S,P,C,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 7,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {6,[S,D,T,B,Q]}
+4 *4 H u0 r0 {2,S}
+5    C ux {1,[S,D,T,B,Q]}
+6    O ux r1 {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 8,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {6,[S,D,T,B,Q]}
+4 *4 H u0 r0 {2,S}
+5    C ux {1,[S,D,T,B,Q]}
+6    C ux r1 {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 9,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 C                      u0 r1 {1,D}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 10,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    O u0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 11,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r1 {1,D} {5,S}
+4 *4 H   u0 r0 {2,S}
+5    O   u0 r1 {3,S} {6,S}
+6    C   u0 r1 {5,S} {7,[S,D,T,B,Q]}
+7    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 12,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 C                      u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,C,F,I,Br,Cl] ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 13,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 C                      u0 r1 {1,D} {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+4 *4 H                      u0 {2,S}
+5    [Si,S,N,P,C,F,I,Br,Cl] ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H                    ux {5,[S,D,T,B,Q]}
+7    R!H                    ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 14,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {5,S} {7,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    N u0 {3,S} {6,S}
+6    C u0 {5,S}
+7    C ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 15,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r1 {1,D} {5,S} {7,[S,D,T,B,Q]}
+4 *4 H   u0 r0 {2,S}
+5    N   u0 r1 {3,S} {6,S}
+6    C   u0 {5,S} {8,[S,D,T,B,Q]}
+7    C   ux r1 {3,[S,D,T,B,Q]}
+8    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r1 {1,D} {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+7    R!H ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r1 {1,D} {5,[S,D,T,B,Q]} {7,S}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    C   ux {5,[S,D,T,B,Q]}
+7    R!H u0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 18,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {5,[S,D,T,B,Q]} {7,S}
+4 *4 H u0 {2,S}
+5    C ux r1 {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    C ux r0 {5,[S,D,T,B,Q]}
+7    N u0 r1 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 19,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {5,[S,D,T,B,Q]} {7,S}
+4 *4 H u0 {2,S}
+5    C ux r1 {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    C ux r0 {5,[S,D,T,B,Q]}
+7    C u0 r1 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 20,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r1 {1,D} {5,S} {7,[S,D,T,B,Q]}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r1 {3,S} {6,S}
+6    O   u0 {5,S}
+7    R!H ux r1 {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 21,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    N ux r1 {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 22,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux r1 {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 23,
+    label = "Root_3R!H->C_N-3C-inRing",
+    group = 
+"""
+1 *2 R!H u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 24,
+    label = "Root_3R!H->C_N-3C-inRing_1R!H->N",
+    group = 
+"""
+1 *2 N u0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 r0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 25,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 26,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 27,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 28,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H u0 {5,[S,D,T,B,Q]}
+7    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 29,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux {3,[S,D,T,B,Q]} {6,T}
+6    C u0 {5,T}
+7    C ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 30,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,T}
+6    C   u0 {5,T}
+7    C   ux {1,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+8    R!H ux {7,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 31,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,[S,D]}
+6    R!H u0 {5,[S,D]}
+7    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 32,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D]}
+6    R!H u0 {5,[S,D]}
+7    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 33,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    O   ux {3,[S,D,T,B,Q]} {6,[S,D]}
+6    R!H u0 {5,[S,D]}
+7    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 34,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    C u0 {3,S} {6,D}
+6    O u0 {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 35,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,S} {7,[S,D,T,B,Q]}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r0 {3,S} {6,D}
+6    O   u0 r0 {5,D}
+7    R!H ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 36,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O",
+    group = 
+"""
+1 *2 C     u0 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 C     u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H     u0 {2,S}
+5    R!H   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    [N,C] ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 37,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R",
+    group = 
+"""
+1 *2 C     u0 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 C     u0 r0 {1,D} {5,[S,D,T,B,Q]} {7,S}
+4 *4 H     u0 {2,S}
+5    C     ux {3,[S,D,T,B,Q]} {6,T}
+6    [N,C] ux {5,T}
+7    C     u0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 38,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,[S,D,T,B,Q]} {7,S}
+4 *4 H u0 {2,S}
+5    C ux r0 {3,[S,D,T,B,Q]} {6,T}
+6    N ux r0 {5,T}
+7    C u0 r0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 39,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,[S,D,T,B,Q]} {7,S}
+4 *4 H u0 {2,S}
+5    C ux r0 {3,[S,D,T,B,Q]} {6,T}
+6    C ux r0 {5,T}
+7    C u0 r0 {3,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 40,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    R!H u0 {3,S} {6,S}
+6    C   u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 41,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    N u0 {3,S} {6,S}
+6    C u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 42,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 {3,S} {6,S}
+6    C u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 43,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H",
+    group = 
+"""
+1 *2 C     u0 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 C     u0 r0 {1,D} {5,S}
+4 *4 H     u0 {2,S}
+5    C     u0 {3,S} {6,T}
+6    [N,C] u0 {5,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 44,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,T}
+6    N u0 r0 {5,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 45,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,T}
+6    C u0 r0 {5,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 46,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]}
+6    R!H ux {3,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 47,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {7,[S,D,T,B,Q]}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D} {5,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+4 *4 H   u0 r0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]}
+6    R!H ux {3,[S,D,T,B,Q]}
+7    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 48,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {6,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux r0 {3,[S,D,T,B,Q]}
+6    C ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C u0 r0 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 49,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D} {6,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 C                      u0 r0 {1,D} {5,S}
+4 *4 H                      u0 {2,S}
+5    C                      u0 {3,S}
+6    C                      u0 {1,S} {7,[S,D,T,B,Q]}
+7    [Si,S,N,P,F,I,Br,Cl,O] ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 50,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {6,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 {3,S}
+6    C u0 r0 {1,S} {7,[S,D,T,B,Q]}
+7    N ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 51,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {6,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 {3,S}
+6    C u0 r0 {1,S} {7,[S,D,T,B,Q]}
+7    O ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 52,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 {2,S}
+5    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 53,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 54,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r1 {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 55,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r1 {1,[S,D,T,B,Q]} {6,S}
+6    N u0 r1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 56,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r1 {1,[S,D,T,B,Q]} {6,S}
+6    C u0 r1 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 57,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r0 {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 58,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 {2,S}
+5    C   ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 59,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    O u0 {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 60,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]} {7,S}
+6    O u0 {5,[S,D,T,B,Q]}
+7    C u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 61,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R",
+    group = 
+"""
+1 *2 C   u0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 {2,S}
+5    C   ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]} {7,S}
+6    O   u0 r0 {5,[S,D,T,B,Q]}
+7    C   u0 r0 {5,S} {8,[S,D,T,B,Q]}
+8    R!H ux {7,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 62,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 C                      u0 r0 {1,D}
+4 *4 H                      u0 {2,S}
+5    C                      u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    [Si,S,N,P,C,F,I,Br,Cl] ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 63,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    N ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 64,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 65,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S} {6,S}
+6    C ux {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 66,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r0 {1,S} {6,S}
+6    C   ux {5,S} {7,[S,D,T,B,Q]}
+7    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 67,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S} {6,T}
+6    C ux {5,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 68,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r0 {1,S} {6,T}
+6    C   ux {5,T} {7,[S,D,T,B,Q]}
+7    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 69,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C",
+    group = 
+"""
+1 *2 C u0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 C u0 r0 {1,D}
+4 *4 H u0 {2,S}
+5    N u0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 70,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 C   u0 r0 {1,D}
+4 *4 H   u0 r0 {2,S}
+5    N   u0 {1,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]}
+7    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 71,
+    label = "Root_N-3R!H->C",
+    group = 
+"""
+1 *2 C                      u0 {2,S} {3,D}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 [Si,S,N,P,F,I,Br,Cl,O] u0 {1,D}
+4 *4 H                      u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 72,
+    label = "Root_N-3R!H->C_1R!H-inRing",
     group = 
 """
 1 *2 C u0 r1 {2,S} {3,D}
@@ -63,544 +1135,618 @@ entry(
 )
 
 entry(
-    index = 2,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C",
+    index = 73,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,D}
+6    R!H ux {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 74,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,D}
+6    C   ux {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 75,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,D}
+6    C   ux {5,D} {7,[S,D,T,B,Q]}
+7    N   ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 76,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    N u0 {3,S} {6,D}
+6    C ux {5,D} {7,S}
+7    N u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 77,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 r1 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    N   u0 r1 {3,S} {6,D}
+6    C   ux r1 {5,D} {7,S} {8,[S,D,T,B,Q]}
+7    N   u0 r1 {6,S}
+8    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 78,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N",
     group = 
 """
 1 *2 C u0 r1 {2,S} {3,D}
 2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H u0 {2,S}
-5    C ux {3,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 3,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 {1,D} {5,S}
-4 *4 H u0 {2,S}
-5    C ux {3,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 4,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D} {6,S}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,S}
-4 *4 H u0 {2,S}
-5    C ux r1 {3,S}
-6    C u0 r1 {1,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 5,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,S}
-4 *4 H                      u0 {2,S}
-5    C                      u0 {3,S}
-6    [Si,S,N,P,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 6,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,S}
-4 *4 H                      u0 {2,S}
-5    C                      u0 {3,S}
-6    [Si,S,N,P,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C                      ux {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 7,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 {1,D} {5,S}
-4 *4 H u0 {2,S}
-5    C u0 {3,S}
-6    N ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C ux {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 8,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R",
-    group = 
-"""
-1 *2 C   u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D} {5,S}
-4 *4 H   u0 {2,S}
-5    C   u0 {3,S} {8,S}
-6    N   ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C   ux {6,[S,D,T,B,Q]}
-8    R!H u0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 9,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O u0 r0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,S}
-4 *4 H u0 r0 {2,S}
-5    C u0 r1 {3,S} {8,S}
-6    N ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C ux r1 {6,[S,D,T,B,Q]}
-8    C u0 r0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 10,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O                      u0 r0 {1,S} {4,S}
-3 *1 N                      u0 r1 {1,D} {5,S}
-4 *4 H                      u0 r0 {2,S}
-5    C                      u0 r1 {3,S} {8,S}
-6    N                      ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C                      ux r1 {6,[S,D,T,B,Q]}
-8    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 11,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O u0 r0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,S}
-4 *4 H u0 r0 {2,S}
-5    C u0 r1 {3,S}
-6    O ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C ux r1 {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 12,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 {1,D} {5,S}
-4 *4 H u0 {2,S}
-5    C u0 {3,S}
-6    N ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+5    C ux {3,[S,D,T,B,Q]} {6,D}
+6    C u0 {5,D} {7,[S,D,T,B,Q]}
 7    N ux {6,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 13,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R",
+    index = 79,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R",
     group = 
 """
-1 *2 C   u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,D} {8,S}
+6    C   u0 {5,D} {7,[S,D,T,B,Q]}
+7    N   ux {6,[S,D,T,B,Q]}
+8    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 80,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 r0 {2,S}
+5    C ux r1 {3,[S,D,T,B,Q]} {6,D} {8,S}
+6    C u0 r1 {5,D} {7,[S,D,T,B,Q]}
+7    N ux r1 {6,[S,D,T,B,Q]}
+8    C u0 r0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 81,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H                      u0 r0 {2,S}
+5    C                      ux r1 {3,[S,D,T,B,Q]} {6,D} {8,S}
+6    C                      u0 r1 {5,D} {7,[S,D,T,B,Q]}
+7    N                      ux r1 {6,[S,D,T,B,Q]}
+8    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 82,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux {3,[S,D,T,B,Q]} {6,D}
+6    C u0 {5,D} {7,[S,D,T,B,Q]}
+7    O ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 83,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
 2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 N   u0 r1 {1,D} {5,S}
+3 *1 N   u0 r1 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H   u0 r0 {2,S}
-5    C   u0 r1 {3,S} {8,[S,D,T,B,Q]}
-6    N   ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    N   ux r1 {6,[S,D,T,B,Q]}
+5    C   ux r1 {3,[S,D,T,B,Q]} {6,D} {8,[S,D,T,B,Q]}
+6    C   u0 r1 {5,D} {7,[S,D,T,B,Q]}
+7    O   ux r1 {6,[S,D,T,B,Q]}
 8    R!H ux {5,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 14,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H",
+    index = 84,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,D}
+6    N   ux {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 85,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 r0 {2,S}
+5    N ux r1 {3,[S,D,T,B,Q]} {6,D}
+6    N u0 r1 {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 86,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N",
     group = 
 """
 1 *2 C u0 r1 {2,S} {3,D}
 2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,D}
-4 *4 H u0 {2,S}
-5    C ux r1 {3,D}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 15,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
-4 *4 H                      u0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 16,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
-4 *4 H                      u0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
-6    C                      ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 17,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
-4 *4 H                      u0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] ux {3,[S,D,T,B,Q]}
-6    C                      ux {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C                      ux {6,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 18,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N",
-    group = 
-"""
-1 *2 C u0 r1 {2,S} {3,D} {6,S}
-2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H u0 {2,S}
-5    N u0 {3,[S,D,T,B,Q]}
-6    C u0 {1,S} {7,D}
-7    C u0 {6,D}
+5    C ux {3,[S,D,T,B,Q]} {6,D}
+6    N ux {5,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 19,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R",
+    index = 87,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R",
     group = 
 """
-1 *2 C   u0 r1 {2,S} {3,D} {6,S}
+1 *2 C   u0 r1 {2,S} {3,D} {8,[S,D,T,B,Q]}
 2 *3 O   u0 r0 {1,S} {4,S}
 3 *1 N   u0 r1 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H   u0 r0 {2,S}
-5    N   u0 r1 {3,[S,D,T,B,Q]}
-6    C   u0 r1 {1,S} {7,D}
-7    C   u0 r1 {6,D} {8,[S,D,T,B,Q]}
-8    R!H ux {7,[S,D,T,B,Q]}
+5    C   ux r1 {3,[S,D,T,B,Q]} {6,D}
+6    N   u0 r1 {5,D} {7,S}
+7    R!H u0 r1 {6,S}
+8    R!H ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 20,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N",
+    index = 88,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N",
     group = 
 """
-1 *2 C u0 r1 {2,S} {3,D} {6,[S,D,T,B,Q]}
+1 *2 C u0 r1 {2,S} {3,D}
 2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,S}
+3 *1 N u0 {1,D} {5,S}
 4 *4 H u0 {2,S}
-5    O ux r1 {3,S}
-6    C ux r1 {1,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
-7    C ux r1 {6,[S,D,T,B,Q]}
+5    C u0 {3,S} {6,D}
+6    N u0 {5,D} {7,S}
+7    N u0 {6,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 21,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C",
+    index = 89,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R",
     group = 
 """
-1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    C   u0 {3,S} {6,D} {8,S}
+6    N   u0 {5,D} {7,S}
+7    N   u0 {6,S}
+8    R!H u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 90,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r1 {3,S} {6,D} {8,S}
+6    N u0 r1 {5,D} {7,S}
+7    N u0 r1 {6,S}
+8    C u0 r0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 91,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r1 {2,S} {3,D}
 2 *3 O                      u0 r0 {1,S} {4,S}
-3 *1 N                      u0 r1 {1,D} {5,[S,D,T,B,Q]}
+3 *1 N                      u0 r1 {1,D} {5,S}
 4 *4 H                      u0 r0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] u0 r1 {3,[S,D,T,B,Q]}
-6    C                      u0 r1 {1,S} {7,D}
-7    [Si,S,N,P,F,I,Br,Cl,O] u0 r1 {6,D}
+5    C                      u0 r1 {3,S} {6,D} {8,S}
+6    N                      u0 r1 {5,D} {7,S}
+7    N                      u0 r1 {6,S}
+8    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {5,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 22,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C",
+    index = 92,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N",
     group = 
 """
-1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
-4 *4 H                      u0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] u0 {3,[S,D,T,B,Q]}
-6    N                      u0 {1,S}
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H u0 {2,S}
+5    C ux {3,[S,D,T,B,Q]} {6,D}
+6    N ux {5,D} {7,[S,D,T,B,Q]}
+7    O ux {6,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 23,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi",
+    index = 93,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R",
     group = 
 """
-1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,[S,D,T,B,Q]}
-4 *4 H                      u0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] u0 {3,[S,D,T,B,Q]} {7,S}
-6    N                      u0 {1,S}
-7    R!H                    u0 {5,S}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux r1 {3,[S,D,T,B,Q]} {6,D} {8,[S,D,T,B,Q]}
+6    N   ux r1 {5,D} {7,[S,D,T,B,Q]}
+7    O   ux r1 {6,[S,D,T,B,Q]}
+8    R!H ux {5,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 24,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C",
+    index = 94,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H",
     group = 
 """
-1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
-2 *3 O                      u0 {1,S} {4,S}
-3 *1 N                      u0 {1,D} {5,S}
-4 *4 H                      u0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] u0 {3,S} {7,S}
-6    N                      u0 {1,S}
-7    C                      u0 {5,S}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    R!H ux {5,[S,T,Q,B]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 25,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N",
+    index = 95,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C",
     group = 
 """
-1 *2 C u0 r1 {2,S} {3,D} {6,S}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    R!H ux {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    C   ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 96,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H ux {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    C   ux {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    C   ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 97,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    N u0 {3,S} {6,[S,T,Q,B]}
+6    C ux {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    C ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 98,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D} {8,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 r1 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    N   u0 r1 {3,S} {6,[S,T,Q,B]}
+6    C   ux r1 {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    C   ux {6,[S,D,T,B,Q]}
+8    R!H ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 99,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
 2 *3 O u0 r0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,S}
+3 *1 N u0 r1 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H u0 r0 {2,S}
-5    N u0 r1 {3,S} {7,S}
-6    N u0 r1 {1,S}
-7    C u0 r1 {5,S}
+5    O ux r1 {3,[S,D,T,B,Q]} {6,S}
+6    C u0 r1 {5,S} {7,D}
+7    C u0 r1 {6,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 26,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N",
+    index = 100,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C",
     group = 
 """
-1 *2 C u0 r1 {2,S} {3,D} {6,S}
-2 *3 O u0 r0 {1,S} {4,S}
-3 *1 N u0 r1 {1,D} {5,S}
-4 *4 H u0 r0 {2,S}
-5    O u0 r1 {3,S} {7,S}
-6    N u0 r1 {1,S}
-7    C u0 r1 {5,S}
+1 *2 C     u0 r1 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 r1 {1,D} {5,S}
+4 *4 H     u0 {2,S}
+5    R!H   u0 r1 {3,S} {6,[S,T,Q,B]}
+6    [N,O] ux r1 {5,[S,T,Q,B]} {7,D}
+7    C     ux r1 {6,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 27,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C",
+    index = 101,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C",
     group = 
 """
-1 *2 C     u0 r1 {2,S} {3,D} {6,S}
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    R!H u0 {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    R!H ux {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    N   ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 102,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C",
+    group = 
+"""
+1 *2 C   u0 r1 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 r1 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   u0 r1 {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    R!H ux r1 {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    N   ux r1 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 103,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D}
 2 *3 O     u0 {1,S} {4,S}
 3 *1 N     u0 {1,D} {5,[S,D,T,B,Q]}
 4 *4 H     u0 {2,S}
-5    N     u0 {3,[S,D,T,B,Q]} {7,S}
-6    N     u0 {1,S}
-7    [N,O] u0 {5,S}
+5    [N,O] u0 {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    R!H   ux {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    N     ux {6,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 28,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H",
+    index = 104,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C",
     group = 
 """
-1 *2 C     u0 r1 {2,S} {3,D} {6,S}
-2 *3 O     u0 r0 {1,S} {4,S}
-3 *1 N     u0 r1 {1,D} {5,S}
-4 *4 H     u0 r0 {2,S}
-5    N     u0 r1 {3,S} {7,S}
-6    N     u0 r1 {1,S}
-7    [N,O] u0 r1 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 29,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H",
-    group = 
-"""
-1 *2 C     u0 r1 {2,S} {3,D} {6,S}
-2 *3 O     u0 r0 {1,S} {4,S}
-3 *1 N     u0 r1 {1,D} {5,D}
-4 *4 H     u0 r0 {2,S}
-5    N     u0 r1 {3,D} {7,S}
-6    N     u0 r1 {1,S}
-7    [N,O] u0 r1 {5,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 30,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi",
-    group = 
-"""
-1 *2 C                      u0 r1 {2,S} {3,D} {6,S}
-2 *3 O                      u0 r0 {1,S} {4,S}
-3 *1 N                      u0 r1 {1,D} {5,[S,D,T,B,Q]}
-4 *4 H                      u0 r0 {2,S}
-5    [Si,S,N,P,F,I,Br,Cl,O] u0 r1 {3,[S,D,T,B,Q]} {7,[B,D,T,Q]}
-6    N                      u0 r1 {1,S}
-7    R!H                    u0 r1 {5,[B,D,T,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 31,
-    label = "Root_N-1R!H-inRing",
-    group = 
-"""
-1 *2 R!H u0 r0 {2,S} {3,D}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 R!H u0 {1,D}
-4 *4 H   u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 32,
-    label = "Root_N-1R!H-inRing_3R!H->C",
-    group = 
-"""
-1 *2 R!H u0 r0 {2,S} {3,D}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 C   u0 {1,D}
-4 *4 H   u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 33,
-    label = "Root_N-1R!H-inRing_3R!H->C_1R!H->N",
-    group = 
-"""
-1 *2 N u0 r0 {2,S} {3,D}
-2 *3 O u0 r0 {1,S} {4,S}
-3 *1 C u0 {1,D}
-4 *4 H u0 r0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 34,
-    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N",
-    group = 
-"""
-1 *2 C u0 r0 {2,S} {3,D}
-2 *3 O u0 {1,S} {4,S}
-3 *1 C u0 {1,D}
-4 *4 H u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 35,
-    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R",
-    group = 
-"""
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 C   u0 r0 {1,D}
-4 *4 H   u0 {2,S}
-5    R!H ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 36,
-    label = "Root_N-1R!H-inRing_N-3R!H->C",
-    group = 
-"""
-1 *2 C     u0 r0 {2,S} {3,D}
+1 *2 C     u0 r1 {2,S} {3,D}
 2 *3 O     u0 {1,S} {4,S}
-3 *1 [S,N] u0 {1,D}
+3 *1 N     u0 {1,D} {5,S}
 4 *4 H     u0 {2,S}
+5    [N,O] u0 {3,S} {6,[S,T,Q,B]}
+6    C     ux {5,[S,T,Q,B]} {7,D}
+7    N     ux {6,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 37,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S",
+    index = 105,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    N u0 r1 {3,S} {6,[S,T,Q,B]}
+6    C ux r1 {5,[S,T,Q,B]} {7,D}
+7    N ux r1 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 106,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N",
+    group = 
+"""
+1 *2 C u0 r1 {2,S} {3,D}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 r1 {1,D} {5,S}
+4 *4 H u0 {2,S}
+5    O u0 r1 {3,S} {6,[S,T,Q,B]}
+6    C ux r1 {5,[S,T,Q,B]} {7,D}
+7    N ux r1 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 107,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H     u0 {2,S}
+5    N     u0 {3,[S,D,T,B,Q]} {6,[S,T,Q,B]}
+6    [N,O] ux {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    N     ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 108,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 r1 {1,D} {5,S}
+4 *4 H     u0 {2,S}
+5    N     u0 r1 {3,S} {6,[S,T,Q,B]}
+6    [N,O] ux r1 {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    N     ux r1 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 109,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi",
+    group = 
+"""
+1 *2 C     u0 r1 {2,S} {3,D}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 r1 {1,D} {5,D}
+4 *4 H     u0 {2,S}
+5    N     u0 r1 {3,D} {6,[S,T,Q,B]}
+6    [N,O] ux r1 {5,[S,T,Q,B]} {7,[S,D,T,B,Q]}
+7    N     ux r1 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 110,
+    label = "Root_N-3R!H->C_N-1R!H-inRing",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 [Si,S,N,P,F,I,Br,Cl,O] u0 {1,D}
+4 *4 H                      u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 111,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D}
@@ -612,8 +1758,8 @@ entry(
 )
 
 entry(
-    index = 38,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R",
+    index = 112,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D} {5,S}
@@ -626,13 +1772,13 @@ entry(
 )
 
 entry(
-    index = 39,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R",
+    index = 113,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R",
     group = 
 """
 1 *2 C   u0 r0 {2,S} {3,D} {5,S}
 2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 S   u0 {1,D}
+3 *1 S   u0 r0 {1,D}
 4 *4 H   u0 r0 {2,S}
 5    C   u0 r0 {1,S} {6,[S,D,T,B,Q]}
 6    R!H ux {5,[S,D,T,B,Q]}
@@ -641,8 +1787,8 @@ entry(
 )
 
 entry(
-    index = 40,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S",
+    index = 114,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D}
@@ -654,8 +1800,8 @@ entry(
 )
 
 entry(
-    index = 41,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R",
+    index = 115,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R",
     group = 
 """
 1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
@@ -668,145 +1814,401 @@ entry(
 )
 
 entry(
-    index = 42,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R",
+    index = 116,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
 2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
+3 *1 N   u0 {1,D} {6,[S,D,T,B,Q]}
 4 *4 H   u0 {2,S}
-5    R!H ux {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    R!H ux {5,[S,D,T,B,Q]}
+5    R!H u0 {1,S}
+6    C   ux {3,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 43,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
+    index = 117,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
 2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 r0 {1,D}
+3 *1 N   u0 {1,D} {6,[S,D,T,B,Q]}
 4 *4 H   u0 {2,S}
-5    R!H ux r1 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    R!H u0 {5,[S,D,T,B,Q]}
+5    R!H u0 {1,S} {7,S}
+6    C   ux {3,[S,D,T,B,Q]}
+7    C   u0 {5,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 44,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
+    index = 118,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
-4 *4 H   u0 {2,S}
-5    R!H ux r0 {1,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
-6    R!H ux {5,[S,D,T,B,Q]}
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {6,[S,D,T,B,Q]}
+4 *4 H u0 r0 {2,S}
+5    N u0 {1,S} {7,S}
+6    C ux {3,[S,D,T,B,Q]}
+7    C u0 r0 {5,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 45,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
+    index = 119,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
-4 *4 H   u0 {2,S}
-5    R!H ux r0 {1,[S,D,T,B,Q]} {6,S}
-6    R!H u0 {5,S}
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {6,[S,D,T,B,Q]}
+4 *4 H u0 r0 {2,S}
+5    O u0 {1,S} {7,S}
+6    C ux {3,[S,D,T,B,Q]}
+7    C u0 r0 {5,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 46,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N",
+    index = 120,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O u0 {1,S} {4,S}
 3 *1 N u0 {1,D}
 4 *4 H u0 {2,S}
-5    N ux r0 {1,[S,D,T,B,Q]} {6,S}
-6    C u0 {5,S}
+5    O ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 47,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N",
+    index = 121,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    O   ux {1,[S,D,T,B,Q]} {6,S}
+6    C   u0 r0 {5,S} {7,[S,D,T,B,Q]}
+7    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 122,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O",
+    group = 
+"""
+1 *2 C     u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 {1,D}
+4 *4 H     u0 {2,S}
+5    [N,C] ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 123,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing",
+    group = 
+"""
+1 *2 C     u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 {1,D}
+4 *4 H     u0 {2,S}
+5    [N,C] ux r1 {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 124,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
 2 *3 O u0 {1,S} {4,S}
-3 *1 N u0 r0 {1,D}
+3 *1 N u0 {1,D}
 4 *4 H u0 {2,S}
-5    N ux r0 {1,[S,D,T,B,Q]} {6,S}
-6    C u0 {5,S} {7,D}
+5    N ux r1 {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 125,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r1 {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 126,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    C ux r1 {1,[S,D,T,B,Q]} {6,S}
+6    O u0 {5,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 127,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    C   ux r1 {1,[S,D,T,B,Q]} {6,S} {8,[S,D,T,B,Q]}
+6    O   u0 r1 {5,S} {7,S}
+7    C   u0 r1 {6,S}
+8    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 128,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 {1,S} {4,S}
+3 *1 N                      u0 {1,D}
+4 *4 H                      u0 {2,S}
+5    C                      u0 r1 {1,S} {6,[S,D,T,B,Q]}
+6    [Si,S,N,P,C,F,I,Br,Cl] ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 129,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D}
+4 *4 H u0 r0 {2,S}
+5    C u0 r1 {1,S} {6,[S,D,T,B,Q]}
+6    N ux r1 {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 130,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D}
+4 *4 H u0 r0 {2,S}
+5    C u0 r1 {1,S} {6,[S,D,T,B,Q]}
+6    C ux r1 {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 131,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing",
+    group = 
+"""
+1 *2 C     u0 r0 {2,S} {3,D} {5,S}
+2 *3 O     u0 {1,S} {4,S}
+3 *1 N     u0 {1,D}
+4 *4 H     u0 {2,S}
+5    [N,C] u0 r0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 132,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    N u0 r0 {1,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 133,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    N u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 134,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D}
+4 *4 H   u0 {2,S}
+5    N   u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C   ux {5,[S,D,T,B,Q]} {7,D}
+7    R!H u0 {6,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 135,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D}
+4 *4 H u0 r0 {2,S}
+5    N u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]} {7,D}
 7    N u0 r0 {6,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 48,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N",
+    index = 136,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N",
     group = 
 """
-1 *2 C                      u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O                      u0 {1,S} {4,S}
+1 *2 C                      u0 r0 {2,S} {3,D} {5,S}
+2 *3 O                      u0 r0 {1,S} {4,S}
 3 *1 N                      u0 r0 {1,D}
-4 *4 H                      u0 {2,S}
-5    N                      ux r0 {1,[S,D,T,B,Q]} {6,S}
-6    C                      u0 {5,S} {7,D}
+4 *4 H                      u0 r0 {2,S}
+5    N                      u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C                      ux {5,[S,D,T,B,Q]} {7,D}
 7    [Si,S,P,C,F,I,Br,Cl,O] u0 r0 {6,D}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 49,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N",
+    index = 137,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N",
     group = 
 """
-1 *2 C   u0 r0 {2,S} {3,D} {5,[S,D,T,B,Q]}
-2 *3 O   u0 {1,S} {4,S}
-3 *1 N   u0 r0 {1,D}
-4 *4 H   u0 {2,S}
-5    C   ux r0 {1,[S,D,T,B,Q]} {6,S}
-6    R!H u0 {5,S}
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 50,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
+    index = 138,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 139,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R",
     group = 
 """
 1 *2 C   u0 r0 {2,S} {3,D} {5,S}
 2 *3 O   u0 r0 {1,S} {4,S}
-3 *1 N   u0 {1,D}
+3 *1 N   u0 r0 {1,D}
 4 *4 H   u0 r0 {2,S}
-5    R!H u0 r0 {1,S} {6,[D,T]}
-6    R!H ux r0 {5,[D,T]}
+5    C   u0 r0 {1,S} {6,[S,D,T,B,Q]}
+6    C   ux {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    R!H ux {6,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 51,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    index = 140,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D} {5,S}
+2 *3 O u0 {1,S} {4,S}
+3 *1 N u0 {1,D}
+4 *4 H u0 {2,S}
+5    C u0 r0 {1,S} {6,D}
+6    O ux {5,D}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 141,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D} {5,S}
+2 *3 O   u0 r0 {1,S} {4,S}
+3 *1 N   u0 r0 {1,D}
+4 *4 H   u0 r0 {2,S}
+5    C   u0 r0 {1,S} {6,D} {7,[S,D,T,B,Q]}
+6    O   ux {5,D}
+7    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 142,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
     group = 
 """
 1 *2 C   u0 r0 {2,S} {3,D}
@@ -821,8 +2223,216 @@ entry(
 )
 
 entry(
-    index = 52,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    index = 143,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    C   ux {5,[S,D,T,B,Q]}
+7    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 144,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux r1 {3,[S,D,T,B,Q]} {6,S} {7,[S,D,T,B,Q]}
+6    C   u0 {5,S}
+7    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 145,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    C   u0 r0 {3,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    C   ux {5,[S,D,T,B,Q]}
+7    R!H ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 146,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]}
+7    C ux {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 147,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+6    C ux r0 {5,[S,D,T,B,Q]}
+7    O u0 r0 {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 148,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C",
+    group = 
+"""
+1 *2 C     u0 r0 {2,S} {3,D}
+2 *3 O     u0 r0 {1,S} {4,S}
+3 *1 N     u0 r0 {1,D} {5,S}
+4 *4 H     u0 r0 {2,S}
+5    C     u0 {3,S} {6,S} {7,[S,D,T,B,Q]}
+6    [N,O] ux {5,S}
+7    R!H   u0 {5,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 149,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    R!H ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 150,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    C   ux {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 151,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,S}
+4 *4 H   u0 {2,S}
+5    C   u0 {3,S} {6,[S,D,T,B,Q]}
+6    R!H ux {5,[S,D,T,B,Q]} {7,S}
+7    C   u0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 152,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,[S,D,T,B,Q]}
+6    N ux {5,[S,D,T,B,Q]} {7,S}
+7    C u0 r0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 153,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N",
+    group = 
+"""
+1 *2 C u0 r0 {2,S} {3,D}
+2 *3 O u0 r0 {1,S} {4,S}
+3 *1 N u0 r0 {1,D} {5,S}
+4 *4 H u0 r0 {2,S}
+5    C u0 r0 {3,S} {6,[S,D,T,B,Q]}
+6    C ux {5,[S,D,T,B,Q]} {7,S}
+7    C u0 r0 {6,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 154,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H",
+    group = 
+"""
+1 *2 C   u0 r0 {2,S} {3,D}
+2 *3 O   u0 {1,S} {4,S}
+3 *1 N   u0 {1,D} {5,[S,D,T,B,Q]}
+4 *4 H   u0 {2,S}
+5    C   ux {3,[S,D,T,B,Q]} {6,[S,D,T,B,Q]}
+6    R!H u0 r0 {5,[S,D,T,B,Q]} {7,T}
+7    C   ux {6,T}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 155,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C",
+    group = 
+"""
+1 *2 C                      u0 r0 {2,S} {3,D}
+2 *3 O                      u0 r0 {1,S} {4,S}
+3 *1 N                      u0 r0 {1,D} {5,S}
+4 *4 H                      u0 r0 {2,S}
+5    C                      u0 r0 {3,S} {6,[S,D,T,B,Q]}
+6    R!H                    ux {5,[S,D,T,B,Q]} {7,[S,D,T,B,Q]}
+7    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {6,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 156,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
     group = 
 """
 1 *2 C u0 r0 {2,S} {3,D}
@@ -836,8 +2446,8 @@ entry(
 )
 
 entry(
-    index = 53,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    index = 157,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
     group = 
 """
 1 *2 C                      u0 r0 {2,S} {3,D}
@@ -853,59 +2463,163 @@ entry(
 tree(
 """
 L1: Root
-    L2: Root_1R!H-inRing
-        L3: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
-            L4: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
-                L5: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
-                L5: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
-                    L6: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
-                            L8: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
-                                L9: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
-                                L9: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
-                    L6: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
-            L4: Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
-        L3: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
-            L4: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
-                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
-                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
-                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
-                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
-            L4: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
-                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
-                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
-                    L6: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
-                        L7: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
-                L5: Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
-    L2: Root_N-1R!H-inRing
-        L3: Root_N-1R!H-inRing_3R!H->C
-            L4: Root_N-1R!H-inRing_3R!H->C_1R!H->N
-            L4: Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
-                L5: Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
-        L3: Root_N-1R!H-inRing_N-3R!H->C
-            L4: Root_N-1R!H-inRing_N-3R!H->C_3NS->S
-                L5: Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
-                    L6: Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
-            L4: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
-                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
-                    L6: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
-                        L7: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-                        L7: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-                            L8: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-                                L9: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
-                                    L10: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
-                                    L10: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
-                                L9: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
-                            L8: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
-                L5: Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
+    L2: Root_3R!H->C
+        L3: Root_3R!H->C_3C-inRing
+            L4: Root_3R!H->C_3C-inRing_Ext-1R!H-R
+                L5: Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C
+                    L6: Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N
+                    L6: Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N
+                        L7: Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O
+                        L7: Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O
+                L5: Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C
+            L4: Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O
+                L5: Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
+            L4: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O
+                L5: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R
+                    L6: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N
+                        L7: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R
+                    L6: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N
+                        L7: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C
+                            L8: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N
+                            L8: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N
+                        L7: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C
+                L5: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N
+                L5: Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N
+        L3: Root_3R!H->C_N-3C-inRing
+            L4: Root_3R!H->C_N-3C-inRing_1R!H->N
+            L4: Root_3R!H->C_N-3C-inRing_N-1R!H->N
+                L5: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R
+                    L6: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N
+                    L6: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R
+                    L6: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C
+                    L6: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N
+                L5: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R
+                    L6: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing
+                            L8: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O
+                                    L10: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R
+                                        L11: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R
+                                L9: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O
+                                    L10: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+                                    L10: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+                                        L11: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C
+                                            L12: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R
+                                        L11: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C
+                                            L12: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R
+                    L6: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C
+                        L7: Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R
+    L2: Root_N-3R!H->C
+        L3: Root_N-3R!H->C_1R!H-inRing
+            L4: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H
+                L5: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R
+                                L9: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C
+                                L9: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R
+                L5: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R
+                                L9: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C
+                                L9: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R
+            L4: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H
+                L5: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C
+                L5: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C
+                    L6: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N
+                        L7: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi
+                            L8: Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi
+        L3: Root_N-3R!H->C_N-1R!H-inRing
+            L4: Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S
+                L5: Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R
+            L4: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S
+                L5: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N
+                                L9: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O
+                                    L10: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R
+                                L9: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O
+                                    L10: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+                                    L10: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N
+                                L9: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R
+                                    L10: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R
+                                        L11: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+                                        L11: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N
+                                L9: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C
+                                    L10: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R
+                                L9: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C
+                                    L10: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R
+                L5: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C
+                L5: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N
+                            L8: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N
+                        L7: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H
+                    L6: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C
+                L5: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+                L5: Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
 """
 )
 

--- a/input/kinetics/families/Ketoenol/rules.py
+++ b/input/kinetics/families/Ketoenol/rules.py
@@ -9,809 +9,2369 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(6.10397e-09,'s^-1'), n=6.18187, w0=(795076,'J/mol'), E0=(134685,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.2195681169559809, var=20.961761804484684, Tref=1000.0, N=33, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 33 training reactions at node Root
-    Total Standard Deviation in ln(k): 9.730161101696131"""),
+    kinetics = ArrheniusBM(A=(3.32286e-24,'s^-1'), n=10.5865, w0=(790871,'J/mol'), E0=(125825,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.020502213722928937, var=35.33159666058211, Tref=1000.0, N=101, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 101 training reactions at node Root
+    Total Standard Deviation in ln(k): 11.967736083166281"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 33 training reactions at node Root
-Total Standard Deviation in ln(k): 9.730161101696131""",
+    shortDesc = """BM rule fitted to 101 training reactions at node Root
+Total Standard Deviation in ln(k): 11.967736083166281""",
     longDesc = 
 """
-BM rule fitted to 33 training reactions at node Root
-Total Standard Deviation in ln(k): 9.730161101696131
+BM rule fitted to 101 training reactions at node Root
+Total Standard Deviation in ln(k): 11.967736083166281
 """,
 )
 
 entry(
     index = 2,
-    label = "Root_1R!H-inRing",
-    kinetics = ArrheniusBM(A=(5.26108e-07,'s^-1'), n=5.66028, w0=(798000,'J/mol'), E0=(149674,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.2986016055903136, var=12.008348340526611, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_1R!H-inRing',), comment="""BM rule fitted to 17 training reactions at node Root_1R!H-inRing
-    Total Standard Deviation in ln(k): 7.697276553951726"""),
+    label = "Root_3R!H->C",
+    kinetics = ArrheniusBM(A=(4.728e-31,'s^-1'), n=12.5654, w0=(783702,'J/mol'), E0=(153702,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.07577106564953576, var=7.170510964780115, Tref=1000.0, N=47, data_mean=0.0, correlation='Root_3R!H->C',), comment="""BM rule fitted to 47 training reactions at node Root_3R!H->C
+    Total Standard Deviation in ln(k): 5.558621017600344"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 17 training reactions at node Root_1R!H-inRing
-Total Standard Deviation in ln(k): 7.697276553951726""",
+    shortDesc = """BM rule fitted to 47 training reactions at node Root_3R!H->C
+Total Standard Deviation in ln(k): 5.558621017600344""",
     longDesc = 
 """
-BM rule fitted to 17 training reactions at node Root_1R!H-inRing
-Total Standard Deviation in ln(k): 7.697276553951726
+BM rule fitted to 47 training reactions at node Root_3R!H->C
+Total Standard Deviation in ln(k): 5.558621017600344
 """,
 )
 
 entry(
     index = 3,
-    label = "Root_N-1R!H-inRing",
-    kinetics = ArrheniusBM(A=(1.08943e-18,'s^-1'), n=8.92199, w0=(791969,'J/mol'), E0=(93809.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.08893667560245318, var=37.94025194284002, Tref=1000.0, N=16, data_mean=0.0, correlation='Root_N-1R!H-inRing',), comment="""BM rule fitted to 16 training reactions at node Root_N-1R!H-inRing
-    Total Standard Deviation in ln(k): 12.571756783434886"""),
+    label = "Root_N-3R!H->C",
+    kinetics = ArrheniusBM(A=(1.62554e-12,'s^-1'), n=7.2226, w0=(797111,'J/mol'), E0=(116655,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.05581774963789573, var=10.461684338397886, Tref=1000.0, N=54, data_mean=0.0, correlation='Root_N-3R!H->C',), comment="""BM rule fitted to 54 training reactions at node Root_N-3R!H->C
+    Total Standard Deviation in ln(k): 6.62446640761746"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 16 training reactions at node Root_N-1R!H-inRing
-Total Standard Deviation in ln(k): 12.571756783434886""",
+    shortDesc = """BM rule fitted to 54 training reactions at node Root_N-3R!H->C
+Total Standard Deviation in ln(k): 6.62446640761746""",
     longDesc = 
 """
-BM rule fitted to 16 training reactions at node Root_N-1R!H-inRing
-Total Standard Deviation in ln(k): 12.571756783434886
+BM rule fitted to 54 training reactions at node Root_N-3R!H->C
+Total Standard Deviation in ln(k): 6.62446640761746
 """,
 )
 
 entry(
     index = 4,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C",
-    kinetics = ArrheniusBM(A=(3.63777e-17,'s^-1'), n=8.55003, w0=(798000,'J/mol'), E0=(118646,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0028809451405216774, var=3.403124387745618, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C',), comment="""BM rule fitted to 8 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
-    Total Standard Deviation in ln(k): 3.705485448648163"""),
+    label = "Root_3R!H->C_3C-inRing",
+    kinetics = ArrheniusBM(A=(6.39312e-20,'s^-1'), n=9.28196, w0=(783500,'J/mol'), E0=(172103,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.05177845734786932, var=3.027945469263943, Tref=1000.0, N=13, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing',), comment="""BM rule fitted to 13 training reactions at node Root_3R!H->C_3C-inRing
+    Total Standard Deviation in ln(k): 3.6185346711093223"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 8 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 3.705485448648163""",
+    shortDesc = """BM rule fitted to 13 training reactions at node Root_3R!H->C_3C-inRing
+Total Standard Deviation in ln(k): 3.6185346711093223""",
     longDesc = 
 """
-BM rule fitted to 8 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C
-Total Standard Deviation in ln(k): 3.705485448648163
+BM rule fitted to 13 training reactions at node Root_3R!H->C_3C-inRing
+Total Standard Deviation in ln(k): 3.6185346711093223
 """,
 )
 
 entry(
     index = 5,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C",
-    kinetics = ArrheniusBM(A=(0.12949,'s^-1'), n=4.13415, w0=(798000,'J/mol'), E0=(168423,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.4467128617852155, var=23.288738414217875, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C',), comment="""BM rule fitted to 9 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
-    Total Standard Deviation in ln(k): 10.79692624441642"""),
+    label = "Root_3R!H->C_N-3C-inRing",
+    kinetics = ArrheniusBM(A=(1.92765e-36,'s^-1'), n=14.1493, w0=(783779,'J/mol'), E0=(144334,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0656552582432251, var=8.974483594895275, Tref=1000.0, N=34, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing',), comment="""BM rule fitted to 34 training reactions at node Root_3R!H->C_N-3C-inRing
+    Total Standard Deviation in ln(k): 6.170636535761763"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 9 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
-Total Standard Deviation in ln(k): 10.79692624441642""",
+    shortDesc = """BM rule fitted to 34 training reactions at node Root_3R!H->C_N-3C-inRing
+Total Standard Deviation in ln(k): 6.170636535761763""",
     longDesc = 
 """
-BM rule fitted to 9 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C
-Total Standard Deviation in ln(k): 10.79692624441642
+BM rule fitted to 34 training reactions at node Root_3R!H->C_N-3C-inRing
+Total Standard Deviation in ln(k): 6.170636535761763
 """,
 )
 
 entry(
     index = 6,
-    label = "Root_N-1R!H-inRing_3R!H->C",
-    kinetics = ArrheniusBM(A=(1.80789e-52,'s^-1'), n=18.7686, w0=(785875,'J/mol'), E0=(142261,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=7.096700906046526, var=111.32985920057283, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_3R!H->C
-    Total Standard Deviation in ln(k): 38.98346113476485"""),
+    label = "Root_N-3R!H->C_1R!H-inRing",
+    kinetics = ArrheniusBM(A=(3.1336e-19,'s^-1'), n=9.15317, w0=(798000,'J/mol'), E0=(125785,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.006668256113493265, var=2.7399268788220748, Tref=1000.0, N=23, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing',), comment="""BM rule fitted to 23 training reactions at node Root_N-3R!H->C_1R!H-inRing
+    Total Standard Deviation in ln(k): 3.3351371525331466"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_3R!H->C
-Total Standard Deviation in ln(k): 38.98346113476485""",
+    shortDesc = """BM rule fitted to 23 training reactions at node Root_N-3R!H->C_1R!H-inRing
+Total Standard Deviation in ln(k): 3.3351371525331466""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_3R!H->C
-Total Standard Deviation in ln(k): 38.98346113476485
+BM rule fitted to 23 training reactions at node Root_N-3R!H->C_1R!H-inRing
+Total Standard Deviation in ln(k): 3.3351371525331466
 """,
 )
 
 entry(
     index = 7,
-    label = "Root_N-1R!H-inRing_N-3R!H->C",
-    kinetics = ArrheniusBM(A=(2.14216e-12,'s^-1'), n=7.10076, w0=(794000,'J/mol'), E0=(95211.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.027300955354671547, var=2.809838899397277, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C',), comment="""BM rule fitted to 12 training reactions at node Root_N-1R!H-inRing_N-3R!H->C
-    Total Standard Deviation in ln(k): 3.4290473906824763"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing",
+    kinetics = ArrheniusBM(A=(2.08503e-11,'s^-1'), n=6.90013, w0=(796452,'J/mol'), E0=(98430,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.01083926466016706, var=1.558911673037586, Tref=1000.0, N=31, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing',), comment="""BM rule fitted to 31 training reactions at node Root_N-3R!H->C_N-1R!H-inRing
+    Total Standard Deviation in ln(k): 2.5302740681460736"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-1R!H-inRing_N-3R!H->C
-Total Standard Deviation in ln(k): 3.4290473906824763""",
+    shortDesc = """BM rule fitted to 31 training reactions at node Root_N-3R!H->C_N-1R!H-inRing
+Total Standard Deviation in ln(k): 2.5302740681460736""",
     longDesc = 
 """
-BM rule fitted to 12 training reactions at node Root_N-1R!H-inRing_N-3R!H->C
-Total Standard Deviation in ln(k): 3.4290473906824763
+BM rule fitted to 31 training reactions at node Root_N-3R!H->C_N-1R!H-inRing
+Total Standard Deviation in ln(k): 2.5302740681460736
 """,
 )
 
 entry(
     index = 8,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H",
-    kinetics = ArrheniusBM(A=(6.35117e-18,'s^-1'), n=8.76855, w0=(798000,'J/mol'), E0=(117401,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.008743366414696061, var=4.057942970727891, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H',), comment="""BM rule fitted to 7 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
-    Total Standard Deviation in ln(k): 4.0603740767018035"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(4.11555e-10,'s^-1'), n=6.40743, w0=(783500,'J/mol'), E0=(180362,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.05801351630604745, var=6.028099843723627, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 5.067826053991267"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 7 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
-Total Standard Deviation in ln(k): 4.0603740767018035""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R
+Total Standard Deviation in ln(k): 5.067826053991267""",
     longDesc = 
 """
-BM rule fitted to 7 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H
-Total Standard Deviation in ln(k): 4.0603740767018035
+BM rule fitted to 4 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R
+Total Standard Deviation in ln(k): 5.067826053991267
 """,
 )
 
 entry(
     index = 9,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H",
-    kinetics = ArrheniusBM(A=(6.87223e-13,'s^-1'), n=7.30388, w0=(798000,'J/mol'), E0=(124360,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O",
+    kinetics = ArrheniusBM(A=(6.74681e-29,'s^-1'), n=11.8652, w0=(783500,'J/mol'), E0=(159410,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0023429600482609584, var=0.03529471902352428, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O
+    Total Standard Deviation in ln(k): 0.38251418372418733"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O
+Total Standard Deviation in ln(k): 0.38251418372418733""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_N-Sp-5C-3R!H
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O
+Total Standard Deviation in ln(k): 0.38251418372418733
 """,
 )
 
 entry(
     index = 10,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C",
-    kinetics = ArrheniusBM(A=(1.50083e-19,'s^-1'), n=9.25255, w0=(798000,'J/mol'), E0=(127699,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0006427823284157327, var=0.5967826247970905, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
-    Total Standard Deviation in ln(k): 1.5503071008497333"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O",
+    kinetics = ArrheniusBM(A=(2.87045e-25,'s^-1'), n=10.8475, w0=(783500,'J/mol'), E0=(165263,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004029042513347415, var=0.5211813278651625, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O',), comment="""BM rule fitted to 7 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O
+    Total Standard Deviation in ln(k): 1.4573993994053007"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
-Total Standard Deviation in ln(k): 1.5503071008497333""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O
+Total Standard Deviation in ln(k): 1.4573993994053007""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C
-Total Standard Deviation in ln(k): 1.5503071008497333
+BM rule fitted to 7 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O
+Total Standard Deviation in ln(k): 1.4573993994053007
 """,
 )
 
 entry(
     index = 11,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C",
-    kinetics = ArrheniusBM(A=(3.15335e+06,'s^-1'), n=2.03333, w0=(798000,'J/mol'), E0=(184034,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.5800252121262526, var=55.895560511264364, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
-    Total Standard Deviation in ln(k): 16.44541751648541"""),
+    label = "Root_3R!H->C_N-3C-inRing_1R!H->N",
+    kinetics = ArrheniusBM(A=(9.27692e-54,'s^-1'), n=19.1913, w0=(793000,'J/mol'), E0=(143942,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_1R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_1R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
-Total Standard Deviation in ln(k): 16.44541751648541""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_1R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 5 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C
-Total Standard Deviation in ln(k): 16.44541751648541
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_1R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 12,
-    label = "Root_N-1R!H-inRing_3R!H->C_1R!H->N",
-    kinetics = ArrheniusBM(A=(9.27692e-54,'s^-1'), n=19.1913, w0=(793000,'J/mol'), E0=(143942,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C_1R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_1R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N",
+    kinetics = ArrheniusBM(A=(1.15269e-35,'s^-1'), n=13.9255, w0=(783500,'J/mol'), E0=(144929,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0728436487566342, var=8.371800000960956, Tref=1000.0, N=33, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N',), comment="""BM rule fitted to 33 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N
+    Total Standard Deviation in ln(k): 5.983537340355543"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_1R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 33 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N
+Total Standard Deviation in ln(k): 5.983537340355543""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_1R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 33 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N
+Total Standard Deviation in ln(k): 5.983537340355543
 """,
 )
 
 entry(
     index = 13,
-    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N",
-    kinetics = ArrheniusBM(A=(75.1006,'s^-1'), n=3.11041, w0=(783500,'J/mol'), E0=(209076,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.00848789959541425, var=6.520606768146176, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C_N-1R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
-    Total Standard Deviation in ln(k): 5.140513384866411"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H",
+    kinetics = ArrheniusBM(A=(6.13834e-19,'s^-1'), n=9.0634, w0=(798000,'J/mol'), E0=(122586,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.010294398172040536, var=2.7787954233685777, Tref=1000.0, N=14, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H',), comment="""BM rule fitted to 14 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H
+    Total Standard Deviation in ln(k): 3.3677024279295247"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
-Total Standard Deviation in ln(k): 5.140513384866411""",
+    shortDesc = """BM rule fitted to 14 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H
+Total Standard Deviation in ln(k): 3.3677024279295247""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N
-Total Standard Deviation in ln(k): 5.140513384866411
+BM rule fitted to 14 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H
+Total Standard Deviation in ln(k): 3.3677024279295247
 """,
 )
 
 entry(
     index = 14,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S",
-    kinetics = ArrheniusBM(A=(1583.91,'s^-1'), n=2.85161, w0=(782000,'J/mol'), E0=(88955.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003045184023974304, var=0.28211849898893376, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_3NS->S',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S
-    Total Standard Deviation in ln(k): 1.0724628112272296"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H",
+    kinetics = ArrheniusBM(A=(3.7659e-19,'s^-1'), n=9.13982, w0=(798000,'J/mol'), E0=(132110,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.013005196560129792, var=2.7040654760368015, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H',), comment="""BM rule fitted to 9 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H
+    Total Standard Deviation in ln(k): 3.329271339154466"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S
-Total Standard Deviation in ln(k): 1.0724628112272296""",
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H
+Total Standard Deviation in ln(k): 3.329271339154466""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S
-Total Standard Deviation in ln(k): 1.0724628112272296
+BM rule fitted to 9 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H
+Total Standard Deviation in ln(k): 3.329271339154466
 """,
 )
 
 entry(
     index = 15,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S",
-    kinetics = ArrheniusBM(A=(1.30473e-11,'s^-1'), n=6.87514, w0=(798000,'J/mol'), E0=(99876.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0117411635116814, var=0.6446492092925814, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S',), comment="""BM rule fitted to 9 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
-    Total Standard Deviation in ln(k): 1.6391032023367265"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S",
+    kinetics = ArrheniusBM(A=(1429.74,'s^-1'), n=2.8636, w0=(782000,'J/mol'), E0=(88608.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0028631478829535175, var=0.25086444047588813, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S
+    Total Standard Deviation in ln(k): 1.01129285627467"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
-Total Standard Deviation in ln(k): 1.6391032023367265""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S
+Total Standard Deviation in ln(k): 1.01129285627467""",
     longDesc = 
 """
-BM rule fitted to 9 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S
-Total Standard Deviation in ln(k): 1.6391032023367265
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S
+Total Standard Deviation in ln(k): 1.01129285627467
 """,
 )
 
 entry(
     index = 16,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C",
-    kinetics = ArrheniusBM(A=(1.03729e-10,'s^-1'), n=6.68631, w0=(798000,'J/mol'), E0=(105099,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S",
+    kinetics = ArrheniusBM(A=(3.04549e-11,'s^-1'), n=6.85438, w0=(798000,'J/mol'), E0=(99727.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0018867322963956807, var=1.03468000726437, Tref=1000.0, N=28, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S',), comment="""BM rule fitted to 28 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S
+    Total Standard Deviation in ln(k): 2.0439414522055452"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 28 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S
+Total Standard Deviation in ln(k): 2.0439414522055452""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_6R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 28 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S
+Total Standard Deviation in ln(k): 2.0439414522055452
 """,
 )
 
 entry(
     index = 17,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C",
-    kinetics = ArrheniusBM(A=(1.69363e-18,'s^-1'), n=8.94137, w0=(798000,'J/mol'), E0=(121373,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0038084715549368104, var=0.5842399037789903, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C',), comment="""BM rule fitted to 6 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
-    Total Standard Deviation in ln(k): 1.5419000584052351"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C",
+    kinetics = ArrheniusBM(A=(1.59677e-16,'s^-1'), n=8.29403, w0=(783500,'J/mol'), E0=(173470,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.005973981573233584, var=1.466149892623437, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C
+    Total Standard Deviation in ln(k): 2.442436990667526"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 6 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
-Total Standard Deviation in ln(k): 1.5419000584052351""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C
+Total Standard Deviation in ln(k): 2.442436990667526""",
     longDesc = 
 """
-BM rule fitted to 6 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C
-Total Standard Deviation in ln(k): 1.5419000584052351
+BM rule fitted to 3 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C
+Total Standard Deviation in ln(k): 2.442436990667526
 """,
 )
 
 entry(
     index = 18,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(1.2013e-18,'s^-1'), n=8.97925, w0=(798000,'J/mol'), E0=(126845,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.007503612341907746, var=0.008054470110497336, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
-    Total Standard Deviation in ln(k): 0.1987716543490167"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(0.0332916,'s^-1'), n=3.98637, w0=(783500,'J/mol'), E0=(171985,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
-Total Standard Deviation in ln(k): 0.1987716543490167""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C
-Total Standard Deviation in ln(k): 0.1987716543490167
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_N-5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 19,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(1.18952e-19,'s^-1'), n=9.32392, w0=(798000,'J/mol'), E0=(137103,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R",
+    kinetics = ArrheniusBM(A=(5.66974e-32,'s^-1'), n=12.7337, w0=(783500,'J/mol'), E0=(150797,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_N-7R!H->C
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 20,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi",
-    kinetics = ArrheniusBM(A=(3.33668e-20,'s^-1'), n=9.45072, w0=(798000,'J/mol'), E0=(138622,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.025999023929210666, var=2.2367127697893783, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
-    Total Standard Deviation in ln(k): 3.0635345236969505"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R",
+    kinetics = ArrheniusBM(A=(1.89196e-24,'s^-1'), n=10.6025, w0=(783500,'J/mol'), E0=(164616,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.002089150051635779, var=0.18931816314976802, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R',), comment="""BM rule fitted to 5 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R
+    Total Standard Deviation in ln(k): 0.8775235281941672"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
-Total Standard Deviation in ln(k): 3.0635345236969505""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R
+Total Standard Deviation in ln(k): 0.8775235281941672""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi
-Total Standard Deviation in ln(k): 3.0635345236969505
+BM rule fitted to 5 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R
+Total Standard Deviation in ln(k): 0.8775235281941672
 """,
 )
 
 entry(
     index = 21,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi",
-    kinetics = ArrheniusBM(A=(7.03103e-17,'s^-1'), n=8.43292, w0=(798000,'J/mol'), E0=(45092.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(7.8149e-27,'s^-1'), n=11.304, w0=(783500,'J/mol'), E0=(171568,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_N-Sp-7R!H-5BrClFINOPSSi
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_5BrCClFINPSSi->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 22,
-    label = "Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R",
-    kinetics = ArrheniusBM(A=(205000,'s^-1'), n=2.37, w0=(783500,'J/mol'), E0=(221387,'J/mol'), Tmin=(600,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(2.16654e-24,'s^-1'), n=10.6408, w0=(783500,'J/mol'), E0=(171460,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_3R!H->C_N-1R!H->N_Ext-1C-R
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_N-5BrCClFINPSSi->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 23,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(2857.3,'s^-1'), n=2.79065, w0=(782000,'J/mol'), E0=(88663.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-2.015825826525184e-07, var=0.0007766175206250726, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 0.05586817935319939"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R",
+    kinetics = ArrheniusBM(A=(4.7171e-39,'s^-1'), n=14.8922, w0=(783500,'J/mol'), E0=(141298,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.01101064541230846, var=9.816149634195241, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R',), comment="""BM rule fitted to 17 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R
+    Total Standard Deviation in ln(k): 6.308647308614286"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
-Total Standard Deviation in ln(k): 0.05586817935319939""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R
+Total Standard Deviation in ln(k): 6.308647308614286""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R
-Total Standard Deviation in ln(k): 0.05586817935319939
+BM rule fitted to 17 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R
+Total Standard Deviation in ln(k): 6.308647308614286
 """,
 )
 
 entry(
     index = 24,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R",
-    kinetics = ArrheniusBM(A=(1.09806e-11,'s^-1'), n=6.89792, w0=(798000,'J/mol'), E0=(99858.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0190200390037195, var=1.0964123289271033, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R',), comment="""BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
-    Total Standard Deviation in ln(k): 2.1469413209668056"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(5.51165e-32,'s^-1'), n=12.8838, w0=(783500,'J/mol'), E0=(147147,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.12567911101373058, var=7.520003975421384, Tref=1000.0, N=13, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R',), comment="""BM rule fitted to 13 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R
+    Total Standard Deviation in ln(k): 5.813286616326508"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
-Total Standard Deviation in ln(k): 2.1469413209668056""",
+    shortDesc = """BM rule fitted to 13 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R
+Total Standard Deviation in ln(k): 5.813286616326508""",
     longDesc = 
 """
-BM rule fitted to 6 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R
-Total Standard Deviation in ln(k): 2.1469413209668056
+BM rule fitted to 13 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R
+Total Standard Deviation in ln(k): 5.813286616326508
 """,
 )
 
 entry(
     index = 25,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(6.24893e-09,'s^-1'), n=6.18216, w0=(798000,'J/mol'), E0=(107861,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C",
+    kinetics = ArrheniusBM(A=(2.48826e-19,'s^-1'), n=9.18271, w0=(798000,'J/mol'), E0=(123275,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00853348498558203, var=1.1330821104625106, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C',), comment="""BM rule fitted to 7 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C
+    Total Standard Deviation in ln(k): 2.1554078269576387"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C
+Total Standard Deviation in ln(k): 2.1554078269576387""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 7 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C
+Total Standard Deviation in ln(k): 2.1554078269576387
 """,
 )
 
 entry(
     index = 26,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
-    kinetics = ArrheniusBM(A=(3.10725e-11,'s^-1'), n=6.76455, w0=(798000,'J/mol'), E0=(102204,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(2.16371e-18,'s^-1'), n=8.89968, w0=(798000,'J/mol'), E0=(122284,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0077821224418591385, var=5.847890659064252, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C',), comment="""BM rule fitted to 7 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C
+    Total Standard Deviation in ln(k): 4.867486096063252"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C
+Total Standard Deviation in ln(k): 4.867486096063252""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 7 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C
+Total Standard Deviation in ln(k): 4.867486096063252
 """,
 )
 
 entry(
     index = 27,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
-    kinetics = ArrheniusBM(A=(6.36022e-11,'s^-1'), n=6.62861, w0=(798000,'J/mol'), E0=(100596,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(1.50083e-19,'s^-1'), n=9.25255, w0=(798000,'J/mol'), E0=(127699,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0006427823284157327, var=0.5967826247970905, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 1.5503071008497333"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.5503071008497333""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.5503071008497333
 """,
 )
 
 entry(
     index = 28,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(1.05792e-18,'s^-1'), n=9.0012, w0=(798000,'J/mol'), E0=(119968,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0011076788615978056, var=1.099229330440946, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
-    Total Standard Deviation in ln(k): 2.104630326801545"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(2.30353e-18,'s^-1'), n=8.91582, w0=(798000,'J/mol'), E0=(136829,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.035586230607452495, var=5.809982458271787, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C',), comment="""BM rule fitted to 5 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 4.921607065115819"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
-Total Standard Deviation in ln(k): 2.104630326801545""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 4.921607065115819""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C
-Total Standard Deviation in ln(k): 2.104630326801545
+BM rule fitted to 5 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 4.921607065115819
 """,
 )
 
 entry(
     index = 29,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(3.10141e-18,'s^-1'), n=8.86353, w0=(798000,'J/mol'), E0=(123814,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-7.630684147407905e-05, var=0.07260338773725893, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 0.5403679094229893"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(2891.98,'s^-1'), n=2.78655, w0=(782000,'J/mol'), E0=(88435.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.1408662726283667e-06, var=3.5438674360202764e-06, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 0.003776812860711284"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
-Total Standard Deviation in ln(k): 0.5403679094229893""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 0.003776812860711284""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C
-Total Standard Deviation in ln(k): 0.5403679094229893
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 0.003776812860711284
 """,
 )
 
 entry(
     index = 30,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(2.9852e-20,'s^-1'), n=9.42069, w0=(798000,'J/mol'), E0=(121194,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00033558131741877046, var=0.002267350901758185, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 0.09630205437896223"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(2.8358e-11,'s^-1'), n=6.87143, w0=(798000,'J/mol'), E0=(99284.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.007319874565151385, var=1.5032457358133045, Tref=1000.0, N=18, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R',), comment="""BM rule fitted to 18 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 2.4763356202116875"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 0.09630205437896223""",
+    shortDesc = """BM rule fitted to 18 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 2.4763356202116875""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 0.09630205437896223
+BM rule fitted to 18 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R
+Total Standard Deviation in ln(k): 2.4763356202116875
 """,
 )
 
 entry(
     index = 31,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(2.95366e-14,'s^-1'), n=7.77475, w0=(798000,'J/mol'), E0=(142358,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(7.24956e-11,'s^-1'), n=6.76655, w0=(798000,'J/mol'), E0=(99955.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0007747771928123646, var=0.25480797716605197, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 1.013907033133442"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 1.013907033133442""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_N-5BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 1.013907033133442
 """,
 )
 
 entry(
     index = 32,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C",
-    kinetics = ArrheniusBM(A=(5.35193e-22,'s^-1'), n=9.96064, w0=(798000,'J/mol'), E0=(136695,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0025574536717999116, var=2.4594978159443808, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
-    Total Standard Deviation in ln(k): 3.1504089146845984"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R",
+    kinetics = ArrheniusBM(A=(1.76833e-11,'s^-1'), n=6.92692, w0=(798000,'J/mol'), E0=(101353,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.006227847479353703, var=0.2545942328714686, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R
+    Total Standard Deviation in ln(k): 1.0271836869728679"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
-Total Standard Deviation in ln(k): 3.1504089146845984""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R
+Total Standard Deviation in ln(k): 1.0271836869728679""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C
-Total Standard Deviation in ln(k): 3.1504089146845984
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R
+Total Standard Deviation in ln(k): 1.0271836869728679
 """,
 )
 
 entry(
     index = 33,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(2.27189e-19,'s^-1'), n=9.21636, w0=(798000,'J/mol'), E0=(138167,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0005520236756471257, var=10.279324647875598, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
-    Total Standard Deviation in ln(k): 6.428845485264807"""),
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N",
+    kinetics = ArrheniusBM(A=(3.10725e-11,'s^-1'), n=6.76455, w0=(798000,'J/mol'), E0=(102204,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
-Total Standard Deviation in ln(k): 6.428845485264807""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C
-Total Standard Deviation in ln(k): 6.428845485264807
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 34,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(85014.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(6.36022e-11,'s^-1'), n=6.62861, w0=(798000,'J/mol'), E0=(100596,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_3NS->S_Ext-1R!H-R_Ext-5R!H-R
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_N-6R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 35,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R",
-    kinetics = ArrheniusBM(A=(2.87238e-12,'s^-1'), n=7.05581, w0=(798000,'J/mol'), E0=(99707.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.02252736485366013, var=0.8629404088644341, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
-    Total Standard Deviation in ln(k): 1.9188917676717938"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N",
+    kinetics = ArrheniusBM(A=(3.65781e-21,'s^-1'), n=9.63784, w0=(783500,'J/mol'), E0=(169134,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 1.9188917676717938""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 5 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R
-Total Standard Deviation in ln(k): 1.9188917676717938
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 36,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(1.02008e-17,'s^-1'), n=8.71849, w0=(798000,'J/mol'), E0=(119287,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003881804765101457, var=0.009199804740706677, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 0.20203867135609896"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(2.75059e-13,'s^-1'), n=7.35321, w0=(783500,'J/mol'), E0=(177699,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.000997566440040575, var=0.3154583489682882, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N
+    Total Standard Deviation in ln(k): 1.1284795153107703"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 0.20203867135609896""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N
+Total Standard Deviation in ln(k): 1.1284795153107703""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 0.20203867135609896
+BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N
+Total Standard Deviation in ln(k): 1.1284795153107703
 """,
 )
 
 entry(
     index = 37,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(5.23245e-20,'s^-1'), n=9.38178, w0=(798000,'J/mol'), E0=(126650,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(1.29619e-20,'s^-1'), n=9.49921, w0=(783500,'J/mol'), E0=(172955,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0015278345520543426, var=0.001002786860426071, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N
+    Total Standard Deviation in ln(k): 0.0673223452312378"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 0.0673223452312378""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_N-6BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 0.0673223452312378
 """,
 )
 
 entry(
     index = 38,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(9.00746e-18,'s^-1'), n=8.75254, w0=(798000,'J/mol'), E0=(125562,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(5.29297e-27,'s^-1'), n=11.3369, w0=(783500,'J/mol'), E0=(159055,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00368447309266697, var=0.3545110352579805, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N',), comment="""BM rule fitted to 3 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N
+    Total Standard Deviation in ln(k): 1.2028933602366145"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 1.2028933602366145""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_N-7R!H->C_Ext-5C-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 1.2028933602366145
 """,
 )
 
 entry(
     index = 39,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(3.57404e-19,'s^-1'), n=9.1193, w0=(798000,'J/mol'), E0=(124449,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(3.39196e-35,'s^-1'), n=13.7658, w0=(783500,'J/mol'), E0=(139509,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.005573865076554089, var=7.000467719691818, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R',), comment="""BM rule fitted to 12 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 5.318212342478503"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 12 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 5.318212342478503""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_6R!H->C_Ext-6C-R_7R!H->C_5BrClFINOPSSi->N_Ext-7C-R
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 12 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 5.318212342478503
 """,
 )
 
 entry(
     index = 40,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(2.52338e-22,'s^-1'), n=10.05, w0=(798000,'J/mol'), E0=(131010,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R",
+    kinetics = ArrheniusBM(A=(5.34388e-49,'s^-1'), n=17.7447, w0=(783500,'J/mol'), E0=(138001,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.7166472026976525e-05, var=0.5906289981210904, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R
+    Total Standard Deviation in ln(k): 1.5407299692665106"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R
+Total Standard Deviation in ln(k): 1.5407299692665106""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_5BrClFINOPSSi->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R
+Total Standard Deviation in ln(k): 1.5407299692665106
 """,
 )
 
 entry(
     index = 41,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N",
-    kinetics = ArrheniusBM(A=(1.62343e-20,'s^-1'), n=9.5285, w0=(798000,'J/mol'), E0=(144945,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(1.00696e-46,'s^-1'), n=17.0834, w0=(783500,'J/mol'), E0=(142618,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_7R!H->C_N-5BrClFINOPSSi->N
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 42,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H",
-    kinetics = ArrheniusBM(A=(4.58562e-24,'s^-1'), n=10.6226, w0=(798000,'J/mol'), E0=(138683,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(1.683e-52,'s^-1'), n=18.8808, w0=(783500,'J/mol'), E0=(145094,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0014539038435330003, var=1.9889329677050145, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 2.830921577724545"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 2.830921577724545""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_Sp-5BrClFINOPSSi-3R!H
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 2.830921577724545
 """,
 )
 
 entry(
     index = 43,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H",
-    kinetics = ArrheniusBM(A=(2.02819e-14,'s^-1'), n=7.71417, w0=(798000,'J/mol'), E0=(137432,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C",
+    kinetics = ArrheniusBM(A=(3.21203e-39,'s^-1'), n=15.0033, w0=(783500,'J/mol'), E0=(138739,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.030738678395982533, var=2.4488970918537047, Tref=1000.0, N=11, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C',), comment="""BM rule fitted to 11 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C
+    Total Standard Deviation in ln(k): 3.214433227350278"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 11 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C
+Total Standard Deviation in ln(k): 3.214433227350278""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_Int-7R!H-5BrClFINOPSSi_Sp-7R!H-5BrClFINOPSSi_N-7R!H->C_N-Sp-5BrClFINOPSSi-3R!H
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 11 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C
+Total Standard Deviation in ln(k): 3.214433227350278
 """,
 )
 
 entry(
     index = 44,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing",
-    kinetics = ArrheniusBM(A=(1.68509e-11,'s^-1'), n=6.88807, w0=(798000,'J/mol'), E0=(102832,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(1.26188e-18,'s^-1'), n=8.82369, w0=(783500,'J/mol'), E0=(132157,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0024538566613426984, var=2.592268687365292, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C
+    Total Standard Deviation in ln(k): 3.233893964713657"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C
+Total Standard Deviation in ln(k): 3.233893964713657""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_5R!H-inRing
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C
+Total Standard Deviation in ln(k): 3.233893964713657
 """,
 )
 
 entry(
     index = 45,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing",
-    kinetics = ArrheniusBM(A=(2.36128e-12,'s^-1'), n=7.07296, w0=(798000,'J/mol'), E0=(99585.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.029593247978928896, var=1.2653129163997325, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-    Total Standard Deviation in ln(k): 2.3294037749260914"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(1.2243e-18,'s^-1'), n=8.98338, w0=(798000,'J/mol'), E0=(122888,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.015261423392135449, var=1.4553369561866838, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N',), comment="""BM rule fitted to 5 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N
+    Total Standard Deviation in ln(k): 2.4568045025233345"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-Total Standard Deviation in ln(k): 2.3294037749260914""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N
+Total Standard Deviation in ln(k): 2.4568045025233345""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing
-Total Standard Deviation in ln(k): 2.3294037749260914
+BM rule fitted to 5 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N
+Total Standard Deviation in ln(k): 2.4568045025233345
 """,
 )
 
 entry(
     index = 46,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(1.36428e-17,'s^-1'), n=8.68106, w0=(798000,'J/mol'), E0=(119355,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=9.875757718463376e-05, var=0.019447819937148978, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
-    Total Standard Deviation in ln(k): 0.2798193482943225"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(3.14253e-21,'s^-1'), n=9.72938, w0=(798000,'J/mol'), E0=(123824,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=4.427944658970612e-06, var=0.049309430357815286, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 0.44517712022807143"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
-Total Standard Deviation in ln(k): 0.2798193482943225""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N
+Total Standard Deviation in ln(k): 0.44517712022807143""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R
-Total Standard Deviation in ln(k): 0.2798193482943225
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N
+Total Standard Deviation in ln(k): 0.44517712022807143
 """,
 )
 
 entry(
     index = 47,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H",
-    kinetics = ArrheniusBM(A=(7.93116e-11,'s^-1'), n=6.59023, w0=(798000,'J/mol'), E0=(104253,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.004083326014350255, var=0.36678964389307633, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-    Total Standard Deviation in ln(k): 1.2243905404532403"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N",
+    kinetics = ArrheniusBM(A=(7.03103e-17,'s^-1'), n=8.43292, w0=(798000,'J/mol'), E0=(136927,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 1.2243905404532403""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 1.2243905404532403
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 48,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H",
-    kinetics = ArrheniusBM(A=(3.02789e-13,'s^-1'), n=7.48219, w0=(798000,'J/mol'), E0=(95953.2,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(2.33364e-18,'s^-1'), n=8.89528, w0=(798000,'J/mol'), E0=(120565,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.007217064126337527, var=6.661339248779683, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N',), comment="""BM rule fitted to 6 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N
+    Total Standard Deviation in ln(k): 5.192268440792522"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N
+Total Standard Deviation in ln(k): 5.192268440792522""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_N-Sp-6R!H-5R!H
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 6 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N
+Total Standard Deviation in ln(k): 5.192268440792522
 """,
 )
 
 entry(
     index = 49,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C",
-    kinetics = ArrheniusBM(A=(9.14825e-17,'s^-1'), n=8.45574, w0=(798000,'J/mol'), E0=(121877,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C",
+    kinetics = ArrheniusBM(A=(1.2013e-18,'s^-1'), n=8.97925, w0=(798000,'J/mol'), E0=(126845,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.007503612341907746, var=0.008054470110497336, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C
+    Total Standard Deviation in ln(k): 0.1987716543490167"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C
+Total Standard Deviation in ln(k): 0.1987716543490167""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C
+Total Standard Deviation in ln(k): 0.1987716543490167
 """,
 )
 
 entry(
     index = 50,
-    label = "Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(4.10787e-17,'s^-1'), n=8.57309, w0=(798000,'J/mol'), E0=(122784,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(1.18952e-19,'s^-1'), n=9.32392, w0=(798000,'J/mol'), E0=(137103,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H-inRing_Ext-3R!H-R_5R!H->C_Sp-5C-3R!H_Ext-5C-R_Ext-6R!H-R_N-6R!H->C_Ext-6BrClFINOPSSi-R_7R!H->C_6BrClFINOPSSi->N_Ext-5C-R_N-8R!H->C
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_N-6R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 51,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N",
-    kinetics = ArrheniusBM(A=(8.42992e-10,'s^-1'), n=6.22192, w0=(798000,'J/mol'), E0=(104542,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-3.0517082806578122e-05, var=0.15820189146844285, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
-    Total Standard Deviation in ln(k): 0.7974520617821278"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
-Total Standard Deviation in ln(k): 0.7974520617821278""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N
-Total Standard Deviation in ln(k): 0.7974520617821278
-""",
-)
-
-entry(
-    index = 52,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N",
-    kinetics = ArrheniusBM(A=(1.30511e-12,'s^-1'), n=7.26372, w0=(798000,'J/mol'), E0=(105105,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C",
+    kinetics = ArrheniusBM(A=(6.87223e-13,'s^-1'), n=7.30388, w0=(798000,'J/mol'), E0=(124360,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_N-5R!H->N
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_5R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
+    index = 52,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(3.33668e-20,'s^-1'), n=9.45072, w0=(798000,'J/mol'), E0=(138622,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.025999023929210666, var=2.2367127697893783, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C
+    Total Standard Deviation in ln(k): 3.0635345236969505"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C
+Total Standard Deviation in ln(k): 3.0635345236969505""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C
+Total Standard Deviation in ln(k): 3.0635345236969505
+""",
+)
+
+entry(
     index = 53,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N",
-    kinetics = ArrheniusBM(A=(1.95577e-10,'s^-1'), n=6.41822, w0=(798000,'J/mol'), E0=(102434,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+    label = "Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(87.5,'s^-1'), n=3.23, w0=(782000,'J/mol'), E0=(84839.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_7R!H->N
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_3BrClFINOPSSi->S_Ext-1R!H-R_Ext-5R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 54,
-    label = "Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N",
-    kinetics = ArrheniusBM(A=(5.58698e-10,'s^-1'), n=6.27942, w0=(798000,'J/mol'), E0=(105618,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R",
+    kinetics = ArrheniusBM(A=(6.49091e-10,'s^-1'), n=6.47564, w0=(798000,'J/mol'), E0=(91433.6,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.050948687716974514, var=4.356214748630402, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R
+    Total Standard Deviation in ln(k): 4.3122040205343355"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R
+Total Standard Deviation in ln(k): 4.3122040205343355""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R
+Total Standard Deviation in ln(k): 4.3122040205343355
+""",
+)
+
+entry(
+    index = 55,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O",
+    kinetics = ArrheniusBM(A=(5.2062e-13,'s^-1'), n=7.41511, w0=(798000,'J/mol'), E0=(98886.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0007950118702081248, var=3.035432359577416, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O
+    Total Standard Deviation in ln(k): 3.4947456507807533"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O
+Total Standard Deviation in ln(k): 3.4947456507807533""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O
+Total Standard Deviation in ln(k): 3.4947456507807533
+""",
+)
+
+entry(
+    index = 56,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O",
+    kinetics = ArrheniusBM(A=(4.05054e-12,'s^-1'), n=7.10803, w0=(798000,'J/mol'), E0=(99123.2,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.016044820132993336, var=1.114823641419179, Tref=1000.0, N=13, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O',), comment="""BM rule fitted to 13 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O
+    Total Standard Deviation in ln(k): 2.1570173449726555"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 13 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O
+Total Standard Deviation in ln(k): 2.1570173449726555""",
+    longDesc = 
+"""
+BM rule fitted to 13 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O
+Total Standard Deviation in ln(k): 2.1570173449726555
+""",
+)
+
+entry(
+    index = 57,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C",
+    kinetics = ArrheniusBM(A=(5.31044e-11,'s^-1'), n=6.81698, w0=(798000,'J/mol'), E0=(98809.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003001110983615405, var=0.0884541218470009, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C
+    Total Standard Deviation in ln(k): 0.6037735039900458"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C
+Total Standard Deviation in ln(k): 0.6037735039900458""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C
+Total Standard Deviation in ln(k): 0.6037735039900458
+""",
+)
+
+entry(
+    index = 58,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(6.24893e-09,'s^-1'), n=6.18216, w0=(798000,'J/mol'), E0=(107861,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H-inRing_N-3R!H->C_N-3NS->S_Ext-1R!H-R_Ext-5R!H-R_N-5R!H-inRing_Sp-6R!H-5R!H_5R!H->N_Ext-6R!H-R_N-7R!H->N
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_N-6R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 59,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(7.96668e-12,'s^-1'), n=7.03092, w0=(798000,'J/mol'), E0=(99812,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.004795327190430439, var=0.334359768750165, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 1.1712635750016842"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.1712635750016842""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.1712635750016842
+""",
+)
+
+entry(
+    index = 60,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(6.42858e-10,'s^-1'), n=6.4885, w0=(798000,'J/mol'), E0=(108792,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 61,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(8.47848e-14,'s^-1'), n=7.46671, w0=(783500,'J/mol'), E0=(172647,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_6BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 62,
+    label = "Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O",
+    kinetics = ArrheniusBM(A=(6.84389e-11,'s^-1'), n=6.70227, w0=(783500,'J/mol'), E0=(188014,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-1R!H-R_5R!H->C_Ext-3C-R_N-6R!H->N_N-6BrCClFIOPSSi->O
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 63,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R",
+    kinetics = ArrheniusBM(A=(1.77862e-15,'s^-1'), n=8.01018, w0=(783500,'J/mol'), E0=(186087,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_5BrCClFINPSSi->N_Ext-6R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 64,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C",
+    kinetics = ArrheniusBM(A=(4.76535e-29,'s^-1'), n=11.9206, w0=(783500,'J/mol'), E0=(153536,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=2.191789256932443e-05, var=1.2430025856755769, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C
+    Total Standard Deviation in ln(k): 2.2351347254382397"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C
+Total Standard Deviation in ln(k): 2.2351347254382397""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C
+Total Standard Deviation in ln(k): 2.2351347254382397
+""",
+)
+
+entry(
+    index = 65,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(8.55896e-23,'s^-1'), n=10.1131, w0=(783500,'J/mol'), E0=(169037,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_N-6R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 66,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(7.05956e-34,'s^-1'), n=13.365, w0=(783500,'J/mol'), E0=(128676,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.07048336468685854, var=13.344115837243992, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R',), comment="""BM rule fitted to 4 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R
+    Total Standard Deviation in ln(k): 7.500310675798327"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R
+Total Standard Deviation in ln(k): 7.500310675798327""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R
+Total Standard Deviation in ln(k): 7.500310675798327
+""",
+)
+
+entry(
+    index = 67,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O",
+    kinetics = ArrheniusBM(A=(9.72018e-31,'s^-1'), n=12.4085, w0=(783500,'J/mol'), E0=(140307,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0010171218693333563, var=8.259939515435356, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O
+    Total Standard Deviation in ln(k): 5.764186347309356"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O
+Total Standard Deviation in ln(k): 5.764186347309356""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O
+Total Standard Deviation in ln(k): 5.764186347309356
+""",
+)
+
+entry(
+    index = 68,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O",
+    kinetics = ArrheniusBM(A=(1.45312e-39,'s^-1'), n=15.0595, w0=(783500,'J/mol'), E0=(141451,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0038146995811367415, var=4.810563762111573, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O',), comment="""BM rule fitted to 6 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O
+    Total Standard Deviation in ln(k): 4.406569602102788"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O
+Total Standard Deviation in ln(k): 4.406569602102788""",
+    longDesc = 
+"""
+BM rule fitted to 6 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O
+Total Standard Deviation in ln(k): 4.406569602102788
+""",
+)
+
+entry(
+    index = 69,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(1.63468e-47,'s^-1'), n=17.3183, w0=(783500,'J/mol'), E0=(139713,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-3C-R_Ext-1C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 70,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(2.12859e-53,'s^-1'), n=18.9999, w0=(783500,'J/mol'), E0=(138885,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_7BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 71,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(7.04433e-53,'s^-1'), n=19.1929, w0=(783500,'J/mol'), E0=(151641,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-1C-R_Ext-6R!H-R_N-7R!H->C_N-7BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 72,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing",
+    kinetics = ArrheniusBM(A=(8.61547e-36,'s^-1'), n=13.9493, w0=(783500,'J/mol'), E0=(131318,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=5.388707861713522e-05, var=0.5506957678026614, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing
+    Total Standard Deviation in ln(k): 1.4878268165252302"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing
+Total Standard Deviation in ln(k): 1.4878268165252302""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing
+Total Standard Deviation in ln(k): 1.4878268165252302
+""",
+)
+
+entry(
+    index = 73,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing",
+    kinetics = ArrheniusBM(A=(1.37354e-40,'s^-1'), n=15.4134, w0=(783500,'J/mol'), E0=(139306,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.023411914775309003, var=2.2294398135979376, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing',), comment="""BM rule fitted to 9 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing
+    Total Standard Deviation in ln(k): 3.0521557492204088"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing
+Total Standard Deviation in ln(k): 3.0521557492204088""",
+    longDesc = 
+"""
+BM rule fitted to 9 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing
+Total Standard Deviation in ln(k): 3.0521557492204088
+""",
+)
+
+entry(
+    index = 74,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R",
+    kinetics = ArrheniusBM(A=(1.5544e-16,'s^-1'), n=8.25988, w0=(783500,'J/mol'), E0=(135169,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_N-5R!H->C_Ext-5BrClFINOPSSi-R_Ext-5BrClFINOPSSi-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 75,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N",
+    kinetics = ArrheniusBM(A=(3.22052e-18,'s^-1'), n=8.86451, w0=(798000,'J/mol'), E0=(132813,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=3.298119424757154e-05, var=0.04751076658266557, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N
+    Total Standard Deviation in ln(k): 0.43705426248998613"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N
+Total Standard Deviation in ln(k): 0.43705426248998613""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N
+Total Standard Deviation in ln(k): 0.43705426248998613
+""",
+)
+
+entry(
+    index = 76,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(1.02008e-17,'s^-1'), n=8.71849, w0=(798000,'J/mol'), E0=(119287,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.003881804765101457, var=0.009199804740706677, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N
+    Total Standard Deviation in ln(k): 0.20203867135609896"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N
+Total Standard Deviation in ln(k): 0.20203867135609896""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N
+Total Standard Deviation in ln(k): 0.20203867135609896
+""",
+)
+
+entry(
+    index = 77,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(5.23245e-20,'s^-1'), n=9.38178, w0=(798000,'J/mol'), E0=(126650,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_N-7R!H->N_Ext-5R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 78,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(1.03729e-10,'s^-1'), n=6.68631, w0=(798000,'J/mol'), E0=(105099,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 79,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(3.96828e-18,'s^-1'), n=8.83096, w0=(798000,'J/mol'), E0=(123934,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.005248291867854506, var=0.020819608889374595, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N
+    Total Standard Deviation in ln(k): 0.30244992057304115"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N
+Total Standard Deviation in ln(k): 0.30244992057304115""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N
+Total Standard Deviation in ln(k): 0.30244992057304115
+""",
+)
+
+entry(
+    index = 80,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(5.26306e-21,'s^-1'), n=9.67718, w0=(798000,'J/mol'), E0=(128106,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-7.852972029802102e-05, var=0.07843541824040957, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 0.5616499114029998"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N
+Total Standard Deviation in ln(k): 0.5616499114029998""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N
+Total Standard Deviation in ln(k): 0.5616499114029998
+""",
+)
+
+entry(
+    index = 81,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N",
+    kinetics = ArrheniusBM(A=(2.9852e-20,'s^-1'), n=9.42069, w0=(798000,'J/mol'), E0=(121194,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00033558131741877046, var=0.002267350901758185, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N
+    Total Standard Deviation in ln(k): 0.09630205437896223"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N
+Total Standard Deviation in ln(k): 0.09630205437896223""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N
+Total Standard Deviation in ln(k): 0.09630205437896223
+""",
+)
+
+entry(
+    index = 82,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(2.95366e-14,'s^-1'), n=7.77475, w0=(798000,'J/mol'), E0=(142358,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 83,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C",
+    kinetics = ArrheniusBM(A=(5.35193e-22,'s^-1'), n=9.96064, w0=(798000,'J/mol'), E0=(136695,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0025574536717999116, var=2.4594978159443808, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C
+    Total Standard Deviation in ln(k): 3.1504089146845984"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C
+Total Standard Deviation in ln(k): 3.1504089146845984""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C
+Total Standard Deviation in ln(k): 3.1504089146845984
+""",
+)
+
+entry(
+    index = 84,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(2.27189e-19,'s^-1'), n=9.21636, w0=(798000,'J/mol'), E0=(138167,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0005520236756471257, var=10.279324647875598, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C
+    Total Standard Deviation in ln(k): 6.428845485264807"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C
+Total Standard Deviation in ln(k): 6.428845485264807""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C
+Total Standard Deviation in ln(k): 6.428845485264807
+""",
+)
+
+entry(
+    index = 85,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R",
+    kinetics = ArrheniusBM(A=(3.14206e-08,'s^-1'), n=5.89269, w0=(798000,'J/mol'), E0=(96466.9,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.007103816317503689, var=1.2657848014962294, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R
+    Total Standard Deviation in ln(k): 2.2733181243649305"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 2.2733181243649305""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R
+Total Standard Deviation in ln(k): 2.2733181243649305
+""",
+)
+
+entry(
+    index = 86,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R",
+    kinetics = ArrheniusBM(A=(7.80609e-12,'s^-1'), n=7.13985, w0=(798000,'J/mol'), E0=(100522,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_5R!H->O_Ext-5O-R_Ext-6R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 87,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing",
+    kinetics = ArrheniusBM(A=(1.91384e-12,'s^-1'), n=7.25794, w0=(798000,'J/mol'), E0=(97947.9,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.009397196092007891, var=0.7686028833011719, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing',), comment="""BM rule fitted to 5 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing
+    Total Standard Deviation in ln(k): 1.781162280149695"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing
+Total Standard Deviation in ln(k): 1.781162280149695""",
+    longDesc = 
+"""
+BM rule fitted to 5 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing
+Total Standard Deviation in ln(k): 1.781162280149695
+""",
+)
+
+entry(
+    index = 88,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing",
+    kinetics = ArrheniusBM(A=(1.06243e-11,'s^-1'), n=6.95264, w0=(798000,'J/mol'), E0=(100401,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.013841978490351722, var=1.4978984770857497, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing',), comment="""BM rule fitted to 8 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing
+    Total Standard Deviation in ln(k): 2.488347293422955"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 8 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing
+Total Standard Deviation in ln(k): 2.488347293422955""",
+    longDesc = 
+"""
+BM rule fitted to 8 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing
+Total Standard Deviation in ln(k): 2.488347293422955
+""",
+)
+
+entry(
+    index = 89,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing",
+    kinetics = ArrheniusBM(A=(3.03926e-10,'s^-1'), n=6.64444, w0=(798000,'J/mol'), E0=(102217,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_5R!H-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 90,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing",
+    kinetics = ArrheniusBM(A=(5.48296e-11,'s^-1'), n=6.80463, w0=(798000,'J/mol'), E0=(98982.9,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0007442885720676981, var=0.183155239978996, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing
+    Total Standard Deviation in ln(k): 0.859829326869262"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing
+Total Standard Deviation in ln(k): 0.859829326869262""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing
+Total Standard Deviation in ln(k): 0.859829326869262
+""",
+)
+
+entry(
+    index = 91,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H",
+    kinetics = ArrheniusBM(A=(4.78578e-12,'s^-1'), n=7.10286, w0=(798000,'J/mol'), E0=(99080.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0002745781153866372, var=1.0547827373537062, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H
+    Total Standard Deviation in ln(k): 2.0596052670482954"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H
+Total Standard Deviation in ln(k): 2.0596052670482954""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H
+Total Standard Deviation in ln(k): 2.0596052670482954
+""",
+)
+
+entry(
+    index = 92,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H",
+    kinetics = ArrheniusBM(A=(1.03652e-10,'s^-1'), n=6.72069, w0=(798000,'J/mol'), E0=(104667,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_N-Sp-7C-6R!H
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 93,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N",
+    kinetics = ArrheniusBM(A=(2.33301e-26,'s^-1'), n=11.129, w0=(783500,'J/mol'), E0=(156331,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 94,
+    label = "Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(9.38708e-30,'s^-1'), n=12.1418, w0=(783500,'J/mol'), E0=(156046,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_3C-inRing_Ext-3C-R_N-5R!H->O_Ext-5BrCClFINPSSi-R_Ext-3C-R_N-5BrCClFINPSSi->N_6R!H->C_N-7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 95,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H",
+    kinetics = ArrheniusBM(A=(1.28865e-37,'s^-1'), n=14.538, w0=(783500,'J/mol'), E0=(130721,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.000346958337291659, var=37.48678228742628, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H
+    Total Standard Deviation in ln(k): 12.275153032997775"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H
+Total Standard Deviation in ln(k): 12.275153032997775""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H
+Total Standard Deviation in ln(k): 12.275153032997775
+""",
+)
+
+entry(
+    index = 96,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H",
+    kinetics = ArrheniusBM(A=(1.1005e-35,'s^-1'), n=13.7813, w0=(783500,'J/mol'), E0=(112552,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00821388997240908, var=44.61659603744424, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H
+    Total Standard Deviation in ln(k): 13.41139728945312"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H
+Total Standard Deviation in ln(k): 13.41139728945312""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H
+Total Standard Deviation in ln(k): 13.41139728945312
+""",
+)
+
+entry(
+    index = 97,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R",
+    kinetics = ArrheniusBM(A=(5.80714e-28,'s^-1'), n=11.6116, w0=(783500,'J/mol'), E0=(139131,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_6R!H->O_Ext-3C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 98,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R",
+    kinetics = ArrheniusBM(A=(2.42468e-39,'s^-1'), n=15.0373, w0=(783500,'J/mol'), E0=(149617,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0005211803673611572, var=3.921589378971721, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R
+    Total Standard Deviation in ln(k): 3.9712870246122276"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R
+Total Standard Deviation in ln(k): 3.9712870246122276""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R
+Total Standard Deviation in ln(k): 3.9712870246122276
+""",
+)
+
+entry(
+    index = 99,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H",
+    kinetics = ArrheniusBM(A=(3.9707e-44,'s^-1'), n=16.3291, w0=(783500,'J/mol'), E0=(138718,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0005557120191888678, var=10.235706611528846, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H
+    Total Standard Deviation in ln(k): 6.415203507633639"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H
+Total Standard Deviation in ln(k): 6.415203507633639""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H
+Total Standard Deviation in ln(k): 6.415203507633639
+""",
+)
+
+entry(
+    index = 100,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H",
+    kinetics = ArrheniusBM(A=(1.70296e-34,'s^-1'), n=13.6036, w0=(783500,'J/mol'), E0=(137799,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.00018330541447844498, var=0.0007798796061297237, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H
+    Total Standard Deviation in ln(k): 0.056445448893047076"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H
+Total Standard Deviation in ln(k): 0.056445448893047076""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H
+Total Standard Deviation in ln(k): 0.056445448893047076
+""",
+)
+
+entry(
+    index = 101,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N",
+    kinetics = ArrheniusBM(A=(2.59344e-34,'s^-1'), n=13.552, w0=(783500,'J/mol'), E0=(139140,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 102,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(1.41171e-33,'s^-1'), n=13.3174, w0=(783500,'J/mol'), E0=(135339,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_5C-inRing_Ext-5C-R_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 103,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(1.49939e-41,'s^-1'), n=15.6867, w0=(783500,'J/mol'), E0=(139332,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.017635097520241096, var=1.3716297688364298, Tref=1000.0, N=8, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R',), comment="""BM rule fitted to 8 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R
+    Total Standard Deviation in ln(k): 2.3921868256112373"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 8 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R
+Total Standard Deviation in ln(k): 2.3921868256112373""",
+    longDesc = 
+"""
+BM rule fitted to 8 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R
+Total Standard Deviation in ln(k): 2.3921868256112373
+""",
+)
+
+entry(
+    index = 104,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R",
+    kinetics = ArrheniusBM(A=(1.19581e-17,'s^-1'), n=8.72753, w0=(798000,'J/mol'), E0=(135275,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_5R!H->N_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 105,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(1.36428e-17,'s^-1'), n=8.68106, w0=(798000,'J/mol'), E0=(119355,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=9.875757718463376e-05, var=0.019447819937148978, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R
+    Total Standard Deviation in ln(k): 0.2798193482943225"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R
+Total Standard Deviation in ln(k): 0.2798193482943225""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R
+Total Standard Deviation in ln(k): 0.2798193482943225
+""",
+)
+
+entry(
+    index = 106,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(4.83626e-18,'s^-1'), n=8.80389, w0=(798000,'J/mol'), E0=(123595,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00010214101403961101, var=0.010815603590169066, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R
+    Total Standard Deviation in ln(k): 0.20874526307047123"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R
+Total Standard Deviation in ln(k): 0.20874526307047123""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R
+Total Standard Deviation in ln(k): 0.20874526307047123
+""",
+)
+
+entry(
+    index = 107,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(4.43945e-20,'s^-1'), n=9.41864, w0=(798000,'J/mol'), E0=(130190,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_N-7R!H->N_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 108,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R",
+    kinetics = ArrheniusBM(A=(3.57404e-19,'s^-1'), n=9.1193, w0=(798000,'J/mol'), E0=(124449,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_7R!H->C_6R!H->C_5R!H->N_Ext-1R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 109,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N",
+    kinetics = ArrheniusBM(A=(2.52338e-22,'s^-1'), n=10.05, w0=(798000,'J/mol'), E0=(131010,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_5NO->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 110,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N",
+    kinetics = ArrheniusBM(A=(1.62343e-20,'s^-1'), n=9.5285, w0=(798000,'J/mol'), E0=(144945,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_6R!H->C_N-5NO->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 111,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi",
+    kinetics = ArrheniusBM(A=(4.58562e-24,'s^-1'), n=10.6226, w0=(798000,'J/mol'), E0=(138683,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_Sp-5NO-3BrClFINNOOPSSi
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 112,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi",
+    kinetics = ArrheniusBM(A=(2.02819e-14,'s^-1'), n=7.71417, w0=(798000,'J/mol'), E0=(137432,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_N-Sp-6R!H=5R!H_Ext-6R!H-R_N-7R!H->C_N-5R!H->C_N-6R!H->C_N-Sp-5NO-3BrClFINNOOPSSi
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 113,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N",
+    kinetics = ArrheniusBM(A=(5.39095e-06,'s^-1'), n=5.24031, w0=(798000,'J/mol'), E0=(98425.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 114,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(6.85036e-08,'s^-1'), n=5.86332, w0=(798000,'J/mol'), E0=(104769,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_Ext-3N-R_Ext-5R!H-R_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 115,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N",
+    kinetics = ArrheniusBM(A=(1.68509e-11,'s^-1'), n=6.88807, w0=(798000,'J/mol'), E0=(102832,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_5CN->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 116,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N",
+    kinetics = ArrheniusBM(A=(4.62114e-12,'s^-1'), n=7.17889, w0=(798000,'J/mol'), E0=(98672.8,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0008524116468629175, var=0.4723812140851986, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N
+    Total Standard Deviation in ln(k): 1.3799960457840075"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N
+Total Standard Deviation in ln(k): 1.3799960457840075""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N
+Total Standard Deviation in ln(k): 1.3799960457840075
+""",
+)
+
+entry(
+    index = 117,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N",
+    kinetics = ArrheniusBM(A=(1.27183e-09,'s^-1'), n=6.27799, w0=(798000,'J/mol'), E0=(100814,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.02066922975027657, var=4.0264856804914295, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N
+    Total Standard Deviation in ln(k): 4.0746551849825074"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N
+Total Standard Deviation in ln(k): 4.0746551849825074""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N
+Total Standard Deviation in ln(k): 4.0746551849825074
+""",
+)
+
+entry(
+    index = 118,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N",
+    kinetics = ArrheniusBM(A=(8.55381e-14,'s^-1'), n=7.63186, w0=(798000,'J/mol'), E0=(99951.4,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.005151236920225529, var=0.6670469698365156, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N',), comment="""BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N
+    Total Standard Deviation in ln(k): 1.6502689532219956"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N
+Total Standard Deviation in ln(k): 1.6502689532219956""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N
+Total Standard Deviation in ln(k): 1.6502689532219956
+""",
+)
+
+entry(
+    index = 119,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C",
+    kinetics = ArrheniusBM(A=(4.06473e-10,'s^-1'), n=6.60955, w0=(798000,'J/mol'), E0=(103273,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 120,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(2.81779e-10,'s^-1'), n=6.57871, w0=(798000,'J/mol'), E0=(100933,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-5R!H-R_6R!H->C_N-5R!H-inRing_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 121,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N",
+    kinetics = ArrheniusBM(A=(3.2546e-11,'s^-1'), n=6.85152, w0=(798000,'J/mol'), E0=(103720,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 122,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N",
+    kinetics = ArrheniusBM(A=(4.48783e-11,'s^-1'), n=6.87686, w0=(798000,'J/mol'), E0=(101775,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-3N-R_Ext-5R!H-R_Ext-6R!H-R_7R!H->C_Sp-7C-6R!H_N-6R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 123,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R",
+    kinetics = ArrheniusBM(A=(2.00799e-42,'s^-1'), n=15.8601, w0=(783500,'J/mol'), E0=(132757,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_Sp-6R!H#5R!H_Ext-7R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 124,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C",
+    kinetics = ArrheniusBM(A=(5.51726e-18,'s^-1'), n=8.84109, w0=(783500,'J/mol'), E0=(146092,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 125,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(1.76964e-27,'s^-1'), n=11.3857, w0=(783500,'J/mol'), E0=(149824,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_Ext-1C-R_N-Sp-6R!H#5R!H_N-5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 126,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N",
+    kinetics = ArrheniusBM(A=(6.97955e-36,'s^-1'), n=14.0901, w0=(783500,'J/mol'), E0=(155645,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 127,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N",
+    kinetics = ArrheniusBM(A=(1.49793e-42,'s^-1'), n=15.9135, w0=(783500,'J/mol'), E0=(144341,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Ext-3C-R_N-6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 128,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N",
+    kinetics = ArrheniusBM(A=(6.56099e-43,'s^-1'), n=15.9484, w0=(783500,'J/mol'), E0=(130721,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 129,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N",
+    kinetics = ArrheniusBM(A=(7.84947e-45,'s^-1'), n=16.5411, w0=(783500,'J/mol'), E0=(146853,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_Sp-6CN-5R!H_N-5R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 130,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N",
+    kinetics = ArrheniusBM(A=(5.93747e-32,'s^-1'), n=12.864, w0=(783500,'J/mol'), E0=(144121,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 131,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N",
+    kinetics = ArrheniusBM(A=(4.21191e-35,'s^-1'), n=13.8299, w0=(783500,'J/mol'), E0=(139136,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-3C-R_Ext-5R!H-R_N-6R!H->O_N-Sp-6CN-5R!H_N-6CN->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 132,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O",
+    kinetics = ArrheniusBM(A=(3.12991e-42,'s^-1'), n=16.0032, w0=(783500,'J/mol'), E0=(147725,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.005104197619452722, var=0.6514006771320477, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O',), comment="""BM rule fitted to 3 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O
+    Total Standard Deviation in ln(k): 1.6308342104428886"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O
+Total Standard Deviation in ln(k): 1.6308342104428886""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O
+Total Standard Deviation in ln(k): 1.6308342104428886
+""",
+)
+
+entry(
+    index = 133,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O",
+    kinetics = ArrheniusBM(A=(2.23905e-41,'s^-1'), n=15.5459, w0=(783500,'J/mol'), E0=(132179,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.01764662734538523, var=2.762297332654543, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O',), comment="""BM rule fitted to 5 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O
+    Total Standard Deviation in ln(k): 3.376240123551729"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O
+Total Standard Deviation in ln(k): 3.376240123551729""",
+    longDesc = 
+"""
+BM rule fitted to 5 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O
+Total Standard Deviation in ln(k): 3.376240123551729
+""",
+)
+
+entry(
+    index = 134,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C",
+    kinetics = ArrheniusBM(A=(9.14825e-17,'s^-1'), n=8.45574, w0=(798000,'J/mol'), E0=(121877,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 135,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(4.10787e-17,'s^-1'), n=8.57309, w0=(798000,'J/mol'), E0=(122784,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_6R!H->C_Ext-6C-R_7R!H->N_N-5R!H->N_Ext-5C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 136,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C",
+    kinetics = ArrheniusBM(A=(2.18792e-17,'s^-1'), n=8.63308, w0=(798000,'J/mol'), E0=(126694,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 137,
+    label = "Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C",
+    kinetics = ArrheniusBM(A=(9.00746e-18,'s^-1'), n=8.75254, w0=(798000,'J/mol'), E0=(125562,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_1R!H-inRing_Ext-3BrClFINOPSSi-R_Ext-5R!H-R_Ext-5R!H-R_Ext-6R!H-R_Ext-6R!H-R_Sp-6R!H=5R!H_N-6R!H->C_N-5R!H->N_Ext-6NO-R_7R!H->N_Ext-5C-R_N-8R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 138,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O",
+    kinetics = ArrheniusBM(A=(2.50132e-12,'s^-1'), n=7.25319, w0=(798000,'J/mol'), E0=(100833,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00011345744626205915, var=0.1436923898370318, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O
+    Total Standard Deviation in ln(k): 0.7602155653984278"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O
+Total Standard Deviation in ln(k): 0.7602155653984278""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O
+Total Standard Deviation in ln(k): 0.7602155653984278
+""",
+)
+
+entry(
+    index = 139,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O",
+    kinetics = ArrheniusBM(A=(9.45314e-12,'s^-1'), n=7.09189, w0=(798000,'J/mol'), E0=(96623.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.002283801048831891, var=1.002884062322813, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O
+    Total Standard Deviation in ln(k): 2.0133620800594025"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O
+Total Standard Deviation in ln(k): 2.0133620800594025""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O
+Total Standard Deviation in ln(k): 2.0133620800594025
+""",
+)
+
+entry(
+    index = 140,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R",
+    kinetics = ArrheniusBM(A=(1.06755e-09,'s^-1'), n=6.27527, w0=(798000,'J/mol'), E0=(101404,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.019664974446828635, var=6.654169286516482, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R',), comment="""BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R
+    Total Standard Deviation in ln(k): 5.220759245944637"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R
+Total Standard Deviation in ln(k): 5.220759245944637""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R
+Total Standard Deviation in ln(k): 5.220759245944637
+""",
+)
+
+entry(
+    index = 141,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C",
+    kinetics = ArrheniusBM(A=(5.14551e-13,'s^-1'), n=7.40529, w0=(798000,'J/mol'), E0=(97522.7,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00075759922583963, var=0.28233106563393995, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C
+    Total Standard Deviation in ln(k): 1.0671161847633435"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C
+Total Standard Deviation in ln(k): 1.0671161847633435""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C
+Total Standard Deviation in ln(k): 1.0671161847633435
+""",
+)
+
+entry(
+    index = 142,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C",
+    kinetics = ArrheniusBM(A=(5.12223e-14,'s^-1'), n=7.69896, w0=(798000,'J/mol'), E0=(103788,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0008528973385954304, var=0.051142726364650844, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C
+    Total Standard Deviation in ln(k): 0.455508937449092"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C
+Total Standard Deviation in ln(k): 0.455508937449092""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C
+Total Standard Deviation in ln(k): 0.455508937449092
+""",
+)
+
+entry(
+    index = 143,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(7.90666e-42,'s^-1'), n=15.8943, w0=(783500,'J/mol'), E0=(146796,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.000190200256858076, var=0.37522901375334483, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R
+    Total Standard Deviation in ln(k): 1.2284971984464699"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R
+Total Standard Deviation in ln(k): 1.2284971984464699""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R
+Total Standard Deviation in ln(k): 1.2284971984464699
+""",
+)
+
+entry(
+    index = 144,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(2.74964e-45,'s^-1'), n=16.6685, w0=(783500,'J/mol'), E0=(135903,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 145,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(4.00881e-40,'s^-1'), n=15.1916, w0=(783500,'J/mol'), E0=(131229,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.013577205760681086, var=1.0511336006433443, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N',), comment="""BM rule fitted to 4 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+    Total Standard Deviation in ln(k): 2.0894643469756167"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 2.0894643469756167""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 2.0894643469756167
+""",
+)
+
+entry(
+    index = 146,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(4.42405e-12,'s^-1'), n=7.19519, w0=(798000,'J/mol'), E0=(101144,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->O_Ext-6O-R_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 147,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(2.83728e-12,'s^-1'), n=7.25327, w0=(798000,'J/mol'), E0=(98862.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 148,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N",
+    kinetics = ArrheniusBM(A=(1.32223e-12,'s^-1'), n=7.33725, w0=(798000,'J/mol'), E0=(91315.1,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 149,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R",
+    kinetics = ArrheniusBM(A=(8.42992e-10,'s^-1'), n=6.22192, w0=(798000,'J/mol'), E0=(104542,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-3.0517082806578122e-05, var=0.15820189146844285, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R
+    Total Standard Deviation in ln(k): 0.7974520617821278"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R
+Total Standard Deviation in ln(k): 0.7974520617821278""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R
+Total Standard Deviation in ln(k): 0.7974520617821278
+""",
+)
+
+entry(
+    index = 150,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R",
+    kinetics = ArrheniusBM(A=(1.3825e-13,'s^-1'), n=7.5932, w0=(798000,'J/mol'), E0=(98979.3,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_6R!H->C_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 151,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(1.30511e-12,'s^-1'), n=7.26372, w0=(798000,'J/mol'), E0=(105105,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_N-5CN->N_Ext-5C-R_N-6R!H->C_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 152,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R",
+    kinetics = ArrheniusBM(A=(1.10569e-41,'s^-1'), n=15.9357, w0=(783500,'J/mol'), E0=(153831,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_6R!H->O_Ext-5C-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 153,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C",
+    kinetics = ArrheniusBM(A=(4.11673e-40,'s^-1'), n=15.217, w0=(783500,'J/mol'), E0=(130288,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=3.269021400113391, var=22.06068708684146, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C
+    Total Standard Deviation in ln(k): 17.629622840907796"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C
+Total Standard Deviation in ln(k): 17.629622840907796""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C
+Total Standard Deviation in ln(k): 17.629622840907796
+""",
+)
+
+entry(
+    index = 154,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C",
+    kinetics = ArrheniusBM(A=(3.05337e-40,'s^-1'), n=15.211, w0=(783500,'J/mol'), E0=(131424,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-6.547473076073497e-05, var=3.0139654942257157, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C',), comment="""BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C
+    Total Standard Deviation in ln(k): 3.480540206394142"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C
+Total Standard Deviation in ln(k): 3.480540206394142""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C
+Total Standard Deviation in ln(k): 3.480540206394142
+""",
+)
+
+entry(
+    index = 155,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(1.95577e-10,'s^-1'), n=6.41822, w0=(798000,'J/mol'), E0=(102434,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 156,
+    label = "Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(5.58698e-10,'s^-1'), n=6.27942, w0=(798000,'J/mol'), E0=(105618,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-3R!H->C_N-1R!H-inRing_N-3BrClFINOPSSi->S_Ext-1R!H-R_N-5R!H->O_N-5CN-inRing_5CN->N_Ext-5N-R_Ext-6R!H-R_N-7R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 157,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R",
+    kinetics = ArrheniusBM(A=(2.34803e-38,'s^-1'), n=14.7488, w0=(783500,'J/mol'), E0=(137450,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_Sp-6C-5C_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 158,
+    label = "Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R",
+    kinetics = ArrheniusBM(A=(1.06626e-37,'s^-1'), n=14.5413, w0=(783500,'J/mol'), E0=(136642,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R',), comment="""BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_3R!H->C_N-3C-inRing_N-1R!H->N_Ext-1C-R_5R!H->C_N-5C-inRing_Ext-5C-R_N-6R!H->O_N-6BrCClFINPSSi->N_N-Sp-6C-5C_Ext-6C-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/Ketoenol/training/dictionary.txt
+++ b/input/kinetics/families/Ketoenol/training/dictionary.txt
@@ -742,3 +742,1841 @@ C3H5N3O-2
 11    H u0 p0 c0 {4,S}
 12    H u0 p0 c0 {4,S}
 
+C3H6N2O-3
+1  *3 O u0 p2 c0 {6,S} {12,S}
+2     N u0 p1 c0 {4,S} {5,D}
+3  *1 N u0 p1 c0 {5,S} {6,D}
+4     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {2,D} {3,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {3,D} {10,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C3H6N2O-4
+1  *3 O u0 p2 c0 {6,D}
+2  *1 N u0 p1 c0 {5,S} {6,S} {10,S}
+3     N u0 p1 c0 {4,S} {5,D}
+4     C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {2,S} {3,D} {11,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {12,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10 *4 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+
+C3H4O2
+1    O u0 p2 c0 {3,S} {4,S}
+2 *3 O u0 p2 c0 {5,S} {9,S}
+3    C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+4 *1 C u0 p0 c0 {1,S} {3,S} {5,D}
+5 *2 C u0 p0 c0 {2,S} {4,D} {8,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {5,S}
+9 *4 H u0 p0 c0 {2,S}
+
+C3H4O2-2
+1    O u0 p2 c0 {3,S} {4,S}
+2 *3 O u0 p2 c0 {5,D}
+3 *1 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4    C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+5 *2 C u0 p0 c0 {2,D} {3,S} {9,S}
+6 *4 H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9    H u0 p0 c0 {5,S}
+
+C4H5NO
+1  *3 O u0 p2 c0 {4,S} {10,S}
+2  *1 N u0 p1 c0 {3,S} {4,D}
+3     C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4  *2 C u0 p0 c0 {1,S} {2,D} {9,S}
+5     C u0 p0 c0 {3,S} {6,T}
+6     C u0 p0 c0 {5,T} {11,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10 *4 H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {6,S}
+
+C4H5NO-2
+1  *3 O u0 p2 c0 {4,D}
+2  *1 N u0 p1 c0 {3,S} {4,S} {9,S}
+3     C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {10,S}
+5     C u0 p0 c0 {3,S} {6,T}
+6     C u0 p0 c0 {5,T} {11,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+
+C5H6O
+1  *3 O u0 p2 c0 {3,S} {11,S}
+2     C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+4  *1 C u0 p0 c0 {3,D} {5,S} {10,S}
+5     C u0 p0 c0 {4,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11 *4 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+
+C5H6O-2
+1  *3 O u0 p2 c0 {4,D}
+2  *1 C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+3     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+5     C u0 p0 c0 {2,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8  *4 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+
+C5H6O-3
+1  *3 O u0 p2 c0 {3,S} {11,S}
+2     C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+3  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+4  *1 C u0 p0 c0 {3,D} {9,S} {10,S}
+5     C u0 p0 c0 {2,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11 *4 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+
+C5H6O-4
+1  *3 O u0 p2 c0 {4,D}
+2     C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+3  *1 C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+5     C u0 p0 c0 {2,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11 *4 H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+
+C4H5NO-3
+1  *3 O u0 p2 c0 {5,S} {11,S}
+2     N u0 p1 c0 {6,T}
+3     C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4  *1 C u0 p0 c0 {3,S} {5,D} {9,S}
+5  *2 C u0 p0 c0 {1,S} {4,D} {10,S}
+6     C u0 p0 c0 {2,T} {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C4H5NO-4
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {6,T}
+3  *1 C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {3,S} {6,S} {9,S} {10,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+6     C u0 p0 c0 {2,T} {4,S}
+7     H u0 p0 c0 {3,S}
+8  *4 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C3H7NO2
+1     O u0 p2 c0 {4,S} {6,S}
+2  *3 O u0 p2 c0 {6,S} {12,S}
+3  *1 N u0 p1 c0 {6,D} {13,S}
+4     C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+5     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {3,S}
+
+C3H7NO2-2
+1     O u0 p2 c0 {4,S} {6,S}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 N u0 p1 c0 {6,S} {12,S} {13,S}
+4     C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+5     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+
+C4H6O2
+1     O u0 p2 c0 {3,S} {5,S}
+2  *3 O u0 p2 c0 {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  *1 C u0 p0 c0 {1,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {2,S} {5,D} {11,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12 *4 H u0 p0 c0 {2,S}
+
+C4H6O2-2
+1     O u0 p2 c0 {3,S} {4,S}
+2  *3 O u0 p2 c0 {6,D}
+3     C u0 p0 c0 {1,S} {4,S} {5,S} {7,S}
+4  *1 C u0 p0 c0 {1,S} {3,S} {6,S} {8,S}
+5     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {2,D} {4,S} {12,S}
+7     H u0 p0 c0 {3,S}
+8  *4 H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+
+C4H8O-3
+1  *3 O u0 p2 c0 {5,S} {13,S}
+2     C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+3     C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+5  *2 C u0 p0 c0 {1,S} {4,D} {12,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {5,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H8O-4
+1  *3 O u0 p2 c0 {5,D}
+2  *1 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {13,S}
+6  *4 H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+
+C2H3NO2-3
+1 *3 O u0 p2 c0 {4,S} {7,S}
+2    O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {4,D} {8,S}
+4 *2 C u0 p0 c0 {1,S} {3,D} {5,S}
+5    C u0 p0 c0 {2,D} {4,S} {6,S}
+6    H u0 p0 c0 {5,S}
+7 *4 H u0 p0 c0 {1,S}
+8    H u0 p0 c0 {3,S}
+
+C2H3NO2-4
+1 *3 O u0 p2 c0 {4,D}
+2    O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {4,S} {7,S} {8,S}
+4 *2 C u0 p0 c0 {1,D} {3,S} {5,S}
+5    C u0 p0 c0 {2,D} {4,S} {6,S}
+6    H u0 p0 c0 {5,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {3,S}
+
+C4H9NO
+1  *3 O u0 p2 c0 {6,S} {15,S}
+2  *1 N u0 p1 c0 {3,S} {6,D}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {1,S} {2,D} {14,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {6,S}
+15 *4 H u0 p0 c0 {1,S}
+
+C4H9NO-2
+1  *3 O u0 p2 c0 {6,D}
+2  *1 N u0 p1 c0 {3,S} {6,S} {14,S}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {15,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14 *4 H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {6,S}
+
+C5H8O
+1  *3 O u0 p2 c0 {5,S} {14,S}
+2     C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4     C u0 p0 c0 {2,S} {3,S} {10,S} {11,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {6,D}
+6  *1 C u0 p0 c0 {5,D} {12,S} {13,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {6,S}
+14 *4 H u0 p0 c0 {1,S}
+
+C5H8O-2
+1  *3 O u0 p2 c0 {6,D}
+2     C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+3     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4     C u0 p0 c0 {2,S} {3,S} {10,S} {11,S}
+5  *1 C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {5,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14 *4 H u0 p0 c0 {5,S}
+
+C5H8O-3
+1  *3 O u0 p2 c0 {6,S} {14,S}
+2     C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+3     C u0 p0 c0 {2,S} {5,S} {9,S} {10,S}
+4     C u0 p0 c0 {6,S} {11,S} {12,S} {13,S}
+5  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {4,S} {5,D}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14 *4 H u0 p0 c0 {1,S}
+
+C5H8O-4
+1  *3 O u0 p2 c0 {6,D}
+2  *1 C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+3     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4     C u0 p0 c0 {2,S} {3,S} {10,S} {11,S}
+5     C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {5,S}
+7  *4 H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+
+C3H5NO2
+1  *3 O u0 p2 c0 {6,S} {11,S}
+2     O u0 p2 c0 {5,D}
+3     N u0 p1 c0 {5,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {5,S} {6,D} {7,S}
+5     C u0 p0 c0 {2,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {1,S} {4,D} {8,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C3H5NO2-2
+1     O u0 p2 c0 {5,D}
+2  *3 O u0 p2 c0 {6,D}
+3     N u0 p1 c0 {5,S} {10,S} {11,S}
+4  *1 C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5     C u0 p0 c0 {1,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {2,D} {4,S} {9,S}
+7     H u0 p0 c0 {4,S}
+8  *4 H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+
+C3H5NO2-3
+1  *3 O u0 p2 c0 {4,S} {11,S}
+2     O u0 p2 c0 {6,D}
+3     N u0 p1 c0 {4,S} {9,S} {10,S}
+4  *2 C u0 p0 c0 {1,S} {3,S} {5,D}
+5  *1 C u0 p0 c0 {4,D} {6,S} {7,S}
+6     C u0 p0 c0 {2,D} {5,S} {8,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {6,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C3H5NO2-4
+1  *3 O u0 p2 c0 {5,D}
+2     O u0 p2 c0 {6,D}
+3     N u0 p1 c0 {5,S} {10,S} {11,S}
+4  *1 C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+6     C u0 p0 c0 {2,D} {4,S} {9,S}
+7     H u0 p0 c0 {4,S}
+8  *4 H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+
+C3H5NO2-5
+1     O u0 p2 c0 {4,S} {5,S}
+2  *3 O u0 p2 c0 {6,S} {10,S}
+3  *1 N u0 p1 c0 {6,D} {11,S}
+4     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6  *2 C u0 p0 c0 {2,S} {3,D} {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10 *4 H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {3,S}
+
+C3H5NO2-6
+1     O u0 p2 c0 {4,S} {5,S}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 N u0 p1 c0 {6,S} {10,S} {11,S}
+4     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10 *4 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+
+C4H7NO
+1  *3 O u0 p2 c0 {6,S} {13,S}
+2     N u0 p1 c0 {3,S} {5,S} {12,S}
+3     C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {6,S} {9,S} {10,S} {11,S}
+5  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {4,S} {5,D}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {2,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-2
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {3,S} {4,S} {13,S}
+3  *1 C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5     C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,D} {3,S} {5,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {2,S}
+
+C4H7NO-3
+1  *3 O u0 p2 c0 {5,S} {13,S}
+2     N u0 p1 c0 {3,S} {4,S} {10,S}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5  *2 C u0 p0 c0 {1,S} {3,S} {6,D}
+6  *1 C u0 p0 c0 {5,D} {11,S} {12,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {2,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-4
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {3,S} {4,S} {13,S}
+3     C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5  *1 C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,D} {3,S} {5,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {2,S}
+
+C4H7NO-5
+1  *3 O u0 p2 c0 {6,S} {13,S}
+2  *1 N u0 p1 c0 {3,S} {6,D}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {2,D} {12,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-6
+1  *3 O u0 p2 c0 {6,D}
+2  *1 N u0 p1 c0 {3,S} {6,S} {12,S}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {13,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+
+C2H5NO2
+1     O u0 p2 c0 {4,S} {5,S}
+2  *3 O u0 p2 c0 {5,S} {9,S}
+3  *1 N u0 p1 c0 {5,D} {10,S}
+4     C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+
+C2H5NO2-2
+1     O u0 p2 c0 {4,S} {5,S}
+2  *3 O u0 p2 c0 {5,D}
+3  *1 N u0 p1 c0 {5,S} {9,S} {10,S}
+4     C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+
+C4H6O
+1  *3 O u0 p2 c0 {5,S} {11,S}
+2     C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+3     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+5  *2 C u0 p0 c0 {1,S} {4,D} {10,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {5,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C4H6O-2
+1  *3 O u0 p2 c0 {5,D}
+2  *1 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3     C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+4     C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {11,S}
+6  *4 H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C4H5NO-5
+1  *3 O u0 p2 c0 {5,S} {11,S}
+2     N u0 p1 c0 {6,T}
+3     C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {3,S} {5,D} {10,S}
+5  *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+6     C u0 p0 c0 {2,T} {5,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C4H5NO-6
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {6,T}
+3  *1 C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {6,S}
+6     C u0 p0 c0 {2,T} {5,S}
+7     H u0 p0 c0 {3,S}
+8  *4 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+
+C3H4O2-3
+1 *3 O u0 p2 c0 {3,S} {9,S}
+2    O u0 p2 c0 {5,D}
+3 *2 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 *1 C u0 p0 c0 {3,D} {7,S} {8,S}
+5    C u0 p0 c0 {2,D} {3,S} {6,S}
+6    H u0 p0 c0 {5,S}
+7    H u0 p0 c0 {4,S}
+8    H u0 p0 c0 {4,S}
+9 *4 H u0 p0 c0 {1,S}
+
+C3H4O2-4
+1 *3 O u0 p2 c0 {4,D}
+2    O u0 p2 c0 {5,D}
+3 *1 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4 *2 C u0 p0 c0 {1,D} {3,S} {5,S}
+5    C u0 p0 c0 {2,D} {4,S} {9,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8 *4 H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {5,S}
+
+C4H6O2-3
+1     O u0 p2 c0 {3,S} {5,S}
+2  *3 O u0 p2 c0 {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {6,S} {9,S} {10,S} {11,S}
+5  *1 C u0 p0 c0 {1,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {2,S} {4,S} {5,D}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12 *4 H u0 p0 c0 {2,S}
+
+C4H6O2-4
+1     O u0 p2 c0 {3,S} {4,S}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+4     C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+5     C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {5,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+
+C4H4O
+1 *3 O u0 p2 c0 {2,S} {8,S}
+2 *2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 *1 C u0 p0 c0 {2,D} {6,S} {7,S}
+4    C u0 p0 c0 {2,S} {5,T}
+5    C u0 p0 c0 {4,T} {9,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8 *4 H u0 p0 c0 {1,S}
+9    H u0 p0 c0 {5,S}
+
+C4H4O-2
+1 *3 O u0 p2 c0 {3,D}
+2 *1 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+3 *2 C u0 p0 c0 {1,D} {2,S} {4,S}
+4    C u0 p0 c0 {3,S} {5,T}
+5    C u0 p0 c0 {4,T} {9,S}
+6    H u0 p0 c0 {2,S}
+7    H u0 p0 c0 {2,S}
+8 *4 H u0 p0 c0 {2,S}
+9    H u0 p0 c0 {5,S}
+
+C4H6O2-5
+1  *3 O u0 p2 c0 {5,S} {12,S}
+2     O u0 p2 c0 {4,D}
+3     C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4     C u0 p0 c0 {2,D} {3,S} {5,S}
+5  *2 C u0 p0 c0 {1,S} {4,S} {6,D}
+6  *1 C u0 p0 c0 {5,D} {10,S} {11,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C4H6O2-6
+1  *3 O u0 p2 c0 {6,D}
+2     O u0 p2 c0 {5,D}
+3     C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+5     C u0 p0 c0 {2,D} {3,S} {6,S}
+6  *2 C u0 p0 c0 {1,D} {4,S} {5,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12 *4 H u0 p0 c0 {4,S}
+
+C3H4N2O-5
+1  *3 O u0 p2 c0 {5,S} {9,S}
+2  *1 N u0 p1 c0 {5,D} {10,S}
+3     N u0 p1 c0 {6,T}
+4     C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,S} {2,D} {4,S}
+6     C u0 p0 c0 {3,T} {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {2,S}
+
+C3H4N2O-6
+1  *3 O u0 p2 c0 {5,D}
+2  *1 N u0 p1 c0 {5,S} {9,S} {10,S}
+3     N u0 p1 c0 {6,T}
+4     C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {4,S}
+6     C u0 p0 c0 {3,T} {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+
+C3H4O3
+1     O u0 p2 c0 {4,S} {10,S}
+2  *3 O u0 p2 c0 {5,S} {9,S}
+3     O u0 p2 c0 {6,D}
+4  *1 C u0 p0 c0 {1,S} {5,D} {6,S}
+5  *2 C u0 p0 c0 {2,S} {4,D} {7,S}
+6     C u0 p0 c0 {3,D} {4,S} {8,S}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {6,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {1,S}
+
+C3H4O3-2
+1     O u0 p2 c0 {4,S} {10,S}
+2  *3 O u0 p2 c0 {5,D}
+3     O u0 p2 c0 {6,D}
+4  *1 C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  *2 C u0 p0 c0 {2,D} {4,S} {8,S}
+6     C u0 p0 c0 {3,D} {4,S} {9,S}
+7  *4 H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {1,S}
+
+C3H3NO-3
+1 *3 O u0 p2 c0 {3,S} {8,S}
+2    N u0 p1 c0 {5,T}
+3 *2 C u0 p0 c0 {1,S} {4,D} {7,S}
+4 *1 C u0 p0 c0 {3,D} {5,S} {6,S}
+5    C u0 p0 c0 {2,T} {4,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {3,S}
+8 *4 H u0 p0 c0 {1,S}
+
+C3H3NO-4
+1 *3 O u0 p2 c0 {4,D}
+2    N u0 p1 c0 {5,T}
+3 *1 C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4 *2 C u0 p0 c0 {1,D} {3,S} {8,S}
+5    C u0 p0 c0 {2,T} {3,S}
+6    H u0 p0 c0 {3,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {4,S}
+
+C2H6N2O
+1  *3 O u0 p2 c0 {5,S} {11,S}
+2     N u0 p1 c0 {5,S} {9,S} {10,S}
+3  *1 N u0 p1 c0 {4,S} {5,D}
+4     C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {2,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C2H6N2O-2
+1  *3 O u0 p2 c0 {5,D}
+2  *1 N u0 p1 c0 {4,S} {5,S} {9,S}
+3     N u0 p1 c0 {5,S} {10,S} {11,S}
+4     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+
+C2H6N2O-3
+1  *3 O u0 p2 c0 {5,S} {10,S}
+2     N u0 p1 c0 {4,S} {5,S} {9,S}
+3  *1 N u0 p1 c0 {5,D} {11,S}
+4     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {2,S}
+10 *4 H u0 p0 c0 {1,S}
+11    H u0 p0 c0 {3,S}
+
+C2H6N2O-4
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {4,S} {5,S} {9,S}
+3  *1 N u0 p1 c0 {5,S} {10,S} {11,S}
+4     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+6     H u0 p0 c0 {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {2,S}
+10 *4 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+
+C3H5NO2-7
+1  *3 O u0 p2 c0 {6,S} {11,S}
+2     O u0 p2 c0 {5,D}
+3  *1 N u0 p1 c0 {5,S} {6,D}
+4     C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {2,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {1,S} {3,D} {10,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {6,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C3H5NO2-8
+1     O u0 p2 c0 {5,D}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 N u0 p1 c0 {5,S} {6,S} {10,S}
+4     C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {1,D} {3,S} {4,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {11,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10 *4 H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {6,S}
+
+C4H7NO-7
+1  *3 O u0 p2 c0 {6,S} {12,S}
+2  *1 N u0 p1 c0 {6,D} {13,S}
+3     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {1,S}
+13    H u0 p0 c0 {2,S}
+
+C4H7NO-8
+1  *3 O u0 p2 c0 {6,D}
+2  *1 N u0 p1 c0 {6,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+
+C4H7NO-9
+1  *3 O u0 p2 c0 {6,S} {13,S}
+2     N u0 p1 c0 {6,S} {11,S} {12,S}
+3     C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+5  *1 C u0 p0 c0 {3,S} {4,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {2,S} {5,D}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-10
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {6,S} {12,S} {13,S}
+3  *1 C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+
+C5H6O-5
+1  *3 O u0 p2 c0 {3,S} {12,S}
+2     C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+3  *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+4  *1 C u0 p0 c0 {3,D} {10,S} {11,S}
+5     C u0 p0 c0 {2,S} {6,T}
+6     C u0 p0 c0 {3,S} {5,T}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C5H6O-6
+1  *3 O u0 p2 c0 {4,D}
+2  *1 C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+3     C u0 p0 c0 {5,S} {10,S} {11,S} {12,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {6,S}
+5     C u0 p0 c0 {3,S} {6,T}
+6     C u0 p0 c0 {4,S} {5,T}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+
+C3H4N2O-7
+1  *3 O u0 p2 c0 {5,S} {10,S}
+2  *1 N u0 p1 c0 {4,S} {5,D}
+3     N u0 p1 c0 {6,T}
+4     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,S} {2,D} {9,S}
+6     C u0 p0 c0 {3,T} {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C3H4N2O-8
+1  *3 O u0 p2 c0 {5,D}
+2  *1 N u0 p1 c0 {4,S} {5,S} {9,S}
+3     N u0 p1 c0 {6,T}
+4     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {10,S}
+6     C u0 p0 c0 {3,T} {4,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {5,S}
+
+C4H9NO-3
+1  *3 O u0 p2 c0 {6,S} {15,S}
+2  *1 N u0 p1 c0 {4,S} {6,D}
+3     C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+6  *2 C u0 p0 c0 {1,S} {2,D} {14,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+15 *4 H u0 p0 c0 {1,S}
+
+C4H9NO-4
+1  *3 O u0 p2 c0 {6,D}
+2  *1 N u0 p1 c0 {4,S} {6,S} {14,S}
+3     C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5     C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {15,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14 *4 H u0 p0 c0 {2,S}
+15    H u0 p0 c0 {6,S}
+
+C5H6O-7
+1  *3 O u0 p2 c0 {4,S} {11,S}
+2     C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3  *1 C u0 p0 c0 {2,S} {4,D} {5,S}
+4  *2 C u0 p0 c0 {1,S} {3,D} {10,S}
+5     C u0 p0 c0 {3,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {4,S}
+11 *4 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+
+C5H6O-8
+1  *3 O u0 p2 c0 {4,D}
+2  *1 C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3     C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {11,S}
+5     C u0 p0 c0 {2,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7  *4 H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+
+C5H6O-9
+1  *3 O u0 p2 c0 {4,S} {11,S}
+2     C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3  *1 C u0 p0 c0 {2,S} {4,D} {10,S}
+4  *2 C u0 p0 c0 {1,S} {3,D} {5,S}
+5     C u0 p0 c0 {4,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {3,S}
+11 *4 H u0 p0 c0 {1,S}
+12    H u0 p0 c0 {6,S}
+
+C5H6O-10
+1  *3 O u0 p2 c0 {4,D}
+2  *1 C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+3     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {5,S}
+5     C u0 p0 c0 {4,S} {6,T}
+6     C u0 p0 c0 {5,T} {12,S}
+7     H u0 p0 c0 {2,S}
+8  *4 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {6,S}
+
+C4H5NO-7
+1  *3 O u0 p2 c0 {5,S} {11,S}
+2     N u0 p1 c0 {6,T}
+3     C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {3,S} {5,D} {6,S}
+5  *2 C u0 p0 c0 {1,S} {4,D} {10,S}
+6     C u0 p0 c0 {2,T} {4,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {5,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C4H5NO-8
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {6,T}
+3  *1 C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {11,S}
+6     C u0 p0 c0 {2,T} {3,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+
+C4H7NO-11
+1  *3 O u0 p2 c0 {6,S} {13,S}
+2     N u0 p1 c0 {3,S} {4,S} {5,S}
+3     C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+4     C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  *1 C u0 p0 c0 {2,S} {6,D} {11,S}
+6  *2 C u0 p0 c0 {1,S} {5,D} {12,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-12
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {3,S} {4,S} {5,S}
+3     C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+4     C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  *1 C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,D} {5,S} {13,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+
+C2H3N3O-7
+1 *3 O u0 p2 c0 {5,S} {9,S}
+2    N u0 p1 c0 {5,S} {6,S} {7,S}
+3 *1 N u0 p1 c0 {4,S} {5,D}
+4    N u0 p1 c0 {3,S} {6,D}
+5 *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6    C u0 p0 c0 {2,S} {4,D} {8,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {1,S}
+
+C2H3N3O-8
+1 *3 O u0 p2 c0 {5,D}
+2    N u0 p1 c0 {5,S} {6,S} {7,S}
+3 *1 N u0 p1 c0 {4,S} {5,S} {9,S}
+4    N u0 p1 c0 {3,S} {6,D}
+5 *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+6    C u0 p0 c0 {2,S} {4,D} {8,S}
+7    H u0 p0 c0 {2,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {3,S}
+
+C3H3NO-5
+1 *3 O u0 p2 c0 {3,S} {8,S}
+2    N u0 p1 c0 {5,T}
+3 *2 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 *1 C u0 p0 c0 {3,D} {6,S} {7,S}
+5    C u0 p0 c0 {2,T} {3,S}
+6    H u0 p0 c0 {4,S}
+7    H u0 p0 c0 {4,S}
+8 *4 H u0 p0 c0 {1,S}
+
+C3H3NO-6
+1 *3 O u0 p2 c0 {4,D}
+2    N u0 p1 c0 {5,T}
+3 *1 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4 *2 C u0 p0 c0 {1,D} {3,S} {5,S}
+5    C u0 p0 c0 {2,T} {4,S}
+6    H u0 p0 c0 {3,S}
+7    H u0 p0 c0 {3,S}
+8 *4 H u0 p0 c0 {3,S}
+
+C3H7NO-3
+1  *3 O u0 p2 c0 {4,S} {12,S}
+2     N u0 p1 c0 {3,S} {4,S} {9,S}
+3     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+4  *2 C u0 p0 c0 {1,S} {2,S} {5,D}
+5  *1 C u0 p0 c0 {4,D} {10,S} {11,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C3H7NO-4
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {3,S} {5,S} {12,S}
+3     C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+4  *1 C u0 p0 c0 {5,S} {9,S} {10,S} {11,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {4,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11 *4 H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {2,S}
+
+C4H9NO-5
+1  *3 O u0 p2 c0 {5,S} {15,S}
+2     N u0 p1 c0 {3,S} {4,S} {5,S}
+3     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  *2 C u0 p0 c0 {1,S} {2,S} {6,D}
+6  *1 C u0 p0 c0 {5,D} {13,S} {14,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {6,S}
+14    H u0 p0 c0 {6,S}
+15 *4 H u0 p0 c0 {1,S}
+
+C4H9NO-6
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {3,S} {4,S} {6,S}
+3     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  *1 C u0 p0 c0 {6,S} {13,S} {14,S} {15,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {5,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {3,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15 *4 H u0 p0 c0 {5,S}
+
+C4H6O2-7
+1  *3 O u0 p2 c0 {5,S} {12,S}
+2     O u0 p2 c0 {6,D}
+3     C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {3,S} {5,D} {10,S}
+5  *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+6     C u0 p0 c0 {2,D} {5,S} {11,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {6,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C4H6O2-8
+1  *3 O u0 p2 c0 {5,D}
+2     O u0 p2 c0 {6,D}
+3  *1 C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {6,S}
+6     C u0 p0 c0 {2,D} {5,S} {12,S}
+7     H u0 p0 c0 {3,S}
+8  *4 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+
+C3H7NO2-3
+1     O u0 p2 c0 {5,S} {6,S}
+2  *3 O u0 p2 c0 {6,S} {13,S}
+3  *1 N u0 p1 c0 {4,S} {6,D}
+4     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5     C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+6  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+7     H u0 p0 c0 {5,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13 *4 H u0 p0 c0 {2,S}
+
+C3H7NO2-4
+1     O u0 p2 c0 {5,S} {6,S}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 N u0 p1 c0 {4,S} {6,S} {13,S}
+4     C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13 *4 H u0 p0 c0 {3,S}
+
+C2H2N2O2-5
+1    O u0 p2 c0 {4,S} {5,S}
+2 *3 O u0 p2 c0 {5,S} {8,S}
+3 *1 N u0 p1 c0 {5,D} {6,S}
+4    N u0 p1 c0 {1,S} {6,D}
+5 *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+6    C u0 p0 c0 {3,S} {4,D} {7,S}
+7    H u0 p0 c0 {6,S}
+8 *4 H u0 p0 c0 {2,S}
+
+C2H2N2O2-6
+1    O u0 p2 c0 {4,S} {5,S}
+2 *3 O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {5,S} {6,S} {7,S}
+4    N u0 p1 c0 {1,S} {6,D}
+5 *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+6    C u0 p0 c0 {3,S} {4,D} {8,S}
+7 *4 H u0 p0 c0 {3,S}
+8    H u0 p0 c0 {6,S}
+
+C3H6O
+1  *3 O u0 p2 c0 {3,S} {10,S}
+2     C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+3  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+4  *1 C u0 p0 c0 {3,D} {8,S} {9,S}
+5     H u0 p0 c0 {2,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C3H6O-2
+1  *3 O u0 p2 c0 {4,D}
+2     C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+3  *1 C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+5     H u0 p0 c0 {2,S}
+6     H u0 p0 c0 {2,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10 *4 H u0 p0 c0 {3,S}
+
+C3H8N2O
+1  *3 O u0 p2 c0 {6,S} {14,S}
+2     N u0 p1 c0 {4,S} {6,S} {13,S}
+3  *1 N u0 p1 c0 {5,S} {6,D}
+4     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {2,S}
+14 *4 H u0 p0 c0 {1,S}
+
+C3H8N2O-2
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {4,S} {6,S} {13,S}
+3  *1 N u0 p1 c0 {5,S} {6,S} {14,S}
+4     C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {2,S}
+14 *4 H u0 p0 c0 {3,S}
+
+C4H6O2-9
+1     O u0 p2 c0 {3,S} {11,S}
+2  *3 O u0 p2 c0 {6,S} {12,S}
+3     C u0 p0 c0 {1,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  *1 C u0 p0 c0 {3,S} {4,S} {6,D}
+6  *2 C u0 p0 c0 {2,S} {5,D} {10,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {1,S}
+12 *4 H u0 p0 c0 {2,S}
+
+C4H6O2-10
+1     O u0 p2 c0 {4,S} {12,S}
+2  *3 O u0 p2 c0 {6,D}
+3  *1 C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4     C u0 p0 c0 {1,S} {3,S} {5,S} {8,S}
+5     C u0 p0 c0 {3,S} {4,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {2,D} {3,S} {11,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {1,S}
+
+C3H5NO
+1  *3 O u0 p2 c0 {5,S} {10,S}
+2     N u0 p1 c0 {3,S} {4,S} {8,S}
+3     C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+5  *2 C u0 p0 c0 {1,S} {4,D} {9,S}
+6     H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {5,S}
+10 *4 H u0 p0 c0 {1,S}
+
+C3H5NO-2
+1  *3 O u0 p2 c0 {5,D}
+2     N u0 p1 c0 {3,S} {4,S} {9,S}
+3  *1 C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4     C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+5  *2 C u0 p0 c0 {1,D} {3,S} {10,S}
+6  *4 H u0 p0 c0 {3,S}
+7     H u0 p0 c0 {4,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {2,S}
+10    H u0 p0 c0 {5,S}
+
+C4H7NO-13
+1  *3 O u0 p2 c0 {6,S} {13,S}
+2     N u0 p1 c0 {3,S} {4,S} {5,S}
+3     C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+5  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {5,D} {12,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-14
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {3,S} {4,S} {5,S}
+3  *1 C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4     C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+6  *2 C u0 p0 c0 {1,D} {3,S} {13,S}
+7  *4 H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {6,S}
+
+C4H7NO-15
+1  *3 O u0 p2 c0 {6,S} {13,S}
+2     N u0 p1 c0 {3,S} {5,S} {11,S}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {5,D} {12,S}
+7     H u0 p0 c0 {3,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {1,S}
+
+C4H7NO-16
+1  *3 O u0 p2 c0 {6,D}
+2     N u0 p1 c0 {3,S} {4,S} {12,S}
+3     C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+5     C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+6  *2 C u0 p0 c0 {1,D} {4,S} {13,S}
+7     H u0 p0 c0 {3,S}
+8  *4 H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {6,S}
+
+C5H8O-5
+1  *3 O u0 p2 c0 {6,S} {14,S}
+2     C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3     C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+4     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+5  *1 C u0 p0 c0 {2,S} {3,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {5,D} {13,S}
+7     H u0 p0 c0 {2,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {6,S}
+14 *4 H u0 p0 c0 {1,S}
+
+C5H8O-6
+1  *3 O u0 p2 c0 {6,D}
+2     C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3  *1 C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
+4     C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+6  *2 C u0 p0 c0 {1,D} {3,S} {14,S}
+7     H u0 p0 c0 {2,S}
+8  *4 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {5,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {6,S}
+
+C3H3NO2-3
+1    O u0 p2 c0 {4,S} {6,S}
+2 *3 O u0 p2 c0 {4,S} {9,S}
+3 *1 N u0 p1 c0 {4,D} {5,S}
+4 *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+5    C u0 p0 c0 {3,S} {6,D} {7,S}
+6    C u0 p0 c0 {1,S} {5,D} {8,S}
+7    H u0 p0 c0 {5,S}
+8    H u0 p0 c0 {6,S}
+9 *4 H u0 p0 c0 {2,S}
+
+C3H3NO2-4
+1    O u0 p2 c0 {5,S} {6,S}
+2 *3 O u0 p2 c0 {5,D}
+3 *1 N u0 p1 c0 {4,S} {5,S} {8,S}
+4    C u0 p0 c0 {3,S} {6,D} {7,S}
+5 *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+6    C u0 p0 c0 {1,S} {4,D} {9,S}
+7    H u0 p0 c0 {4,S}
+8 *4 H u0 p0 c0 {3,S}
+9    H u0 p0 c0 {6,S}
+
+C4H8O3
+1     O u0 p2 c0 {5,S} {6,S}
+2     O u0 p2 c0 {4,S} {7,S}
+3  *3 O u0 p2 c0 {6,S} {15,S}
+4     C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+5     C u0 p0 c0 {1,S} {8,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {1,S} {3,S} {7,D}
+7  *1 C u0 p0 c0 {2,S} {6,D} {14,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {4,S}
+13    H u0 p0 c0 {4,S}
+14    H u0 p0 c0 {7,S}
+15 *4 H u0 p0 c0 {3,S}
+
+C4H8O3-2
+1     O u0 p2 c0 {4,S} {5,S}
+2     O u0 p2 c0 {6,S} {7,S}
+3  *3 O u0 p2 c0 {7,D}
+4  *1 C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+5     C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6     C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+7  *2 C u0 p0 c0 {2,S} {3,D} {4,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {5,S}
+14    H u0 p0 c0 {5,S}
+15    H u0 p0 c0 {5,S}
+
+C4H5NO2-3
+1  *3 O u0 p2 c0 {6,S} {12,S}
+2     O u0 p2 c0 {7,D}
+3     N u0 p1 c0 {4,S} {5,S} {7,S}
+4     C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  *1 C u0 p0 c0 {3,S} {4,S} {6,D}
+6  *2 C u0 p0 c0 {1,S} {5,D} {10,S}
+7     C u0 p0 c0 {2,D} {3,S} {11,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {7,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C4H5NO2-4
+1  *3 O u0 p2 c0 {6,D}
+2     O u0 p2 c0 {7,D}
+3     N u0 p1 c0 {4,S} {5,S} {7,S}
+4  *1 C u0 p0 c0 {3,S} {5,S} {6,S} {8,S}
+5     C u0 p0 c0 {3,S} {4,S} {9,S} {10,S}
+6  *2 C u0 p0 c0 {1,D} {4,S} {11,S}
+7     C u0 p0 c0 {2,D} {3,S} {12,S}
+8  *4 H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {7,S}
+
+C3H5N3O-3
+1  *3 O u0 p2 c0 {7,S} {12,S}
+2     N u0 p1 c0 {4,S} {7,S} {11,S}
+3  *1 N u0 p1 c0 {6,S} {7,D}
+4     N u0 p1 c0 {2,S} {6,D}
+5     C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6     C u0 p0 c0 {3,S} {4,D} {5,S}
+7  *2 C u0 p0 c0 {1,S} {2,S} {3,D}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {2,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C3H5N3O-4
+1  *3 O u0 p2 c0 {7,D}
+2  *1 N u0 p1 c0 {6,S} {7,S} {11,S}
+3     N u0 p1 c0 {4,S} {7,S} {12,S}
+4     N u0 p1 c0 {3,S} {6,D}
+5     C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6     C u0 p0 c0 {2,S} {4,D} {5,S}
+7  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11 *4 H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {3,S}
+
+C3H5N3O-5
+1  *3 O u0 p2 c0 {7,S} {12,S}
+2     N u0 p1 c0 {6,S} {7,S} {11,S}
+3     N u0 p1 c0 {4,S} {6,D}
+4  *1 N u0 p1 c0 {3,S} {7,D}
+5     C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6     C u0 p0 c0 {2,S} {3,D} {5,S}
+7  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {2,S}
+12 *4 H u0 p0 c0 {1,S}
+
+C3H5N3O-6
+1  *3 O u0 p2 c0 {7,D}
+2     N u0 p1 c0 {6,S} {7,S} {11,S}
+3  *1 N u0 p1 c0 {4,S} {7,S} {12,S}
+4     N u0 p1 c0 {3,S} {6,D}
+5     C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6     C u0 p0 c0 {2,S} {4,D} {5,S}
+7  *2 C u0 p0 c0 {1,D} {2,S} {3,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {2,S}
+12 *4 H u0 p0 c0 {3,S}
+
+C6H8O
+1  *3 O u0 p2 c0 {5,S} {14,S}
+2     C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+3     C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4  *1 C u0 p0 c0 {2,S} {3,S} {5,D}
+5  *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+6     C u0 p0 c0 {5,S} {7,T}
+7     C u0 p0 c0 {6,T} {15,S}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {3,S}
+11    H u0 p0 c0 {2,S}
+12    H u0 p0 c0 {2,S}
+13    H u0 p0 c0 {2,S}
+14 *4 H u0 p0 c0 {1,S}
+15    H u0 p0 c0 {7,S}
+
+C6H8O-2
+1  *3 O u0 p2 c0 {5,D}
+2  *1 C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+3     C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+4     C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+5  *2 C u0 p0 c0 {1,D} {2,S} {6,S}
+6     C u0 p0 c0 {5,S} {7,T}
+7     C u0 p0 c0 {6,T} {15,S}
+8  *4 H u0 p0 c0 {2,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {3,S}
+13    H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {7,S}
+
+C5H3NO
+1  *3 O u0 p2 c0 {3,S} {9,S}
+2     N u0 p1 c0 {6,T}
+3  *2 C u0 p0 c0 {1,S} {4,D} {6,S}
+4  *1 C u0 p0 c0 {3,D} {5,S} {8,S}
+5     C u0 p0 c0 {4,S} {7,T}
+6     C u0 p0 c0 {2,T} {3,S}
+7     C u0 p0 c0 {5,T} {10,S}
+8     H u0 p0 c0 {4,S}
+9  *4 H u0 p0 c0 {1,S}
+10    H u0 p0 c0 {7,S}
+
+C5H3NO-2
+1  *3 O u0 p2 c0 {4,D}
+2     N u0 p1 c0 {6,T}
+3  *1 C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+4  *2 C u0 p0 c0 {1,D} {3,S} {6,S}
+5     C u0 p0 c0 {3,S} {7,T}
+6     C u0 p0 c0 {2,T} {4,S}
+7     C u0 p0 c0 {5,T} {10,S}
+8     H u0 p0 c0 {3,S}
+9  *4 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {7,S}
+
+C5H6O2
+1     O u0 p2 c0 {3,S} {12,S}
+2  *3 O u0 p2 c0 {5,S} {13,S}
+3     C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
+4  *1 C u0 p0 c0 {5,D} {7,S} {11,S}
+5  *2 C u0 p0 c0 {2,S} {4,D} {10,S}
+6     C u0 p0 c0 {3,S} {7,T}
+7     C u0 p0 c0 {4,S} {6,T}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {5,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {1,S}
+13 *4 H u0 p0 c0 {2,S}
+
+C5H6O2-2
+1     O u0 p2 c0 {4,S} {13,S}
+2  *3 O u0 p2 c0 {5,D}
+3  *1 C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
+4     C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+5  *2 C u0 p0 c0 {2,D} {3,S} {12,S}
+6     C u0 p0 c0 {3,S} {7,T}
+7     C u0 p0 c0 {4,S} {6,T}
+8     H u0 p0 c0 {3,S}
+9  *4 H u0 p0 c0 {3,S}
+10    H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {4,S}
+12    H u0 p0 c0 {5,S}
+13    H u0 p0 c0 {1,S}
+
+C4H4O3
+1  *3 O u0 p2 c0 {4,S} {11,S}
+2     O u0 p2 c0 {5,D}
+3     O u0 p2 c0 {7,D}
+4  *2 C u0 p0 c0 {1,S} {5,S} {6,D}
+5     C u0 p0 c0 {2,D} {4,S} {7,S}
+6  *1 C u0 p0 c0 {4,D} {9,S} {10,S}
+7     C u0 p0 c0 {3,D} {5,S} {8,S}
+8     H u0 p0 c0 {7,S}
+9     H u0 p0 c0 {6,S}
+10    H u0 p0 c0 {6,S}
+11 *4 H u0 p0 c0 {1,S}
+
+C4H4O3-2
+1  *3 O u0 p2 c0 {5,D}
+2     O u0 p2 c0 {6,D}
+3     O u0 p2 c0 {7,D}
+4  *1 C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  *2 C u0 p0 c0 {1,D} {4,S} {6,S}
+6     C u0 p0 c0 {2,D} {5,S} {7,S}
+7     C u0 p0 c0 {3,D} {6,S} {11,S}
+8     H u0 p0 c0 {4,S}
+9     H u0 p0 c0 {4,S}
+10 *4 H u0 p0 c0 {4,S}
+11    H u0 p0 c0 {7,S}
+
+C4H8N2O
+1  *3 O u0 p2 c0 {7,S} {14,S}
+2     N u0 p1 c0 {4,S} {5,S} {13,S}
+3  *1 N u0 p1 c0 {7,D} {15,S}
+4     C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+6     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  *2 C u0 p0 c0 {1,S} {3,D} {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {2,S}
+14 *4 H u0 p0 c0 {1,S}
+15    H u0 p0 c0 {3,S}
+
+C4H8N2O-2
+1  *3 O u0 p2 c0 {7,D}
+2     N u0 p1 c0 {4,S} {5,S} {13,S}
+3  *1 N u0 p1 c0 {7,S} {14,S} {15,S}
+4     C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+6     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  *2 C u0 p0 c0 {1,D} {3,S} {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13    H u0 p0 c0 {2,S}
+14 *4 H u0 p0 c0 {3,S}
+15    H u0 p0 c0 {3,S}
+
+C4H7NO2
+1     O u0 p2 c0 {4,S} {5,S}
+2  *3 O u0 p2 c0 {7,S} {13,S}
+3  *1 N u0 p1 c0 {7,D} {14,S}
+4     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  *2 C u0 p0 c0 {2,S} {3,D} {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {2,S}
+14    H u0 p0 c0 {3,S}
+
+C4H7NO2-2
+1     O u0 p2 c0 {4,S} {5,S}
+2  *3 O u0 p2 c0 {7,D}
+3  *1 N u0 p1 c0 {7,S} {13,S} {14,S}
+4     C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5     C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6     C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  *2 C u0 p0 c0 {2,D} {3,S} {4,S}
+8     H u0 p0 c0 {5,S}
+9     H u0 p0 c0 {5,S}
+10    H u0 p0 c0 {6,S}
+11    H u0 p0 c0 {6,S}
+12    H u0 p0 c0 {6,S}
+13 *4 H u0 p0 c0 {3,S}
+14    H u0 p0 c0 {3,S}
+
+C2H3N3O2
+1     O u0 p2 c0 {5,S} {7,S}
+2  *3 O u0 p2 c0 {7,S} {10,S}
+3     N u0 p1 c0 {6,S} {8,S} {9,S}
+4  *1 N u0 p1 c0 {6,S} {7,D}
+5     N u0 p1 c0 {1,S} {6,D}
+6     C u0 p0 c0 {3,S} {4,S} {5,D}
+7  *2 C u0 p0 c0 {1,S} {2,S} {4,D}
+8     H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {3,S}
+10 *4 H u0 p0 c0 {2,S}
+
+C2H3N3O2-2
+1     O u0 p2 c0 {5,S} {7,S}
+2  *3 O u0 p2 c0 {7,D}
+3  *1 N u0 p1 c0 {6,S} {7,S} {8,S}
+4     N u0 p1 c0 {6,S} {9,S} {10,S}
+5     N u0 p1 c0 {1,S} {6,D}
+6     C u0 p0 c0 {3,S} {4,S} {5,D}
+7  *2 C u0 p0 c0 {1,S} {2,D} {3,S}
+8  *4 H u0 p0 c0 {3,S}
+9     H u0 p0 c0 {4,S}
+10    H u0 p0 c0 {4,S}
+

--- a/input/kinetics/families/Ketoenol/training/reactions.py
+++ b/input/kinetics/families/Ketoenol/training/reactions.py
@@ -298,7 +298,6 @@ entry(
     shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
-Training reaction from kinetics library: 20220318_ketoenol_tmp
 Original entry: r000842 <=> p000842
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
@@ -538,6 +537,1162 @@ entry(
     longDesc = 
 """
 Original entry: r011937 <=> p011937
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 33,
+    label = "C3H6N2O-3 <=> C3H6N2O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.2546e-11,'s^-1'), n=6.85152, Ea=(77.9947,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 107.804, dn = +|- 0.621031, dEa = +|- 3.20236 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000049 <=> r000049
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 34,
+    label = "C3H4O2 <=> C3H4O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.69794e-26,'s^-1'), n=10.9363, Ea=(125.211,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1447.77, dn = +|- 0.965688, dEa = +|- 4.97959 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000208 <=> r000208
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 35,
+    label = "C4H5NO <=> C4H5NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.03652e-10,'s^-1'), n=6.72069, Ea=(82.5831,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 138.327, dn = +|- 0.654111, dEa = +|- 3.37294 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000634 <=> r000634
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 36,
+    label = "C5H6O <=> C5H6O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.42334e-31,'s^-1'), n=12.8324, Ea=(120.373,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 3626.22, dn = +|- 1.08752, dEa = +|- 5.60782 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000721 <=> r000721
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 37,
+    label = "C5H6O-3 <=> C5H6O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.34803e-38,'s^-1'), n=14.7488, Ea=(110.291,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 7501.31, dn = +|- 1.18397, dEa = +|- 6.10517 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000726 <=> r000721
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 38,
+    label = "C4H5NO-3 <=> C4H5NO-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.84947e-45,'s^-1'), n=16.5411, Ea=(129.059,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 13981.8, dn = +|- 1.26659, dEa = +|- 6.53122 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000744 <=> r000744
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 39,
+    label = "C3H7NO2 <=> C3H7NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.80609e-12,'s^-1'), n=7.13985, Ea=(64.5475,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 98.3219, dn = +|- 0.608814, dEa = +|- 3.13937 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p000813 <=> r000813
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 40,
+    label = "C4H6O2 <=> C4H6O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.66974e-32,'s^-1'), n=12.7337, Ea=(112.625,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 3067.51, dn = +|- 1.06532, dEa = +|- 5.49333 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001050 <=> r001050
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 41,
+    label = "C4H8O-3 <=> C4H8O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.22009e-49,'s^-1'), n=17.8112, Ea=(124.163,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 16475.9, dn = +|- 1.28837, dEa = +|- 6.64353 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001147 <=> r001147
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 42,
+    label = "C2H3NO2-3 <=> C2H3NO2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.03997e-16,'s^-1'), n=8.33012, Ea=(78.2703,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 324.839, dn = +|- 0.76739, dEa = +|- 3.95706 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001169 <=> r001169
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 43,
+    label = "C4H9NO <=> C4H9NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.06473e-10,'s^-1'), n=6.60955, Ea=(80.838,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 135.547, dn = +|- 0.651418, dEa = +|- 3.35905 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001357 <=> r001357
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 44,
+    label = "C5H8O <=> C5H8O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.41171e-33,'s^-1'), n=13.3174, Ea=(105.78,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 3720.31, dn = +|- 1.09092, dEa = +|- 5.62535 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001387 <=> r001387
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 45,
+    label = "C5H8O-3 <=> C5H8O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.84389e-11,'s^-1'), n=6.70227, Ea=(141.395,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 198.059, dn = +|- 0.70174, dEa = +|- 3.61854 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001388 <=> r001387
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 46,
+    label = "C3H5NO2 <=> C3H5NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.42686e-33,'s^-1'), n=13.1831, Ea=(126.309,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 3814.42, dn = +|- 1.09423, dEa = +|- 5.64244 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001614 <=> r001614
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 47,
+    label = "C3H5NO2-3 <=> C3H5NO2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.51726e-18,'s^-1'), n=8.84109, Ea=(138.906,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 333.788, dn = +|- 0.770996, dEa = +|- 3.97566 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001615 <=> r001614
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 48,
+    label = "C3H5NO2-5 <=> C3H5NO2-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.40998e-13,'s^-1'), n=7.50448, Ea=(76.2627,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 184.62, dn = +|- 0.692416, dEa = +|- 3.57046 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p001627 <=> r001627
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 49,
+    label = "C4H7NO <=> C4H7NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.65781e-21,'s^-1'), n=9.63784, Ea=(120.135,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 817.928, dn = +|- 0.889922, dEa = +|- 4.5889 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002203 <=> r002203
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 50,
+    label = "C4H7NO-3 <=> C4H7NO-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.59344e-34,'s^-1'), n=13.552, Ea=(109.766,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 4513.65, dn = +|- 1.11657, dEa = +|- 5.75761 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002204 <=> r002203
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 51,
+    label = "C4H7NO-5 <=> C4H7NO-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.03926e-10,'s^-1'), n=6.64444, Ea=(82.2627,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 148.108, dn = +|- 0.663176, dEa = +|- 3.41968 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002312 <=> r002312
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 52,
+    label = "C2H5NO2 <=> C2H5NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.51923e-11,'s^-1'), n=6.9247, Ea=(66.5174,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 99.4801, dn = +|- 0.610368, dEa = +|- 3.14738 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002594 <=> r002594
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 53,
+    label = "C4H6O <=> C4H6O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.16654e-24,'s^-1'), n=10.6408, Ea=(128.297,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1671.79, dn = +|- 0.984779, dEa = +|- 5.07803 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002675 <=> r002675
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 54,
+    label = "C4H5NO-5 <=> C4H5NO-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.12859e-53,'s^-1'), n=18.9999, Ea=(126.793,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 19011.4, dn = +|- 1.30737, dEa = +|- 6.74147 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002689 <=> r002689
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 55,
+    label = "C3H4O2-3 <=> C3H4O2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.07484e-44,'s^-1'), n=16.5795, Ea=(142.735,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 21235.6, dn = +|- 1.32205, dEa = +|- 6.81717 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002760 <=> r002760
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 56,
+    label = "C4H6O2-3 <=> C4H6O2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(8.47848e-14,'s^-1'), n=7.46671, Ea=(127.454,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 187.906, dn = +|- 0.694757, dEa = +|- 3.58253 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002801 <=> r002801
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 57,
+    label = "C4H4O <=> C4H4O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.92778e-40,'s^-1'), n=15.2017, Ea=(113.63,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 8229.85, dn = +|- 1.19627, dEa = +|- 6.16859 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002874 <=> r002874
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 58,
+    label = "C4H6O2-5 <=> C4H6O2-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.57345e-42,'s^-1'), n=16.0376, Ea=(138.173,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 20557.6, dn = +|- 1.31774, dEa = +|- 6.79497 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p002881 <=> r002881
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 59,
+    label = "C3H4N2O-5 <=> C3H4N2O-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.3825e-13,'s^-1'), n=7.5932, Ea=(75.6216,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 171.089, dn = +|- 0.682317, dEa = +|- 3.51838 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003070 <=> r003070
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 60,
+    label = "C3H4O3 <=> C3H4O3-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.80714e-28,'s^-1'), n=11.6116, Ea=(140.422,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1748.44, dn = +|- 0.990727, dEa = +|- 5.10871 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003195 <=> r003195
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 61,
+    label = "C3H3NO-3 <=> C3H3NO-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.93747e-32,'s^-1'), n=12.864, Ea=(134.379,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 3910.61, dn = +|- 1.09754, dEa = +|- 5.65948 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003323 <=> r003323
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 62,
+    label = "C2H6N2O <=> C2H6N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.757e-07,'s^-1'), n=6.00798, Ea=(69.774,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 63.7085, dn = +|- 0.551237, dEa = +|- 2.84246 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003344 <=> r003344
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 63,
+    label = "C2H6N2O-3 <=> C2H6N2O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.33821e-07,'s^-1'), n=5.68082, Ea=(75.8132,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 64.0288, dn = +|- 0.551902, dEa = +|- 2.84589 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003346 <=> r003344
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 64,
+    label = "C2H4O <=> C2H4O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.20593e-38,'s^-1'), n=14.7335, Ea=(119.026,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 7706.9, dn = +|- 1.18756, dEa = +|- 6.12367 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003348 <=> r003348
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 65,
+    label = "C3H5NO2-7 <=> C3H5NO2-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.81779e-10,'s^-1'), n=6.57871, Ea=(74.9502,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 79.2848, dn = +|- 0.58026, dEa = +|- 2.99212 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003431 <=> r003431
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 66,
+    label = "C4H7NO-7 <=> C4H7NO-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.32223e-12,'s^-1'), n=7.33725, Ea=(69.6232,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 115.77, dn = +|- 0.63049, dEa = +|- 3.25114 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003437 <=> r003437
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 67,
+    label = "C4H7NO-9 <=> C4H7NO-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(0.0332916,'s^-1'), n=3.98637, Ea=(105.771,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 12.7338, dn = +|- 0.337598, dEa = +|- 1.74083 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003440 <=> r003437
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 68,
+    label = "C5H6O-5 <=> C5H6O-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.06626e-37,'s^-1'), n=14.5413, Ea=(112.927,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 6576.73, dn = +|- 1.16652, dEa = +|- 6.01517 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003718 <=> r003718
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 69,
+    label = "C3H4N2O-7 <=> C3H4N2O-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.42858e-10,'s^-1'), n=6.4885, Ea=(88.6777,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 126.543, dn = +|- 0.642297, dEa = +|- 3.31202 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003937 <=> r003937
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 70,
+    label = "C4H9NO-3 <=> C4H9NO-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.48783e-11,'s^-1'), n=6.87686, Ea=(77.6406,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 144.417, dn = +|- 0.659829, dEa = +|- 3.40242 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p003958 <=> r003958
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 71,
+    label = "C5H6O-7 <=> C5H6O-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.49793e-42,'s^-1'), n=15.9135, Ea=(134.508,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 10202, dn = +|- 1.22477, dEa = +|- 6.31557 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004414 <=> r004414
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 72,
+    label = "C5H6O-9 <=> C5H6O-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.00696e-46,'s^-1'), n=17.0834, Ea=(126.242,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 15132.4, dn = +|- 1.27709, dEa = +|- 6.58533 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004467 <=> r004467
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 73,
+    label = "C4H5NO-7 <=> C4H5NO-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.97955e-36,'s^-1'), n=14.0901, Ea=(149.791,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 6721.17, dn = +|- 1.1694, dEa = +|- 6.03003 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004505 <=> r004505
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 74,
+    label = "C4H7NO-11 <=> C4H7NO-12",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.56099e-43,'s^-1'), n=15.9484, Ea=(111.981,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 8672.61, dn = +|- 1.20322, dEa = +|- 6.20445 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004547 <=> r004547
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 75,
+    label = "C2H3N3O-7 <=> C2H3N3O-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.15125e-17,'s^-1'), n=8.71952, Ea=(109.961,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 548.261, dn = +|- 0.836843, dEa = +|- 4.3152 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004625 <=> p000017
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 76,
+    label = "C3H3NO-5 <=> C3H3NO-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.74964e-45,'s^-1'), n=16.6685, Ea=(116.975,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 11919.2, dn = +|- 1.24542, dEa = +|- 6.42201 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004643 <=> r004643
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 77,
+    label = "C3H7NO-3 <=> C3H7NO-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.92786e-16,'s^-1'), n=8.20829, Ea=(93.7874,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 339.338, dn = +|- 0.773184, dEa = +|- 3.98694 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004778 <=> r004778
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 78,
+    label = "C4H9NO-5 <=> C4H9NO-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.5544e-16,'s^-1'), n=8.25988, Ea=(88.0644,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 253.098, dn = +|- 0.734277, dEa = +|- 3.78631 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004794 <=> r004794
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 79,
+    label = "C4H6O2-7 <=> C4H6O2-8",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.04433e-53,'s^-1'), n=19.1929, Ea=(152.81,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 34234.4, dn = +|- 1.38541, dEa = +|- 7.14392 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p004852 <=> r004852
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 80,
+    label = "C3H7NO2-3 <=> C3H7NO2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(6.85036e-08,'s^-1'), n=5.86332, Ea=(65.6947,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 52.4027, dn = +|- 0.525314, dEa = +|- 2.70879 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005118 <=> r005118
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 81,
+    label = "C2H2N2O2-5 <=> C2H2N2O2-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.9201e-20,'s^-1'), n=9.47072, Ea=(116.615,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 723.084, dn = +|- 0.873568, dEa = +|- 4.50457 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005148 <=> r005148
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 82,
+    label = "C3H6O <=> C3H6O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.12867e-34,'s^-1'), n=13.5809, Ea=(114.48,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 4959.64, dn = +|- 1.12907, dEa = +|- 5.82208 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005196 <=> r005196
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 83,
+    label = "C3H8N2O <=> C3H8N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(5.39095e-06,'s^-1'), n=5.24031, Ea=(67.2473,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 46.2739, dn = +|- 0.50881, dEa = +|- 2.62369 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005308 <=> r005308
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 84,
+    label = "C4H6O2-9 <=> C4H6O2-10",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(8.55896e-23,'s^-1'), n=10.1131, Ea=(126.084,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1260.86, dn = +|- 0.947347, dEa = +|- 4.88502 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005356 <=> r005356
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 85,
+    label = "C3H5NO <=> C3H5NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(7.8149e-27,'s^-1'), n=11.304, Ea=(126.826,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1929.78, dn = +|- 1.00382, dEa = +|- 5.17623 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005491 <=> r005491
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 86,
+    label = "C4H7NO-13 <=> C4H7NO-14",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.49665e-24,'s^-1'), n=10.5562, Ea=(120.825,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1215.89, dn = +|- 0.942528, dEa = +|- 4.86017 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p005998 <=> r005998
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 87,
+    label = "C4H7NO-15 <=> C4H7NO-16",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.33301e-26,'s^-1'), n=11.129, Ea=(116.406,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1558.75, dn = +|- 0.975489, dEa = +|- 5.03013 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p006089 <=> r006089
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 88,
+    label = "C5H8O-5 <=> C5H8O-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(9.38708e-30,'s^-1'), n=12.1418, Ea=(114.989,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 2972.53, dn = +|- 1.06114, dEa = +|- 5.47181 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p006263 <=> r006263
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 89,
+    label = "C3H3NO2-3 <=> C3H3NO2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(3.83088e-20,'s^-1'), n=9.42661, Ea=(108.576,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 712.966, dn = +|- 0.871698, dEa = +|- 4.49493 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p006320 <=> r006320
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 90,
+    label = "C4H8O3 <=> C4H8O3-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.76964e-27,'s^-1'), n=11.3857, Ea=(99.7486,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 2247.38, dn = +|- 1.02404, dEa = +|- 5.28047 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p006396 <=> r006396
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 91,
+    label = "C4H5NO2-3 <=> C4H5NO2-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.77862e-15,'s^-1'), n=8.01018, Ea=(145.434,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 308.012, dn = +|- 0.760332, dEa = +|- 3.92067 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p006798 <=> r006798
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 92,
+    label = "C3H5N3O-3 <=> C3H5N3O-4",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.18792e-17,'s^-1'), n=8.63308, Ea=(112.872,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 509.177, dn = +|- 0.82703, dEa = +|- 4.2646 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p007773 <=> r007773
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 93,
+    label = "C3H5N3O-5 <=> C3H5N3O-6",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.19581e-17,'s^-1'), n=8.72753, Ea=(108.255,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 535.86, dn = +|- 0.833807, dEa = +|- 4.29955 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p007777 <=> r007773
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 94,
+    label = "C6H8O <=> C6H8O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.63468e-47,'s^-1'), n=17.3183, Ea=(128.068,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 13506, dn = +|- 1.262, dEa = +|- 6.50753 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p009289 <=> r009289
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 95,
+    label = "C5H3NO <=> C5H3NO-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.00799e-42,'s^-1'), n=15.8601, Ea=(125.554,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 10206.4, dn = +|- 1.22483, dEa = +|- 6.31587 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p009379 <=> r009379
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 96,
+    label = "C5H6O2 <=> C5H6O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.21191e-35,'s^-1'), n=13.8299, Ea=(127.361,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 5392.23, dn = +|- 1.14017, dEa = +|- 5.8793 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p009772 <=> r009772
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 97,
+    label = "C4H4O3 <=> C4H4O3-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(1.10569e-41,'s^-1'), n=15.9357, Ea=(145.27,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 17910.8, dn = +|- 1.29945, dEa = +|- 6.70066 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p009945 <=> r009945
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 98,
+    label = "C4H8N2O <=> C4H8N2O-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(2.83728e-12,'s^-1'), n=7.25327, Ea=(73.9748,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 146.099, dn = +|- 0.661365, dEa = +|- 3.41034 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p010345 <=> r010345
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 99,
+    label = "C4H7NO2 <=> C4H7NO2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.42405e-12,'s^-1'), n=7.19519, Ea=(76.6476,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 150.32, dn = +|- 0.665144, dEa = +|- 3.42983 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p010564 <=> r010564
+Calculated by Kevin Spiekermann
+opt, freq: wB97X-D3/def2-TZVP
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
+""",
+)
+
+entry(
+    index = 100,
+    label = "C2H3N3O2 <=> C2H3N3O2-2",
+    degeneracy = 1.0,
+    kinetics = Arrhenius(A=(4.43945e-20,'s^-1'), n=9.41864, Ea=(117.984,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 692.603, dn = +|- 0.867853, dEa = +|- 4.4751 kJ/mol"""),
+    rank = 4,
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    longDesc = 
+"""
+Original entry: p011399 <=> r011399
 Calculated by Kevin Spiekermann
 opt, freq: wB97X-D3/def2-TZVP
 sp: CCSD(T)-F12a/cc-pVDZ-F12

--- a/input/kinetics/families/Retroene/groups.py
+++ b/input/kinetics/families/Retroene/groups.py
@@ -150,7 +150,7 @@ entry(
 5 *1 O                      u0 r0 {3,D}
 6 *6 H                      u0 {4,S}
 7    N                      u0 r0 {1,S}
-8    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {4,S}
+8    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {4,S}
 """,
     kinetics = None,
 )
@@ -201,7 +201,7 @@ entry(
 5 *1 O                      u0 r0 {3,D}
 6 *6 H                      u0 r0 {4,S}
 7    N                      u0 r0 {1,S}
-8    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {2,S}
+8    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {2,S}
 """,
     kinetics = None,
 )
@@ -217,7 +217,7 @@ entry(
 4 *5 C                      u0 {2,[S,D]} {6,S}
 5 *1 O                      u0 {3,[D,T,B]}
 6 *6 H                      u0 {4,S}
-7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+7    [Si,S,P,C,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
 """,
     kinetics = None,
 )
@@ -233,7 +233,7 @@ entry(
 4 *5 C                      u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
 5 *1 O                      u0 {3,[D,T,B]}
 6 *6 H                      u0 {4,S}
-7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+7    [Si,S,P,C,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
 8    R!H                    ux {4,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -241,58 +241,7 @@ entry(
 
 entry(
     index = 13,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O",
-    group = 
-"""
-1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B,Q]}
-2 *4 C   u0 {1,S} {4,[S,D]}
-3 *2 C   u0 {1,S} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    O   ux {1,[S,D,T,B,Q]}
-8    R!H ux {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 14,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C",
-    group = 
-"""
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
-2 *4 C u0 r0 {1,S} {4,[S,D]}
-3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 r0 {4,S}
-7    O ux {1,[S,D,T,B,Q]}
-8    C ux {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 15,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C",
-    group = 
-"""
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
-2 *4 C u0 r0 {1,S} {4,[S,D]}
-3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 r0 {4,S}
-7    O ux {1,[S,D,T,B,Q]}
-8    N ux {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 16,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C",
     group = 
 """
 1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B,Q]}
@@ -308,25 +257,8 @@ entry(
 )
 
 entry(
-    index = 17,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C",
-    group = 
-"""
-1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
-2 *4 C u0 r0 {1,S} {4,[S,D]}
-3 *2 C u0 {1,S} {5,[D,T,B]}
-4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 r0 {4,S}
-7    C ux {1,[S,D,T,B,Q]}
-8    C ux {4,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 18,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C",
+    index = 14,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N",
     group = 
 """
 1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
@@ -342,6 +274,74 @@ entry(
 )
 
 entry(
+    index = 15,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N",
+    group = 
+"""
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
+3 *2 C u0 {1,S} {5,[D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 r0 {4,S}
+7    C ux {1,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 16,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C",
+    group = 
+"""
+1 *3 C   u0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 {1,S} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    O   ux {1,[S,D,T,B,Q]}
+8    R!H ux {4,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 17,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N",
+    group = 
+"""
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
+3 *2 C u0 {1,S} {5,[D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 r0 {4,S}
+7    O ux {1,[S,D,T,B,Q]}
+8    N ux {4,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 18,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N",
+    group = 
+"""
+1 *3 C u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
+2 *4 C u0 r0 {1,S} {4,[S,D]}
+3 *2 C u0 {1,S} {5,[D,T,B]}
+4 *5 C u0 r0 {2,[S,D]} {6,S} {8,[S,D,T,B,Q]}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 r0 {4,S}
+7    O ux {1,[S,D,T,B,Q]}
+8    C ux {4,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
     index = 19,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R",
     group = 
@@ -352,7 +352,7 @@ entry(
 4 *5 C                      u0 {2,[S,D]} {6,S}
 5 *1 O                      u0 {3,[D,T,B]}
 6 *6 H                      u0 {4,S}
-7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+7    [Si,S,P,C,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
 8    R!H                    ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -369,7 +369,7 @@ entry(
 4 *5 C                      u0 {2,[S,D]} {6,S}
 5 *1 O                      u0 {3,[D,T,B]}
 6 *6 H                      u0 {4,S}
-7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+7    [Si,S,P,C,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
 8    C                      ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -377,24 +377,7 @@ entry(
 
 entry(
     index = 21,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O",
-    group = 
-"""
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
-2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    O ux {1,[S,D,T,B,Q]}
-8    C ux {2,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 22,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C",
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
@@ -404,6 +387,23 @@ entry(
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
 7    C ux {1,[S,D,T,B,Q]}
+8    C ux {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 22,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C",
+    group = 
+"""
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C u0 {1,S} {4,[S,D]} {8,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    O ux {1,[S,D,T,B,Q]}
 8    C ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -420,7 +420,7 @@ entry(
 4 *5 C                      u0 {2,[S,D]} {6,S}
 5 *1 O                      u0 {3,[D,T,B]}
 6 *6 H                      u0 {4,S}
-7    [S,C,P,Si,F,I,Cl,Br,O] ux {1,[S,D,T,B,Q]}
+7    [Si,S,P,C,F,I,Br,Cl,O] ux {1,[S,D,T,B,Q]}
 8    O                      ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -428,7 +428,7 @@ entry(
 
 entry(
     index = 24,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C",
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
@@ -437,7 +437,7 @@ entry(
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    O ux {1,[S,D,T,B,Q]}
+7    C ux {1,[S,D,T,B,Q]}
 8    O ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -445,7 +445,7 @@ entry(
 
 entry(
     index = 25,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C",
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
@@ -454,7 +454,7 @@ entry(
 4 *5 C u0 {2,[S,D]} {6,S}
 5 *1 O u0 {3,[D,T,B]}
 6 *6 H u0 {4,S}
-7    C ux {1,[S,D,T,B,Q]}
+7    O ux {1,[S,D,T,B,Q]}
 8    O ux {2,[S,D,T,B,Q]}
 """,
     kinetics = None,
@@ -462,7 +462,23 @@ entry(
 
 entry(
     index = 26,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O",
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C",
+    group = 
+"""
+1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C ux {1,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 27,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C",
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
@@ -477,135 +493,8 @@ entry(
 )
 
 entry(
-    index = 27,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O",
-    group = 
-"""
-1 *3 C u0 {2,S} {3,[S,D]} {7,[S,D,T,B,Q]}
-2 *4 C u0 {1,S} {4,[S,D]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C ux {1,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
     index = 28,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O",
-    group = 
-"""
-1 *3 C u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 29,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R",
-    group = 
-"""
-1 *3 C   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,[S,D]} {7,S}
-3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C   u0 {2,[S,D]} {6,S}
-5 *1 O   u0 {3,[D,T,B]}
-6 *6 H   u0 {4,S}
-7    R!H u0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 30,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C",
-    group = 
-"""
-1 *3 C u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,S}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    C u0 r0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 31,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C",
-    group = 
-"""
-1 *3 C                      u0 {2,S} {3,[S,D]}
-2 *4 C                      u0 {1,S} {4,[S,D]} {7,S}
-3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C                      u0 {2,[S,D]} {6,S}
-5 *1 O                      u0 {3,[D,T,B]}
-6 *6 H                      u0 {4,S}
-7    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {2,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 32,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R",
-    group = 
-"""
-1 *3 C   u0 {2,S} {3,S}
-2 *4 C   u0 {1,S} {4,S}
-3 *2 C   u0 {1,S} {5,D}
-4 *5 C   u0 {2,S} {6,S} {7,S}
-5 *1 O   u0 {3,D}
-6 *6 H   u0 {4,S}
-7    R!H u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 33,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C",
-    group = 
-"""
-1 *3 C u0 r0 {2,S} {3,S}
-2 *4 C u0 r0 {1,S} {4,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S} {7,S}
-5 *1 O u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-7    C u0 r0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 34,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C",
-    group = 
-"""
-1 *3 C                      u0 r0 {2,S} {3,S}
-2 *4 C                      u0 r0 {1,S} {4,S}
-3 *2 C                      u0 r0 {1,S} {5,D}
-4 *5 C                      u0 r0 {2,S} {6,S} {7,S}
-5 *1 O                      u0 r0 {3,D}
-6 *6 H                      u0 r0 {4,S}
-7    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 35,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O",
+    label = "Root_1R!H->C_2R!H->C_5R!H->C",
     group = 
 """
 1 *3 C u0 {2,S} {3,[S,D]}
@@ -619,8 +508,8 @@ entry(
 )
 
 entry(
-    index = 36,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R",
+    index = 29,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R",
     group = 
 """
 1 *3 C u0 {2,S} {3,S}
@@ -635,8 +524,8 @@ entry(
 )
 
 entry(
-    index = 37,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R",
+    index = 30,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R",
     group = 
 """
 1 *3 C   u0 {2,S} {3,S}
@@ -652,8 +541,8 @@ entry(
 )
 
 entry(
-    index = 38,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R",
+    index = 31,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R",
     group = 
 """
 1 *3 C   u0 {2,S} {3,S}
@@ -670,8 +559,8 @@ entry(
 )
 
 entry(
-    index = 39,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R",
+    index = 32,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R",
     group = 
 """
 1  *3 C u0 {2,S} {3,S}
@@ -689,8 +578,8 @@ entry(
 )
 
 entry(
-    index = 40,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R",
+    index = 33,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R",
     group = 
 """
 1  *3 C   u0 r0 {2,S} {3,S}
@@ -709,8 +598,8 @@ entry(
 )
 
 entry(
-    index = 41,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R",
+    index = 34,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R",
     group = 
 """
 1 *3 C   u0 {2,S} {3,[S,D]}
@@ -725,12 +614,123 @@ entry(
 )
 
 entry(
+    index = 35,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C",
+    group = 
+"""
+1 *3 C u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 36,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R",
+    group = 
+"""
+1 *3 C   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]} {7,S}
+3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S}
+5 *1 O   u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
+7    R!H u0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 37,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C",
+    group = 
+"""
+1 *3 C u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,S}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    C u0 r0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 38,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C",
+    group = 
+"""
+1 *3 C                      u0 {2,S} {3,[S,D]}
+2 *4 C                      u0 {1,S} {4,[S,D]} {7,S}
+3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C                      u0 {2,[S,D]} {6,S}
+5 *1 O                      u0 {3,[D,T,B]}
+6 *6 H                      u0 {4,S}
+7    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {2,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 39,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R",
+    group = 
+"""
+1 *3 C   u0 {2,S} {3,S}
+2 *4 C   u0 {1,S} {4,S}
+3 *2 C   u0 {1,S} {5,D}
+4 *5 C   u0 {2,S} {6,S} {7,S}
+5 *1 O   u0 {3,D}
+6 *6 H   u0 {4,S}
+7    R!H u0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 40,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C",
+    group = 
+"""
+1 *3 C u0 r0 {2,S} {3,S}
+2 *4 C u0 r0 {1,S} {4,S}
+3 *2 C u0 r0 {1,S} {5,D}
+4 *5 C u0 r0 {2,S} {6,S} {7,S}
+5 *1 O u0 r0 {3,D}
+6 *6 H u0 r0 {4,S}
+7    C u0 r0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 41,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C",
+    group = 
+"""
+1 *3 C                      u0 r0 {2,S} {3,S}
+2 *4 C                      u0 r0 {1,S} {4,S}
+3 *2 C                      u0 r0 {1,S} {5,D}
+4 *5 C                      u0 r0 {2,S} {6,S} {7,S}
+5 *1 O                      u0 r0 {3,D}
+6 *6 H                      u0 r0 {4,S}
+7    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
     index = 42,
     label = "Root_1R!H->C_N-2R!H->C",
     group = 
 """
 1 *3 C       u0 {2,S} {3,[S,D]}
-2 *4 [O,S,N] u0 {1,S} {4,[S,D]}
+2 *4 [S,N,O] u0 {1,S} {4,[S,D]}
 3 *2 C       u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 C       u0 {2,[S,D]} {6,S}
 5 *1 C       u0 {3,[D,T,B]}
@@ -745,7 +745,7 @@ entry(
     group = 
 """
 1 *3 C       u0 r0 {2,S} {3,S} {7,[S,D,T,B,Q]}
-2 *4 [O,S,N] u0 r0 {1,S} {4,[S,D]}
+2 *4 [S,N,O] u0 r0 {1,S} {4,[S,D]}
 3 *2 C       u0 {1,S} {5,[D,T,B]}
 4 *5 C       u0 r0 {2,[S,D]} {6,S}
 5 *1 C       u0 {3,[D,T,B]}
@@ -776,7 +776,7 @@ entry(
     group = 
 """
 1 *3 C     u0 {2,S} {3,S}
-2 *4 [O,N] u0 {1,S} {4,S}
+2 *4 [N,O] u0 {1,S} {4,S}
 3 *2 C     u0 {1,S} {5,D}
 4 *5 C     u0 {2,S} {6,S}
 5 *1 C     u0 {3,D}
@@ -787,22 +787,7 @@ entry(
 
 entry(
     index = 46,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O",
-    group = 
-"""
-1 *3 C u0 r0 {2,S} {3,S}
-2 *4 O u0 r0 {1,S} {4,S}
-3 *2 C u0 r0 {1,S} {5,D}
-4 *5 C u0 r0 {2,S} {6,S}
-5 *1 C u0 r0 {3,D}
-6 *6 H u0 r0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 47,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O",
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N",
     group = 
 """
 1 *3 C u0 r0 {2,S} {3,S}
@@ -816,11 +801,26 @@ entry(
 )
 
 entry(
+    index = 47,
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N",
+    group = 
+"""
+1 *3 C u0 r0 {2,S} {3,S}
+2 *4 O u0 r0 {1,S} {4,S}
+3 *2 C u0 r0 {1,S} {5,D}
+4 *5 C u0 r0 {2,S} {6,S}
+5 *1 C u0 r0 {3,D}
+6 *6 H u0 r0 {4,S}
+""",
+    kinetics = None,
+)
+
+entry(
     index = 48,
     label = "Root_N-1R!H->C",
     group = 
 """
-1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
+1 *3 [Si,S,N,P,F,I,Br,Cl,O] u0 {2,S} {3,[S,D]}
 2 *4 C                      u0 {1,S} {4,[S,D]}
 3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 R!H                    u0 {2,[S,D]} {6,S}
@@ -832,40 +832,10 @@ entry(
 
 entry(
     index = 49,
-    label = "Root_N-1R!H->C_5R!H->N",
+    label = "Root_N-1R!H->C_Ext-2R!H-R",
     group = 
 """
-1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
-2 *4 C                      u0 {1,S} {4,[S,D]}
-3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 R!H                    u0 {2,[S,D]} {6,S}
-5 *1 N                      u0 {3,[D,T,B]}
-6 *6 H                      u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 50,
-    label = "Root_N-1R!H->C_N-5R!H->N",
-    group = 
-"""
-1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
-2 *4 C                      u0 {1,S} {4,[S,D]}
-3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 R!H                    u0 {2,[S,D]} {6,S}
-5 *1 [O,C]                  u0 {3,[D,T,B]}
-6 *6 H                      u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 51,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R",
-    group = 
-"""
-1 *3 [S,N,P,Si,F,I,Cl,Br,O] u0 {2,S} {3,[S,D]}
+1 *3 [Si,S,N,P,F,I,Br,Cl,O] u0 {2,S} {3,[S,D]}
 2 *4 C                      u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
 3 *2 C                      u0 {1,[S,D]} {5,[D,T,B]}
 4 *5 R!H                    u0 {2,[S,D]} {6,S}
@@ -877,8 +847,24 @@ entry(
 )
 
 entry(
-    index = 52,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O",
+    index = 50,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N",
+    group = 
+"""
+1 *3 N   u0 r0 {2,S} {3,S}
+2 *4 C   u0 r0 {1,S} {4,S} {7,[S,D,T,B,Q]}
+3 *2 C   u0 r0 {1,S} {5,D}
+4 *5 R!H u0 r0 {2,S} {6,S}
+5 *1 O   u0 r0 {3,D}
+6 *6 H   u0 r0 {4,S}
+7    R!H u0 {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 51,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -893,13 +879,13 @@ entry(
 )
 
 entry(
-    index = 53,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R",
+    index = 52,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
+1 *3 O   u0 {2,S} {3,S}
 2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
-3 *2 C   u0 {1,[S,D]} {5,D}
+3 *2 C   u0 {1,S} {5,D}
 4 *5 C   u0 {2,S} {6,S}
 5 *1 O   u0 {3,D}
 6 *6 H   u0 {4,S}
@@ -910,16 +896,16 @@ entry(
 )
 
 entry(
-    index = 54,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R",
+    index = 53,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R",
     group = 
 """
-1 *3 O   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
-3 *2 C   u0 r0 {1,[S,D]} {5,D}
-4 *5 C   u0 {2,S} {6,S} {9,[S,D,T,B,Q]}
+1 *3 O   u0 r0 {2,S} {3,S}
+2 *4 C   u0 r0 {1,S} {4,S} {7,[S,D,T,B,Q]} {8,[S,D,T,B,Q]}
+3 *2 C   u0 r0 {1,S} {5,D}
+4 *5 C   u0 r0 {2,S} {6,S} {9,[S,D,T,B,Q]}
 5 *1 O   u0 r0 {3,D}
-6 *6 H   u0 {4,S}
+6 *6 H   u0 r0 {4,S}
 7    R!H ux {2,[S,D,T,B,Q]}
 8    R!H ux {2,[S,D,T,B,Q]}
 9    R!H ux {4,[S,D,T,B,Q]}
@@ -928,8 +914,8 @@ entry(
 )
 
 entry(
-    index = 55,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R",
+    index = 54,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,S}
@@ -946,8 +932,8 @@ entry(
 )
 
 entry(
-    index = 56,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
+    index = 55,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
     group = 
 """
 1  *3 O   u0 r0 {2,S} {3,S}
@@ -965,24 +951,8 @@ entry(
 )
 
 entry(
-    index = 57,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O",
-    group = 
-"""
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
-3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-7    O ux {2,[S,D,T,B,Q]}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 58,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O",
+    index = 56,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -997,8 +967,8 @@ entry(
 )
 
 entry(
-    index = 59,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R",
+    index = 57,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1014,8 +984,8 @@ entry(
 )
 
 entry(
-    index = 60,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R",
+    index = 58,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1032,8 +1002,8 @@ entry(
 )
 
 entry(
-    index = 61,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing",
+    index = 59,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing",
     group = 
 """
 1 *3 O u0 r0 {2,S} {3,S}
@@ -1050,8 +1020,8 @@ entry(
 )
 
 entry(
-    index = 62,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
+    index = 60,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
     group = 
 """
 1 *3 O u0 r0 {2,S} {3,S}
@@ -1068,8 +1038,8 @@ entry(
 )
 
 entry(
-    index = 63,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R",
+    index = 61,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1086,8 +1056,8 @@ entry(
 )
 
 entry(
-    index = 64,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
+    index = 62,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
     group = 
 """
 1  *3 O   u0 r0 {2,S} {3,S}
@@ -1105,8 +1075,8 @@ entry(
 )
 
 entry(
-    index = 65,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
+    index = 63,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1123,8 +1093,8 @@ entry(
 )
 
 entry(
-    index = 66,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
+    index = 64,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1141,8 +1111,8 @@ entry(
 )
 
 entry(
-    index = 67,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
+    index = 65,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
     group = 
 """
 1 *3 O u0 r0 {2,S} {3,S}
@@ -1159,8 +1129,8 @@ entry(
 )
 
 entry(
-    index = 68,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
+    index = 66,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
     group = 
 """
 1 *3 O u0 r0 {2,S} {3,S}
@@ -1177,8 +1147,8 @@ entry(
 )
 
 entry(
-    index = 69,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R",
+    index = 67,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1194,8 +1164,8 @@ entry(
 )
 
 entry(
-    index = 70,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R",
+    index = 68,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1212,8 +1182,8 @@ entry(
 )
 
 entry(
-    index = 71,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
+    index = 69,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1230,8 +1200,8 @@ entry(
 )
 
 entry(
-    index = 72,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
+    index = 70,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1248,8 +1218,8 @@ entry(
 )
 
 entry(
-    index = 73,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R",
+    index = 71,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1265,39 +1235,54 @@ entry(
 )
 
 entry(
-    index = 74,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O",
+    index = 72,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C",
+    group = 
+"""
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]} {7,[S,D,T,B,Q]}
+3 *2 C u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
+7    O ux {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 73,
+    label = "Root_N-1R!H->C_1BrClFINOPSSi->N",
     group = 
 """
 1 *3 N   u0 {2,S} {3,[S,D]}
-2 *4 C   u0 {1,S} {4,S} {7,[S,D,T,B,Q]}
-3 *2 C   u0 r0 {1,[S,D]} {5,D}
-4 *5 R!H u0 {2,S} {6,S}
-5 *1 O   u0 r0 {3,D}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 R!H u0 {2,[S,D]} {6,S}
+5 *1 R!H u0 {3,[D,T,B]}
 6 *6 H   u0 {4,S}
-7    R!H u0 {2,[S,D,T,B,Q]}
+""",
+    kinetics = None,
+)
+
+entry(
+    index = 74,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N",
+    group = 
+"""
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S}
+5 *1 R!H u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
 """,
     kinetics = None,
 )
 
 entry(
     index = 75,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O",
-    group = 
-"""
-1 *3 O     u0 {2,S} {3,[S,D]}
-2 *4 C     u0 {1,S} {4,[S,D]}
-3 *2 C     u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C     u0 {2,[S,D]} {6,S}
-5 *1 [O,C] u0 {3,[D,T,B]}
-6 *6 H     u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 76,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing",
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1311,8 +1296,8 @@ entry(
 )
 
 entry(
-    index = 77,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R",
+    index = 76,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1327,23 +1312,23 @@ entry(
 )
 
 entry(
-    index = 78,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing",
+    index = 77,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing",
     group = 
 """
-1 *3 O     u0 {2,S} {3,[S,D]}
-2 *4 C     u0 {1,S} {4,[S,D]}
-3 *2 C     u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C     u0 {2,[S,D]} {6,S}
-5 *1 [O,C] u0 {3,[D,T,B]}
-6 *6 H     u0 {4,S}
+1 *3 O   u0 {2,S} {3,[S,D]}
+2 *4 C   u0 {1,S} {4,[S,D]}
+3 *2 C   u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C   u0 {2,[S,D]} {6,S}
+5 *1 R!H u0 {3,[D,T,B]}
+6 *6 H   u0 {4,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 79,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R",
+    index = 78,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1358,8 +1343,8 @@ entry(
 )
 
 entry(
-    index = 80,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
+    index = 79,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1374,8 +1359,8 @@ entry(
 )
 
 entry(
-    index = 81,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
+    index = 80,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1390,8 +1375,8 @@ entry(
 )
 
 entry(
-    index = 82,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
+    index = 81,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1406,8 +1391,8 @@ entry(
 )
 
 entry(
-    index = 83,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
+    index = 82,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1423,8 +1408,8 @@ entry(
 )
 
 entry(
-    index = 84,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
+    index = 83,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1441,8 +1426,8 @@ entry(
 )
 
 entry(
-    index = 85,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
+    index = 84,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1459,8 +1444,8 @@ entry(
 )
 
 entry(
-    index = 86,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
+    index = 85,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1477,8 +1462,8 @@ entry(
 )
 
 entry(
-    index = 87,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
+    index = 86,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,[S,D]}
@@ -1494,8 +1479,8 @@ entry(
 )
 
 entry(
-    index = 88,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
+    index = 87,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1510,8 +1495,8 @@ entry(
 )
 
 entry(
-    index = 89,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R",
+    index = 88,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R",
     group = 
 """
 1 *3 O   u0 r0 {2,S} {3,S}
@@ -1528,8 +1513,8 @@ entry(
 )
 
 entry(
-    index = 90,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R",
+    index = 89,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R",
     group = 
 """
 1 *3 O   u0 {2,S} {3,S}
@@ -1544,8 +1529,8 @@ entry(
 )
 
 entry(
-    index = 91,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
+    index = 90,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1560,8 +1545,8 @@ entry(
 )
 
 entry(
-    index = 92,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
+    index = 91,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
     group = 
 """
 1 *3 O u0 {2,S} {3,S}
@@ -1577,8 +1562,8 @@ entry(
 )
 
 entry(
-    index = 93,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
+    index = 92,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
     group = 
 """
 1 *3 O   u0 r0 {2,S} {3,S}
@@ -1595,8 +1580,8 @@ entry(
 )
 
 entry(
-    index = 94,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
+    index = 93,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
     group = 
 """
 1 *3 O                      u0 r0 {2,S} {3,S}
@@ -1605,29 +1590,14 @@ entry(
 4 *5 C                      u0 r0 {2,S} {6,S}
 5 *1 O                      u0 r0 {3,D}
 6 *6 H                      u0 r0 {4,S}
-7    [S,N,P,Si,F,I,Cl,Br,O] u0 r0 {3,S}
+7    [Si,S,N,P,F,I,Br,Cl,O] u0 r0 {3,S}
 """,
     kinetics = None,
 )
 
 entry(
-    index = 95,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O",
-    group = 
-"""
-1 *3 O u0 {2,S} {3,[S,D]}
-2 *4 C u0 {1,S} {4,[S,D]}
-3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
-4 *5 C u0 {2,[S,D]} {6,S}
-5 *1 O u0 {3,[D,T,B]}
-6 *6 H u0 {4,S}
-""",
-    kinetics = None,
-)
-
-entry(
-    index = 96,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O",
+    index = 94,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C",
     group = 
 """
 1 *3 O u0 {2,S} {3,[S,D]}
@@ -1641,16 +1611,16 @@ entry(
 )
 
 entry(
-    index = 97,
-    label = "Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O",
+    index = 95,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C",
     group = 
 """
-1 *3 N     u0 {2,S} {3,[S,D]}
-2 *4 C     u0 {1,S} {4,[S,D]}
-3 *2 C     u0 {1,[S,D]} {5,[D,T,B]}
-4 *5 R!H   u0 {2,[S,D]} {6,S}
-5 *1 [O,C] u0 {3,[D,T,B]}
-6 *6 H     u0 {4,S}
+1 *3 O u0 {2,S} {3,[S,D]}
+2 *4 C u0 {1,S} {4,[S,D]}
+3 *2 C u0 r0 {1,[S,D]} {5,[D,T,B]}
+4 *5 C u0 {2,[S,D]} {6,S}
+5 *1 O u0 {3,[D,T,B]}
+6 *6 H u0 {4,S}
 """,
     kinetics = None,
 )
@@ -1670,91 +1640,89 @@ L1: Root
                         L7: Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
                 L5: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
                     L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
-                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
+                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N
+                        L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N
                     L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
                         L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C
                         L7: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
-                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
-                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
-                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
-            L4: Root_1R!H->C_2R!H->C_5R!H->O
-                L5: Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-                    L6: Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
-                    L6: Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
-                L5: Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-                    L6: Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
-                    L6: Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
-            L4: Root_1R!H->C_2R!H->C_N-5R!H->O
-                L5: Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-                    L6: Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-                        L7: Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-                            L8: Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-                                L9: Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
-                L5: Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C
+                            L8: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C
+                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C
+                    L6: Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C
+            L4: Root_1R!H->C_2R!H->C_5R!H->C
+                L5: Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R
+                    L6: Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R
+                        L7: Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+                            L8: Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+                                L9: Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+                L5: Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R
+            L4: Root_1R!H->C_2R!H->C_N-5R!H->C
+                L5: Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R
+                    L6: Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C
+                    L6: Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C
+                L5: Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R
+                    L6: Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C
+                    L6: Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C
         L3: Root_1R!H->C_N-2R!H->C
             L4: Root_1R!H->C_N-2R!H->C_Ext-1C-R
             L4: Root_1R!H->C_N-2R!H->C_2NOS->S
             L4: Root_1R!H->C_N-2R!H->C_N-2NOS->S
-                L5: Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-                L5: Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
+                L5: Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N
+                L5: Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N
     L2: Root_N-1R!H->C
-        L3: Root_N-1R!H->C_5R!H->N
-        L3: Root_N-1R!H->C_N-5R!H->N
-            L4: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
-                L5: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
-                    L6: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
-                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
-                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
-                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
-                    L6: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
-                    L6: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
-                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
-                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
-                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-                                    L10: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
-                                    L10: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
-                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
-                            L8: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
-                                L9: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
-                        L7: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
-                L5: Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
-            L4: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
-                L5: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
-                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
-                L5: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
-                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
-                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
-                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-                                L9: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-                                    L10: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
-                                    L10: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
-                                    L10: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-                                L9: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
-                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
-                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
-                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-                            L8: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-                                L9: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
-                        L7: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
-                    L6: Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
-            L4: Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
+        L3: Root_N-1R!H->C_Ext-2R!H-R
+            L4: Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N
+            L4: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N
+                L5: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R
+                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R
+                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R
+                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+                L5: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C
+                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R
+                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+                                L9: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+                                L9: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R
+                        L7: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+                            L8: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
+                    L6: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R
+                L5: Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C
+        L3: Root_N-1R!H->C_1BrClFINOPSSi->N
+        L3: Root_N-1R!H->C_N-1BrClFINOPSSi->N
+            L4: Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing
+                L5: Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R
+            L4: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing
+                L5: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R
+                    L6: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+                        L7: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
+                        L7: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+                            L8: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+                                L9: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+                                L9: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
+                                L9: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
+                            L8: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
+                    L6: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+                        L7: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
+                L5: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R
+                    L6: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+                        L7: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+                            L8: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+                    L6: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+                L5: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C
+                L5: Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C
 """
 )
 

--- a/input/kinetics/families/Retroene/rules.py
+++ b/input/kinetics/families/Retroene/rules.py
@@ -9,155 +9,170 @@ longDesc = """
 entry(
     index = 1,
     label = "Root",
-    kinetics = ArrheniusBM(A=(351.483,'s^-1'), n=2.72887, w0=(1.11181e+06,'J/mol'), E0=(141064,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.13055717705123002, var=19.959654271360805, Tref=1000.0, N=68, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 68 training reactions at node Root
-    Total Standard Deviation in ln(k): 9.284433424755495"""),
+    kinetics = ArrheniusBM(A=(3.10012e+10,'s^-1'), n=0.352209, w0=(1.11205e+06,'J/mol'), E0=(162219,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0315482980354495, var=11.3165183829301, Tref=1000.0, N=67, data_mean=0.0, correlation='Root',), comment="""BM rule fitted to 67 training reactions at node Root
+    Total Standard Deviation in ln(k): 6.823202550259767"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 68 training reactions at node Root
-Total Standard Deviation in ln(k): 9.284433424755495""",
+    shortDesc = """BM rule fitted to 67 training reactions at node Root
+Total Standard Deviation in ln(k): 6.823202550259767""",
     longDesc = 
 """
-BM rule fitted to 68 training reactions at node Root
-Total Standard Deviation in ln(k): 9.284433424755495
+BM rule fitted to 67 training reactions at node Root
+Total Standard Deviation in ln(k): 6.823202550259767
 """,
 )
 
 entry(
     index = 2,
     label = "Root_1R!H->C",
-    kinetics = ArrheniusBM(A=(1.75934e+14,'s^-1'), n=-0.752179, w0=(1.04926e+06,'J/mol'), E0=(177823,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09940871819346306, var=3.010161187748991, Tref=1000.0, N=31, data_mean=0.0, correlation='Root_1R!H->C',), comment="""BM rule fitted to 31 training reactions at node Root_1R!H->C
-    Total Standard Deviation in ln(k): 3.7279491413387"""),
+    kinetics = ArrheniusBM(A=(7.08414e+11,'s^-1'), n=-0.0384258, w0=(1.04926e+06,'J/mol'), E0=(173468,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0885800887239561, var=2.933633025269101, Tref=1000.0, N=31, data_mean=0.0, correlation='Root_1R!H->C',), comment="""BM rule fitted to 31 training reactions at node Root_1R!H->C
+    Total Standard Deviation in ln(k): 3.65624353954917"""),
     rank = 11,
     shortDesc = """BM rule fitted to 31 training reactions at node Root_1R!H->C
-Total Standard Deviation in ln(k): 3.7279491413387""",
+Total Standard Deviation in ln(k): 3.65624353954917""",
     longDesc = 
 """
 BM rule fitted to 31 training reactions at node Root_1R!H->C
-Total Standard Deviation in ln(k): 3.7279491413387
+Total Standard Deviation in ln(k): 3.65624353954917
 """,
 )
 
 entry(
     index = 3,
     label = "Root_N-1R!H->C",
-    kinetics = ArrheniusBM(A=(0.0523035,'s^-1'), n=3.89104, w0=(1.16422e+06,'J/mol'), E0=(117784,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.32245522758811473, var=39.144342334518626, Tref=1000.0, N=37, data_mean=0.0, correlation='Root_N-1R!H->C',), comment="""BM rule fitted to 37 training reactions at node Root_N-1R!H->C
-    Total Standard Deviation in ln(k): 13.352902155690218"""),
+    kinetics = ArrheniusBM(A=(2.51696e+11,'s^-1'), n=0.0936269, w0=(1.16612e+06,'J/mol'), E0=(153183,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.03495653711814081, var=24.398290288554755, Tref=1000.0, N=36, data_mean=0.0, correlation='Root_N-1R!H->C',), comment="""BM rule fitted to 36 training reactions at node Root_N-1R!H->C
+    Total Standard Deviation in ln(k): 9.990144333888548"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 37 training reactions at node Root_N-1R!H->C
-Total Standard Deviation in ln(k): 13.352902155690218""",
+    shortDesc = """BM rule fitted to 36 training reactions at node Root_N-1R!H->C
+Total Standard Deviation in ln(k): 9.990144333888548""",
     longDesc = 
 """
-BM rule fitted to 37 training reactions at node Root_N-1R!H->C
-Total Standard Deviation in ln(k): 13.352902155690218
+BM rule fitted to 36 training reactions at node Root_N-1R!H->C
+Total Standard Deviation in ln(k): 9.990144333888548
 """,
 )
 
 entry(
     index = 4,
     label = "Root_1R!H->C_2R!H->C",
-    kinetics = ArrheniusBM(A=(1.13656e+14,'s^-1'), n=-0.713758, w0=(1.0543e+06,'J/mol'), E0=(175246,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09769890056487542, var=2.561580468547625, Tref=1000.0, N=27, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C',), comment="""BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
-    Total Standard Deviation in ln(k): 3.4540407270731786"""),
+    kinetics = ArrheniusBM(A=(5.60991e+11,'s^-1'), n=-0.0273666, w0=(1.0543e+06,'J/mol'), E0=(171027,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.08769201295031893, var=2.499675655451367, Tref=1000.0, N=27, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C',), comment="""BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
+    Total Standard Deviation in ln(k): 3.3898905398944907"""),
     rank = 11,
     shortDesc = """BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
-Total Standard Deviation in ln(k): 3.4540407270731786""",
+Total Standard Deviation in ln(k): 3.3898905398944907""",
     longDesc = 
 """
 BM rule fitted to 27 training reactions at node Root_1R!H->C_2R!H->C
-Total Standard Deviation in ln(k): 3.4540407270731786
+Total Standard Deviation in ln(k): 3.3898905398944907
 """,
 )
 
 entry(
     index = 5,
     label = "Root_1R!H->C_N-2R!H->C",
-    kinetics = ArrheniusBM(A=(4.66316e+09,'s^-1'), n=1.02661, w0=(1.01525e+06,'J/mol'), E0=(221066,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=3.6261064499336317, var=38.37240951049941, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
-    Total Standard Deviation in ln(k): 21.529245395988614"""),
+    kinetics = ArrheniusBM(A=(2.0937e+10,'s^-1'), n=0.830793, w0=(1.01525e+06,'J/mol'), E0=(222264,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=3.600131383473395, var=38.10179994091674, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
+    Total Standard Deviation in ln(k): 21.42011538066948"""),
     rank = 11,
     shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
-Total Standard Deviation in ln(k): 21.529245395988614""",
+Total Standard Deviation in ln(k): 21.42011538066948""",
     longDesc = 
 """
 BM rule fitted to 4 training reactions at node Root_1R!H->C_N-2R!H->C
-Total Standard Deviation in ln(k): 21.529245395988614
+Total Standard Deviation in ln(k): 21.42011538066948
 """,
 )
 
 entry(
     index = 6,
-    label = "Root_N-1R!H->C_5R!H->N",
-    kinetics = ArrheniusBM(A=(9.59135e+09,'s^-1'), n=0.736578, w0=(1.0955e+06,'J/mol'), E0=(70461.5,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_5R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_5R!H->N
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R",
+    kinetics = ArrheniusBM(A=(4.59138e+06,'s^-1'), n=1.59388, w0=(1.17869e+06,'J/mol'), E0=(147231,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.21962150556401386, var=2.9313754415001467, Tref=1000.0, N=18, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R',), comment="""BM rule fitted to 18 training reactions at node Root_N-1R!H->C_Ext-2R!H-R
+    Total Standard Deviation in ln(k): 3.984171878119655"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_5R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 18 training reactions at node Root_N-1R!H->C_Ext-2R!H-R
+Total Standard Deviation in ln(k): 3.984171878119655""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_5R!H->N
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 18 training reactions at node Root_N-1R!H->C_Ext-2R!H-R
+Total Standard Deviation in ln(k): 3.984171878119655
 """,
 )
 
 entry(
     index = 7,
-    label = "Root_N-1R!H->C_N-5R!H->N",
-    kinetics = ArrheniusBM(A=(4.02942e+10,'s^-1'), n=0.375329, w0=(1.16612e+06,'J/mol'), E0=(154169,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.06684469846581474, var=24.965000021544366, Tref=1000.0, N=36, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N',), comment="""BM rule fitted to 36 training reactions at node Root_N-1R!H->C_N-5R!H->N
-    Total Standard Deviation in ln(k): 10.184607864683809"""),
+    label = "Root_N-1R!H->C_1BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(9.54463e+09,'s^-1'), n=0.829688, w0=(1.0865e+06,'J/mol'), E0=(100226,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_1BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_1BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 36 training reactions at node Root_N-1R!H->C_N-5R!H->N
-Total Standard Deviation in ln(k): 10.184607864683809""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_1BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 36 training reactions at node Root_N-1R!H->C_N-5R!H->N
-Total Standard Deviation in ln(k): 10.184607864683809
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_1BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 8,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R",
-    kinetics = ArrheniusBM(A=(4.46238e+12,'s^-1'), n=-0.158546, w0=(1.0845e+06,'J/mol'), E0=(176009,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09120859003038287, var=2.28830828228651, Tref=1000.0, N=15, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
-    Total Standard Deviation in ln(k): 3.261761201768912"""),
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(6.16445e+10,'s^-1'), n=0.126877, w0=(1.1575e+06,'J/mol'), E0=(162948,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.10956172353909022, var=13.764781872707946, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N',), comment="""BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 7.71303207558061"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
-Total Standard Deviation in ln(k): 3.261761201768912""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 7.71303207558061""",
     longDesc = 
 """
-BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
-Total Standard Deviation in ln(k): 3.261761201768912
+BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 7.71303207558061
 """,
 )
 
 entry(
     index = 9,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O",
-    kinetics = ArrheniusBM(A=(3.94505e+09,'s^-1'), n=0.601596, w0=(1.0845e+06,'J/mol'), E0=(169425,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.07591793873856297, var=4.052420941329839, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
-    Total Standard Deviation in ln(k): 4.226405752097704"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R",
+    kinetics = ArrheniusBM(A=(1.50265e+10,'s^-1'), n=0.582016, w0=(1.0845e+06,'J/mol'), E0=(171532,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.07578885385627057, var=2.175429915116852, Tref=1000.0, N=15, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
+    Total Standard Deviation in ln(k): 3.147275918033949"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
-Total Standard Deviation in ln(k): 4.226405752097704""",
+    shortDesc = """BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
+Total Standard Deviation in ln(k): 3.147275918033949""",
     longDesc = 
 """
-BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O
-Total Standard Deviation in ln(k): 4.226405752097704
+BM rule fitted to 15 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R
+Total Standard Deviation in ln(k): 3.147275918033949
 """,
 )
 
 entry(
     index = 10,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O",
-    kinetics = ArrheniusBM(A=(1.32288e+18,'s^-1'), n=-2.21337, w0=(968000,'J/mol'), E0=(173278,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0927421085454212, var=3.278681656229481, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O',), comment="""BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
-    Total Standard Deviation in ln(k): 3.863020288060733"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->C",
+    kinetics = ArrheniusBM(A=(2.14192e+15,'s^-1'), n=-1.36604, w0=(968000,'J/mol'), E0=(168571,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.07722342872883733, var=3.2717649671082105, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C',), comment="""BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C
+    Total Standard Deviation in ln(k): 3.820197694621681"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
-Total Standard Deviation in ln(k): 3.863020288060733""",
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C
+Total Standard Deviation in ln(k): 3.820197694621681""",
     longDesc = 
 """
-BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O
-Total Standard Deviation in ln(k): 3.863020288060733
+BM rule fitted to 7 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C
+Total Standard Deviation in ln(k): 3.820197694621681
 """,
 )
 
 entry(
     index = 11,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(5.31421e+08,'s^-1'), n=0.798496, w0=(1.0845e+06,'J/mol'), E0=(166008,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.06646347756542345, var=3.684389843138008, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C
+    Total Standard Deviation in ln(k): 4.015035432311303"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C
+Total Standard Deviation in ln(k): 4.015035432311303""",
+    longDesc = 
+"""
+BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C
+Total Standard Deviation in ln(k): 4.015035432311303
+""",
+)
+
+entry(
+    index = 12,
     label = "Root_1R!H->C_N-2R!H->C_Ext-1C-R",
     kinetics = ArrheniusBM(A=(2.8e+12,'s^-1'), n=0, w0=(1.0665e+06,'J/mol'), E0=(218338,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_Ext-1C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_Ext-1C-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
@@ -172,7 +187,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 12,
+    index = 13,
     label = "Root_1R!H->C_N-2R!H->C_2NOS->S",
     kinetics = ArrheniusBM(A=(5.6608e+10,'s^-1'), n=0, w0=(953500,'J/mol'), E0=(119669,'J/mol'), Tmin=(588,'K'), Tmax=(691,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_2NOS->S',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_2NOS->S
     Total Standard Deviation in ln(k): 11.540182761524994"""),
@@ -187,9 +202,9 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 13,
+    index = 14,
     label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S",
-    kinetics = ArrheniusBM(A=(3.11827e+11,'s^-1'), n=-0.293682, w0=(1.0205e+06,'J/mol'), E0=(160991,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.001642907944431047, var=4.049121298193099, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
+    kinetics = ArrheniusBM(A=(1.18273e+11,'s^-1'), n=-0.16585, w0=(1.0205e+06,'J/mol'), E0=(160293,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.001642907944431047, var=4.049121298193099, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
     Total Standard Deviation in ln(k): 4.03814174042697"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S
@@ -202,234 +217,309 @@ Total Standard Deviation in ln(k): 4.03814174042697
 )
 
 entry(
-    index = 14,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R",
-    kinetics = ArrheniusBM(A=(4.82035e+06,'s^-1'), n=1.67734, w0=(1.17869e+06,'J/mol'), E0=(152460,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.2285837836968013, var=2.96975919141528, Tref=1000.0, N=18, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R',), comment="""BM rule fitted to 18 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
-    Total Standard Deviation in ln(k): 4.029088922385259"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 18 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
-Total Standard Deviation in ln(k): 4.029088922385259""",
-    longDesc = 
-"""
-BM rule fitted to 18 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R
-Total Standard Deviation in ln(k): 4.029088922385259
-""",
-)
-
-entry(
     index = 15,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O",
-    kinetics = ArrheniusBM(A=(1.42412e+12,'s^-1'), n=-0.284057, w0=(1.1575e+06,'J/mol'), E0=(165357,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.11656939014923065, var=13.786674344573177, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O',), comment="""BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
-    Total Standard Deviation in ln(k): 7.736551688175035"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
-Total Standard Deviation in ln(k): 7.736551688175035""",
-    longDesc = 
-"""
-BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O
-Total Standard Deviation in ln(k): 7.736551688175035
-""",
-)
-
-entry(
-    index = 16,
-    label = "Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O",
-    kinetics = ArrheniusBM(A=(3.96843e+10,'s^-1'), n=0.78544, w0=(1.0865e+06,'J/mol'), E0=(108783,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
+    label = "Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(1.93151e+06,'s^-1'), n=1.81611, w0=(1.1055e+06,'J/mol'), E0=(159124,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_N-1BrClFINOPSSi->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_1BrClFINOPSSi->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
-    index = 17,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N",
-    kinetics = ArrheniusBM(A=(1.03404e+08,'s^-1'), n=1.25673, w0=(1.0845e+06,'J/mol'), E0=(177221,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.03936081494595298, var=1.4404859165336958, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
-    Total Standard Deviation in ln(k): 2.5049844677356727"""),
+    index = 16,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N",
+    kinetics = ArrheniusBM(A=(3.62979e+09,'s^-1'), n=0.813364, w0=(1.183e+06,'J/mol'), E0=(152248,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.07834185115310821, var=3.1028790984589047, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N',), comment="""BM rule fitted to 17 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N
+    Total Standard Deviation in ln(k): 3.728177867462698"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
-Total Standard Deviation in ln(k): 2.5049844677356727""",
+    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 3.728177867462698""",
     longDesc = 
 """
-BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
-Total Standard Deviation in ln(k): 2.5049844677356727
+BM rule fitted to 17 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N
+Total Standard Deviation in ln(k): 3.728177867462698
+""",
+)
+
+entry(
+    index = 17,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing",
+    kinetics = ArrheniusBM(A=(1.93725e+10,'s^-1'), n=-0.00164902, w0=(1.0245e+06,'J/mol'), E0=(139223,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.010065863716581231, var=81.8360764684643, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing
+    Total Standard Deviation in ln(k): 18.160785079462567"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing
+Total Standard Deviation in ln(k): 18.160785079462567""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing
+Total Standard Deviation in ln(k): 18.160785079462567
 """,
 )
 
 entry(
     index = 18,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N",
-    kinetics = ArrheniusBM(A=(1.18472e+12,'s^-1'), n=-0.0115244, w0=(1.0845e+06,'J/mol'), E0=(169271,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.07049718312528079, var=2.319532999988916, Tref=1000.0, N=10, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N',), comment="""BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
-    Total Standard Deviation in ln(k): 3.230342756293489"""),
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing",
+    kinetics = ArrheniusBM(A=(5.0377e+09,'s^-1'), n=0.503998, w0=(1.17523e+06,'J/mol'), E0=(165380,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.07023301752382041, var=14.693850144505003, Tref=1000.0, N=15, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing',), comment="""BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing
+    Total Standard Deviation in ln(k): 7.861127261438902"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
-Total Standard Deviation in ln(k): 3.230342756293489""",
+    shortDesc = """BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing
+Total Standard Deviation in ln(k): 7.861127261438902""",
     longDesc = 
 """
-BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
-Total Standard Deviation in ln(k): 3.230342756293489
+BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing
+Total Standard Deviation in ln(k): 7.861127261438902
 """,
 )
 
 entry(
     index = 19,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R",
-    kinetics = ArrheniusBM(A=(4.16228e+08,'s^-1'), n=0.988266, w0=(1.0845e+06,'J/mol'), E0=(162518,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0025626047091315556, var=9.251604624994211, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-    Total Standard Deviation in ln(k): 6.104131234895419"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N",
+    kinetics = ArrheniusBM(A=(1.06632e+07,'s^-1'), n=1.54494, w0=(1.0845e+06,'J/mol'), E0=(175232,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.03160873187820852, var=1.3512789532393483, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
+    Total Standard Deviation in ln(k): 2.409813687361464"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-Total Standard Deviation in ln(k): 6.104131234895419""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
+Total Standard Deviation in ln(k): 2.409813687361464""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R
-Total Standard Deviation in ln(k): 6.104131234895419
+BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N
+Total Standard Deviation in ln(k): 2.409813687361464
 """,
 )
 
 entry(
     index = 20,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(7.24523e+06,'s^-1'), n=1.35008, w0=(1.0845e+06,'J/mol'), E0=(171424,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.024461205742499107, var=5.078314475822991, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 4.579154043078822"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N",
+    kinetics = ArrheniusBM(A=(2.11272e+10,'s^-1'), n=0.508892, w0=(1.0845e+06,'J/mol'), E0=(165988,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.05946298457203635, var=2.1502413853175404, Tref=1000.0, N=10, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N',), comment="""BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
+    Total Standard Deviation in ln(k): 3.0890881384700166"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.579154043078822""",
+    shortDesc = """BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
+Total Standard Deviation in ln(k): 3.0890881384700166""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.579154043078822
+BM rule fitted to 10 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N
+Total Standard Deviation in ln(k): 3.0890881384700166
 """,
 )
 
 entry(
     index = 21,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(4.54595e+20,'s^-1'), n=-3.0326, w0=(968000,'J/mol'), E0=(170265,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.12749579816800816, var=3.8667024035834454, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 4.2624387205240515"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(4.48935e+16,'s^-1'), n=-1.81548, w0=(968000,'J/mol'), E0=(163551,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.10791093733813462, var=3.878221135229738, Tref=1000.0, N=5, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R',), comment="""BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 4.21909782627248"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.2624387205240515""",
+    shortDesc = """BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.21909782627248""",
     longDesc = 
 """
-BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 4.2624387205240515
+BM rule fitted to 5 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.21909782627248
 """,
 )
 
 entry(
     index = 22,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(3.23333e+11,'s^-1'), n=0, w0=(968000,'J/mol'), E0=(182946,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(3.23333e+11,'s^-1'), n=0, w0=(968000,'J/mol'), E0=(182946,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-5C-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-5C-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 23,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O",
-    kinetics = ArrheniusBM(A=(4.1009e+10,'s^-1'), n=0, w0=(1.0665e+06,'J/mol'), E0=(167048,'J/mol'), Tmin=(725,'K'), Tmax=(810,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R",
+    kinetics = ArrheniusBM(A=(7.01606e+09,'s^-1'), n=0.528417, w0=(1.0845e+06,'J/mol'), E0=(162089,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0004170773678849364, var=7.571252332200875, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R
+    Total Standard Deviation in ln(k): 5.517258674761662"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R
+Total Standard Deviation in ln(k): 5.517258674761662""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R
+Total Standard Deviation in ln(k): 5.517258674761662
 """,
 )
 
 entry(
     index = 24,
-    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O",
-    kinetics = ArrheniusBM(A=(7.8141e+10,'s^-1'), n=0, w0=(974500,'J/mol'), E0=(160561,'J/mol'), Tmin=(602,'K'), Tmax=(694,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(3.72448e+06,'s^-1'), n=1.38418, w0=(1.0845e+06,'J/mol'), E0=(169437,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.023226627232403933, var=4.996815442657889, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 4.539654493299976"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.539654493299976""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R
+Total Standard Deviation in ln(k): 4.539654493299976
 """,
 )
 
 entry(
     index = 25,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O",
-    kinetics = ArrheniusBM(A=(1.39378e+10,'s^-1'), n=0.636142, w0=(1.183e+06,'J/mol'), E0=(153232,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0820842374791673, var=3.1024987137828046, Tref=1000.0, N=17, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O',), comment="""BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
-    Total Standard Deviation in ln(k): 3.737364386568372"""),
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N",
+    kinetics = ArrheniusBM(A=(7.8141e+10,'s^-1'), n=0, w0=(974500,'J/mol'), E0=(160561,'J/mol'), Tmin=(602,'K'), Tmax=(694,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
-Total Standard Deviation in ln(k): 3.737364386568372""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 17 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O
-Total Standard Deviation in ln(k): 3.737364386568372
+BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_2NO->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 26,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O",
-    kinetics = ArrheniusBM(A=(1.15515e+06,'s^-1'), n=1.91844, w0=(1.1055e+06,'J/mol'), E0=(160816,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+    label = "Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N",
+    kinetics = ArrheniusBM(A=(4.1009e+10,'s^-1'), n=0, w0=(1.0665e+06,'J/mol'), E0=(167048,'J/mol'), Tmin=(725,'K'), Tmax=(810,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_N-1BrClFINOPSSi->O
+BM rule fitted to 1 training reactions at node Root_1R!H->C_N-2R!H->C_N-2NOS->S_N-2NO->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 27,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing",
-    kinetics = ArrheniusBM(A=(7.51733e+12,'s^-1'), n=-0.801522, w0=(1.0245e+06,'J/mol'), E0=(143090,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.010065863716581231, var=81.8360764684643, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
-    Total Standard Deviation in ln(k): 18.160785079462567"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R",
+    kinetics = ArrheniusBM(A=(5.585e+08,'s^-1'), n=1.03057, w0=(1.183e+06,'J/mol'), E0=(137902,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.9849605138850569, var=2.175969446453559, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R
+    Total Standard Deviation in ln(k): 5.431993466301682"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
-Total Standard Deviation in ln(k): 18.160785079462567""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R
+Total Standard Deviation in ln(k): 5.431993466301682""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing
-Total Standard Deviation in ln(k): 18.160785079462567
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R
+Total Standard Deviation in ln(k): 5.431993466301682
 """,
 )
 
 entry(
     index = 28,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing",
-    kinetics = ArrheniusBM(A=(5.71204e+08,'s^-1'), n=0.79256, w0=(1.17523e+06,'J/mol'), E0=(163842,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.06341933757336864, var=14.689759202912304, Tref=1000.0, N=15, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing',), comment="""BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
-    Total Standard Deviation in ln(k): 7.842937637670613"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C",
+    kinetics = ArrheniusBM(A=(2.72971e+09,'s^-1'), n=0.858007, w0=(1.183e+06,'J/mol'), E0=(158565,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.09327428286217945, var=0.3885302816570969, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C',), comment="""BM rule fitted to 12 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C
+    Total Standard Deviation in ln(k): 1.4839529178212068"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
-Total Standard Deviation in ln(k): 7.842937637670613""",
+    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C
+Total Standard Deviation in ln(k): 1.4839529178212068""",
     longDesc = 
 """
-BM rule fitted to 15 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing
-Total Standard Deviation in ln(k): 7.842937637670613
+BM rule fitted to 12 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C
+Total Standard Deviation in ln(k): 1.4839529178212068
 """,
 )
 
 entry(
     index = 29,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(6.63512e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(94204,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 30,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(550000,'s^-1'), n=0.9, w0=(1.0245e+06,'J/mol'), E0=(131295,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 31,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(4.97792e+06,'s^-1'), n=1.65745, w0=(1.183e+06,'J/mol'), E0=(173053,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.015698585890881855, var=0.33104774169034074, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 1.192903060789605"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 1.192903060789605""",
+    longDesc = 
+"""
+BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R
+Total Standard Deviation in ln(k): 1.192903060789605
+""",
+)
+
+entry(
+    index = 32,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R",
+    kinetics = ArrheniusBM(A=(2.86778e+11,'s^-1'), n=-0.20998, w0=(1.183e+06,'J/mol'), E0=(161018,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.007000260714869858, var=47.42592109938536, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R
+    Total Standard Deviation in ln(k): 13.82349346766583"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R
+Total Standard Deviation in ln(k): 13.82349346766583""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R
+Total Standard Deviation in ln(k): 13.82349346766583
+""",
+)
+
+entry(
+    index = 33,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C",
+    kinetics = ArrheniusBM(A=(3.33333e+07,'s^-1'), n=1.2, w0=(1.0665e+06,'J/mol'), E0=(165825,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 34,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C",
+    kinetics = ArrheniusBM(A=(3.96667e+10,'s^-1'), n=0.59, w0=(1.183e+06,'J/mol'), E0=(179850,'J/mol'), Tmin=(500,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_N-5R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 35,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(8.30743e+07,'s^-1'), n=1.34294, w0=(1.0845e+06,'J/mol'), E0=(186642,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.014692611028300074, var=6.989117524371048, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
+    kinetics = ArrheniusBM(A=(7.17483e+06,'s^-1'), n=1.66626, w0=(1.0845e+06,'J/mol'), E0=(184882,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.014692611028300074, var=6.989117524371048, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
     Total Standard Deviation in ln(k): 5.336822036500276"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R
@@ -442,277 +532,292 @@ Total Standard Deviation in ln(k): 5.336822036500276
 )
 
 entry(
-    index = 30,
+    index = 36,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R",
-    kinetics = ArrheniusBM(A=(5.08779e+07,'s^-1'), n=1.30493, w0=(1.0845e+06,'J/mol'), E0=(168720,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.00044315246718255245, var=0.04701835067671197, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
-    Total Standard Deviation in ln(k): 0.43581449398144884"""),
+    kinetics = ArrheniusBM(A=(8.9437e+07,'s^-1'), n=1.20317, w0=(1.0845e+06,'J/mol'), E0=(168361,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=4.289085629588869e-05, var=0.0032978926118627083, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
+    Total Standard Deviation in ln(k): 0.11523425074443258"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 0.43581449398144884""",
+Total Standard Deviation in ln(k): 0.11523425074443258""",
     longDesc = 
 """
 BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 0.43581449398144884
-""",
-)
-
-entry(
-    index = 31,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(2.10319e+11,'s^-1'), n=0.204824, w0=(1.0845e+06,'J/mol'), E0=(175924,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.061353959294217005, var=3.4900972510040535, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 3.899362049801037"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 3.899362049801037""",
-    longDesc = 
-"""
-BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
-Total Standard Deviation in ln(k): 3.899362049801037
-""",
-)
-
-entry(
-    index = 32,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R",
-    kinetics = ArrheniusBM(A=(9.59974e+09,'s^-1'), n=0.653804, w0=(1.0845e+06,'J/mol'), E0=(159613,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.006151428258272596, var=1.8383731639583567, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
-    Total Standard Deviation in ln(k): 2.7336083899052577"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 2.7336083899052577""",
-    longDesc = 
-"""
-BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
-Total Standard Deviation in ln(k): 2.7336083899052577
-""",
-)
-
-entry(
-    index = 33,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(1.2535e+06,'s^-1'), n=1.80968, w0=(1.0845e+06,'J/mol'), E0=(155867,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 34,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(11.5839,'s^-1'), n=3.09547, w0=(1.0845e+06,'J/mol'), E0=(137668,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 35,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(21.2645,'s^-1'), n=2.97303, w0=(1.0845e+06,'J/mol'), E0=(145085,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 36,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(3.78363e+11,'s^-1'), n=0.169307, w0=(1.0845e+06,'J/mol'), E0=(163318,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-2C-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+Total Standard Deviation in ln(k): 0.11523425074443258
 """,
 )
 
 entry(
     index = 37,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(6.80655,'s^-1'), n=3.07798, w0=(1.0845e+06,'J/mol'), E0=(148263,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(4.26489e+09,'s^-1'), n=0.721231, w0=(1.0845e+06,'J/mol'), E0=(173168,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.05463853673654339, var=3.498019671653633, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 3.8867374747822776"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
+Total Standard Deviation in ln(k): 3.8867374747822776""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R
+Total Standard Deviation in ln(k): 3.8867374747822776
 """,
 )
 
 entry(
     index = 38,
-    label = "Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(2419.21,'s^-1'), n=2.3826, w0=(1.0845e+06,'J/mol'), E0=(171107,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R",
+    kinetics = ArrheniusBM(A=(1.63884e+10,'s^-1'), n=0.553788, w0=(1.0845e+06,'J/mol'), E0=(159149,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0054573965212036946, var=1.5050092139275335, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
+    Total Standard Deviation in ln(k): 2.4730973283903155"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
+Total Standard Deviation in ln(k): 2.4730973283903155""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->O_Ext-4R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R
+Total Standard Deviation in ln(k): 2.4730973283903155
 """,
 )
 
 entry(
     index = 39,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R",
-    kinetics = ArrheniusBM(A=(1.5405e+21,'s^-1'), n=-3.24953, w0=(968000,'J/mol'), E0=(163723,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.12977356299501228, var=2.998907670868144, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-    Total Standard Deviation in ln(k): 3.797735031217385"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 3.797735031217385""",
-    longDesc = 
-"""
-BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 3.797735031217385
-""",
-)
-
-entry(
-    index = 40,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R",
-    kinetics = ArrheniusBM(A=(7.30229e+08,'s^-1'), n=0.995367, w0=(1.183e+06,'J/mol'), E0=(138104,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.9718999266707798, var=2.1443634364201256, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
-    Total Standard Deviation in ln(k): 5.377622526546486"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
-Total Standard Deviation in ln(k): 5.377622526546486""",
-    longDesc = 
-"""
-BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R
-Total Standard Deviation in ln(k): 5.377622526546486
-""",
-)
-
-entry(
-    index = 41,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O",
-    kinetics = ArrheniusBM(A=(6.63512e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(94204,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(11.5839,'s^-1'), n=3.09547, w0=(1.0845e+06,'J/mol'), E0=(137668,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_7R!H->O
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_7BrCClFIOPSSi->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
-    index = 42,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O",
-    kinetics = ArrheniusBM(A=(6.01185e+09,'s^-1'), n=0.754214, w0=(1.183e+06,'J/mol'), E0=(159151,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.09510809546145511, var=0.3875877430471234, Tref=1000.0, N=12, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O',), comment="""BM rule fitted to 12 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
-    Total Standard Deviation in ln(k): 1.4870438652189866"""),
+    index = 40,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(1.2535e+06,'s^-1'), n=1.80968, w0=(1.0845e+06,'J/mol'), E0=(155867,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 12 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
-Total Standard Deviation in ln(k): 1.4870438652189866""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 12 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O
-Total Standard Deviation in ln(k): 1.4870438652189866
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_N-7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 41,
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R",
+    kinetics = ArrheniusBM(A=(1.47918e+17,'s^-1'), n=-2.02819, w0=(968000,'J/mol'), E0=(156988,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.11215013592975923, var=3.0170948703094664, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R
+    Total Standard Deviation in ln(k): 3.763966312410604"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 3.763966312410604""",
+    longDesc = 
+"""
+BM rule fitted to 4 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 3.763966312410604
+""",
+)
+
+entry(
+    index = 42,
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(21.2645,'s^-1'), n=2.97303, w0=(1.0845e+06,'J/mol'), E0=(146892,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 43,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(550000,'s^-1'), n=0.9, w0=(1.0245e+06,'J/mol'), E0=(131295,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(3.78363e+11,'s^-1'), n=0.169307, w0=(1.0845e+06,'J/mol'), E0=(166826,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_3R!H-inRing_Ext-4R!H-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-2C-R_N-7R!H->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 44,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(9.86666e+06,'s^-1'), n=1.56749, w0=(1.183e+06,'J/mol'), E0=(173559,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.017669062395274753, var=0.3308386397993182, Tref=1000.0, N=9, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 1.1974896656222527"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(6.80655,'s^-1'), n=3.07798, w0=(1.0845e+06,'J/mol'), E0=(150022,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 1.1974896656222527""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 9 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R
-Total Standard Deviation in ln(k): 1.1974896656222527
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 45,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R",
-    kinetics = ArrheniusBM(A=(1.01976e+11,'s^-1'), n=-0.0738756, w0=(1.183e+06,'J/mol'), E0=(160257,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0038772587838617587, var=47.426029943831864, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
-    Total Standard Deviation in ln(k): 13.815662571697391"""),
+    label = "Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(2419.21,'s^-1'), n=2.3826, w0=(1.0845e+06,'J/mol'), E0=(172708,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
-Total Standard Deviation in ln(k): 13.815662571697391""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R
-Total Standard Deviation in ln(k): 13.815662571697391
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->C_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 46,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O",
-    kinetics = ArrheniusBM(A=(3.96667e+10,'s^-1'), n=0.59, w0=(1.183e+06,'J/mol'), E0=(179850,'J/mol'), Tmin=(500,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(4.45626e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(142579,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_5CO->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 47,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O",
-    kinetics = ArrheniusBM(A=(3.33333e+07,'s^-1'), n=1.2, w0=(1.0665e+06,'J/mol'), E0=(165353,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R",
+    kinetics = ArrheniusBM(A=(3.47446e+08,'s^-1'), n=1.09592, w0=(1.183e+06,'J/mol'), E0=(138292,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.9397855924827363, var=2.0052075611816607, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R
+    Total Standard Deviation in ln(k): 5.200082488575585"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R
+Total Standard Deviation in ln(k): 5.200082488575585""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_N-5CO->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R
+Total Standard Deviation in ln(k): 5.200082488575585
 """,
 )
 
 entry(
     index = 48,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(4.72256e+08,'s^-1'), n=1.05476, w0=(1.183e+06,'J/mol'), E0=(153718,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.8089351856699499, var=2.4771942159743126, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R',), comment="""BM rule fitted to 7 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R
+    Total Standard Deviation in ln(k): 5.187774025217704"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R
+Total Standard Deviation in ln(k): 5.187774025217704""",
+    longDesc = 
+"""
+BM rule fitted to 7 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R
+Total Standard Deviation in ln(k): 5.187774025217704
+""",
+)
+
+entry(
+    index = 49,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(7.77656e+09,'s^-1'), n=0.762969, w0=(1.183e+06,'J/mol'), E0=(163796,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.1381107593472458, var=0.05384276569539632, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 0.8121915671689098"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.8121915671689098""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.8121915671689098
+""",
+)
+
+entry(
+    index = 50,
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R",
+    kinetics = ArrheniusBM(A=(1.32388e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(156130,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-3R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 51,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(2.55471e+06,'s^-1'), n=1.74582, w0=(1.183e+06,'J/mol'), E0=(172104,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.06042635539233208, var=0.15875309730657372, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 0.9505882960246963"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 0.9505882960246963""",
+    longDesc = 
+"""
+BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 0.9505882960246963
+""",
+)
+
+entry(
+    index = 52,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(9.41708e+14,'s^-1'), n=-0.896351, w0=(1.183e+06,'J/mol'), E0=(201255,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-5.3172441301014085e-15, var=0.04558127893527205, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 0.4280063799185306"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 0.4280063799185306""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 0.4280063799185306
+""",
+)
+
+entry(
+    index = 53,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
+    kinetics = ArrheniusBM(A=(1.7237e+13,'s^-1'), n=-0.218608, w0=(1.183e+06,'J/mol'), E0=(173278,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.008485639854909011, var=0.595884305542138, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+    Total Standard Deviation in ln(k): 1.5688467338498606"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.5688467338498606""",
+    longDesc = 
+"""
+BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
+Total Standard Deviation in ln(k): 1.5688467338498606
+""",
+)
+
+entry(
+    index = 54,
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
+    kinetics = ArrheniusBM(A=(58002.5,'s^-1'), n=0.286, w0=(1.183e+06,'J/mol'), E0=(125149,'J/mol'), Tmin=(500,'K'), Tmax=(1300,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
+    longDesc = 
+"""
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
+Total Standard Deviation in ln(k): 11.540182761524994
+""",
+)
+
+entry(
+    index = 55,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C",
     kinetics = ArrheniusBM(A=(1708.21,'s^-1'), n=2.62955, w0=(1.0845e+06,'J/mol'), E0=(162976,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
@@ -727,7 +832,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 49,
+    index = 56,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C",
     kinetics = ArrheniusBM(A=(85500.5,'s^-1'), n=2.19797, w0=(1.0845e+06,'J/mol'), E0=(186561,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-4R!H-R_N-8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
@@ -742,7 +847,7 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 50,
+    index = 57,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C",
     kinetics = ArrheniusBM(A=(111514,'s^-1'), n=2.05353, w0=(1.0845e+06,'J/mol'), E0=(161295,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
@@ -757,9 +862,9 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 51,
+    index = 58,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(6.3077e+06,'s^-1'), n=1.41637, w0=(1.0845e+06,'J/mol'), E0=(156860,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
+    kinetics = ArrheniusBM(A=(6.3077e+06,'s^-1'), n=1.41637, w0=(1.0845e+06,'J/mol'), E0=(158519,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
     shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_7R!H->N_Ext-2C-R_N-8R!H->C
@@ -772,39 +877,39 @@ Total Standard Deviation in ln(k): 11.540182761524994
 )
 
 entry(
-    index = 52,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(2.01084e+12,'s^-1'), n=0.0883205, w0=(1.0845e+06,'J/mol'), E0=(183925,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.021492990850914453, var=5.303057773824753, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
-    Total Standard Deviation in ln(k): 4.670580394351897"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 4.670580394351897""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 4.670580394351897
-""",
-)
-
-entry(
-    index = 53,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(9.58447e+09,'s^-1'), n=0.427548, w0=(1.0845e+06,'J/mol'), E0=(167154,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.023199101818381307, var=14.082287951603485, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+    index = 59,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(4.85194e+07,'s^-1'), n=1.12718, w0=(1.0845e+06,'J/mol'), E0=(163383,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.023199101818381307, var=14.082287951603485, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C
     Total Standard Deviation in ln(k): 7.581333161482922"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C
 Total Standard Deviation in ln(k): 7.581333161482922""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C
 Total Standard Deviation in ln(k): 7.581333161482922
 """,
 )
 
 entry(
-    index = 54,
+    index = 60,
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(1.86934e+11,'s^-1'), n=0.401442, w0=(1.0845e+06,'J/mol'), E0=(182171,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.021492990850914453, var=5.303057773824753, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C
+    Total Standard Deviation in ln(k): 4.670580394351897"""),
+    rank = 11,
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 4.670580394351897""",
+    longDesc = 
+"""
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 4.670580394351897
+""",
+)
+
+entry(
+    index = 61,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C",
-    kinetics = ArrheniusBM(A=(2.6009e+07,'s^-1'), n=1.28561, w0=(1.0845e+06,'J/mol'), E0=(152714,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0072034781886713035, var=1.112822940211039, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
+    kinetics = ArrheniusBM(A=(1.37571e+07,'s^-1'), n=1.37128, w0=(1.0845e+06,'J/mol'), E0=(152318,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0072034781886713035, var=1.112822940211039, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
     Total Standard Deviation in ln(k): 2.1329027100545948"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C
@@ -817,661 +922,526 @@ Total Standard Deviation in ln(k): 2.1329027100545948
 )
 
 entry(
-    index = 55,
+    index = 62,
     label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(5.01614e+11,'s^-1'), n=0.272082, w0=(1.0845e+06,'J/mol'), E0=(164653,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0004677404420120619, var=2.2953718575893025, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-    Total Standard Deviation in ln(k): 3.038446033140682"""),
+    kinetics = ArrheniusBM(A=(1.35624e+13,'s^-1'), n=-0.218688, w0=(1.0845e+06,'J/mol'), E0=(165536,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.00045559036986736554, var=2.308582681294396, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
+    Total Standard Deviation in ln(k): 3.0471433462500226"""),
     rank = 11,
     shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-Total Standard Deviation in ln(k): 3.038446033140682""",
+Total Standard Deviation in ln(k): 3.0471433462500226""",
     longDesc = 
 """
 BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C
-Total Standard Deviation in ln(k): 3.038446033140682
-""",
-)
-
-entry(
-    index = 56,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.84364e+21,'s^-1'), n=-3.37687, w0=(968000,'J/mol'), E0=(155107,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.12158036022019265, var=4.26315521405602, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 4.4447369115914395"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 4.4447369115914395""",
-    longDesc = 
-"""
-BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 4.4447369115914395
-""",
-)
-
-entry(
-    index = 57,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(4.45626e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(142579,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 58,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R",
-    kinetics = ArrheniusBM(A=(7.82163e+08,'s^-1'), n=0.989298, w0=(1.183e+06,'J/mol'), E0=(138899,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.9397855924827363, var=2.0052075611816607, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
-    Total Standard Deviation in ln(k): 5.200082488575585"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
-Total Standard Deviation in ln(k): 5.200082488575585""",
-    longDesc = 
-"""
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R
-Total Standard Deviation in ln(k): 5.200082488575585
-""",
-)
-
-entry(
-    index = 59,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(8.60674e+08,'s^-1'), n=0.975857, w0=(1.183e+06,'J/mol'), E0=(154165,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.810653195545372, var=2.4765646224643563, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R',), comment="""BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
-    Total Standard Deviation in ln(k): 5.191689641779036"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
-Total Standard Deviation in ln(k): 5.191689641779036""",
-    longDesc = 
-"""
-BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R
-Total Standard Deviation in ln(k): 5.191689641779036
-""",
-)
-
-entry(
-    index = 60,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(2.09881e+10,'s^-1'), n=0.632458, w0=(1.183e+06,'J/mol'), E0=(164532,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.140869378589362, var=0.05370776408169411, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 0.8185392257471298"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.8185392257471298""",
-    longDesc = 
-"""
-BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.8185392257471298
-""",
-)
-
-entry(
-    index = 61,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R",
-    kinetics = ArrheniusBM(A=(1.32388e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(156130,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-3R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 62,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(4.72908e+06,'s^-1'), n=1.66491, w0=(1.183e+06,'J/mol'), E0=(172562,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.062098400931787215, var=0.15842678078199102, Tref=1000.0, N=7, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C',), comment="""BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-    Total Standard Deviation in ln(k): 0.9539680653938947"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 0.9539680653938947""",
-    longDesc = 
-"""
-BM rule fitted to 7 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 0.9539680653938947
+Total Standard Deviation in ln(k): 3.0471433462500226
 """,
 )
 
 entry(
     index = 63,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(5.40789e+14,'s^-1'), n=-0.823434, w0=(1.183e+06,'J/mol'), E0=(200846,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-5.3172441301014085e-15, var=0.04558127893527205, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 0.4280063799185306"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(2.2474e+17,'s^-1'), n=-2.18683, w0=(968000,'J/mol'), E0=(148502,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.10639571125003566, var=4.305704753171537, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 4.427189719338195"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 0.4280063799185306""",
+    shortDesc = """BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 4.427189719338195""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 0.4280063799185306
+BM rule fitted to 3 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 4.427189719338195
 """,
 )
 
 entry(
     index = 64,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C",
-    kinetics = ArrheniusBM(A=(6.72258e+12,'s^-1'), n=-0.0948649, w0=(1.183e+06,'J/mol'), E0=(172576,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0053888710926292245, var=0.5959934258564467, Tref=1000.0, N=3, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C',), comment="""BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-    Total Standard Deviation in ln(k): 1.5612075953824893"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
+    kinetics = ArrheniusBM(A=(1.39881e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(136330,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 1.5612075953824893""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 3 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C
-Total Standard Deviation in ln(k): 1.5612075953824893
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 65,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C",
-    kinetics = ArrheniusBM(A=(58002.5,'s^-1'), n=0.286, w0=(1.183e+06,'J/mol'), E0=(125149,'J/mol'), Tmin=(500,'K'), Tmax=(1300,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(1.16921e+13,'s^-1'), n=-0.324602, w0=(1.183e+06,'J/mol'), E0=(155605,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-0.0006121978434024415, var=0.049410262461096775, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R
+    Total Standard Deviation in ln(k): 0.4471591044090268"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.4471591044090268""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_N-7R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R
+Total Standard Deviation in ln(k): 0.4471591044090268
 """,
 )
 
 entry(
     index = 66,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C",
-    kinetics = ArrheniusBM(A=(6.1395e+07,'s^-1'), n=1.36832, w0=(1.0845e+06,'J/mol'), E0=(163924,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(2.81965e+13,'s^-1'), n=-0.54761, w0=(1.183e+06,'J/mol'), E0=(142581,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.011656401367828983, var=1.7600602599389328, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 2.6889145927230276"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 2.6889145927230276""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 2.6889145927230276
 """,
 )
 
 entry(
     index = 67,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(2.87851e+08,'s^-1'), n=1.30992, w0=(1.0845e+06,'J/mol'), E0=(187582,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(1.09597e+13,'s^-1'), n=-0.328822, w0=(1.183e+06,'J/mol'), E0=(160198,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0010628098785811556, var=0.16224599752348345, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R
+    Total Standard Deviation in ln(k): 0.8101730807390738"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 0.8101730807390738""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->O_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R
+Total Standard Deviation in ln(k): 0.8101730807390738
 """,
 )
 
 entry(
     index = 68,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C",
-    kinetics = ArrheniusBM(A=(459.236,'s^-1'), n=2.68918, w0=(1.0845e+06,'J/mol'), E0=(145855,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(165471,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_8R!H->C
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 69,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C",
-    kinetics = ArrheniusBM(A=(6552.1,'s^-1'), n=2.29082, w0=(1.0845e+06,'J/mol'), E0=(167773,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
+    kinetics = ArrheniusBM(A=(1.99592e+06,'s^-1'), n=1.77995, w0=(1.183e+06,'J/mol'), E0=(172186,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.045572513486908654, var=0.10435748944687856, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing',), comment="""BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+    Total Standard Deviation in ln(k): 0.7621216381393935"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+Total Standard Deviation in ln(k): 0.7621216381393935""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->O_N-8R!H->C
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
+Total Standard Deviation in ln(k): 0.7621216381393935
 """,
 )
 
 entry(
     index = 70,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(1.65185e+07,'s^-1'), n=1.51788, w0=(1.0845e+06,'J/mol'), E0=(159604,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(193178,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->O
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 71,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(1017.11,'s^-1'), n=2.55399, w0=(1.0845e+06,'J/mol'), E0=(143955,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(1.49982e+12,'s^-1'), n=0.105014, w0=(1.183e+06,'J/mol'), E0=(171575,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=-1.6694644050553874e-15, var=2.116729755416145, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+    Total Standard Deviation in ln(k): 2.9166861328622327"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+Total Standard Deviation in ln(k): 2.9166861328622327""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->O
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
+Total Standard Deviation in ln(k): 2.9166861328622327
 """,
 )
 
 entry(
     index = 72,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(8.27867e+08,'s^-1'), n=1.04991, w0=(1.0845e+06,'J/mol'), E0=(160247,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N",
+    kinetics = ArrheniusBM(A=(6552.1,'s^-1'), n=2.29082, w0=(1.0845e+06,'J/mol'), E0=(167773,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->O
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_8R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 73,
-    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O",
-    kinetics = ArrheniusBM(A=(2.0173e+12,'s^-1'), n=0.0499164, w0=(1.0845e+06,'J/mol'), E0=(158672,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N",
+    kinetics = ArrheniusBM(A=(459.236,'s^-1'), n=2.68918, w0=(1.0845e+06,'J/mol'), E0=(145855,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->O
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_7BrCClFIOPSSi->C_N-8R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 74,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R",
-    kinetics = ArrheniusBM(A=(1.34275e+16,'s^-1'), n=-2.11924, w0=(968000,'J/mol'), E0=(122130,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0013608568101268583, var=1.6674726433047609, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-    Total Standard Deviation in ln(k): 2.5921468035711666"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N",
+    kinetics = ArrheniusBM(A=(2.87851e+08,'s^-1'), n=1.30992, w0=(1.0845e+06,'J/mol'), E0=(187582,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 2.5921468035711666""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
-Total Standard Deviation in ln(k): 2.5921468035711666
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_8R!H->N
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 75,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R",
-    kinetics = ArrheniusBM(A=(1.39881e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(136330,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N",
+    kinetics = ArrheniusBM(A=(6.1395e+07,'s^-1'), n=1.36832, w0=(1.0845e+06,'J/mol'), E0=(163924,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_Ext-2R!H-R_Ext-3R!H-R_Ext-9R!H-R
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-4R!H-R_N-7BrCClFIOPSSi->C_N-8R!H->N
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 76,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(3.2598e+13,'s^-1'), n=-0.459377, w0=(1.183e+06,'J/mol'), E0=(156365,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-0.0006121978434024415, var=0.049410262461096775, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-    Total Standard Deviation in ln(k): 0.4471591044090268"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(1017.11,'s^-1'), n=2.55399, w0=(1.0845e+06,'J/mol'), E0=(143955,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.4471591044090268""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 0.4471591044090268
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 77,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.2699e+13,'s^-1'), n=-0.442692, w0=(1.183e+06,'J/mol'), E0=(141989,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.008973758145679172, var=1.7601354275190648, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 2.682231075380441"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(1.65185e+07,'s^-1'), n=1.51788, w0=(1.0845e+06,'J/mol'), E0=(159604,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 2.682231075380441""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 2.682231075380441
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_8R!H->C_N-7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 78,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(2.4107e+13,'s^-1'), n=-0.432391, w0=(1.183e+06,'J/mol'), E0=(160784,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0010628098785811556, var=0.16224599752348345, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 0.8101730807390738"""),
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(2.0173e+12,'s^-1'), n=0.0499164, w0=(1.0845e+06,'J/mol'), E0=(160428,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 0.8101730807390738""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 0.8101730807390738
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_7BrCClFIOPSSi->C
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 79,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing",
-    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(165471,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
+    label = "Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C",
+    kinetics = ArrheniusBM(A=(8.27867e+08,'s^-1'), n=1.04991, w0=(1.0845e+06,'J/mol'), E0=(162025,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_7C-inRing
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_Ext-1C-R_N-7R!H->N_Ext-2C-R_N-8R!H->C_N-7BrCClFIOPSSi->C
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 80,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing",
-    kinetics = ArrheniusBM(A=(3.93467e+06,'s^-1'), n=1.69077, w0=(1.183e+06,'J/mol'), E0=(172691,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.047594001962377265, var=0.10410275187919844, Tref=1000.0, N=6, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing',), comment="""BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-    Total Standard Deviation in ln(k): 0.7664098514942174"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R",
+    kinetics = ArrheniusBM(A=(2.29826e+14,'s^-1'), n=-1.58523, w0=(968000,'J/mol'), E0=(118901,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0013608568101268583, var=1.6674726433047609, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R',), comment="""BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+    Total Standard Deviation in ln(k): 2.5921468035711666"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-Total Standard Deviation in ln(k): 0.7664098514942174""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 2.5921468035711666""",
     longDesc = 
 """
-BM rule fitted to 6 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing
-Total Standard Deviation in ln(k): 0.7664098514942174
+BM rule fitted to 2 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R
+Total Standard Deviation in ln(k): 2.5921468035711666
 """,
 )
 
 entry(
     index = 81,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(193178,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing",
+    kinetics = ArrheniusBM(A=(1.25594e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(155092,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_N-7R!H->C_Ext-7BrClFINOPSSi-R_Ext-8R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 82,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(6.26357e+11,'s^-1'), n=0.219784, w0=(1.183e+06,'J/mol'), E0=(170925,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=-1.6694644050553874e-15, var=2.116729755416145, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-    Total Standard Deviation in ln(k): 2.9166861328622327"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
+    kinetics = ArrheniusBM(A=(1.98582e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(160232,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-Total Standard Deviation in ln(k): 2.9166861328622327""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R
-Total Standard Deviation in ln(k): 2.9166861328622327
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 83,
-    label = "Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R",
-    kinetics = ArrheniusBM(A=(6.5e+10,'s^-1'), n=0, w0=(968000,'J/mol'), E0=(139431,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(1.32702e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(116943,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_N-5R!H->O_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 84,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing",
-    kinetics = ArrheniusBM(A=(1.25594e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(155092,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
+    kinetics = ArrheniusBM(A=(8.37297e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(151179,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_7C-inRing
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 85,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing",
-    kinetics = ArrheniusBM(A=(1.98582e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(160232,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
+    kinetics = ArrheniusBM(A=(3.61437e+13,'s^-1'), n=-0.487071, w0=(1.183e+06,'J/mol'), E0=(151204,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=3.255606157999161e-05, var=0.017017844750293856, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+    Total Standard Deviation in ln(k): 0.2616044249499389"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
-Total Standard Deviation in ln(k): 11.540182761524994""",
+    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+Total Standard Deviation in ln(k): 0.2616044249499389""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-4R!H-R_N-7C-inRing
-Total Standard Deviation in ln(k): 11.540182761524994
+BM rule fitted to 2 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
+Total Standard Deviation in ln(k): 0.2616044249499389
 """,
 )
 
 entry(
     index = 86,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(1.32702e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(116943,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
+    kinetics = ArrheniusBM(A=(1.11936e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(158970,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Ext-8R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 87,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H",
-    kinetics = ArrheniusBM(A=(8.37297e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(151179,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
+    kinetics = ArrheniusBM(A=(1.99054e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(166153,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_Sp-9R!H=8R!H
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 88,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H",
-    kinetics = ArrheniusBM(A=(8.84721e+12,'s^-1'), n=-0.302094, w0=(1.183e+06,'J/mol'), E0=(150154,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=3.255606157999161e-05, var=0.017017844750293856, Tref=1000.0, N=2, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H',), comment="""BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-    Total Standard Deviation in ln(k): 0.2616044249499389"""),
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(85171.3,'s^-1'), n=2.12989, w0=(1.183e+06,'J/mol'), E0=(165322,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.6638418747586526, var=1.1683510553150969, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+    Total Standard Deviation in ln(k): 3.8348683456525428"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-Total Standard Deviation in ln(k): 0.2616044249499389""",
+    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+Total Standard Deviation in ln(k): 3.8348683456525428""",
     longDesc = 
 """
-BM rule fitted to 2 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H
-Total Standard Deviation in ln(k): 0.2616044249499389
+BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
+Total Standard Deviation in ln(k): 3.8348683456525428
 """,
 )
 
 entry(
     index = 89,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H",
-    kinetics = ArrheniusBM(A=(1.11936e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(158970,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(3.16053e+06,'s^-1'), n=1.87467, w0=(1.183e+06,'J/mol'), E0=(182477,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_Sp-9R!H-8R!H
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 90,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H",
-    kinetics = ArrheniusBM(A=(1.99054e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(166153,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(6.96433e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(174127,'J/mol'), Tmin=(900,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-4R!H-R_Ext-8R!H-R_N-Sp-9R!H-8R!H
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 91,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(139248,'s^-1'), n=2.06526, w0=(1.183e+06,'J/mol'), E0=(165686,'J/mol'), Tmin=(300,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.6647699949854299, var=1.1672292911792304, Tref=1000.0, N=4, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R',), comment="""BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-    Total Standard Deviation in ln(k): 3.8361597962833978"""),
+    label = "Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R",
+    kinetics = ArrheniusBM(A=(6.5e+10,'s^-1'), n=0, w0=(968000,'J/mol'), E0=(139431,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R',), comment="""BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+    Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-Total Standard Deviation in ln(k): 3.8361597962833978""",
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 4 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R
-Total Standard Deviation in ln(k): 3.8361597962833978
+BM rule fitted to 1 training reactions at node Root_1R!H->C_2R!H->C_5R!H->C_Ext-4R!H-R_Ext-7R!H-R_Ext-8R!H-R_Ext-7R!H-R_Ext-5C-R
+Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 92,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(3.16053e+06,'s^-1'), n=1.87467, w0=(1.183e+06,'J/mol'), E0=(182477,'J/mol'), Tmin=(300,'K'), Tmax=(2000,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
+    kinetics = ArrheniusBM(A=(1.32702e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(152192,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-4R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 93,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(6.96433e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(174127,'J/mol'), Tmin=(900,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+    label = "Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
+    kinetics = ArrheniusBM(A=(1.32702e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(151418,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-3R!H-R_7R!H->C_Ext-7C-R_Ext-8R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_Ext-2R!H-R_N-1BrClFINOPSSi->N_7R!H->C_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 94,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing",
-    kinetics = ArrheniusBM(A=(1.32702e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(152192,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
+    kinetics = ArrheniusBM(A=(7.94328e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(172170,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_7C-inRing
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 95,
-    label = "Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing",
-    kinetics = ArrheniusBM(A=(1.32702e+12,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(151418,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(170162,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_Ext-2R!H-R_1BrClFINOPSSi->O_N-7R!H->O_Ext-7C-R_Ext-8R!H-R_N-Sp-9R!H=8R!H_N-7C-inRing
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )
 
 entry(
     index = 96,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R",
-    kinetics = ArrheniusBM(A=(7.94328e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(172170,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+    label = "Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
+    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(168938,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
     Total Standard Deviation in ln(k): 11.540182761524994"""),
     rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
+    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994""",
     longDesc = 
 """
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-4R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 97,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R",
-    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(170162,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-7C-R
-Total Standard Deviation in ln(k): 11.540182761524994
-""",
-)
-
-entry(
-    index = 98,
-    label = "Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R",
-    kinetics = ArrheniusBM(A=(7.92445e+11,'s^-1'), n=0, w0=(1.183e+06,'J/mol'), E0=(168938,'J/mol'), Tmin=(500,'K'), Tmax=(1500,'K'), uncertainty=RateUncertainty(mu=0.0, var=33.13686319048999, Tref=1000.0, N=1, data_mean=0.0, correlation='Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R',), comment="""BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-    Total Standard Deviation in ln(k): 11.540182761524994"""),
-    rank = 11,
-    shortDesc = """BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
-Total Standard Deviation in ln(k): 11.540182761524994""",
-    longDesc = 
-"""
-BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-5R!H->N_1BrClFINOPSSi->O_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
+BM rule fitted to 1 training reactions at node Root_N-1R!H->C_N-1BrClFINOPSSi->N_N-3R!H-inRing_Ext-4R!H-R_7R!H->C_N-7C-inRing_Ext-7C-R_Ext-8R!H-R
 Total Standard Deviation in ln(k): 11.540182761524994
 """,
 )

--- a/input/kinetics/families/Retroene/training/dictionary.txt
+++ b/input/kinetics/families/Retroene/training/dictionary.txt
@@ -1960,26 +1960,6 @@ CHNO
 3 *4 C u0 p0 c0 {1,D} {2,D}
 4    H u0 p0 c0 {2,S}
 
-C2H4N2O2-2
-1  *3 O u0 p2 c0 {5,S} {6,S}
-2     O u0 p2 c0 {5,D}
-3  *5 N u0 p1 c0 {5,S} {8,S} {9,S}
-4  *1 N u0 p1 c0 {6,D} {10,S}
-5  *4 C u0 p0 c0 {1,S} {2,D} {3,S}
-6  *2 C u0 p0 c0 {1,S} {4,D} {7,S}
-7     H u0 p0 c0 {6,S}
-8  *6 H u0 p0 c0 {3,S}
-9     H u0 p0 c0 {3,S}
-10    H u0 p0 c0 {4,S}
-
-CH3NO-2
-1 *3 O u0 p2 c0 {3,D}
-2 *1 N u0 p1 c0 {3,S} {4,S} {5,S}
-3 *2 C u0 p0 c0 {1,D} {2,S} {6,S}
-4    H u0 p0 c0 {2,S}
-5 *6 H u0 p0 c0 {2,S}
-6    H u0 p0 c0 {3,S}
-
 C2H4N2O
 1 *1 O u0 p2 c0 {5,D}
 2 *3 N u0 p1 c0 {4,S} {5,S} {6,S}

--- a/input/kinetics/families/Retroene/training/reactions.py
+++ b/input/kinetics/families/Retroene/training/reactions.py
@@ -855,50 +855,33 @@ entry(
     index = 65,
     label = "C2H4N2O2 <=> CH3NO + CHNO",
     degeneracy = 2.0,
-    kinetics = Arrhenius(A=(2.3103e+06,'s^-1'), n=1.91844, Ea=(215.344,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 2.14216, dn = +|- 0.101085, dEa = +|- 0.521248 kJ/mol"""),
+    kinetics = Arrhenius(A=(3.86302e+06,'s^-1'), n=1.81611, Ea=(228.248,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 3.23831, dn = +|- 0.155918, dEa = +|- 0.803992 kJ/mol"""),
     rank = 4,
-    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
+Original entry: r001085 <=> p001091_0 + p001091_1
 Calculated by Kevin Spiekermann
-Reaction index that corresponds to the raw QM log files from the kinetics dataset from Spiekermann et al.: rxn001091
 opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12/cc-pVDZ-F12
-Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 
 entry(
     index = 66,
-    label = "C2H4N2O2-2 <=> CH3NO-2 + CHNO",
-    degeneracy = 2.0,
-    kinetics = Arrhenius(A=(1.91827e+10,'s^-1'), n=0.736578, Ea=(60.3985,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.14366, dn = +|- 0.0178114, dEa = +|- 0.0918447 kJ/mol"""),
-    rank = 4,
-    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
-    longDesc = 
-"""
-Calculated by Kevin Spiekermann
-Reaction index that corresponds to the raw QM log files from the kinetics dataset from Spiekermann et al.: rxn001689
-opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12/cc-pVDZ-F12
-Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
-""",
-)
-
-entry(
-    index = 67,
     label = "C2H4N2O <=> CH3NO + CHN",
     degeneracy = 1.0,
-    kinetics = Arrhenius(A=(3.96843e+10,'s^-1'), n=0.78544, Ea=(151.759,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.12608, dn = +|- 0.0157564, dEa = +|- 0.0812481 kJ/mol"""),
+    kinetics = Arrhenius(A=(9.54463e+09,'s^-1'), n=0.829688, Ea=(151.966,'kJ/mol'), T0=(1,'K'), Tmin=(300,'K'), Tmax=(2000,'K'), comment="""Fitted to 50 data points; dA = *|/ 1.298, dn = +|- 0.034609, dEa = +|- 0.178462 kJ/mol"""),
     rank = 4,
-    shortDesc = """CCSD(T)-F12/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
+    shortDesc = """CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP""",
     longDesc = 
 """
+Original entry: r005588 <=> p005591_0 + p001091_1
 Calculated by Kevin Spiekermann
-Reaction index that corresponds to the raw QM log files from the kinetics dataset from Spiekermann et al.: rxn005591
 opt, freq: wB97X-D3/def2-TZVP
-sp: CCSD(T)-F12/cc-pVDZ-F12
-Species have no rotatable bonds and any rings are planar (either aromatic or 3-membered)
+sp: CCSD(T)-F12a/cc-pVDZ-F12
+All species include systematic conformer search and 1D rotor scans
 """,
 )
 

--- a/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
+++ b/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
@@ -83,6 +83,75 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 
 entry(
     index = 1,
+    label = "p000049",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {12,S}
+2  N u0 p1 c0 {4,S} {5,D}
+3  N u0 p1 c0 {5,S} {6,D}
+4  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {2,D} {3,S} {11,S}
+6  C u0 p0 c0 {1,S} {3,D} {10,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.63265,0.0311299,1.5192e-06,-1.86464e-08,7.80231e-12,-7886.38,11.1185], Tmin=(10,'K'), Tmax=(1010.22,'K')),
+            NASAPolynomial(coeffs=[5.01781,0.0356248,-1.99727e-05,5.31518e-09,-5.47381e-13,-8675.47,1.9015], Tmin=(1010.22,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-65.6001,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 2,
+    label = "p000208",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {5,S} {9,S}
+3 C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+4 C u0 p0 c0 {1,S} {3,S} {5,D}
+5 C u0 p0 c0 {2,S} {4,D} {8,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {5,S}
+9 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.81333,0.0204806,3.62902e-06,-1.57751e-08,6.56952e-12,-10720,9.23438], Tmin=(10,'K'), Tmax=(983.11,'K')),
+            NASAPolynomial(coeffs=[5.08542,0.0231528,-1.24222e-05,3.22948e-09,-3.28088e-13,-11349.4,1.1901], Tmin=(983.11,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-89.126,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 3,
     label = "p000314",
     molecule = 
 """
@@ -115,7 +184,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 2,
+    index = 4,
     label = "p000399",
     molecule = 
 """
@@ -148,7 +217,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 3,
+    index = 5,
     label = "p000401",
     molecule = 
 """
@@ -181,7 +250,186 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 4,
+    index = 6,
+    label = "p000634",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {10,S}
+2  N u0 p1 c0 {3,S} {4,D}
+3  C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {1,S} {2,D} {9,S}
+5  C u0 p0 c0 {3,S} {6,T}
+6  C u0 p0 c0 {5,T} {11,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {1,S}
+11 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.83886,0.0139251,0.000191255,-6.59717e-07,6.99288e-10,11212.2,10.4675], Tmin=(10,'K'), Tmax=(310.255,'K')),
+            NASAPolynomial(coeffs=[3.36206,0.0394479,-2.58155e-05,8.00429e-09,-9.4812e-13,11148.5,10.7069], Tmin=(310.255,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (93.2547,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 7,
+    label = "p000721",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {11,S}
+2  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3  C u0 p0 c0 {1,S} {2,S} {4,D}
+4  C u0 p0 c0 {3,D} {5,S} {10,S}
+5  C u0 p0 c0 {4,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.80596,0.0145653,0.000179922,-5.26243e-07,4.55672e-10,5604.76,10.3639], Tmin=(10,'K'), Tmax=(396.315,'K')),
+            NASAPolynomial(coeffs=[4.37112,0.0387071,-2.44151e-05,7.50698e-09,-8.9093e-13,5325.58,5.20332], Tmin=(396.315,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (46.6098,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 8,
+    label = "p000726",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {11,S}
+2  C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+3  C u0 p0 c0 {1,S} {2,S} {4,D}
+4  C u0 p0 c0 {3,D} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.79047,0.0134968,0.000172855,-4.23838e-07,2.98893e-10,8411.79,10.4369], Tmin=(10,'K'), Tmax=(501.479,'K')),
+            NASAPolynomial(coeffs=[6.25923,0.036542,-2.39093e-05,7.68141e-09,-9.49864e-13,7626.81,-5.12745], Tmin=(501.479,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (69.887,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 9,
+    label = "p000744",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {11,S}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4  C u0 p0 c0 {3,S} {5,D} {9,S}
+5  C u0 p0 c0 {1,S} {4,D} {10,S}
+6  C u0 p0 c0 {2,T} {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86044,0.0145339,0.000207876,-9.15058e-07,1.28653e-09,-2838.79,11.247], Tmin=(10,'K'), Tmax=(224.356,'K')),
+            NASAPolynomial(coeffs=[3.22672,0.037547,-2.43061e-05,7.59276e-09,-9.09665e-13,-2839.84,12.7002], Tmin=(224.356,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-23.5639,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 10,
+    label = "p000813",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {6,S}
+2  O u0 p2 c0 {6,S} {12,S}
+3  N u0 p1 c0 {6,D} {13,S}
+4  C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+5  C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,S} {2,S} {3,D}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.90723,0.0359907,-7.07218e-06,-9.51471e-09,4.13273e-12,-46353.2,8.70544], Tmin=(10,'K'), Tmax=(1260.14,'K')),
+            NASAPolynomial(coeffs=[13.2832,0.0222572,-9.80344e-06,2.02375e-09,-1.58842e-13,-49988.8,-43.7455], Tmin=(1260.14,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-385.336,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (291.007,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 11,
     label = "p000842",
     molecule = 
 """
@@ -217,7 +465,43 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 5,
+    index = 12,
+    label = "p001050",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {5,S}
+2  O u0 p2 c0 {6,S} {12,S}
+3  C u0 p0 c0 {1,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {1,S} {3,S} {6,D}
+6  C u0 p0 c0 {2,S} {5,D} {11,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.62708,0.0349892,-1.38434e-05,-1.85582e-09,1.91845e-12,-16444.3,10.5772], Tmin=(10,'K'), Tmax=(1154.87,'K')),
+            NASAPolynomial(coeffs=[7.34748,0.0288117,-1.4533e-05,3.57203e-09,-3.45359e-13,-17751,-9.8441], Tmin=(1154.87,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-136.75,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 13,
     label = "p001085",
     molecule = 
 """
@@ -251,7 +535,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 6,
+    index = 14,
     label = "p001088",
     molecule = 
 """
@@ -285,7 +569,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 7,
+    index = 15,
     label = "p001089",
     molecule = 
 """
@@ -319,7 +603,76 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 8,
+    index = 16,
+    label = "p001147",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {13,S}
+2  C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+3  C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {5,D}
+5  C u0 p0 c0 {1,S} {4,D} {12,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.65306,0.0315714,-4.7653e-06,-8.32774e-09,3.49633e-12,-24168.8,10.2154], Tmin=(10,'K'), Tmax=(1158.43,'K')),
+            NASAPolynomial(coeffs=[5.6154,0.0324883,-1.59135e-05,3.8204e-09,-3.6245e-13,-25139.6,-1.7682], Tmin=(1158.43,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-200.977,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (295.164,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 17,
+    label = "p001169",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {7,S}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {4,D} {8,S}
+4 C u0 p0 c0 {1,S} {3,D} {5,S}
+5 C u0 p0 c0 {2,D} {4,S} {6,S}
+6 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {1,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94233,0.00322041,0.000105484,-2.14975e-07,1.33819e-10,-31718.4,9.45332], Tmin=(10,'K'), Tmax=(523.115,'K')),
+            NASAPolynomial(coeffs=[2.43759,0.031122,-2.15359e-05,6.81512e-09,-8.09867e-13,-31785.3,13.5936], Tmin=(523.115,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-263.746,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 18,
     label = "p001235",
     molecule = 
 """
@@ -351,7 +704,227 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 9,
+    index = 19,
+    label = "p001357",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {15,S}
+2  N u0 p1 c0 {3,S} {6,D}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5  C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+6  C u0 p0 c0 {1,S} {2,D} {14,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {6,S}
+15 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88185,0.0101296,0.00026352,-8.24169e-07,8.42998e-10,-27192.1,10.3398], Tmin=(10,'K'), Tmax=(295.269,'K')),
+            NASAPolynomial(coeffs=[1.65322,0.0545043,-3.39624e-05,1.01821e-08,-1.17885e-12,-27122.4,17.326], Tmin=(295.269,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-226.057,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (340.893,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 20,
+    label = "p001387",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {14,S}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3  C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4  C u0 p0 c0 {2,S} {3,S} {10,S} {11,S}
+5  C u0 p0 c0 {1,S} {2,S} {6,D}
+6  C u0 p0 c0 {5,D} {12,S} {13,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {6,S}
+14 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85754,0.00856986,0.000169806,-3.43926e-07,2.10051e-10,-9429.2,10.4147], Tmin=(10,'K'), Tmax=(545.135,'K')),
+            NASAPolynomial(coeffs=[2.44471,0.0505768,-3.28419e-05,1.03712e-08,-1.25827e-12,-9745.29,12.0616], Tmin=(545.135,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-78.4517,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (324.264,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 21,
+    label = "p001388",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {14,S}
+2  C u0 p0 c0 {3,S} {5,S} {7,S} {8,S}
+3  C u0 p0 c0 {2,S} {5,S} {9,S} {10,S}
+4  C u0 p0 c0 {6,S} {11,S} {12,S} {13,S}
+5  C u0 p0 c0 {2,S} {3,S} {6,D}
+6  C u0 p0 c0 {1,S} {4,S} {5,D}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86246,0.00881132,0.000178944,-3.89233e-07,2.58997e-10,-4839.64,10.6522], Tmin=(10,'K'), Tmax=(492.332,'K')),
+            NASAPolynomial(coeffs=[2.08613,0.0506836,-3.22323e-05,9.92755e-09,-1.17592e-12,-4997.29,14.5858], Tmin=(492.332,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-40.2735,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (324.264,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 22,
+    label = "p001614",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {11,S}
+2  O u0 p2 c0 {5,D}
+3  N u0 p1 c0 {5,S} {9,S} {10,S}
+4  C u0 p0 c0 {5,S} {6,D} {7,S}
+5  C u0 p0 c0 {2,D} {3,S} {4,S}
+6  C u0 p0 c0 {1,S} {4,D} {8,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.72702,0.0224947,0.000134371,-4.47717e-07,4.13474e-10,-39632.5,10.3516], Tmin=(10,'K'), Tmax=(381.842,'K')),
+            NASAPolynomial(coeffs=[4.78479,0.0372583,-2.51495e-05,8.04806e-09,-9.77345e-13,-39901.7,3.7998], Tmin=(381.842,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-329.508,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 23,
+    label = "p001615",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {11,S}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {4,S} {9,S} {10,S}
+4  C u0 p0 c0 {1,S} {3,S} {5,D}
+5  C u0 p0 c0 {4,D} {6,S} {7,S}
+6  C u0 p0 c0 {2,D} {5,S} {8,S}
+7  H u0 p0 c0 {5,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.858,0.00968688,0.000155078,-3.88805e-07,2.93332e-10,-41383.7,10.2394], Tmin=(10,'K'), Tmax=(450.972,'K')),
+            NASAPolynomial(coeffs=[4.14523,0.0347414,-2.00658e-05,5.82841e-09,-6.74665e-13,-41690.3,5.97052], Tmin=(450.972,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-344.1,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 24,
+    label = "p001627",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {6,S} {10,S}
+3  N u0 p1 c0 {6,D} {11,S}
+4  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6  C u0 p0 c0 {2,S} {3,D} {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91608,0.00487646,0.000129902,-2.40017e-07,1.35521e-10,-24978.8,10.4281], Tmin=(10,'K'), Tmax=(564.273,'K')),
+            NASAPolynomial(coeffs=[0.501141,0.0476099,-3.29423e-05,1.05596e-08,-1.27439e-12,-24888.3,22.3357], Tmin=(564.273,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-207.721,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 25,
     label = "p001958",
     molecule = 
 """
@@ -383,7 +956,118 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 10,
+    index = 26,
+    label = "p002203",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {13,S}
+2  N u0 p1 c0 {3,S} {5,S} {12,S}
+3  C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {6,S} {9,S} {10,S} {11,S}
+5  C u0 p0 c0 {2,S} {3,S} {6,D}
+6  C u0 p0 c0 {1,S} {4,S} {5,D}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.82764,0.0125963,0.000188724,-5.1754e-07,4.28856e-10,4508.76,10.2277], Tmin=(10,'K'), Tmax=(406.756,'K')),
+            NASAPolynomial(coeffs=[3.77374,0.0419153,-2.55621e-05,7.67524e-09,-8.97285e-13,4274.99,7.51173], Tmin=(406.756,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (37.4913,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 27,
+    label = "p002204",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {13,S}
+2  N u0 p1 c0 {3,S} {4,S} {10,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,S} {3,S} {6,D}
+6  C u0 p0 c0 {5,D} {11,S} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86782,0.00750574,0.000152415,-2.86946e-07,1.61025e-10,-1164.11,10.1179], Tmin=(10,'K'), Tmax=(596.695,'K')),
+            NASAPolynomial(coeffs=[2.2463,0.0501745,-3.47846e-05,1.15167e-08,-1.44251e-12,-1536.69,12.3599], Tmin=(596.695,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-9.73776,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 28,
+    label = "p002312",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {13,S}
+2  N u0 p1 c0 {3,S} {6,D}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,S} {2,D} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.89827,0.00614791,0.000156893,-3.05477e-07,1.83212e-10,-6980.98,10.1325], Tmin=(10,'K'), Tmax=(531.611,'K')),
+            NASAPolynomial(coeffs=[0.578424,0.0526025,-3.4778e-05,1.08762e-08,-1.29424e-12,-6931.46,21.1971], Tmin=(531.611,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-58.0801,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 29,
     label = "p002513",
     molecule = 
 """
@@ -414,7 +1098,144 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 11,
+    index = 30,
+    label = "p002594",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {5,S} {9,S}
+3  N u0 p1 c0 {5,D} {10,S}
+4  C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,S} {2,S} {3,D}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.9103,0.00575796,0.000122298,-2.62827e-07,1.7312e-10,-41720.2,10.2154], Tmin=(10,'K'), Tmax=(490.434,'K')),
+            NASAPolynomial(coeffs=[2.19959,0.0367526,-2.46225e-05,7.74213e-09,-9.2073e-13,-41757.4,15.1603], Tmin=(490.434,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-346.904,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 31,
+    label = "p002675",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {11,S}
+2  C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+3  C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4  C u0 p0 c0 {2,S} {3,S} {5,D}
+5  C u0 p0 c0 {1,S} {4,D} {10,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91425,0.00491787,0.000118211,-2.17517e-07,1.21734e-10,1003.28,9.06703], Tmin=(10,'K'), Tmax=(580.799,'K')),
+            NASAPolynomial(coeffs=[1.48157,0.0415479,-2.77244e-05,8.91584e-09,-1.0942e-12,950.621,16.5956], Tmin=(580.799,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (8.30413,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (253.591,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 32,
+    label = "p002689",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {11,S}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  C u0 p0 c0 {3,S} {5,D} {10,S}
+5  C u0 p0 c0 {1,S} {4,D} {6,S}
+6  C u0 p0 c0 {2,T} {5,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.82036,0.0189417,0.000221985,-1.14186e-06,1.76217e-09,-3680.95,10.2873], Tmin=(10,'K'), Tmax=(222.234,'K')),
+            NASAPolynomial(coeffs=[4.11775,0.0342765,-2.11515e-05,6.38507e-09,-7.47089e-13,-3745.25,8.15052], Tmin=(222.234,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-30.5603,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 33,
+    label = "p002760",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {9,S}
+2 O u0 p2 c0 {5,D}
+3 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 C u0 p0 c0 {3,D} {7,S} {8,S}
+5 C u0 p0 c0 {2,D} {3,S} {6,S}
+6 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {4,S}
+9 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91878,0.00553418,9.26815e-05,-1.86784e-07,1.21047e-10,-33219.5,9.29758], Tmin=(10,'K'), Tmax=(396.506,'K')),
+            NASAPolynomial(coeffs=[0.910002,0.0358871,-2.2145e-05,6.28032e-09,-6.80819e-13,-32980.9,21.0299], Tmin=(396.506,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-276.226,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (199.547,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 34,
     label = "p002774",
     molecule = 
 """
@@ -445,7 +1266,146 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 12,
+    index = 35,
+    label = "p002801",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {5,S}
+2  O u0 p2 c0 {6,S} {12,S}
+3  C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {6,S} {9,S} {10,S} {11,S}
+5  C u0 p0 c0 {1,S} {3,S} {6,D}
+6  C u0 p0 c0 {2,S} {4,S} {5,D}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86044,0.0151987,0.000330194,-1.80935e-06,3.07654e-09,-16645.6,9.69766], Tmin=(10,'K'), Tmax=(199.852,'K')),
+            NASAPolynomial(coeffs=[4.09868,0.0361854,-2.06257e-05,5.73488e-09,-6.23456e-13,-16706.6,7.64512], Tmin=(199.852,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-138.241,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 36,
+    label = "p002874",
+    molecule = 
+"""
+1 O u0 p2 c0 {2,S} {8,S}
+2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 C u0 p0 c0 {2,D} {6,S} {7,S}
+4 C u0 p0 c0 {2,S} {5,T}
+5 C u0 p0 c0 {4,T} {9,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {1,S}
+9 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86792,0.0084503,0.00011779,-2.79503e-07,1.93169e-10,12258,9.19808], Tmin=(10,'K'), Tmax=(504.792,'K')),
+            NASAPolynomial(coeffs=[4.95457,0.026928,-1.76106e-05,5.62279e-09,-6.89654e-13,11803.2,1.27999], Tmin=(504.792,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (101.884,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 37,
+    label = "p002881",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {12,S}
+2  O u0 p2 c0 {4,D}
+3  C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  C u0 p0 c0 {2,D} {3,S} {5,S}
+5  C u0 p0 c0 {1,S} {4,S} {6,D}
+6  C u0 p0 c0 {5,D} {10,S} {11,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.69017,0.0225328,5.08911e-05,-1.12327e-07,6.89656e-11,-39468.1,10.8486], Tmin=(10,'K'), Tmax=(427.27,'K')),
+            NASAPolynomial(coeffs=[1.36919,0.0442611,-2.5389e-05,6.69167e-09,-6.72742e-13,-39269.8,20.0724], Tmin=(427.27,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-328.233,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 38,
+    label = "p003070",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {9,S}
+2  N u0 p1 c0 {5,D} {10,S}
+3  N u0 p1 c0 {6,T}
+4  C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,S} {2,D} {4,S}
+6  C u0 p0 c0 {3,T} {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85817,0.00996158,0.000148892,-3.91546e-07,3.07498e-10,-6652.54,10.5691], Tmin=(10,'K'), Tmax=(432.843,'K')),
+            NASAPolynomial(coeffs=[4.0374,0.0337178,-2.15e-05,6.53263e-09,-7.662e-13,-6906.11,7.10456], Tmin=(432.843,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-55.3208,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 39,
     label = "p003183",
     molecule = 
 """
@@ -477,7 +1437,283 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 13,
+    index = 40,
+    label = "p003195",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {10,S}
+2  O u0 p2 c0 {5,S} {9,S}
+3  O u0 p2 c0 {6,D}
+4  C u0 p0 c0 {1,S} {5,D} {6,S}
+5  C u0 p0 c0 {2,S} {4,D} {7,S}
+6  C u0 p0 c0 {3,D} {4,S} {8,S}
+7  H u0 p0 c0 {5,S}
+8  H u0 p0 c0 {6,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91369,0.0073615,0.000189066,-6.19452e-07,6.54015e-10,-52568.8,10.8658], Tmin=(10,'K'), Tmax=(298.063,'K')),
+            NASAPolynomial(coeffs=[2.85217,0.0353819,-2.12683e-05,6.0461e-09,-6.68696e-13,-52566.7,13.6757], Tmin=(298.063,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-437.062,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 41,
+    label = "p003323",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {8,S}
+2 N u0 p1 c0 {5,T}
+3 C u0 p0 c0 {1,S} {4,D} {7,S}
+4 C u0 p0 c0 {3,D} {5,S} {6,S}
+5 C u0 p0 c0 {2,T} {4,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88496,0.00897189,9.54324e-05,-2.63293e-07,2.1839e-10,-642.782,8.99471], Tmin=(10,'K'), Tmax=(398.048,'K')),
+            NASAPolynomial(coeffs=[3.43636,0.0261666,-1.7173e-05,5.37551e-09,-6.41803e-13,-707.576,9.48319], Tmin=(398.048,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-5.34073,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 42,
+    label = "p003344",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {11,S}
+2  N u0 p1 c0 {5,S} {9,S} {10,S}
+3  N u0 p1 c0 {4,S} {5,D}
+4  C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,S} {2,S} {3,D}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.93375,0.00753724,0.000315939,-1.88131e-06,3.99066e-09,-22602.1,8.71993], Tmin=(10,'K'), Tmax=(118.139,'K')),
+            NASAPolynomial(coeffs=[3.15661,0.0338523,-1.82138e-05,4.51698e-09,-4.22639e-13,-22583.7,10.8092], Tmin=(118.139,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-186.665,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 43,
+    label = "p003346",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {10,S}
+2  N u0 p1 c0 {4,S} {5,S} {9,S}
+3  N u0 p1 c0 {5,D} {11,S}
+4  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,S} {2,S} {3,D}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {1,S}
+11 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.72914,0.0209959,3.3901e-05,-7.49023e-08,4.28295e-11,-22643.5,10.1494], Tmin=(10,'K'), Tmax=(467.895,'K')),
+            NASAPolynomial(coeffs=[1.64191,0.0388395,-2.33029e-05,6.60325e-09,-7.1962e-13,-22448.2,18.6338], Tmin=(467.895,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-188.314,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 44,
+    label = "p003348",
+    molecule = 
+"""
+1 O u0 p2 c0 {2,S} {7,S}
+2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 C u0 p0 c0 {2,D} {5,S} {6,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.96458,0.00201312,5.8329e-05,-1.02463e-07,5.55792e-11,-16471.7,6.25516], Tmin=(10,'K'), Tmax=(582.088,'K')),
+            NASAPolynomial(coeffs=[2.1722,0.0223264,-1.46231e-05,4.68929e-09,-5.77452e-13,-16398.5,12.7688], Tmin=(582.088,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-136.97,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (153.818,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 45,
+    label = "p003431",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {11,S}
+2  O u0 p2 c0 {5,D}
+3  N u0 p1 c0 {5,S} {6,D}
+4  C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {2,D} {3,S} {4,S}
+6  C u0 p0 c0 {1,S} {3,D} {10,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91064,0.0237174,1.73272e-05,-3.43609e-08,1.31223e-11,-39980.3,10.8451], Tmin=(10,'K'), Tmax=(1023.99,'K')),
+            NASAPolynomial(coeffs=[7.32512,0.0282348,-1.54454e-05,4.00383e-09,-4.01477e-13,-41615.7,-10.2796], Tmin=(1023.99,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-332.347,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 46,
+    label = "p003437",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {12,S}
+2  N u0 p1 c0 {6,D} {13,S}
+3  C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,S} {2,D} {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {1,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.87031,0.0162902,6.72365e-05,-1.03494e-07,4.41068e-11,-12355.7,10.2333], Tmin=(10,'K'), Tmax=(796.601,'K')),
+            NASAPolynomial(coeffs=[1.94139,0.0462748,-2.74475e-05,7.73435e-09,-8.39351e-13,-12692.4,15.058], Tmin=(796.601,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-102.714,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 47,
+    label = "p003440",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {13,S}
+2  N u0 p1 c0 {6,S} {11,S} {12,S}
+3  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {3,S} {5,S} {9,S} {10,S}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {1,S} {2,S} {5,D}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84221,0.0107492,0.00017705,-4.24284e-07,3.08195e-10,-363.607,11.2834], Tmin=(10,'K'), Tmax=(456.254,'K')),
+            NASAPolynomial(coeffs=[2.85792,0.0466002,-3.031e-05,9.47233e-09,-1.13027e-12,-557.124,12.1546], Tmin=(456.254,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-3.04447,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 48,
     label = "p003454",
     molecule = 
 """
@@ -513,7 +1749,116 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 14,
+    index = 49,
+    label = "p003718",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {12,S}
+2  C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+3  C u0 p0 c0 {1,S} {4,D} {6,S}
+4  C u0 p0 c0 {3,D} {10,S} {11,S}
+5  C u0 p0 c0 {2,S} {6,T}
+6  C u0 p0 c0 {3,S} {5,T}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.81777,0.0189526,0.000239308,-1.12816e-06,1.6444e-09,6587.54,10.3937], Tmin=(10,'K'), Tmax=(226.98,'K')),
+            NASAPolynomial(coeffs=[3.63445,0.0406158,-2.56677e-05,7.88671e-09,-9.34435e-13,6548.38,9.96025], Tmin=(226.98,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (54.8133,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (278.535,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 50,
+    label = "p003937",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {10,S}
+2  N u0 p1 c0 {4,S} {5,D}
+3  N u0 p1 c0 {6,T}
+4  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,S} {2,D} {9,S}
+6  C u0 p0 c0 {3,T} {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.8793,0.0123597,0.00024728,-1.16525e-06,1.73112e-09,-1348.66,10.3028], Tmin=(10,'K'), Tmax=(220.963,'K')),
+            NASAPolynomial(coeffs=[3.62058,0.034557,-2.22982e-05,6.79804e-09,-7.92977e-13,-1379.98,10.1929], Tmin=(220.963,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-11.1718,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 51,
+    label = "p003958",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {15,S}
+2  N u0 p1 c0 {4,S} {6,D}
+3  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+6  C u0 p0 c0 {1,S} {2,D} {14,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {5,S}
+14 H u0 p0 c0 {6,S}
+15 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.4651,0.0589936,-0.000198921,5.80714e-07,-5.66297e-10,-25575.5,10.807], Tmin=(10,'K'), Tmax=(377.465,'K')),
+            NASAPolynomial(coeffs=[-0.306317,0.0585795,-3.68106e-05,1.09918e-08,-1.25752e-12,-25003.1,29.138], Tmin=(377.465,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-212.671,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (340.893,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 52,
     label = "p004006",
     molecule = 
 """
@@ -545,7 +1890,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 15,
+    index = 53,
     label = "p004007",
     molecule = 
 """
@@ -577,7 +1922,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 16,
+    index = 54,
     label = "p004142",
     molecule = 
 """
@@ -610,7 +1955,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 17,
+    index = 55,
     label = "p004295",
     molecule = 
 """
@@ -644,7 +1989,216 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 18,
+    index = 56,
+    label = "p004414",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {11,S}
+2  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3  C u0 p0 c0 {2,S} {4,D} {5,S}
+4  C u0 p0 c0 {1,S} {3,D} {10,S}
+5  C u0 p0 c0 {3,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.83602,0.0136053,0.000163827,-4.90397e-07,4.52511e-10,7814.11,11.5083], Tmin=(10,'K'), Tmax=(350.288,'K')),
+            NASAPolynomial(coeffs=[2.89462,0.041158,-2.61113e-05,8.03227e-09,-9.50738e-13,7776.98,13.5911], Tmin=(350.288,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (64.9926,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 57,
+    label = "p004467",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {11,S}
+2  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+3  C u0 p0 c0 {2,S} {4,D} {10,S}
+4  C u0 p0 c0 {1,S} {3,D} {5,S}
+5  C u0 p0 c0 {4,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.78918,0.0170915,0.000168895,-5.35296e-07,5.01214e-10,7926.15,10.6828], Tmin=(10,'K'), Tmax=(363.96,'K')),
+            NASAPolynomial(coeffs=[4.04299,0.0392086,-2.49045e-05,7.7083e-09,-9.18713e-13,7742.71,7.44865], Tmin=(363.96,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (65.9248,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 58,
+    label = "p004505",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {11,S}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  C u0 p0 c0 {3,S} {5,D} {6,S}
+5  C u0 p0 c0 {1,S} {4,D} {10,S}
+6  C u0 p0 c0 {2,T} {4,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.66996,0.0299912,-3.16416e-06,-1.52793e-08,7.72203e-12,-5068.88,10.4117], Tmin=(10,'K'), Tmax=(896.133,'K')),
+            NASAPolynomial(coeffs=[5.23008,0.0306747,-1.7109e-05,4.61763e-09,-4.85401e-13,-5655.56,1.34281], Tmin=(896.133,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-42.1674,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 59,
+    label = "p004547",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {13,S}
+2  N u0 p1 c0 {3,S} {4,S} {5,S}
+3  C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {6,D} {11,S}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.73051,0.0241363,6.93902e-05,-1.9221e-07,1.54862e-10,5164.25,11.1143], Tmin=(10,'K'), Tmax=(321.184,'K')),
+            NASAPolynomial(coeffs=[2.07304,0.0447784,-2.70135e-05,7.89148e-09,-8.91937e-13,5270.72,17.2282], Tmin=(321.184,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (42.9277,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 60,
+    label = "p004625",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,S} {9,S}
+2 N u0 p1 c0 {5,S} {6,S} {7,S}
+3 N u0 p1 c0 {4,S} {5,D}
+4 N u0 p1 c0 {3,S} {6,D}
+5 C u0 p0 c0 {1,S} {2,S} {3,D}
+6 C u0 p0 c0 {2,S} {4,D} {8,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {6,S}
+9 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.08627,-0.00820118,0.000155302,-2.66393e-07,1.4341e-10,2334.39,9.64406], Tmin=(10,'K'), Tmax=(606.544,'K')),
+            NASAPolynomial(coeffs=[1.46698,0.0369679,-2.5389e-05,8.03362e-09,-9.5377e-13,2139,16.7411], Tmin=(606.544,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (19.3912,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 61,
+    label = "p004643",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {8,S}
+2 N u0 p1 c0 {5,T}
+3 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 C u0 p0 c0 {3,D} {6,S} {7,S}
+5 C u0 p0 c0 {2,T} {3,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88273,0.00815436,0.000105928,-2.79617e-07,2.16681e-10,1075.01,9.44408], Tmin=(10,'K'), Tmax=(445.905,'K')),
+            NASAPolynomial(coeffs=[4.43085,0.0237291,-1.53979e-05,4.83737e-09,-5.82526e-13,822.405,4.95805], Tmin=(445.905,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (8.92689,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 62,
     label = "p004717",
     molecule = 
 """
@@ -676,7 +2230,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 19,
+    index = 63,
     label = "p004719",
     molecule = 
 """
@@ -708,7 +2262,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 20,
+    index = 64,
     label = "p004749",
     molecule = 
 """
@@ -743,7 +2297,118 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 21,
+    index = 65,
+    label = "p004778",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {12,S}
+2  N u0 p1 c0 {3,S} {4,S} {9,S}
+3  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+4  C u0 p0 c0 {1,S} {2,S} {5,D}
+5  C u0 p0 c0 {4,D} {10,S} {11,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.83381,0.010622,0.000156501,-3.65874e-07,2.51396e-10,-18062.5,9.59093], Tmin=(10,'K'), Tmax=(503.873,'K')),
+            NASAPolynomial(coeffs=[4.87846,0.0366766,-2.33127e-05,7.32217e-09,-8.90901e-13,-18603.8,0.9404], Tmin=(503.873,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-150.224,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 66,
+    label = "p004794",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {15,S}
+2  N u0 p1 c0 {3,S} {4,S} {5,S}
+3  C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,S} {2,S} {6,D}
+6  C u0 p0 c0 {5,D} {13,S} {14,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {6,S}
+14 H u0 p0 c0 {6,S}
+15 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.71518,0.0440718,-2.12556e-05,3.73914e-09,1.92182e-14,-17747.8,9.58673], Tmin=(10,'K'), Tmax=(1669.94,'K')),
+            NASAPolynomial(coeffs=[21.1952,0.0122056,-1.61781e-06,-5.13346e-10,1.1881e-13,-24980.8,-87.8841], Tmin=(1669.94,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-147.622,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (340.893,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 67,
+    label = "p004852",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {12,S}
+2  O u0 p2 c0 {6,D}
+3  C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+4  C u0 p0 c0 {3,S} {5,D} {10,S}
+5  C u0 p0 c0 {1,S} {4,D} {6,S}
+6  C u0 p0 c0 {2,D} {5,S} {11,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.64706,0.0282324,6.42592e-06,-1.86683e-08,6.4372e-12,-37959.2,10.72], Tmin=(10,'K'), Tmax=(1157.93,'K')),
+            NASAPolynomial(coeffs=[3.9264,0.0383156,-2.09481e-05,5.33204e-09,-5.23603e-13,-38764.6,6.13308], Tmin=(1157.93,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-315.655,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 68,
     label = "p005032",
     molecule = 
 """
@@ -775,7 +2440,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 22,
+    index = 69,
     label = "p005102",
     molecule = 
 """
@@ -808,7 +2473,184 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 23,
+    index = 70,
+    label = "p005118",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {6,S}
+2  O u0 p2 c0 {6,S} {13,S}
+3  N u0 p1 c0 {4,S} {6,D}
+4  C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+5  C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+6  C u0 p0 c0 {1,S} {2,S} {3,D}
+7  H u0 p0 c0 {5,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.53848,0.0464096,-0.000122743,3.20634e-07,-2.83128e-10,-40970.4,11.0149], Tmin=(10,'K'), Tmax=(426.538,'K')),
+            NASAPolynomial(coeffs=[-0.340623,0.0518072,-3.27786e-05,9.74134e-09,-1.10542e-12,-40357.6,29.7277], Tmin=(426.538,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-340.659,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (291.007,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 71,
+    label = "p005148",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u0 p2 c0 {5,S} {8,S}
+3 N u0 p1 c0 {5,D} {6,S}
+4 N u0 p1 c0 {1,S} {6,D}
+5 C u0 p0 c0 {1,S} {2,S} {3,D}
+6 C u0 p0 c0 {3,S} {4,D} {7,S}
+7 H u0 p0 c0 {6,S}
+8 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.10924,-0.010865,0.000169698,-3.10681e-07,1.78969e-10,-14461,9.68359], Tmin=(10,'K'), Tmax=(574.532,'K')),
+            NASAPolynomial(coeffs=[2.62701,0.0309781,-2.18492e-05,7.08461e-09,-8.5815e-13,-14810.9,11.4852], Tmin=(574.532,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-120.259,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 72,
+    label = "p005196",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {10,S}
+2  C u0 p0 c0 {3,S} {5,S} {6,S} {7,S}
+3  C u0 p0 c0 {1,S} {2,S} {4,D}
+4  C u0 p0 c0 {3,D} {8,S} {9,S}
+5  H u0 p0 c0 {2,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91532,0.00513114,0.000106228,-2.14837e-07,1.32152e-10,-22138.8,8.11858], Tmin=(10,'K'), Tmax=(537.356,'K')),
+            NASAPolynomial(coeffs=[2.87373,0.031565,-1.97063e-05,6.09666e-09,-7.33743e-13,-22296.5,9.98724], Tmin=(537.356,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-184.102,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 73,
+    label = "p005308",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {14,S}
+2  N u0 p1 c0 {4,S} {6,S} {13,S}
+3  N u0 p1 c0 {5,S} {6,D}
+4  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {10,S} {11,S} {12,S}
+6  C u0 p0 c0 {1,S} {2,S} {3,D}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {2,S}
+14 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.53949,0.039169,-1.04812e-05,-5.85351e-09,2.82972e-12,-21456.1,11.9599], Tmin=(10,'K'), Tmax=(1276.71,'K')),
+            NASAPolynomial(coeffs=[8.4109,0.0344058,-1.72204e-05,4.10685e-09,-3.81985e-13,-23555.7,-16.083], Tmin=(1276.71,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-178.453,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (315.95,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 74,
+    label = "p005356",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {11,S}
+2  O u0 p2 c0 {6,S} {12,S}
+3  C u0 p0 c0 {1,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {2,S} {5,D} {10,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {1,S}
+12 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84702,0.0101717,0.000162506,-3.8237e-07,2.69959e-10,-17787.7,11.2434], Tmin=(10,'K'), Tmax=(474.481,'K')),
+            NASAPolynomial(coeffs=[3.24953,0.0429029,-2.85204e-05,9.04297e-09,-1.08841e-12,-18042.7,10.3954], Tmin=(474.481,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-147.924,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 75,
     label = "p005432",
     molecule = 
 """
@@ -842,7 +2684,41 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 24,
+    index = 76,
+    label = "p005491",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {10,S}
+2  N u0 p1 c0 {3,S} {4,S} {8,S}
+3  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4  C u0 p0 c0 {2,S} {3,S} {5,D}
+5  C u0 p0 c0 {1,S} {4,D} {9,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.89957,0.00658032,0.000122061,-2.78486e-07,1.93453e-10,10453.9,9.09847], Tmin=(10,'K'), Tmax=(477.686,'K')),
+            NASAPolynomial(coeffs=[3.21634,0.0320351,-1.98367e-05,6.03054e-09,-7.11568e-13,10294,9.53323], Tmin=(477.686,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (86.8978,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 77,
     label = "p005546",
     molecule = 
 """
@@ -876,7 +2752,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 25,
+    index = 78,
     label = "p005588",
     molecule = 
 """
@@ -909,7 +2785,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 26,
+    index = 79,
     label = "p005763",
     molecule = 
 """
@@ -941,7 +2817,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 27,
+    index = 80,
     label = "p005826",
     molecule = 
 """
@@ -973,7 +2849,227 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 28,
+    index = 81,
+    label = "p005998",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {13,S}
+2  N u0 p1 c0 {3,S} {4,S} {5,S}
+3  C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+5  C u0 p0 c0 {2,S} {3,S} {6,D}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84087,0.0123529,0.00019779,-5.81469e-07,5.2568e-10,9453.01,10.1111], Tmin=(10,'K'), Tmax=(366.362,'K')),
+            NASAPolynomial(coeffs=[3.33342,0.0424009,-2.55771e-05,7.58059e-09,-8.76088e-13,9325.72,9.80498], Tmin=(366.362,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (78.6172,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 82,
+    label = "p006089",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {13,S}
+2  N u0 p1 c0 {3,S} {5,S} {11,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {3,S} {6,D}
+6  C u0 p0 c0 {1,S} {5,D} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.8356,0.0128195,0.000196784,-5.82469e-07,5.28756e-10,5381.75,10.2389], Tmin=(10,'K'), Tmax=(365.52,'K')),
+            NASAPolynomial(coeffs=[3.37798,0.0424411,-2.57828e-05,7.69562e-09,-8.94012e-13,5250.78,9.73694], Tmin=(365.52,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (44.7675,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 83,
+    label = "p006263",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {14,S}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3  C u0 p0 c0 {2,S} {5,S} {8,S} {9,S}
+4  C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+5  C u0 p0 c0 {2,S} {3,S} {6,D}
+6  C u0 p0 c0 {1,S} {5,D} {13,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {6,S}
+14 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85725,0.00921034,0.000179683,-3.97852e-07,2.68854e-10,-2878.7,10.6368], Tmin=(10,'K'), Tmax=(487.975,'K')),
+            NASAPolynomial(coeffs=[2.45509,0.0492,-3.08373e-05,9.42969e-09,-1.11491e-12,-3081.13,12.9191], Tmin=(487.975,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-23.9686,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (324.264,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 84,
+    label = "p006320",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {6,S}
+2 O u0 p2 c0 {4,S} {9,S}
+3 N u0 p1 c0 {4,D} {5,S}
+4 C u0 p0 c0 {1,S} {2,S} {3,D}
+5 C u0 p0 c0 {3,S} {6,D} {7,S}
+6 C u0 p0 c0 {1,S} {5,D} {8,S}
+7 H u0 p0 c0 {5,S}
+8 H u0 p0 c0 {6,S}
+9 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.15411,-0.0145665,0.000200127,-3.5905e-07,2.03248e-10,-26710.5,9.73058], Tmin=(10,'K'), Tmax=(585.346,'K')),
+            NASAPolynomial(coeffs=[2.46604,0.0350423,-2.45655e-05,7.9791e-09,-9.68942e-13,-27165.2,11.399], Tmin=(585.346,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-222.108,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 85,
+    label = "p006396",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {6,S}
+2  O u0 p2 c0 {4,S} {7,S}
+3  O u0 p2 c0 {6,S} {15,S}
+4  C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+5  C u0 p0 c0 {1,S} {8,S} {9,S} {10,S}
+6  C u0 p0 c0 {1,S} {3,S} {7,D}
+7  C u0 p0 c0 {2,S} {6,D} {14,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {7,S}
+15 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.70248,0.0305716,0.000309157,-1.57589e-06,2.34863e-09,-53802,11.7158], Tmin=(10,'K'), Tmax=(233.988,'K')),
+            NASAPolynomial(coeffs=[4.51832,0.0502145,-3.20964e-05,9.90503e-09,-1.17533e-12,-53932.1,6.99996], Tmin=(233.988,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-447.289,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (336.736,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 86,
+    label = "p006798",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,S} {12,S}
+2  O u0 p2 c0 {7,D}
+3  N u0 p1 c0 {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {4,S} {6,D}
+6  C u0 p0 c0 {1,S} {5,D} {10,S}
+7  C u0 p0 c0 {2,D} {3,S} {11,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {7,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.80593,0.0175497,0.000205165,-7.49604e-07,8.38744e-10,-5480.15,11.3802], Tmin=(10,'K'), Tmax=(293.215,'K')),
+            NASAPolynomial(coeffs=[3.30283,0.0438686,-2.90045e-05,9.10975e-09,-1.09087e-12,-5534.29,11.764], Tmin=(293.215,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-45.529,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 87,
     label = "p007269",
     molecule = 
 """
@@ -1007,7 +3103,79 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 29,
+    index = 88,
+    label = "p007773",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {12,S}
+2  N u0 p1 c0 {4,S} {7,S} {11,S}
+3  N u0 p1 c0 {6,S} {7,D}
+4  N u0 p1 c0 {2,S} {6,D}
+5  C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6  C u0 p0 c0 {3,S} {4,D} {5,S}
+7  C u0 p0 c0 {1,S} {2,S} {3,D}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91233,0.00557554,0.000152006,-3.11236e-07,1.98867e-10,-7077.23,11.2029], Tmin=(10,'K'), Tmax=(487.209,'K')),
+            NASAPolynomial(coeffs=[0.550275,0.0494164,-3.29631e-05,1.02735e-08,-1.21034e-12,-6942.36,23.0275], Tmin=(487.209,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-58.8661,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 89,
+    label = "p007777",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {12,S}
+2  N u0 p1 c0 {6,S} {7,S} {11,S}
+3  N u0 p1 c0 {4,S} {6,D}
+4  N u0 p1 c0 {3,S} {7,D}
+5  C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6  C u0 p0 c0 {2,S} {3,D} {5,S}
+7  C u0 p0 c0 {1,S} {2,S} {4,D}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.90177,0.00637248,0.000155865,-3.31653e-07,2.19468e-10,-3668.66,11.0459], Tmin=(10,'K'), Tmax=(476.556,'K')),
+            NASAPolynomial(coeffs=[1.07965,0.0480164,-3.1731e-05,9.84659e-09,-1.15959e-12,-3603.58,20.4301], Tmin=(476.556,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-30.5245,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 90,
     label = "p007945",
     molecule = 
 """
@@ -1041,7 +3209,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 30,
+    index = 91,
     label = "p008828",
     molecule = 
 """
@@ -1078,7 +3246,80 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 31,
+    index = 92,
+    label = "p009289",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {14,S}
+2  C u0 p0 c0 {4,S} {11,S} {12,S} {13,S}
+3  C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+4  C u0 p0 c0 {2,S} {3,S} {5,D}
+5  C u0 p0 c0 {1,S} {4,D} {6,S}
+6  C u0 p0 c0 {5,S} {7,T}
+7  C u0 p0 c0 {6,T} {15,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {2,S}
+14 H u0 p0 c0 {1,S}
+15 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.72698,0.0275308,0.000288229,-1.37207e-06,1.94005e-09,3155.48,11.1256], Tmin=(10,'K'), Tmax=(243.475,'K')),
+            NASAPolynomial(coeffs=[4.25583,0.0490313,-3.02187e-05,9.1332e-09,-1.07074e-12,3040.25,7.48377], Tmin=(243.475,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (26.2699,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (345.051,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 93,
+    label = "p009379",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {9,S}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {1,S} {4,D} {6,S}
+4  C u0 p0 c0 {3,D} {5,S} {8,S}
+5  C u0 p0 c0 {4,S} {7,T}
+6  C u0 p0 c0 {2,T} {3,S}
+7  C u0 p0 c0 {5,T} {10,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {1,S}
+10 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.73427,0.0197222,0.000167474,-5.40533e-07,4.78768e-10,29634.3,11.1324], Tmin=(10,'K'), Tmax=(412.048,'K')),
+            NASAPolynomial(coeffs=[6.93218,0.0299901,-2.0295e-05,6.58643e-09,-8.12793e-13,29020.1,-5.71597], Tmin=(412.048,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (246.395,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 94,
     label = "p009513",
     molecule = 
 """
@@ -1114,7 +3355,118 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 32,
+    index = 95,
+    label = "p009772",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {12,S}
+2  O u0 p2 c0 {5,S} {13,S}
+3  C u0 p0 c0 {1,S} {6,S} {8,S} {9,S}
+4  C u0 p0 c0 {5,D} {7,S} {11,S}
+5  C u0 p0 c0 {2,S} {4,D} {10,S}
+6  C u0 p0 c0 {3,S} {7,T}
+7  C u0 p0 c0 {4,S} {6,T}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {1,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.69302,0.0303832,0.000195373,-9.17719e-07,1.21314e-09,-10367.5,12.0315], Tmin=(10,'K'), Tmax=(265.816,'K')),
+            NASAPolynomial(coeffs=[4.47215,0.044396,-2.89355e-05,9.09241e-09,-1.09435e-12,-10499.8,7.5946], Tmin=(265.816,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-86.1644,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 96,
+    label = "p009945",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {11,S}
+2  O u0 p2 c0 {5,D}
+3  O u0 p2 c0 {7,D}
+4  C u0 p0 c0 {1,S} {5,S} {6,D}
+5  C u0 p0 c0 {2,D} {4,S} {7,S}
+6  C u0 p0 c0 {4,D} {9,S} {10,S}
+7  C u0 p0 c0 {3,D} {5,S} {8,S}
+8  H u0 p0 c0 {7,S}
+9  H u0 p0 c0 {6,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.75638,0.0282337,3.75684e-05,-8.87626e-08,4.53133e-11,-44724.1,11.9247], Tmin=(10,'K'), Tmax=(742.624,'K')),
+            NASAPolynomial(coeffs=[6.62206,0.0355397,-2.31234e-05,6.95798e-09,-7.92472e-13,-45776.8,-5.26991], Tmin=(742.624,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-371.862,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 97,
+    label = "p010345",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,S} {14,S}
+2  N u0 p1 c0 {4,S} {5,S} {13,S}
+3  N u0 p1 c0 {7,D} {15,S}
+4  C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+6  C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  C u0 p0 c0 {1,S} {3,D} {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {2,S}
+14 H u0 p0 c0 {1,S}
+15 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86713,0.00804737,0.000190333,-3.76696e-07,2.28139e-10,-8673.12,11.5164], Tmin=(10,'K'), Tmax=(532.719,'K')),
+            NASAPolynomial(coeffs=[0.450195,0.0620141,-4.13379e-05,1.2984e-08,-1.54939e-12,-8710.77,22.0789], Tmin=(532.719,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-72.1602,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (345.051,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 98,
     label = "p010419",
     molecule = 
 """
@@ -1151,7 +3503,79 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 33,
+    index = 99,
+    label = "p010564",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {7,S} {13,S}
+3  N u0 p1 c0 {7,D} {14,S}
+4  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6  C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  C u0 p0 c0 {2,S} {3,D} {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {2,S}
+14 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85487,0.00928251,0.000191096,-4.13575e-07,2.73214e-10,-30624.6,11.4914], Tmin=(10,'K'), Tmax=(493.475,'K')),
+            NASAPolynomial(coeffs=[1.61208,0.0559147,-3.71375e-05,1.15993e-08,-1.37653e-12,-30749.7,17.2174], Tmin=(493.475,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-254.664,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (320.107,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 100,
+    label = "p011399",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {7,S}
+2  O u0 p2 c0 {7,S} {10,S}
+3  N u0 p1 c0 {6,S} {8,S} {9,S}
+4  N u0 p1 c0 {6,S} {7,D}
+5  N u0 p1 c0 {1,S} {6,D}
+6  C u0 p0 c0 {3,S} {4,S} {5,D}
+7  C u0 p0 c0 {1,S} {2,S} {4,D}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86414,0.00827743,0.000135438,-2.91288e-07,1.84123e-10,-17028.5,11.1865], Tmin=(10,'K'), Tmax=(540.689,'K')),
+            NASAPolynomial(coeffs=[3.94813,0.0370814,-2.61036e-05,8.54494e-09,-1.05044e-12,-17467.7,6.85549], Tmin=(540.689,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-141.631,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 101,
     label = "p011443",
     molecule = 
 """
@@ -1186,7 +3610,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 34,
+    index = 102,
     label = "p011506",
     molecule = 
 """
@@ -1221,7 +3645,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 35,
+    index = 103,
     label = "p011937",
     molecule = 
 """
@@ -1257,7 +3681,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 36,
+    index = 104,
     label = "r000017",
     molecule = 
 """
@@ -1290,7 +3714,76 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 37,
+    index = 105,
+    label = "r000049",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {5,S} {6,S} {10,S}
+3  N u0 p1 c0 {4,S} {5,D}
+4  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {2,S} {3,D} {11,S}
+6  C u0 p0 c0 {1,D} {2,S} {12,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {2,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.47881,0.0456237,-8.90262e-05,1.56198e-07,-1.02388e-10,-14356.3,10.8945], Tmin=(10,'K'), Tmax=(540.815,'K')),
+            NASAPolynomial(coeffs=[0.985387,0.0433803,-2.54308e-05,7.07886e-09,-7.61831e-13,-13784.1,24.188], Tmin=(540.815,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-119.389,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 106,
+    label = "r000208",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {5,D}
+3 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 C u0 p0 c0 {1,S} {3,S} {7,S} {8,S}
+5 C u0 p0 c0 {2,D} {3,S} {9,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {4,S}
+9 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.94423,0.00319184,9.27872e-05,-1.65378e-07,9.06193e-11,-21428.1,9.16342], Tmin=(10,'K'), Tmax=(574.793,'K')),
+            NASAPolynomial(coeffs=[1.03557,0.0357635,-2.43904e-05,7.84959e-09,-9.56338e-13,-21297.4,19.8136], Tmin=(574.793,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-178.188,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 107,
     label = "r000314",
     molecule = 
 """
@@ -1323,7 +3816,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 38,
+    index = 108,
     label = "r000399",
     molecule = 
 """
@@ -1356,7 +3849,150 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 39,
+    index = 109,
+    label = "r000634",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  N u0 p1 c0 {3,S} {4,S} {9,S}
+3  C u0 p0 c0 {2,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {1,D} {2,S} {10,S}
+5  C u0 p0 c0 {3,S} {6,T}
+6  C u0 p0 c0 {5,T} {11,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.59855,0.0352029,-1.93983e-05,3.86983e-09,1.14201e-13,6050.43,11.5181], Tmin=(10,'K'), Tmax=(1243.33,'K')),
+            NASAPolynomial(coeffs=[8.07321,0.0251851,-1.25941e-05,3.05354e-09,-2.91113e-13,4599.35,-12.4049], Tmin=(1243.33,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (50.2695,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 110,
+    label = "r000721",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+3  C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {1,D} {2,S} {3,S}
+5  C u0 p0 c0 {2,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.85612,0.0157803,0.000219581,-1.10874e-06,1.91889e-09,2570.55,11.7834], Tmin=(10,'K'), Tmax=(145.276,'K')),
+            NASAPolynomial(coeffs=[3.00091,0.0393263,-2.35264e-05,6.82078e-09,-7.65685e-13,2595.4,14.2595], Tmin=(145.276,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (21.6655,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 111,
+    label = "r000744",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {3,S} {6,S} {9,S} {10,S}
+5  C u0 p0 c0 {1,D} {3,S} {11,S}
+6  C u0 p0 c0 {2,T} {4,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.78574,0.0181084,0.000196515,-7.51293e-07,8.25469e-10,-7574.76,10.3769], Tmin=(10,'K'), Tmax=(324.042,'K')),
+            NASAPolynomial(coeffs=[5.36242,0.0316194,-1.86637e-05,5.43169e-09,-6.20499e-13,-7850.06,1.87582], Tmin=(324.042,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-62.9455,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 112,
+    label = "r000813",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {6,S}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {6,S} {12,S} {13,S}
+4  C u0 p0 c0 {1,S} {5,S} {7,S} {8,S}
+5  C u0 p0 c0 {4,S} {9,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,S} {2,D} {3,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.5098,0.0507652,-0.000136283,3.50844e-07,-3.17409e-10,-55957.2,10.992], Tmin=(10,'K'), Tmax=(402.453,'K')),
+            NASAPolynomial(coeffs=[0.871363,0.0498127,-3.14431e-05,9.38988e-09,-1.0734e-12,-55524.7,24.0538], Tmin=(402.453,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-465.269,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (291.007,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 113,
     label = "r000842",
     molecule = 
 """
@@ -1392,7 +4028,43 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 40,
+    index = 114,
+    label = "r001050",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {4,S}
+2  O u0 p2 c0 {6,D}
+3  C u0 p0 c0 {1,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {1,S} {3,S} {6,S} {8,S}
+5  C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+6  C u0 p0 c0 {2,D} {4,S} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84107,0.013959,0.000130878,-3.70016e-07,3.38511e-10,-26355.7,10.1926], Tmin=(10,'K'), Tmax=(278.507,'K')),
+            NASAPolynomial(coeffs=[1.79877,0.0432912,-2.71012e-05,8.14237e-09,-9.40573e-13,-26241.9,17.4348], Tmin=(278.507,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-219.124,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 115,
     label = "r001085",
     molecule = 
 """
@@ -1426,7 +4098,76 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 41,
+    index = 116,
+    label = "r001147",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3  C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+4  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,D} {2,S} {13,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.60074,0.0337286,-2.19956e-05,2.75355e-08,-1.93979e-11,-27959.2,10.4819], Tmin=(10,'K'), Tmax=(588.792,'K')),
+            NASAPolynomial(coeffs=[1.15713,0.0423606,-2.36849e-05,6.4617e-09,-6.89966e-13,-27533.3,22.1496], Tmin=(588.792,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-232.498,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (295.164,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 117,
+    label = "r001169",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,D}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {4,S} {7,S} {8,S}
+4 C u0 p0 c0 {1,D} {3,S} {5,S}
+5 C u0 p0 c0 {2,D} {4,S} {6,S}
+6 H u0 p0 c0 {5,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.87785,0.00985029,0.000111657,-3.3666e-07,3.06237e-10,-38050.8,8.61326], Tmin=(10,'K'), Tmax=(362.75,'K')),
+            NASAPolynomial(coeffs=[3.46831,0.0278891,-1.88532e-05,5.9594e-09,-7.14121e-13,-38110.1,8.94744], Tmin=(362.75,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-316.358,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (174.604,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 118,
     label = "r001235",
     molecule = 
 """
@@ -1458,7 +4199,154 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 42,
+    index = 119,
+    label = "r001357",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {6,S} {14,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+5  C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+6  C u0 p0 c0 {1,D} {2,S} {15,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {4,S}
+14 H u0 p0 c0 {2,S}
+15 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.58775,0.0400818,-6.12051e-06,-1.25044e-08,5.53931e-12,-32566.3,11.6241], Tmin=(10,'K'), Tmax=(1098.01,'K')),
+            NASAPolynomial(coeffs=[6.6601,0.0396724,-2.02921e-05,5.04393e-09,-4.9254e-13,-33891,-6.4455], Tmin=(1098.01,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-270.789,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (340.893,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 120,
+    label = "r001387",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  C u0 p0 c0 {3,S} {4,S} {6,S} {7,S}
+3  C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+4  C u0 p0 c0 {2,S} {3,S} {10,S} {11,S}
+5  C u0 p0 c0 {6,S} {12,S} {13,S} {14,S}
+6  C u0 p0 c0 {1,D} {2,S} {5,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {5,S}
+14 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.82859,0.0233408,4.35094e-05,-7.01401e-08,2.84301e-11,-16385.6,10.4118], Tmin=(10,'K'), Tmax=(867.519,'K')),
+            NASAPolynomial(coeffs=[3.13547,0.0447625,-2.50439e-05,6.75895e-09,-7.09429e-13,-16951.2,9.70437], Tmin=(867.519,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-136.208,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (324.264,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 121,
+    label = "r001614",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {5,S} {10,S} {11,S}
+4  C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,D} {3,S} {4,S}
+6  C u0 p0 c0 {2,D} {4,S} {9,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {6,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.83725,0.0185434,0.000284942,-1.72662e-06,3.15396e-09,-42834.7,10.6846], Tmin=(10,'K'), Tmax=(189.643,'K')),
+            NASAPolynomial(coeffs=[4.26207,0.033339,-1.9985e-05,5.84995e-09,-6.66287e-13,-42893.6,8.21508], Tmin=(189.643,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-355.887,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 122,
+    label = "r001627",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {6,S} {10,S} {11,S}
+4  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6  C u0 p0 c0 {2,D} {3,S} {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.89194,0.00625897,0.000132368,-2.53588e-07,1.45691e-10,-31147.5,10.5218], Tmin=(10,'K'), Tmax=(576.506,'K')),
+            NASAPolynomial(coeffs=[2.08868,0.0437911,-3.03865e-05,9.90193e-09,-1.2163e-12,-31355.4,14.6222], Tmin=(576.506,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-259.021,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 123,
     label = "r001958",
     molecule = 
 """
@@ -1490,7 +4378,81 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 43,
+    index = 124,
+    label = "r002203",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {4,S} {13,S}
+3  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4  C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5  C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+6  C u0 p0 c0 {1,D} {3,S} {5,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.95032,0.0034355,0.000165845,-3.51422e-07,2.44892e-10,-7842.34,11.5867], Tmin=(10,'K'), Tmax=(367.423,'K')),
+            NASAPolynomial(coeffs=[-0.529974,0.0522225,-3.33749e-05,1.01361e-08,-1.17586e-12,-7513.18,28.7146], Tmin=(367.423,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-65.2048,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 125,
+    label = "r002312",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {6,S} {12,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,D} {2,S} {13,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.89481,0.00900335,0.000172137,-4.50122e-07,3.89162e-10,-11694.6,10.6737], Tmin=(10,'K'), Tmax=(294.319,'K')),
+            NASAPolynomial(coeffs=[0.966709,0.0487989,-3.06844e-05,9.29936e-09,-1.08469e-12,-11522.2,21.2187], Tmin=(294.319,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-97.218,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 126,
     label = "r002513",
     molecule = 
 """
@@ -1521,7 +4483,144 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 44,
+    index = 127,
+    label = "r002594",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {5,D}
+3  N u0 p1 c0 {5,S} {9,S} {10,S}
+4  C u0 p0 c0 {1,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,S} {2,D} {3,S}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.55649,0.0447116,-0.000156842,3.70957e-07,-2.9886e-10,-51633.3,10.1328], Tmin=(10,'K'), Tmax=(440.297,'K')),
+            NASAPolynomial(coeffs=[1.0653,0.0362349,-2.19834e-05,6.2943e-09,-6.92228e-13,-51112.4,23.5321], Tmin=(440.297,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-429.312,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 128,
+    label = "r002675",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3  C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  C u0 p0 c0 {1,D} {2,S} {11,S}
+6  H u0 p0 c0 {2,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.98716,0.00059573,0.00011649,-2.03868e-07,1.16084e-10,-9520.51,9.61522], Tmin=(10,'K'), Tmax=(453.162,'K')),
+            NASAPolynomial(coeffs=[-0.950031,0.0441715,-2.77354e-05,8.28798e-09,-9.47028e-13,-9073,29.527], Tmin=(453.162,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-79.1653,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (253.591,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 129,
+    label = "r002689",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+5  C u0 p0 c0 {1,D} {3,S} {6,S}
+6  C u0 p0 c0 {2,T} {5,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.39264,0.0507281,-0.000100584,1.38285e-07,-7.38699e-11,-6543.14,10.6187], Tmin=(10,'K'), Tmax=(594.114,'K')),
+            NASAPolynomial(coeffs=[3.93055,0.0326331,-1.83561e-05,5.01055e-09,-5.3429e-13,-6351.62,10.4535], Tmin=(594.114,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-54.4522,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 130,
+    label = "r002760",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,D}
+2 O u0 p2 c0 {5,D}
+3 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4 C u0 p0 c0 {1,D} {3,S} {5,S}
+5 C u0 p0 c0 {2,D} {4,S} {9,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+9 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.69446,0.0349524,-0.000138541,4.32315e-07,-4.46542e-10,-34925.8,9.64959], Tmin=(10,'K'), Tmax=(353.752,'K')),
+            NASAPolynomial(coeffs=[1.59971,0.0329829,-2.14034e-05,6.5481e-09,-7.62926e-13,-34617.1,19.8477], Tmin=(353.752,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-290.406,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (199.547,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 131,
     label = "r002774",
     molecule = 
 """
@@ -1552,7 +4651,146 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 45,
+    index = 132,
+    label = "r002801",
+    molecule = 
+"""
+1  O u0 p2 c0 {3,S} {4,S}
+2  O u0 p2 c0 {6,D}
+3  C u0 p0 c0 {1,S} {4,S} {6,S} {7,S}
+4  C u0 p0 c0 {1,S} {3,S} {8,S} {9,S}
+5  C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+6  C u0 p0 c0 {2,D} {3,S} {5,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.81324,0.0238081,2.59734e-05,-4.8698e-08,2.02206e-11,-28175,10.6668], Tmin=(10,'K'), Tmax=(883.013,'K')),
+            NASAPolynomial(coeffs=[4.43505,0.0360151,-2.02844e-05,5.49467e-09,-5.77845e-13,-28870.5,4.42775], Tmin=(883.013,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-234.238,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 133,
+    label = "r002874",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,D}
+2 C u0 p0 c0 {3,S} {6,S} {7,S} {8,S}
+3 C u0 p0 c0 {1,D} {2,S} {4,S}
+4 C u0 p0 c0 {3,S} {5,T}
+5 C u0 p0 c0 {4,T} {9,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {2,S}
+8 H u0 p0 c0 {2,S}
+9 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.88407,0.0120773,0.00012427,-5.57224e-07,8.4074e-10,7322.67,9.36884], Tmin=(10,'K'), Tmax=(167.007,'K')),
+            NASAPolynomial(coeffs=[3.22964,0.0277516,-1.65136e-05,4.76504e-09,-5.32777e-13,7344.53,11.3548], Tmin=(167.007,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (60.9552,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (203.705,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 134,
+    label = "r002881",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  O u0 p2 c0 {6,D}
+3  C u0 p0 c0 {5,S} {10,S} {11,S} {12,S}
+4  C u0 p0 c0 {6,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,D} {3,S} {6,S}
+6  C u0 p0 c0 {2,D} {4,S} {5,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.473,0.0575986,-0.000215741,5.62256e-07,-5.08033e-10,-42054.3,10.3215], Tmin=(10,'K'), Tmax=(384.753,'K')),
+            NASAPolynomial(coeffs=[1.71872,0.0423904,-2.60572e-05,7.65275e-09,-8.6446e-13,-41671.8,20.3264], Tmin=(384.753,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-349.68,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 135,
+    label = "r003070",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {5,S} {9,S} {10,S}
+3  N u0 p1 c0 {6,T}
+4  C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,D} {2,S} {4,S}
+6  C u0 p0 c0 {3,T} {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.84074,0.0107791,0.000142598,-3.63598e-07,2.71162e-10,-12665.7,11.0067], Tmin=(10,'K'), Tmax=(464.531,'K')),
+            NASAPolynomial(coeffs=[4.70602,0.0324552,-2.14478e-05,6.80898e-09,-8.25114e-13,-13060.3,4.1131], Tmin=(464.531,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-105.332,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 136,
     label = "r003183",
     molecule = 
 """
@@ -1584,7 +4822,211 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 46,
+    index = 137,
+    label = "r003195",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {10,S}
+2  O u0 p2 c0 {5,D}
+3  O u0 p2 c0 {6,D}
+4  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {2,D} {4,S} {8,S}
+6  C u0 p0 c0 {3,D} {4,S} {9,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {6,S}
+10 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.74977,0.0247196,2.20066e-05,-4.77242e-08,2.04272e-11,-53024.4,10.2329], Tmin=(10,'K'), Tmax=(895.361,'K')),
+            NASAPolynomial(coeffs=[5.7407,0.0331994,-2.13069e-05,6.19885e-09,-6.80393e-13,-54077.3,-3.0412], Tmin=(895.361,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-440.867,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (220.334,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 138,
+    label = "r003323",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,D}
+2 N u0 p1 c0 {5,T}
+3 C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4 C u0 p0 c0 {1,D} {3,S} {8,S}
+5 C u0 p0 c0 {2,T} {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.82658,0.0160054,2.92058e-05,-9.68375e-08,8.66392e-11,-2633.01,9.89265], Tmin=(10,'K'), Tmax=(290.304,'K')),
+            NASAPolynomial(coeffs=[3.20775,0.0245321,-1.48516e-05,4.33775e-09,-4.89482e-13,-2597.08,12.1128], Tmin=(290.304,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-21.8957,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 139,
+    label = "r003344",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {4,S} {5,S} {9,S}
+3  N u0 p1 c0 {5,S} {10,S} {11,S}
+4  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,D} {2,S} {3,S}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.63726,0.0344771,-4.61877e-05,8.11645e-08,-6.12713e-11,-29710.5,10.3702], Tmin=(10,'K'), Tmax=(472.283,'K')),
+            NASAPolynomial(coeffs=[2.51988,0.0351889,-2.06523e-05,5.88224e-09,-6.51344e-13,-29507.3,15.956], Tmin=(472.283,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-247.04,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 140,
+    label = "r003348",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,D}
+2 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3 C u0 p0 c0 {1,D} {2,S} {7,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.9738,0.00137426,3.91207e-05,-5.62547e-08,2.61134e-11,-21449.8,7.33205], Tmin=(10,'K'), Tmax=(556.409,'K')),
+            NASAPolynomial(coeffs=[1.45062,0.0195144,-9.78575e-06,2.34672e-09,-2.18451e-13,-21169.1,18.0256], Tmin=(556.409,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-178.358,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (153.818,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 141,
+    label = "r003431",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {5,S} {6,S} {10,S}
+4  C u0 p0 c0 {5,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,D} {3,S} {4,S}
+6  C u0 p0 c0 {2,D} {3,S} {11,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.60031,0.0374981,-6.70704e-05,1.41011e-07,-1.11264e-10,-46539.6,10.9125], Tmin=(10,'K'), Tmax=(470.791,'K')),
+            NASAPolynomial(coeffs=[1.27367,0.0407993,-2.51236e-05,7.31808e-09,-8.18792e-13,-46138,22.3225], Tmin=(470.791,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-386.964,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 142,
+    label = "r003437",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {6,S} {12,S} {13,S}
+3  C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {8,S} {9,S}
+5  C u0 p0 c0 {3,S} {4,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,D} {2,S} {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.86464,0.00813316,0.000159056,-3.22649e-07,1.96944e-10,-18461.2,10.6957], Tmin=(10,'K'), Tmax=(546.587,'K')),
+            NASAPolynomial(coeffs=[2.6327,0.0472492,-3.08953e-05,9.78597e-09,-1.18889e-12,-18776.1,11.7818], Tmin=(546.587,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-153.545,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 143,
     label = "r003454",
     molecule = 
 """
@@ -1620,7 +5062,116 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 47,
+    index = 144,
+    label = "r003718",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  C u0 p0 c0 {4,S} {7,S} {8,S} {9,S}
+3  C u0 p0 c0 {5,S} {10,S} {11,S} {12,S}
+4  C u0 p0 c0 {1,D} {2,S} {6,S}
+5  C u0 p0 c0 {3,S} {6,T}
+6  C u0 p0 c0 {4,S} {5,T}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.47135,0.0533914,-0.000144443,3.05137e-07,-2.36598e-10,1183.86,10.884], Tmin=(10,'K'), Tmax=(436.519,'K')),
+            NASAPolynomial(coeffs=[2.61691,0.0396432,-2.30532e-05,6.50584e-09,-7.14081e-13,1464.04,16.6527], Tmin=(436.519,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (9.8301,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (278.535,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 145,
+    label = "r003937",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {4,S} {5,S} {9,S}
+3  N u0 p1 c0 {6,T}
+4  C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,D} {2,S} {10,S}
+6  C u0 p0 c0 {3,T} {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.70695,0.0294465,-1.20901e-05,-1.21261e-09,1.48383e-12,-5883.48,11.6657], Tmin=(10,'K'), Tmax=(1193.54,'K')),
+            NASAPolynomial(coeffs=[7.57607,0.0226921,-1.1409e-05,2.76799e-09,-2.63426e-13,-7249.56,-9.53882], Tmin=(1193.54,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-48.9316,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 146,
+    label = "r003958",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {4,S} {6,S} {14,S}
+3  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  C u0 p0 c0 {3,S} {11,S} {12,S} {13,S}
+6  C u0 p0 c0 {1,D} {2,S} {15,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {5,S}
+14 H u0 p0 c0 {2,S}
+15 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.47497,0.0545043,-0.000138611,3.36993e-07,-2.87593e-10,-31232.3,13.0289], Tmin=(10,'K'), Tmax=(425.326,'K')),
+            NASAPolynomial(coeffs=[0.591341,0.0527895,-3.08737e-05,8.73228e-09,-9.59117e-13,-30726.2,27.5414], Tmin=(425.326,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-259.694,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (340.893,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 147,
     label = "r004006",
     molecule = 
 """
@@ -1652,7 +5203,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 48,
+    index = 148,
     label = "r004142",
     molecule = 
 """
@@ -1685,7 +5236,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 49,
+    index = 149,
     label = "r004202",
     molecule = 
 """
@@ -1716,7 +5267,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 50,
+    index = 150,
     label = "r004295",
     molecule = 
 """
@@ -1750,7 +5301,183 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 51,
+    index = 151,
+    label = "r004414",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3  C u0 p0 c0 {2,S} {8,S} {9,S} {10,S}
+4  C u0 p0 c0 {1,D} {2,S} {11,S}
+5  C u0 p0 c0 {2,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.91508,0.0112862,0.000457476,-3.21785e-06,7.51634e-09,5274.03,8.95723], Tmin=(10,'K'), Tmax=(136.224,'K')),
+            NASAPolynomial(coeffs=[3.52911,0.0387889,-2.34075e-05,6.86935e-09,-7.81649e-13,5269.55,9.49926], Tmin=(136.224,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (46.4775,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 152,
+    label = "r004467",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  C u0 p0 c0 {3,S} {4,S} {7,S} {8,S}
+3  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {1,D} {2,S} {5,S}
+5  C u0 p0 c0 {4,S} {6,T}
+6  C u0 p0 c0 {5,T} {12,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.40686,0.048024,-6.72642e-05,7.40868e-08,-3.50097e-11,4113.55,10.6937], Tmin=(10,'K'), Tmax=(640.639,'K')),
+            NASAPolynomial(coeffs=[4.02415,0.0360872,-2.03903e-05,5.6148e-09,-6.04314e-13,4200.32,9.28502], Tmin=(640.639,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (34.1374,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 153,
+    label = "r004505",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4  C u0 p0 c0 {3,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {1,D} {3,S} {11,S}
+6  C u0 p0 c0 {2,T} {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.54716,0.0405001,-5.15858e-05,6.22935e-08,-3.54552e-11,-6622.96,10.5931], Tmin=(10,'K'), Tmax=(523.891,'K')),
+            NASAPolynomial(coeffs=[3.81099,0.0339832,-2.00346e-05,5.73859e-09,-6.38722e-13,-6588.82,10.0805], Tmin=(523.891,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-55.0947,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (249.434,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 154,
+    label = "r004547",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {4,S} {5,S}
+3  C u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {6,S} {11,S} {12,S}
+6  C u0 p0 c0 {1,D} {5,S} {13,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.95837,0.0223625,3.26208e-05,-5.00299e-08,1.82748e-11,654.574,10.4751], Tmin=(10,'K'), Tmax=(1005.87,'K')),
+            NASAPolynomial(coeffs=[5.68131,0.036315,-1.92095e-05,4.88371e-09,-4.83862e-13,-744.487,-3.07867], Tmin=(1005.87,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (5.52696,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 155,
+    label = "r004643",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,D}
+2 N u0 p1 c0 {5,T}
+3 C u0 p0 c0 {4,S} {6,S} {7,S} {8,S}
+4 C u0 p0 c0 {1,D} {3,S} {5,S}
+5 C u0 p0 c0 {2,T} {4,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.72633,0.0225271,-1.25847e-05,3.22993e-09,-2.80997e-13,-3217.6,9.56394], Tmin=(10,'K'), Tmax=(1573.86,'K')),
+            NASAPolynomial(coeffs=[8.36858,0.0129527,-5.57914e-06,1.1603e-09,-9.4861e-14,-4954.29,-15.8127], Tmin=(1573.86,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-26.7934,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (178.761,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 156,
     label = "r004717",
     molecule = 
 """
@@ -1782,7 +5509,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 52,
+    index = 157,
     label = "r004749",
     molecule = 
 """
@@ -1817,7 +5544,118 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 53,
+    index = 158,
+    label = "r004778",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {3,S} {5,S} {12,S}
+3  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+4  C u0 p0 c0 {5,S} {6,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,D} {2,S} {4,S}
+6  H u0 p0 c0 {4,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {3,S}
+11 H u0 p0 c0 {3,S}
+12 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.75728,0.0207672,2.84138e-05,-5.1798e-08,2.31406e-11,-30315.1,12.1033], Tmin=(10,'K'), Tmax=(737.639,'K')),
+            NASAPolynomial(coeffs=[1.69568,0.0386948,-2.17646e-05,5.95453e-09,-6.36117e-13,-30194.6,20.1776], Tmin=(737.639,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-252.079,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 159,
+    label = "r004794",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {4,S} {6,S}
+3  C u0 p0 c0 {2,S} {13,S} {14,S} {15,S}
+4  C u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {6,S} {10,S} {11,S} {12,S}
+6  C u0 p0 c0 {1,D} {2,S} {5,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.34487,0.0665201,-0.000210814,4.64385e-07,-3.56138e-10,-29752.7,10.098], Tmin=(10,'K'), Tmax=(452.99,'K')),
+            NASAPolynomial(coeffs=[0.946242,0.0493713,-2.71084e-05,7.23555e-09,-7.55435e-13,-29142.1,24.1112], Tmin=(452.99,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-247.389,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (340.893,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 160,
+    label = "r004852",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  O u0 p2 c0 {6,D}
+3  C u0 p0 c0 {4,S} {5,S} {7,S} {8,S}
+4  C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+5  C u0 p0 c0 {1,D} {3,S} {6,S}
+6  C u0 p0 c0 {2,D} {5,S} {12,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.44288,0.0523764,-0.000114382,2.08001e-07,-1.47095e-10,-37951.7,10.7976], Tmin=(10,'K'), Tmax=(467.571,'K')),
+            NASAPolynomial(coeffs=[2.99662,0.0402857,-2.45591e-05,7.16459e-09,-8.05502e-13,-37736.1,14.4709], Tmin=(467.571,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-315.567,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (270.22,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 161,
     label = "r005102",
     molecule = 
 """
@@ -1850,7 +5688,184 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 54,
+    index = 162,
+    label = "r005118",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {6,S}
+2  O u0 p2 c0 {6,D}
+3  N u0 p1 c0 {4,S} {6,S} {13,S}
+4  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,S} {10,S} {11,S} {12,S}
+6  C u0 p0 c0 {1,S} {2,D} {3,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.46811,0.0481552,-0.000102156,1.9927e-07,-1.40875e-10,-51420,11.2306], Tmin=(10,'K'), Tmax=(511.451,'K')),
+            NASAPolynomial(coeffs=[0.318229,0.0479002,-2.84103e-05,7.99232e-09,-8.67504e-13,-50772.3,27.4974], Tmin=(511.451,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-427.547,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (291.007,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 163,
+    label = "r005148",
+    molecule = 
+"""
+1 O u0 p2 c0 {4,S} {5,S}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {5,S} {6,S} {7,S}
+4 N u0 p1 c0 {1,S} {6,D}
+5 C u0 p0 c0 {1,S} {2,D} {3,S}
+6 C u0 p0 c0 {3,S} {4,D} {8,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.0797,-0.00780614,0.000140519,-2.48772e-07,1.39155e-10,-17804.1,9.72764], Tmin=(10,'K'), Tmax=(582.348,'K')),
+            NASAPolynomial(coeffs=[1.9372,0.0308663,-2.0798e-05,6.54341e-09,-7.76664e-13,-17960.8,15.4178], Tmin=(582.348,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-148.049,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (182.918,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 164,
+    label = "r005196",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  C u0 p0 c0 {4,S} {8,S} {9,S} {10,S}
+3  C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4  C u0 p0 c0 {1,D} {2,S} {3,S}
+5  H u0 p0 c0 {3,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.73713,0.0305419,-0.000127759,3.76111e-07,-3.44699e-10,-27937.5,8.94659], Tmin=(10,'K'), Tmax=(410.113,'K')),
+            NASAPolynomial(coeffs=[0.128924,0.0331953,-1.84518e-05,4.96363e-09,-5.19954e-13,-27367.9,26.4742], Tmin=(410.113,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-232.297,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (224.491,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 165,
+    label = "r005308",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {4,S} {6,S} {14,S}
+3  N u0 p1 c0 {5,S} {6,S} {13,S}
+4  C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+5  C u0 p0 c0 {3,S} {7,S} {8,S} {9,S}
+6  C u0 p0 c0 {1,D} {2,S} {3,S}
+7  H u0 p0 c0 {5,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {4,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.25423,0.0760547,-0.000274043,6.00408e-07,-4.60214e-10,-29305.2,9.98099], Tmin=(10,'K'), Tmax=(441.735,'K')),
+            NASAPolynomial(coeffs=[1.92586,0.0454705,-2.54875e-05,6.90731e-09,-7.29287e-13,-28772.1,20.0101], Tmin=(441.735,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-243.672,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (315.95,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 166,
+    label = "r005356",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {12,S}
+2  O u0 p2 c0 {6,D}
+3  C u0 p0 c0 {4,S} {5,S} {6,S} {7,S}
+4  C u0 p0 c0 {1,S} {3,S} {5,S} {8,S}
+5  C u0 p0 c0 {3,S} {4,S} {9,S} {10,S}
+6  C u0 p0 c0 {2,D} {3,S} {11,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.87516,0.00724038,0.000146596,-2.83682e-07,1.63999e-10,-29128.1,10.0984], Tmin=(10,'K'), Tmax=(576.932,'K')),
+            NASAPolynomial(coeffs=[2.28834,0.0472386,-3.27874e-05,1.07178e-08,-1.32124e-12,-29427.6,12.6988], Tmin=(576.932,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-242.238,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 167,
     label = "r005432",
     molecule = 
 """
@@ -1884,7 +5899,41 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 55,
+    index = 168,
+    label = "r005491",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  N u0 p1 c0 {3,S} {4,S} {9,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {6,S}
+4  C u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
+5  C u0 p0 c0 {1,D} {3,S} {10,S}
+6  H u0 p0 c0 {3,S}
+7  H u0 p0 c0 {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {2,S}
+10 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.96531,0.00221584,0.000108049,-2.05358e-07,1.26945e-10,-855.051,9.54708], Tmin=(10,'K'), Tmax=(417.228,'K')),
+            NASAPolynomial(coeffs=[0.119742,0.0391509,-2.49797e-05,7.58813e-09,-8.82236e-13,-534.741,24.7312], Tmin=(417.228,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-7.11776,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 169,
     label = "r005546",
     molecule = 
 """
@@ -1918,7 +5967,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 56,
+    index = 170,
     label = "r005588",
     molecule = 
 """
@@ -1951,7 +6000,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 57,
+    index = 171,
     label = "r005763",
     molecule = 
 """
@@ -1983,7 +6032,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 58,
+    index = 172,
     label = "r005826",
     molecule = 
 """
@@ -2015,7 +6064,227 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 59,
+    index = 173,
+    label = "r005998",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {4,S} {5,S}
+3  C u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+4  C u0 p0 c0 {2,S} {3,S} {8,S} {9,S}
+5  C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+6  C u0 p0 c0 {1,D} {3,S} {13,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.89968,0.00631904,0.000157636,-3.23814e-07,2.0661e-10,-1145.33,10.5234], Tmin=(10,'K'), Tmax=(498.142,'K')),
+            NASAPolynomial(coeffs=[1.06053,0.0490965,-3.13373e-05,9.60521e-09,-1.12973e-12,-1110.36,19.754], Tmin=(498.142,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-9.55095,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 174,
+    label = "r006089",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  N u0 p1 c0 {3,S} {4,S} {12,S}
+3  C u0 p0 c0 {2,S} {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {2,S} {3,S} {6,S} {8,S}
+5  C u0 p0 c0 {3,S} {9,S} {10,S} {11,S}
+6  C u0 p0 c0 {1,D} {4,S} {13,S}
+7  H u0 p0 c0 {3,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {2,S}
+13 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.90261,0.0066036,0.000166565,-3.7089e-07,2.60543e-10,-4735.23,10.5242], Tmin=(10,'K'), Tmax=(442.96,'K')),
+            NASAPolynomial(coeffs=[1.07345,0.0485043,-3.06995e-05,9.34132e-09,-1.09103e-12,-4645.03,20.0585], Tmin=(442.96,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-39.3819,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 175,
+    label = "r006263",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {7,S}
+3  C u0 p0 c0 {2,S} {4,S} {6,S} {8,S}
+4  C u0 p0 c0 {2,S} {3,S} {9,S} {10,S}
+5  C u0 p0 c0 {2,S} {11,S} {12,S} {13,S}
+6  C u0 p0 c0 {1,D} {3,S} {14,S}
+7  H u0 p0 c0 {2,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {5,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {5,S}
+14 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.79939,0.0257272,3.35591e-05,-5.66387e-08,2.24546e-11,-13112.8,10.0042], Tmin=(10,'K'), Tmax=(904.437,'K')),
+            NASAPolynomial(coeffs=[3.58758,0.04353,-2.39389e-05,6.36208e-09,-6.59015e-13,-13764.3,7.19114], Tmin=(904.437,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-108.999,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (324.264,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 176,
+    label = "r006320",
+    molecule = 
+"""
+1 O u0 p2 c0 {5,S} {6,S}
+2 O u0 p2 c0 {5,D}
+3 N u0 p1 c0 {4,S} {5,S} {7,S}
+4 C u0 p0 c0 {3,S} {6,D} {8,S}
+5 C u0 p0 c0 {1,S} {2,D} {3,S}
+6 C u0 p0 c0 {1,S} {4,D} {9,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {4,S}
+9 H u0 p0 c0 {6,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.0933,-0.00914814,0.000160807,-2.86387e-07,1.61867e-10,-31226.3,9.75233], Tmin=(10,'K'), Tmax=(573.958,'K')),
+            NASAPolynomial(coeffs=[1.55657,0.0348779,-2.3108e-05,7.21398e-09,-8.53207e-13,-31369.1,16.8016], Tmin=(573.958,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-259.65,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (207.862,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 177,
+    label = "r006396",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {6,S} {7,S}
+3  O u0 p2 c0 {7,D}
+4  C u0 p0 c0 {1,S} {7,S} {8,S} {9,S}
+5  C u0 p0 c0 {1,S} {13,S} {14,S} {15,S}
+6  C u0 p0 c0 {2,S} {10,S} {11,S} {12,S}
+7  C u0 p0 c0 {2,S} {3,D} {4,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {5,S}
+14 H u0 p0 c0 {5,S}
+15 H u0 p0 c0 {5,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.1275,0.0765231,-0.000199038,3.42298e-07,-2.13476e-10,-66436.3,12.6431], Tmin=(10,'K'), Tmax=(541.259,'K')),
+            NASAPolynomial(coeffs=[1.34206,0.0527094,-3.04805e-05,8.36136e-09,-8.87152e-13,-65700.9,25.1686], Tmin=(541.259,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-552.42,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (336.736,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 178,
+    label = "r006798",
+    molecule = 
+"""
+1  O u0 p2 c0 {6,D}
+2  O u0 p2 c0 {7,D}
+3  N u0 p1 c0 {4,S} {5,S} {7,S}
+4  C u0 p0 c0 {3,S} {5,S} {6,S} {8,S}
+5  C u0 p0 c0 {3,S} {4,S} {9,S} {10,S}
+6  C u0 p0 c0 {1,D} {4,S} {11,S}
+7  C u0 p0 c0 {2,D} {3,S} {12,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.61896,0.0310019,1.38437e-05,-4.18429e-08,1.98312e-11,-15632.7,9.8542], Tmin=(10,'K'), Tmax=(790.923,'K')),
+            NASAPolynomial(coeffs=[3.58678,0.041322,-2.49921e-05,7.12884e-09,-7.80492e-13,-15945.3,7.99349], Tmin=(790.923,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-130.021,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (274.378,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 179,
     label = "r007269",
     molecule = 
 """
@@ -2049,7 +6318,43 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 60,
+    index = 180,
+    label = "r007773",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,D}
+2  N u0 p1 c0 {6,S} {7,S} {11,S}
+3  N u0 p1 c0 {4,S} {7,S} {12,S}
+4  N u0 p1 c0 {3,S} {6,D}
+5  C u0 p0 c0 {6,S} {8,S} {9,S} {10,S}
+6  C u0 p0 c0 {2,S} {4,D} {5,S}
+7  C u0 p0 c0 {1,D} {2,S} {3,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {5,S}
+11 H u0 p0 c0 {2,S}
+12 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.83021,0.0138801,0.000103183,-2.19465e-07,1.39626e-10,-10282.8,10.7154], Tmin=(10,'K'), Tmax=(498.756,'K')),
+            NASAPolynomial(coeffs=[1.65741,0.0443936,-2.79465e-05,8.42273e-09,-9.74057e-13,-10228.9,18.0545], Tmin=(498.756,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-85.5207,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (278.535,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 181,
     label = "r007945",
     molecule = 
 """
@@ -2083,7 +6388,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 61,
+    index = 182,
     label = "r008828",
     molecule = 
 """
@@ -2120,7 +6425,80 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 62,
+    index = 183,
+    label = "r009289",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  C u0 p0 c0 {3,S} {4,S} {5,S} {8,S}
+3  C u0 p0 c0 {2,S} {12,S} {13,S} {14,S}
+4  C u0 p0 c0 {2,S} {9,S} {10,S} {11,S}
+5  C u0 p0 c0 {1,D} {2,S} {6,S}
+6  C u0 p0 c0 {5,S} {7,T}
+7  C u0 p0 c0 {6,T} {15,S}
+8  H u0 p0 c0 {2,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {3,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.37801,0.0505732,-3.17767e-05,1.00978e-08,-1.28997e-12,598.192,12.7676], Tmin=(10,'K'), Tmax=(1541.05,'K')),
+            NASAPolynomial(coeffs=[11.6551,0.0307784,-1.41538e-05,3.18545e-09,-2.84018e-13,-2153.52,-31.3951], Tmin=(1541.05,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (4.9002,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (345.051,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 184,
+    label = "r009379",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,D}
+2  N u0 p1 c0 {6,T}
+3  C u0 p0 c0 {4,S} {5,S} {8,S} {9,S}
+4  C u0 p0 c0 {1,D} {3,S} {6,S}
+5  C u0 p0 c0 {3,S} {7,T}
+6  C u0 p0 c0 {2,T} {4,S}
+7  C u0 p0 c0 {5,T} {10,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.72675,0.0266593,0.000106216,-4.98068e-07,6.14774e-10,28496.2,12.733], Tmin=(10,'K'), Tmax=(289.873,'K')),
+            NASAPolynomial(coeffs=[4.45768,0.0340904,-2.28844e-05,7.31646e-09,-8.89663e-13,28380.2,8.84239], Tmin=(289.873,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (236.962,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 185,
     label = "r009513",
     molecule = 
 """
@@ -2156,7 +6534,118 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 63,
+    index = 186,
+    label = "r009772",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {13,S}
+2  O u0 p2 c0 {5,D}
+3  C u0 p0 c0 {5,S} {6,S} {8,S} {9,S}
+4  C u0 p0 c0 {1,S} {7,S} {10,S} {11,S}
+5  C u0 p0 c0 {2,D} {3,S} {12,S}
+6  C u0 p0 c0 {3,S} {7,T}
+7  C u0 p0 c0 {4,S} {6,T}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {3,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {4,S}
+12 H u0 p0 c0 {5,S}
+13 H u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.39971,0.0588001,-0.000124397,2.24483e-07,-1.62875e-10,-12685.8,12.3694], Tmin=(10,'K'), Tmax=(438.48,'K')),
+            NASAPolynomial(coeffs=[3.71663,0.0429733,-2.60032e-05,7.60365e-09,-8.59888e-13,-12589.2,12.5198], Tmin=(438.48,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-105.493,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (299.321,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 187,
+    label = "r009945",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,D}
+2  O u0 p2 c0 {6,D}
+3  O u0 p2 c0 {7,D}
+4  C u0 p0 c0 {5,S} {8,S} {9,S} {10,S}
+5  C u0 p0 c0 {1,D} {4,S} {6,S}
+6  C u0 p0 c0 {2,D} {5,S} {7,S}
+7  C u0 p0 c0 {3,D} {6,S} {11,S}
+8  H u0 p0 c0 {4,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+11 H u0 p0 c0 {7,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.15066,0.0823308,-0.000280165,5.23265e-07,-3.57862e-10,-46049.6,10.3415], Tmin=(10,'K'), Tmax=(458.584,'K')),
+            NASAPolynomial(coeffs=[5.71541,0.031094,-1.81544e-05,5.10699e-09,-5.57385e-13,-45981.3,3.2769], Tmin=(458.584,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-382.899,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (245.277,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 188,
+    label = "r010345",
+    molecule = 
+"""
+1  O u0 p2 c0 {7,D}
+2  N u0 p1 c0 {4,S} {5,S} {13,S}
+3  N u0 p1 c0 {7,S} {14,S} {15,S}
+4  C u0 p0 c0 {2,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {2,S} {4,S} {8,S} {9,S}
+6  C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  C u0 p0 c0 {1,D} {3,S} {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {2,S}
+14 H u0 p0 c0 {3,S}
+15 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.76587,0.0185473,0.000164042,-3.92394e-07,2.82824e-10,-15338,10.4026], Tmin=(10,'K'), Tmax=(444.339,'K')),
+            NASAPolynomial(coeffs=[1.54928,0.0584459,-3.79761e-05,1.17231e-08,-1.38113e-12,-15337.9,17.0828], Tmin=(444.339,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-127.545,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (345.051,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 189,
     label = "r010419",
     molecule = 
 """
@@ -2193,7 +6682,79 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 64,
+    index = 190,
+    label = "r010564",
+    molecule = 
+"""
+1  O u0 p2 c0 {4,S} {5,S}
+2  O u0 p2 c0 {7,D}
+3  N u0 p1 c0 {7,S} {13,S} {14,S}
+4  C u0 p0 c0 {1,S} {5,S} {6,S} {7,S}
+5  C u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+6  C u0 p0 c0 {4,S} {10,S} {11,S} {12,S}
+7  C u0 p0 c0 {2,D} {3,S} {4,S}
+8  H u0 p0 c0 {5,S}
+9  H u0 p0 c0 {5,S}
+10 H u0 p0 c0 {6,S}
+11 H u0 p0 c0 {6,S}
+12 H u0 p0 c0 {6,S}
+13 H u0 p0 c0 {3,S}
+14 H u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.68656,0.028609,6.8426e-05,-1.47108e-07,8.07383e-11,-37127.5,10.55], Tmin=(10,'K'), Tmax=(636.768,'K')),
+            NASAPolynomial(coeffs=[3.62428,0.0500262,-3.15552e-05,9.42363e-09,-1.07592e-12,-37545.8,7.47521], Tmin=(636.768,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-308.738,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (320.107,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 191,
+    label = "r011399",
+    molecule = 
+"""
+1  O u0 p2 c0 {5,S} {7,S}
+2  O u0 p2 c0 {7,D}
+3  N u0 p1 c0 {6,S} {7,S} {8,S}
+4  N u0 p1 c0 {6,S} {9,S} {10,S}
+5  N u0 p1 c0 {1,S} {6,D}
+6  C u0 p0 c0 {3,S} {4,S} {5,D}
+7  C u0 p0 c0 {1,S} {2,D} {3,S}
+8  H u0 p0 c0 {3,S}
+9  H u0 p0 c0 {4,S}
+10 H u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.87916,0.00725781,0.000128337,-2.66523e-07,1.64035e-10,-19723.5,11.2851], Tmin=(10,'K'), Tmax=(550.334,'K')),
+            NASAPolynomial(coeffs=[3.50068,0.0368306,-2.53731e-05,8.23851e-09,-1.01077e-12,-20088,9.19478], Tmin=(550.334,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-164.036,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (228.648,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 192,
     label = "r011443",
     molecule = 
 """
@@ -2228,7 +6789,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 65,
+    index = 193,
     label = "r011506",
     molecule = 
 """
@@ -2263,7 +6824,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 66,
+    index = 194,
     label = "r011937",
     molecule = 
 """

--- a/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
+++ b/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
@@ -604,6 +604,64 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 
 entry(
     index = 16,
+    label = "p001091_0",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,D}
+2 N u0 p1 c0 {3,D} {4,S}
+3 C u0 p0 c0 {1,D} {2,D}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.98565,0.000809807,2.38288e-05,-4.13856e-08,2.21924e-11,-15775.5,4.98696], Tmin=(10,'K'), Tmax=(587.751,'K')),
+            NASAPolynomial(coeffs=[3.21484,0.00929968,-6.11737e-06,1.97211e-09,-2.44116e-13,-15740.9,7.81935], Tmin=(587.751,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-131.172,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (83.1447,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 17,
+    label = "p001091_1",
+    molecule = 
+"""
+1 O u0 p2 c0 {3,S} {5,S}
+2 N u0 p1 c0 {3,D} {6,S}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[4.03412,-0.00275045,5.5691e-05,-8.33609e-08,3.96279e-11,-17161.3,7.11129], Tmin=(10,'K'), Tmax=(659.917,'K')),
+            NASAPolynomial(coeffs=[1.85443,0.01866,-1.16107e-05,3.45518e-09,-3.93126e-13,-17052.1,15.3685], Tmin=(659.917,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (-142.687,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (128.874,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 18,
     label = "p001147",
     molecule = 
 """
@@ -640,7 +698,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 17,
+    index = 19,
     label = "p001169",
     molecule = 
 """
@@ -672,7 +730,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 18,
+    index = 20,
     label = "p001235",
     molecule = 
 """
@@ -704,7 +762,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 19,
+    index = 21,
     label = "p001357",
     molecule = 
 """
@@ -743,7 +801,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 20,
+    index = 22,
     label = "p001387",
     molecule = 
 """
@@ -781,7 +839,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 21,
+    index = 23,
     label = "p001388",
     molecule = 
 """
@@ -819,7 +877,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 22,
+    index = 24,
     label = "p001614",
     molecule = 
 """
@@ -854,7 +912,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 23,
+    index = 25,
     label = "p001615",
     molecule = 
 """
@@ -889,7 +947,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 24,
+    index = 26,
     label = "p001627",
     molecule = 
 """
@@ -924,7 +982,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 25,
+    index = 27,
     label = "p001958",
     molecule = 
 """
@@ -956,7 +1014,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 26,
+    index = 28,
     label = "p002203",
     molecule = 
 """
@@ -993,7 +1051,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 27,
+    index = 29,
     label = "p002204",
     molecule = 
 """
@@ -1030,7 +1088,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 28,
+    index = 30,
     label = "p002312",
     molecule = 
 """
@@ -1067,7 +1125,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 29,
+    index = 31,
     label = "p002513",
     molecule = 
 """
@@ -1098,7 +1156,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 30,
+    index = 32,
     label = "p002594",
     molecule = 
 """
@@ -1132,7 +1190,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 31,
+    index = 33,
     label = "p002675",
     molecule = 
 """
@@ -1167,7 +1225,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 32,
+    index = 34,
     label = "p002689",
     molecule = 
 """
@@ -1202,7 +1260,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 33,
+    index = 35,
     label = "p002760",
     molecule = 
 """
@@ -1235,7 +1293,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 34,
+    index = 36,
     label = "p002774",
     molecule = 
 """
@@ -1266,7 +1324,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 35,
+    index = 37,
     label = "p002801",
     molecule = 
 """
@@ -1302,7 +1360,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 36,
+    index = 38,
     label = "p002874",
     molecule = 
 """
@@ -1335,7 +1393,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 37,
+    index = 39,
     label = "p002881",
     molecule = 
 """
@@ -1371,7 +1429,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 38,
+    index = 40,
     label = "p003070",
     molecule = 
 """
@@ -1405,7 +1463,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 39,
+    index = 41,
     label = "p003183",
     molecule = 
 """
@@ -1437,7 +1495,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 40,
+    index = 42,
     label = "p003195",
     molecule = 
 """
@@ -1471,7 +1529,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 41,
+    index = 43,
     label = "p003323",
     molecule = 
 """
@@ -1503,7 +1561,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 42,
+    index = 44,
     label = "p003344",
     molecule = 
 """
@@ -1538,7 +1596,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 43,
+    index = 45,
     label = "p003346",
     molecule = 
 """
@@ -1573,7 +1631,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 44,
+    index = 46,
     label = "p003348",
     molecule = 
 """
@@ -1604,7 +1662,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 45,
+    index = 47,
     label = "p003431",
     molecule = 
 """
@@ -1639,7 +1697,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 46,
+    index = 48,
     label = "p003437",
     molecule = 
 """
@@ -1676,7 +1734,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 47,
+    index = 49,
     label = "p003440",
     molecule = 
 """
@@ -1713,7 +1771,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 48,
+    index = 50,
     label = "p003454",
     molecule = 
 """
@@ -1749,7 +1807,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 49,
+    index = 51,
     label = "p003718",
     molecule = 
 """
@@ -1785,7 +1843,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 50,
+    index = 52,
     label = "p003937",
     molecule = 
 """
@@ -1819,7 +1877,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 51,
+    index = 53,
     label = "p003958",
     molecule = 
 """
@@ -1858,7 +1916,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 52,
+    index = 54,
     label = "p004006",
     molecule = 
 """
@@ -1890,7 +1948,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 53,
+    index = 55,
     label = "p004007",
     molecule = 
 """
@@ -1922,7 +1980,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 54,
+    index = 56,
     label = "p004142",
     molecule = 
 """
@@ -1955,7 +2013,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 55,
+    index = 57,
     label = "p004295",
     molecule = 
 """
@@ -1989,7 +2047,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 56,
+    index = 58,
     label = "p004414",
     molecule = 
 """
@@ -2025,7 +2083,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 57,
+    index = 59,
     label = "p004467",
     molecule = 
 """
@@ -2061,7 +2119,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 58,
+    index = 60,
     label = "p004505",
     molecule = 
 """
@@ -2096,7 +2154,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 59,
+    index = 61,
     label = "p004547",
     molecule = 
 """
@@ -2133,7 +2191,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 60,
+    index = 62,
     label = "p004625",
     molecule = 
 """
@@ -2166,7 +2224,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 61,
+    index = 63,
     label = "p004643",
     molecule = 
 """
@@ -2198,7 +2256,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 62,
+    index = 64,
     label = "p004717",
     molecule = 
 """
@@ -2230,7 +2288,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 63,
+    index = 65,
     label = "p004719",
     molecule = 
 """
@@ -2262,7 +2320,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 64,
+    index = 66,
     label = "p004749",
     molecule = 
 """
@@ -2297,7 +2355,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 65,
+    index = 67,
     label = "p004778",
     molecule = 
 """
@@ -2333,7 +2391,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 66,
+    index = 68,
     label = "p004794",
     molecule = 
 """
@@ -2372,7 +2430,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 67,
+    index = 69,
     label = "p004852",
     molecule = 
 """
@@ -2408,7 +2466,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 68,
+    index = 70,
     label = "p005032",
     molecule = 
 """
@@ -2440,7 +2498,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 69,
+    index = 71,
     label = "p005102",
     molecule = 
 """
@@ -2473,7 +2531,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 70,
+    index = 72,
     label = "p005118",
     molecule = 
 """
@@ -2510,7 +2568,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 71,
+    index = 73,
     label = "p005148",
     molecule = 
 """
@@ -2542,7 +2600,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 72,
+    index = 74,
     label = "p005196",
     molecule = 
 """
@@ -2576,7 +2634,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 73,
+    index = 75,
     label = "p005308",
     molecule = 
 """
@@ -2614,7 +2672,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 74,
+    index = 76,
     label = "p005356",
     molecule = 
 """
@@ -2650,7 +2708,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 75,
+    index = 77,
     label = "p005432",
     molecule = 
 """
@@ -2684,7 +2742,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 76,
+    index = 78,
     label = "p005491",
     molecule = 
 """
@@ -2718,7 +2776,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 77,
+    index = 79,
     label = "p005546",
     molecule = 
 """
@@ -2752,7 +2810,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 78,
+    index = 80,
     label = "p005588",
     molecule = 
 """
@@ -2785,7 +2843,34 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 79,
+    index = 81,
+    label = "p005591_0",
+    molecule = 
+"""
+1 N u0 p1 c0 {2,T}
+2 C u0 p0 c0 {1,T} {3,S}
+3 H u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+        polynomials = [
+            NASAPolynomial(coeffs=[3.99634,0.000168319,4.75233e-06,-5.28777e-09,1.93772e-12,14028.4,-2.98844], Tmin=(10,'K'), Tmax=(693.882,'K')),
+            NASAPolynomial(coeffs=[3.54694,0.00275826,-8.44924e-07,8.84639e-11,1.24421e-15,14090.8,-0.984441], Tmin=(693.882,'K'), Tmax=(3000,'K')),
+        ],
+        Tmin = (10,'K'),
+        Tmax = (3000,'K'),
+        E0 = (116.638,'kJ/mol'),
+        Cp0 = (33.2579,'J/(mol*K)'),
+        CpInf = (58.2013,'J/(mol*K)'),
+    ),
+    shortDesc = """Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.""",
+    longDesc = 
+"""
+Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
+""",
+)
+
+entry(
+    index = 82,
     label = "p005763",
     molecule = 
 """
@@ -2817,7 +2902,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 80,
+    index = 83,
     label = "p005826",
     molecule = 
 """
@@ -2849,7 +2934,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 81,
+    index = 84,
     label = "p005998",
     molecule = 
 """
@@ -2886,7 +2971,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 82,
+    index = 85,
     label = "p006089",
     molecule = 
 """
@@ -2923,7 +3008,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 83,
+    index = 86,
     label = "p006263",
     molecule = 
 """
@@ -2961,7 +3046,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 84,
+    index = 87,
     label = "p006320",
     molecule = 
 """
@@ -2994,7 +3079,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 85,
+    index = 88,
     label = "p006396",
     molecule = 
 """
@@ -3033,7 +3118,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 86,
+    index = 89,
     label = "p006798",
     molecule = 
 """
@@ -3069,7 +3154,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 87,
+    index = 90,
     label = "p007269",
     molecule = 
 """
@@ -3103,7 +3188,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 88,
+    index = 91,
     label = "p007773",
     molecule = 
 """
@@ -3139,7 +3224,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 89,
+    index = 92,
     label = "p007777",
     molecule = 
 """
@@ -3175,7 +3260,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 90,
+    index = 93,
     label = "p007945",
     molecule = 
 """
@@ -3209,7 +3294,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 91,
+    index = 94,
     label = "p008828",
     molecule = 
 """
@@ -3246,7 +3331,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 92,
+    index = 95,
     label = "p009289",
     molecule = 
 """
@@ -3285,7 +3370,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 93,
+    index = 96,
     label = "p009379",
     molecule = 
 """
@@ -3319,7 +3404,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 94,
+    index = 97,
     label = "p009513",
     molecule = 
 """
@@ -3355,7 +3440,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 95,
+    index = 98,
     label = "p009772",
     molecule = 
 """
@@ -3392,7 +3477,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 96,
+    index = 99,
     label = "p009945",
     molecule = 
 """
@@ -3427,7 +3512,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 97,
+    index = 100,
     label = "p010345",
     molecule = 
 """
@@ -3466,7 +3551,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 98,
+    index = 101,
     label = "p010419",
     molecule = 
 """
@@ -3503,7 +3588,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 99,
+    index = 102,
     label = "p010564",
     molecule = 
 """
@@ -3541,7 +3626,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 100,
+    index = 103,
     label = "p011399",
     molecule = 
 """
@@ -3575,7 +3660,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 101,
+    index = 104,
     label = "p011443",
     molecule = 
 """
@@ -3610,7 +3695,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 102,
+    index = 105,
     label = "p011506",
     molecule = 
 """
@@ -3645,7 +3730,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 103,
+    index = 106,
     label = "p011937",
     molecule = 
 """
@@ -3681,7 +3766,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 104,
+    index = 107,
     label = "r000017",
     molecule = 
 """
@@ -3714,7 +3799,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 105,
+    index = 108,
     label = "r000049",
     molecule = 
 """
@@ -3750,7 +3835,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 106,
+    index = 109,
     label = "r000208",
     molecule = 
 """
@@ -3783,7 +3868,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 107,
+    index = 110,
     label = "r000314",
     molecule = 
 """
@@ -3816,7 +3901,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 108,
+    index = 111,
     label = "r000399",
     molecule = 
 """
@@ -3849,7 +3934,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 109,
+    index = 112,
     label = "r000634",
     molecule = 
 """
@@ -3884,7 +3969,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 110,
+    index = 113,
     label = "r000721",
     molecule = 
 """
@@ -3920,7 +4005,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 111,
+    index = 114,
     label = "r000744",
     molecule = 
 """
@@ -3955,7 +4040,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 112,
+    index = 115,
     label = "r000813",
     molecule = 
 """
@@ -3992,7 +4077,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 113,
+    index = 116,
     label = "r000842",
     molecule = 
 """
@@ -4028,7 +4113,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 114,
+    index = 117,
     label = "r001050",
     molecule = 
 """
@@ -4064,7 +4149,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 115,
+    index = 118,
     label = "r001085",
     molecule = 
 """
@@ -4098,7 +4183,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 116,
+    index = 119,
     label = "r001147",
     molecule = 
 """
@@ -4135,7 +4220,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 117,
+    index = 120,
     label = "r001169",
     molecule = 
 """
@@ -4167,7 +4252,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 118,
+    index = 121,
     label = "r001235",
     molecule = 
 """
@@ -4199,7 +4284,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 119,
+    index = 122,
     label = "r001357",
     molecule = 
 """
@@ -4238,7 +4323,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 120,
+    index = 123,
     label = "r001387",
     molecule = 
 """
@@ -4276,7 +4361,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 121,
+    index = 124,
     label = "r001614",
     molecule = 
 """
@@ -4311,7 +4396,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 122,
+    index = 125,
     label = "r001627",
     molecule = 
 """
@@ -4346,7 +4431,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 123,
+    index = 126,
     label = "r001958",
     molecule = 
 """
@@ -4378,7 +4463,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 124,
+    index = 127,
     label = "r002203",
     molecule = 
 """
@@ -4415,7 +4500,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 125,
+    index = 128,
     label = "r002312",
     molecule = 
 """
@@ -4452,7 +4537,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 126,
+    index = 129,
     label = "r002513",
     molecule = 
 """
@@ -4483,7 +4568,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 127,
+    index = 130,
     label = "r002594",
     molecule = 
 """
@@ -4517,7 +4602,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 128,
+    index = 131,
     label = "r002675",
     molecule = 
 """
@@ -4552,7 +4637,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 129,
+    index = 132,
     label = "r002689",
     molecule = 
 """
@@ -4587,7 +4672,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 130,
+    index = 133,
     label = "r002760",
     molecule = 
 """
@@ -4620,7 +4705,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 131,
+    index = 134,
     label = "r002774",
     molecule = 
 """
@@ -4651,7 +4736,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 132,
+    index = 135,
     label = "r002801",
     molecule = 
 """
@@ -4687,7 +4772,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 133,
+    index = 136,
     label = "r002874",
     molecule = 
 """
@@ -4720,7 +4805,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 134,
+    index = 137,
     label = "r002881",
     molecule = 
 """
@@ -4756,7 +4841,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 135,
+    index = 138,
     label = "r003070",
     molecule = 
 """
@@ -4790,7 +4875,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 136,
+    index = 139,
     label = "r003183",
     molecule = 
 """
@@ -4822,7 +4907,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 137,
+    index = 140,
     label = "r003195",
     molecule = 
 """
@@ -4856,7 +4941,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 138,
+    index = 141,
     label = "r003323",
     molecule = 
 """
@@ -4888,7 +4973,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 139,
+    index = 142,
     label = "r003344",
     molecule = 
 """
@@ -4923,7 +5008,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 140,
+    index = 143,
     label = "r003348",
     molecule = 
 """
@@ -4954,7 +5039,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 141,
+    index = 144,
     label = "r003431",
     molecule = 
 """
@@ -4989,7 +5074,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 142,
+    index = 145,
     label = "r003437",
     molecule = 
 """
@@ -5026,7 +5111,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 143,
+    index = 146,
     label = "r003454",
     molecule = 
 """
@@ -5062,7 +5147,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 144,
+    index = 147,
     label = "r003718",
     molecule = 
 """
@@ -5098,7 +5183,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 145,
+    index = 148,
     label = "r003937",
     molecule = 
 """
@@ -5132,7 +5217,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 146,
+    index = 149,
     label = "r003958",
     molecule = 
 """
@@ -5171,7 +5256,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 147,
+    index = 150,
     label = "r004006",
     molecule = 
 """
@@ -5203,7 +5288,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 148,
+    index = 151,
     label = "r004142",
     molecule = 
 """
@@ -5236,7 +5321,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 149,
+    index = 152,
     label = "r004202",
     molecule = 
 """
@@ -5267,7 +5352,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 150,
+    index = 153,
     label = "r004295",
     molecule = 
 """
@@ -5301,7 +5386,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 151,
+    index = 154,
     label = "r004414",
     molecule = 
 """
@@ -5337,7 +5422,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 152,
+    index = 155,
     label = "r004467",
     molecule = 
 """
@@ -5373,7 +5458,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 153,
+    index = 156,
     label = "r004505",
     molecule = 
 """
@@ -5408,7 +5493,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 154,
+    index = 157,
     label = "r004547",
     molecule = 
 """
@@ -5445,7 +5530,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 155,
+    index = 158,
     label = "r004643",
     molecule = 
 """
@@ -5477,7 +5562,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 156,
+    index = 159,
     label = "r004717",
     molecule = 
 """
@@ -5509,7 +5594,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 157,
+    index = 160,
     label = "r004749",
     molecule = 
 """
@@ -5544,7 +5629,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 158,
+    index = 161,
     label = "r004778",
     molecule = 
 """
@@ -5580,7 +5665,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 159,
+    index = 162,
     label = "r004794",
     molecule = 
 """
@@ -5619,7 +5704,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 160,
+    index = 163,
     label = "r004852",
     molecule = 
 """
@@ -5655,7 +5740,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 161,
+    index = 164,
     label = "r005102",
     molecule = 
 """
@@ -5688,7 +5773,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 162,
+    index = 165,
     label = "r005118",
     molecule = 
 """
@@ -5725,7 +5810,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 163,
+    index = 166,
     label = "r005148",
     molecule = 
 """
@@ -5757,7 +5842,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 164,
+    index = 167,
     label = "r005196",
     molecule = 
 """
@@ -5791,7 +5876,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 165,
+    index = 168,
     label = "r005308",
     molecule = 
 """
@@ -5829,7 +5914,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 166,
+    index = 169,
     label = "r005356",
     molecule = 
 """
@@ -5865,7 +5950,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 167,
+    index = 170,
     label = "r005432",
     molecule = 
 """
@@ -5899,7 +5984,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 168,
+    index = 171,
     label = "r005491",
     molecule = 
 """
@@ -5933,7 +6018,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 169,
+    index = 172,
     label = "r005546",
     molecule = 
 """
@@ -5967,7 +6052,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 170,
+    index = 173,
     label = "r005588",
     molecule = 
 """
@@ -6000,7 +6085,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 171,
+    index = 174,
     label = "r005763",
     molecule = 
 """
@@ -6032,7 +6117,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 172,
+    index = 175,
     label = "r005826",
     molecule = 
 """
@@ -6064,7 +6149,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 173,
+    index = 176,
     label = "r005998",
     molecule = 
 """
@@ -6101,7 +6186,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 174,
+    index = 177,
     label = "r006089",
     molecule = 
 """
@@ -6138,7 +6223,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 175,
+    index = 178,
     label = "r006263",
     molecule = 
 """
@@ -6176,7 +6261,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 176,
+    index = 179,
     label = "r006320",
     molecule = 
 """
@@ -6209,7 +6294,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 177,
+    index = 180,
     label = "r006396",
     molecule = 
 """
@@ -6248,7 +6333,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 178,
+    index = 181,
     label = "r006798",
     molecule = 
 """
@@ -6284,7 +6369,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 179,
+    index = 182,
     label = "r007269",
     molecule = 
 """
@@ -6318,7 +6403,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 180,
+    index = 183,
     label = "r007773",
     molecule = 
 """
@@ -6354,7 +6439,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 181,
+    index = 184,
     label = "r007945",
     molecule = 
 """
@@ -6388,7 +6473,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 182,
+    index = 185,
     label = "r008828",
     molecule = 
 """
@@ -6425,7 +6510,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 183,
+    index = 186,
     label = "r009289",
     molecule = 
 """
@@ -6464,7 +6549,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 184,
+    index = 187,
     label = "r009379",
     molecule = 
 """
@@ -6498,7 +6583,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 185,
+    index = 188,
     label = "r009513",
     molecule = 
 """
@@ -6534,7 +6619,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 186,
+    index = 189,
     label = "r009772",
     molecule = 
 """
@@ -6571,7 +6656,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 187,
+    index = 190,
     label = "r009945",
     molecule = 
 """
@@ -6606,7 +6691,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 188,
+    index = 191,
     label = "r010345",
     molecule = 
 """
@@ -6645,7 +6730,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 189,
+    index = 192,
     label = "r010419",
     molecule = 
 """
@@ -6682,7 +6767,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 190,
+    index = 193,
     label = "r010564",
     molecule = 
 """
@@ -6720,7 +6805,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 191,
+    index = 194,
     label = "r011399",
     molecule = 
 """
@@ -6754,7 +6839,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 192,
+    index = 195,
     label = "r011443",
     molecule = 
 """
@@ -6789,7 +6874,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 193,
+    index = 196,
     label = "r011506",
     molecule = 
 """
@@ -6824,7 +6909,7 @@ Calculated at CCSD(T)-F12a/cc-pVDZ-F12//wB97X-D3/def2-TZVP by Kevin Spiekermann.
 )
 
 entry(
-    index = 194,
+    index = 197,
     label = "r011937",
     molecule = 
 """

--- a/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
+++ b/input/thermo/libraries/Spiekermann_refining_elementary_reactions.py
@@ -1862,12 +1862,12 @@ entry(
     label = "p004006",
     molecule = 
 """
-1 O u0 p3 c-1 {6,S}
-2 N u0 p0 c+1 {5,D} {6,S} {7,S}
-3 N u0 p1 c0 {4,S} {5,S} {8,S}
-4 N u0 p1 c0 {3,S} {6,D}
-5 N u0 p1 c0 {2,D} {3,S}
-6 C u0 p0 c0 {1,S} {2,S} {4,D}
+1 O u0 p2 c0 {6,D}
+2 N u0 p1 c0 {5,S} {6,S} {7,S}
+3 N u0 p0 c+1 {4,S} {5,D} {8,S}
+4 N u0 p2 c-1 {3,S} {6,S}
+5 N u0 p1 c0 {2,S} {3,D}
+6 C u0 p0 c0 {1,D} {2,S} {4,S}
 7 H u0 p0 c0 {2,S}
 8 H u0 p0 c0 {3,S}
 """,


### PR DESCRIPTION
This PR updates the values of retroene training reactions added in PR https://github.com/ReactionMechanismGenerator/RMG-database/pull/523 by incorporating rotor scans and then refitting the rate tree. In general, the standard deviation of ln(k) is lower now after updating the values. All species were calculated at CCSD(T)-F12a/cc-pVDZ-F12//ωB97X-D3/def2-TZVP. A thorough conformer search was done with ACS on the reactant, TS, and product. 1D rotor scans were also done on the reactant, TS, and product. All scans start and end in the same place and have the lowest energy well at 0 degrees. The notebook below has assert glog.success which was True for all species. Also included in the zip file is the notebook for running ATG to refit the rate rules. This PR should be merged in after https://github.com/ReactionMechanismGenerator/RMG-database/pull/571.
[notebooks.zip](https://github.com/ReactionMechanismGenerator/RMG-database/files/8366908/notebooks.zip)

I accidentally closed #572 and didn't have permission to reopen it so I'm just making this new PR.