### PR TITLE
Update metal.py with DFT method

### DIFF
--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -4,7 +4,9 @@
 name = "Metal Binding Energies"
 shortDesc = ""
 longDesc = """
-Metal binding energies and surface site densities
+Metal binding energies and surface site densities. 
+The DFT calculations were performed by Katrin Blondal and Bjarne Kreitz (both Brown University) using Quantum Espresso with PAW PBE pseudopotentials. PBE was used as the xc-functional and a vdW-corr (DFT-D3) was applied. A 3x3 cell was used for the fcc(111) and hcp(0001) facets with 4 layers and a 1x3 cell with 12 layers for the (211) facets. Further the following settings were used: vaccum=10A (above and below), dftd3_version=4, dftd3_threebody=True, occupations='smearing', smearing='marzari-vanderbilt', degauss=0.005, mixing_mode='local-TF', tprnfor=True, nosym=True. 
+Structures were optimized in a multistep procedure according to Blondal et al. (https://doi.org/10.1021/acs.iecr.9b01464) with (1) a (2,2,1) k-point grid ((2,1,1) for (211) facets) and 40 eV cutoff and (2) (4,4,1) grid ((4,2,1) for (211) facets) and 50 eV until forces were below 0.01 eV/A. The single point energy was computed on a (6,6,1) grid ((6,4,1) for (211) facets) and 60 eV. Prior to the relaxation, the lattice constant of the bulk metal was determined through optimization with the calculator settings using a k-point grid of (21,21,21).
 """
 entry(
     index = 0,
@@ -21,7 +23,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.93 Angstrom.
 """,
 )
 
@@ -40,7 +42,7 @@ entry(
     shortDesc = """hcp""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=2.70 Angstrom and c=4.27 Angstrom.
 """,
 )
 
@@ -59,7 +61,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.8 Angstrom.
 """,
 )
 
@@ -78,7 +80,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.85 Angstrom.
 """,
 )
 
@@ -97,7 +99,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=4.11 Angstrom.
 """,
 )
 
@@ -116,7 +118,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.96 Angstrom.
 """,
 )
 
@@ -135,7 +137,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.56 Angstrom.
 """,
 )
 
@@ -154,7 +156,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=4.09 Angstrom.
 """,
 )
 
@@ -173,7 +175,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.49 Angstrom.
 """,
 )
 
@@ -192,7 +194,7 @@ entry(
     shortDesc = """hcp""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=2.48 Angstrom and c=4.01 Angstrom.
 """,
 )
 
@@ -211,7 +213,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.93 Angstrom.
 """,
 )
 
@@ -230,7 +232,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.8 Angstrom.
 """,
 )
 
@@ -249,7 +251,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=4.09 Angstrom.
 """,
 )
 
@@ -268,7 +270,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.96 Angstrom.
 """,
 )
 
@@ -287,7 +289,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=4.11 Angstrom.
 """,
 )
 
@@ -306,7 +308,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.85 Angstrom.
 """,
 )
 
@@ -325,7 +327,7 @@ entry(
     shortDesc = """hcp""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=2.70 Angstrom and c=4.27 Angstrom.
 """,
 )
 
@@ -344,7 +346,7 @@ entry(
     shortDesc = """hcp""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=2.48 Angstrom and c=4.01 Angstrom.
 """,
 )
 
@@ -363,7 +365,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.49 Angstrom.
 """,
 )
 
@@ -382,7 +384,7 @@ entry(
     shortDesc = """fcc""",
     longDesc = 
 """
-Calculated by Katrin Blondal and Bjarne Kreitz at Brown University
+Calculated by Katrin Blondal and Bjarne Kreitz at Brown University. The lattice constant is a=3.56 Angstrom.
 """,
 )
 


### PR DESCRIPTION
The metal.py file with the binding energies for the descriptor atoms on the various (111) and (211) facets used for the linear scaling relations does not contain information on the DFT method. An issue was raised (#592) reporting this. 

Katrin and I added a detailed description of the DFT method and settings, so the calculations can be reproduced by others. Please check if the information is correct or if something is missing. 