### PR TITLE
Removed a comment from 2003_Miller kin lib

### DIFF
--- a/input/kinetics/libraries/2003_Miller_Propargyl_Recomb_High_P/reactions.py
+++ b/input/kinetics/libraries/2003_Miller_Propargyl_Recomb_High_P/reactions.py
@@ -103,16 +103,5 @@ entry(
     index = 14,
     label = "IV <=> B",
     degeneracy = 1,
-    kinetics = Arrhenius(
-        A = (1.012e+13, 's^-1'),
-        n = 0.1,
-        Ea = (41.203, 'kcal/mol'),
-        T0 = (1, 'K'),
-        comment = 'CBS-QB3 calculated',
-    ),
-    longDesc = 
-u"""
-CBS-QB3 calculated
-""",
+    kinetics = Arrhenius(A=(1.012e+13, 's^-1'), n=0.1, Ea=(41.203, 'kcal/mol'), T0=(1, 'K')),
 )
-


### PR DESCRIPTION
I got the following trace when simulating an RMG-genrated Chemkin file usng RMG's constant T/P reactor:
```

  File "rmgpy/chemkin.pyx", line 945, in rmgpy.chemkin.load_chemkin_file
  File "rmgpy/chemkin.pyx", line 972, in rmgpy.chemkin.load_chemkin_file
  File "rmgpy/chemkin.pyx", line 1446, in rmgpy.chemkin.read_reactions_block
  File "rmgpy/chemkin.pyx", line 1440, in rmgpy.chemkin.read_reactions_block
  File "rmgpy/chemkin.pyx", line 716, in rmgpy.chemkin.read_reaction_comments
rmgpy.exceptions.ChemkinError: Unexpected species identifier CBS-QB3 encountered in flux pairs for reaction C6H6(272) <=> B(274).
```

RMG did not read the flux pair correctly, and for some reason read the following line which was taken from a library comment.

This is the reaction it errored on:

```
! Reaction index: Chemkin #2097; RMG #2090
! Library reaction: 2003_Miller_Propargyl_Recomb_High_P
! Flux pairs: C6H6(272), B(274); 
! CBS-QB3 calculated
! Ea raised from 172.4 to 187.3 kJ/mol to match endothermicity of reaction.
C6H6(272)=B(274)                                    1.012000e+13 0.100     44.755   
```

I couldn't understand why RMG read two lines instead of one when analyzing the flux pairs. The reaction comment above can be used to debug it. As a quick patch, I'm removing the single comment from the `2003_Miller_Propargyl_Recomb_High_P`kinetic library.