### PR TITLE
k_low and T1, T3 corrected for KLI_GLB_2016, NOx2018; PdepArrhenius info added for Nitrogen_GLB_JMZ

### DIFF
--- a/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
+++ b/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
@@ -1965,18 +1965,21 @@ entry(
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(3.1e+18, 's^-1'), n=-1.017, Ea=(91712, 'cal/mol'), T0=(1, 'K')),
         arrheniusLow = Arrhenius(
-            A = (5.4e+23, 'cm^3/(mol*s)'),
+            A = (3.25e+47, 'cm^3/(mol*s)'),
             n = -8.3446,
             Ea = (99596, 'cal/mol'),
             T0 = (1, 'K'),
         ),
         alpha = 0.9922,
-        T3 = (943, 'K'),
-        T1 = (47310, 'K'),
+        T3 = (47310, 'K'),
+        T1 = (943, 'K'),
         T2 = (47110, 'K'),
         efficiencies = {},
     ),
     shortDesc = u"""The chemkin file reaction is CH3OH <=> CH2(S) + H2O""",
+    longDesc = u"""These entries have different numbers than the entries in the original mechanism files 
+    from the Jasper et al., 2007. A factors for low pressure limit should be multiplied by avogadro's 
+    number since the number in the original paper has the unit of molecule rather than mol )"""
 )
 
 entry(

--- a/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
+++ b/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
@@ -1977,9 +1977,14 @@ entry(
         efficiencies = {},
     ),
     shortDesc = u"""The chemkin file reaction is CH3OH <=> CH2(S) + H2O""",
-    longDesc = u"""These entries have different numbers than the entries in the original mechanism files 
-    from the Jasper et al., 2007. A factors for low pressure limit should be multiplied by avogadro's 
-    number since the number in the original paper has the unit of molecule rather than mol )"""
+    longDesc = u"""This entry has different numbers than the entry in the
+    mechanism file (Hashemi et al.). It uses the kinetic parameters from
+    the original source (Jasper et al. J. Phys. Chem. A, 2007, 111, 19,
+    3932-3950). Jasper et al. reported kinetic unit in molecule, cm^3,
+    and s, but Hashemi et al. didn't multiply the A factor of the low-pressure
+    limit Arrhenius by Avogadro's number when compiling the mechanism (with
+    the unit in mol, cm^3, and s). Besides, Hashemi et al. mistakenly reversed
+    the order of the T1 and T3 parameters."""
 )
 
 entry(

--- a/input/kinetics/libraries/NOx2018/reactions.py
+++ b/input/kinetics/libraries/NOx2018/reactions.py
@@ -1810,17 +1810,21 @@ entry(
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(3.1e+18, 's^-1'), n=-1.017, Ea=(91712, 'cal/mol'), T0=(1, 'K')),
         arrheniusLow = Arrhenius(
-            A = (5.4e+23, 'cm^3/(mol*s)'),
+            A = (3.25e+47, 'cm^3/(mol*s)'),
             n = -8.3446,
             Ea = (99596, 'cal/mol'),
             T0 = (1, 'K'),
         ),
         alpha = 0.9922,
-        T3 = (943, 'K'),
-        T1 = (47310, 'K'),
+        T3 = (47310, 'K'),
+        T1 = (943, 'K'),
         T2 = (47110, 'K'),
         efficiencies = {},
     ),
+    shortDesc = u"""The chemkin file reaction is CH3OH <=> CH2(S) + H2O""",
+    longDesc = u"""These entries have different numbers than the entries in the original mechanism files 
+    from the Jasper et al., 2007. A factors for low pressure limit should be multiplied by avogadro's 
+    number since the number in the original paper has the unit of molecule rather than mol )"""
 )
 
 entry(

--- a/input/kinetics/libraries/NOx2018/reactions.py
+++ b/input/kinetics/libraries/NOx2018/reactions.py
@@ -1310,7 +1310,7 @@ entry(
     kinetics = PDepArrhenius(
         pressures = ([0.01, 1, 10, 20, 50, 100], 'atm'),
         arrhenius = [
-            Arrhenius(A=(6.8e+24, 'cm^3/(mol*s)'), n=-3, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(8.3476e+20, 'cm^3/(mol*s)'), n=-4, Ea=(0, 'cal/mol'), T0=(1, 'K')),
             Arrhenius(A=(5e+22, 'cm^3/(mol*s)'), n=-3.85, Ea=(2000, 'cal/mol'), T0=(1, 'K')),
             Arrhenius(
                 A = (3.4e+21, 'cm^3/(mol*s)'),
@@ -1368,6 +1368,9 @@ entry(
             ),
         ],
     ),
+    longDesc=u"""low pressure limit k_0 was taken from Fernandes et al., 2006. However, it has to 
+    be noted that [M] should be multiplied to 7E-31300^3T^-3 [cm6/#2/s]. Thus, 
+    k_0~ 7E-31300^3T^-3 [cm6/#2/s] * P/RT [#/cm3] = 7E-31300^31013.25/8.314E6*(6.02E23)^2 [cm6/#/s] = 8.348E+20*T^-4"""
 )
 
 entry(

--- a/input/kinetics/libraries/NOx2018/reactions.py
+++ b/input/kinetics/libraries/NOx2018/reactions.py
@@ -1368,9 +1368,15 @@ entry(
             ),
         ],
     ),
-    longDesc=u"""low pressure limit k_0 was taken from Fernandes et al., 2006. However, it has to 
-    be noted that [M] should be multiplied to 7E-31300^3T^-3 [cm6/#2/s]. Thus, 
-    k_0~ 7E-31300^3T^-3 [cm6/#2/s] * P/RT [#/cm3] = 7E-31300^31013.25/8.314E6*(6.02E23)^2 [cm6/#/s] = 8.348E+20*T^-4"""
+    longDesc=u"""This entry has different rate constants at P = 0.01 atm than
+    the entry in the mechanism file (Glarborg et al.). In Glarborg et al.,
+    k at 0.01 atm was taken from the low-pressure limit k0 of the Troe kinetics
+    in Fernandes et al. (Fernandes et al., JPCA, 110, 13, 4442-4449). However,
+    according to the definition by Fernandes et al., k0 (7E-31*(T/300)^-3 [cm6/#2/s])
+    has to be multiplied by [M] (P/RT) to get the rate constants at a specific pressure.
+    Thus, k(P=0.01 atm) = 7E-31*(T/300)^-3 [cm6/#2/s] * P/RT
+    = 7E-31*(300^3)(6.02E23)^2(1013.25/8.314E6)(T^-4) [cm3/mol/s]
+    = 8.348E+20T^-4 [cm3/mol/s]"""
 )
 
 entry(
@@ -1825,9 +1831,14 @@ entry(
         efficiencies = {},
     ),
     shortDesc = u"""The chemkin file reaction is CH3OH <=> CH2(S) + H2O""",
-    longDesc = u"""These entries have different numbers than the entries in the original mechanism files 
-    from the Jasper et al., 2007. A factors for low pressure limit should be multiplied by avogadro's 
-    number since the number in the original paper has the unit of molecule rather than mol )"""
+    longDesc = u"""This entry has different numbers than the entry in the
+    mechanism file (Hashemi et al.). It uses the kinetic parameters from
+    the original source (Jasper et al. J. Phys. Chem. A, 2007, 111, 19,
+    3932-3950). Jasper et al. reported kinetic unit in molecule, cm^3,
+    and s, but Hashemi et al. didn't multiply the A factor of the low-pressure
+    limit Arrhenius by Avogadro's number when compiling the mechanism (with
+    the unit in mol, cm^3, and s). Besides, Hashemi et al. mistakenly reversed
+    the order of the T1 and T3 parameters."""
 )
 
 entry(

--- a/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/reactions.py
+++ b/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/reactions.py
@@ -3631,11 +3631,34 @@ entry(
     index = 474,
     label = "C2H2 + CH3 <=> CH2CHCH2",
     degeneracy = 1,
-    kinetics = Arrhenius(
-        A = (2.7e+53, 'cm^3/(mol*s)'),
-        n = -12.82,
-        Ea = (35730, 'cal/mol'),
-        T0 = (1, 'K'),
+    kinetics = PDepArrhenius(
+        pressures = ([0.1, 1, 10, 100], 'atm'),
+        arrhenius = [
+            Arrhenius(
+                A = (8.20e+53, 'cm^3/(mol*s)'),
+                n = -13.32,
+                Ea = (33200, 'cal/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (2.7e+53, 'cm^3/(mol*s)'),
+                n = -12.82,
+                Ea = (35730, 'cal/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (4.4e+49, 'cm^3/(mol*s)'),
+                n = -11.4,
+                Ea = (36700, 'cal/mol'),
+                T0 = (1, 'K'),
+            ),
+            Arrhenius(
+                A = (3.8e+44, 'cm^3/(mol*s)'),
+                n = -9.63,
+                Ea = (37600, 'cal/mol'),
+                T0 = (1, 'K'),
+            ),
+        ],
     ),
 )
 

--- a/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/reactions.py
+++ b/input/kinetics/libraries/Nitrogen_Glarborg_Gimenez_et_al/reactions.py
@@ -3660,6 +3660,12 @@ entry(
             ),
         ],
     ),
+    longDesc=u"""This entry has different kinetics than the entry in the mechanism file 
+    (Lopez et al.). The original reference of this reaction 
+    (Davis et al. , J. Phys. Chem. A 1999, 103, 5889-5899) reported Pdep kinetics.
+    However, the kinetics in the mechanism file of Lopez et al. only contained the rate 
+    coefficient at 1 atm and used it as the high-pressure limit rate coefficient. 
+    This entry instead reported the Pdep kinetics from the original source."""
 )
 
 entry(


### PR DESCRIPTION
Klippenstein_Glaborg_2016 and NOx_2018 CH3OH -> CH2(S) + H2O's low pressure k has been corrected. Also, T1 and T3 for Troe format have been corrected