### PR TITLE
Fix GAV S6ddd ref

### DIFF
--- a/input/thermo/groups/group.py
+++ b/input/thermo/groups/group.py
@@ -56379,7 +56379,7 @@ entry(
 """
 1 * S6ddd u0
 """,
-    thermo = 'S6ddd-XdXdXd',
+    thermo = 'S6ddd-OdXdXd',
     shortDesc = """Sulfur/Oxygen Extension, Ryan Gillis""",
     longDesc = 
 """


### PR DESCRIPTION
Group `S6ddd` refers to a non-existing group called `S6ddd-XdXdXd`. It was now changed to the most generic group in this tree that has data, `S6ddd-OdXdXd`.