### PR TITLE
Set rmg py branch back to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 5
     env: # update this if needed to match a pull request on the RMG-database
-      RMG_PY_BRANCH: fix_intra_r_add_endocyclic
+      RMG_PY_BRANCH: main
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
I foolishly merged https://github.com/ReactionMechanismGenerator/RMG-database/pull/579 without removing the last commit that was only added for the twin RMG-Py and RMG-database PR. This PR reverts the github workflows back to what it should be i.e. checking out the main branch of RMG-Py.