### PR TITLE
NH3 thermo and kinetic data additions

### DIFF
--- a/input/forbiddenStructures.py
+++ b/input/forbiddenStructures.py
@@ -65,6 +65,41 @@ u"""
 )
 
 entry(
+    label = "NNOH",
+    molecule =
+"""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {4,S}
+2 N u0 p1 c0 {1,S} {3,D}
+3 N u1 p1 c0 {2,D}
+4 H u0 p0 c0 {1,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+See https://doi.org/10.1002/cphc.202200373 for a discussion of the NNOH radical.
+""",
+)
+
+entry(
+    label = "NNOOH",
+    molecule =
+"""
+multiplicity 2
+1 N u1 p1 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {3,S} {5,S}
+5 H u0 p0 c0 {4,S}
+""",
+    shortDesc = u"""""",
+    longDesc =
+u"""
+See https://doi.org/10.1002/cphc.202200373 for a discussion of the NNOOH radical.
+""",
+)
+
+entry(
     label = "Carbene_D_triplet",
     group =
 """
@@ -491,7 +526,6 @@ u"""
 We assume that CO2 binds only via physisorption to the surface
 """,
 )
-
 
 entry(
     label = "O2X2",

--- a/input/kinetics/libraries/HydrazinePDep/reactions.py
+++ b/input/kinetics/libraries/HydrazinePDep/reactions.py
@@ -139,11 +139,11 @@ entry(
     index = 7,
     label = "N2H3 + NH2 <=> N2H2 + NH3",
     duplicate = True,
-    kinetics = Arrhenius(A=(9.2e+05, 'cm^3/(mol*s)'), n=1.94, Ea=(-1.152, 'kcal/mol'), T0=(1, 'K')),
+    kinetics = Arrhenius(A=(6.08e-01, 'cm^3/(mol*s)'), n=3.57, Ea=(1194, 'cal/mol'), T0=(1, 'K')),
     longDesc =
 u"""
-Taken from the Nitrogen_Dean_and_Bozzelli library
-The same rate appears in the NOx2018 library
+Taken from https://doi.org/10.1021/acs.jpca.0c03144
+Also available from D&B (the same rate appears in the NOx2018 library)
 D&B estimated this rate of the direct hydrogen transfer reaction (not including the well-skipping rate)
 """,
 )

--- a/input/kinetics/libraries/primaryH2O2/reactions.py
+++ b/input/kinetics/libraries/primaryH2O2/reactions.py
@@ -5,225 +5,238 @@ name = "primaryH2O2"
 shortDesc = u"primaryH2O2"
 longDesc = u"""
 Based on:
-[Konnov2015] A.A. Konnov, "On the role of excited species in hydrogen combustion", Combustion and Flame 2015, 
-162, 3755-3772, DOI: 10.1016/j.combustflame.2015.07.014
-[Konnov2019] A.A. Konnov, "Yet another kinetic mechanism for hydrogen combustion", Combustion and Flame 2019, 
-203, 14-22, DOI: 10.1016/j.combustflame.2019.01.032
+[Baulch2005] D.L. Baulch, C.T. Bowman, C.J. Cobos, R.A. Cox, Th. Just, J.A. Kerr, M.J. Pilling, D. Stocker, J. Troe,
+    W. Tsang, R.W. Walker, J. Warnatz, J. Phys. Chem. Ref. Data, 2005, 34, 757-1397, doi: 10.1063/1.1748524
+[Hosein2007] M.S. Hosein, S. Vahid, Bull. Chem. Soc. Jpn., 2007, 80(10), 1901-1913, doi: 10.1246/bcsj.80.1901
 [Klippenstein2022] S.J. Klippenstein, R. Sivaramakrishnan, U. Burke, K.P. Somers, H.J. Curran, L. Cai, H. Pitsch,
-M. Pelucchi, T. Faravelli, P. Glarborg, "HO2 + HO2: High level theory and the role of singlet channels",
-Combustion and Flame 2022, 243, 111975, DOI: 10.1016/j.combustflame.2021.111975
+    M. Pelucchi, T. Faravelli, P. Glarborg, "HO2 + HO2: High level theory and the role of singlet channels",
+    Combustion and Flame 2022, 243, 111975, doi: 10.1016/j.combustflame.2021.111975
+[Konnov2015] A.A. Konnov, "On the role of excited species in hydrogen combustion", Combustion and Flame 2015, 
+    162, 3755-3772, doi: 10.1016/j.combustflame.2015.07.014
+[Konnov2019] A.A. Konnov, "Yet another kinetic mechanism for hydrogen combustion", Combustion and Flame 2019, 
+    203, 14-22, doi: 10.1016/j.combustflame.2019.01.032
+[Tsang1986] W. Tsang, R.F. Hampson, "Chemical Kinetic Data Base for Combustion Chemistry. Part I. Methane and Related Compounds",
+    Journal of Physical and Chemical Reference Data, 1986,  15, 1087–1279, doi: 10.1063/1.555759
 """
 
 entry(
-    index = 1,
-    label = "H + H <=> H2",
-    kinetics = ThirdBody(
+    index=1,
+    label="H + H <=> H2",
+    kinetics=ThirdBody(
         arrheniusLow=Arrhenius(A=(7e+17, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.0, Ea=(0, 'cal/mol'), T0=(1, 'K'),
                                Tmin=(77, 'K'), Tmax=(5000, 'K')),
         efficiencies={'[Ar]': 0.0, '[He]': 0.0, 'N#N': 0.0, '[H]': 0.0, '[H][H]': 0.0, '[O][O]': 0.0, 'O': 14.3}),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 1a""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 1a""",
 )
 
 entry(
-    index = 2,
-    label = "H + H + O2 <=> H2 + O2",
-    kinetics = Arrhenius(A=(8.80e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
-                         Tmax=(3000, 'K')),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 1""",
+    index=2,
+    label="H + H + O2 <=> H2 + O2",
+    kinetics=Arrhenius(A=(8.80e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
+                       Tmax=(3000, 'K')),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""Table 1, Reaction 1""",
 )
 
 entry(
-    index = 3,
-    label = "H2 + Ar <=> H + H + Ar",
-    kinetics = Arrhenius(A=(5.84e+18, 'cm^3/(mol*s)'), n=-1.10, Ea=(104380, 'cal/mol'), T0 = (1, 'K')),
-    shortDesc = u"""Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986)""",
+    index=3,
+    label="H2 + Ar <=> H + H + Ar",
+    kinetics=Arrhenius(A=(5.84e+18, 'cm^3/(mol*s)'), n=-1.10, Ea=(104380, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Tsang1986]""",
 )
 
 entry(
-    index = 4,
-    label = "H2 + He <=> H + H + He",
-    kinetics = Arrhenius(A=(5.84e+18, 'cm^3/(mol*s)'), n=-1.10, Ea=(104380, 'cal/mol'), T0 = (1, 'K')),
-    shortDesc = u"""Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986)""",
+    index=4,
+    label="H2 + He <=> H + H + He",
+    kinetics=Arrhenius(A=(5.84e+18, 'cm^3/(mol*s)'), n=-1.10, Ea=(104380, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Tsang1986]""",
 )
 
 entry(
-    index = 5,
-    label = "H + H + H2 <=> H2 + H2",
-    kinetics = Arrhenius(A=(1e+17, 'cm^6/(mol^2*s)', '*|/', 2.5),n=-0.6, Ea=(0, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(50, 'K'), Tmax=(5000, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 1b""",
+    index=5,
+    label="H + H + H2 <=> H2 + H2",
+    kinetics=Arrhenius(A=(1e+17, 'cm^6/(mol^2*s)', '*|/', 2.5), n=-0.6, Ea=(0, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(50, 'K'), Tmax=(5000, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 1b""",
 )
 
 entry(
-    index = 6,
-    label = "H + H + N2 <=> H2 + N2",
-    kinetics = Arrhenius(A=(5.4e+18, 'cm^6/(mol^2*s)', '*|/', 3.2), n=-1.3, Ea=(0, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(77, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 1c""",
+    index=6,
+    label="H + H + N2 <=> H2 + N2",
+    kinetics=Arrhenius(A=(5.4e+18, 'cm^6/(mol^2*s)', '*|/', 3.2), n=-1.3, Ea=(0, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(77, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 1c""",
 )
 
 entry(
-    index = 7,
-    label = "H + H + H <=> H2 + H",
-    kinetics = Arrhenius(A=(3.2e+15, 'cm^6/(mol^2*s)', '*|/', 3.2), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'), Tmin=(50, 'K'),
-                         Tmax=(5000, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 1d""",
+    index=7,
+    label="H + H + H <=> H2 + H",
+    kinetics=Arrhenius(A=(3.2e+15, 'cm^6/(mol^2*s)', '*|/', 3.2), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'), Tmin=(50, 'K'),
+                       Tmax=(5000, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 1d""",
 )
 
 entry(
-    index = 8,
-    label = "H + O2 + H <=> OH + OH",
-    kinetics = Arrhenius(A=(4.00e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
-                         Tmax=(3000, 'K')),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 2""",
+    index=8,
+    label="H + O2 + H <=> OH + OH",
+    kinetics=Arrhenius(A=(4.00e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
+                       Tmax=(3000, 'K')),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""Table 1, Reaction 2""",
 )
 
 entry(
-    index = 9,
-    label = "O + H <=> OH",
-    kinetics = ThirdBody(
+    index=9,
+    label="O + H <=> OH",
+    kinetics=ThirdBody(
         arrheniusLow=Arrhenius(A=(6.75e+18, 'cm^6/(mol^2*s)'), n=-1, Ea=(0, 'cal/mol'), T0=(1, 'K'), Tmin=(2950, 'K'),
-                         Tmax=(3700, 'K')),
-        efficiencies={'O': 5.0, '[H][H]': 2.5, '[C-]#[O+]': 1.9, 'O=C=O': 3.8, '[Ar]': 0.75, '[He]': 0.75, '[O][O]': 0.0}),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 3
-    The efficiency for H2O was taken from Konnov 2015, other collider efficiencies were taken from Curran 10.1016/j.combustflame.2015.09.014
-    Note that in the Curran library th efficiency for O2 was 12, her for consistency we remain with
-    the Konnov recommendation of collision efficiency for O2 of 5.
-    """,
+                               Tmax=(3700, 'K')),
+        efficiencies={'O': 5.0, '[H][H]': 2.5, '[C-]#[O+]': 1.9, 'O=C=O': 3.8, '[Ar]': 0.75, '[He]': 0.75,
+                      '[O][O]': 0.0}),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+Table 1, Reaction 3
+The efficiency for H2O was taken from Konnov 2015, other collider efficiencies were taken from Curran 10.1016/j.combustflame.2015.09.014
+Note that in the Curran library th efficiency for O2 was 12, her for consistency we remain with
+the Konnov recommendation of collision efficiency for O2 of 5.
+""",
 )
 
 entry(
-    index = 10,
-    label = "H + O + O2 <=> OH + O2",
-    kinetics = Arrhenius(A=(7.35e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
-                         Tmax=(3000, 'K')),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 3""",
+    index=10,
+    label="H + O + O2 <=> OH + O2",
+    kinetics=Arrhenius(A=(7.35e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
+                       Tmax=(3000, 'K')),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""Table 1, Reaction 3""",
 )
 
 entry(
-    index = 11,
-    label = "H2O <=> H + OH",
-    kinetics = ThirdBody(
-        arrheniusLow=Arrhenius( A=(6.06e+27, 'cm^3/(mol*s)'), n=-3.312, Ea=(120770, 'cal/mol'), T0=(1, 'K'),
-                        Tmin=(300, 'K'), Tmax=(3400, 'K')),
+    index=11,
+    label="H2O <=> H + OH",
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(6.06e+27, 'cm^3/(mol*s)'), n=-3.312, Ea=(120770, 'cal/mol'), T0=(1, 'K'),
+                               Tmin=(300, 'K'), Tmax=(3400, 'K')),
         efficiencies={'N#N': 2.0, 'O': 0.0, '[H][H]': 3.0, '[He]': 1.1, '[O][O]': 0.0, '[C-]#[O+]': 1.9, 'O=C=O': 3.8}),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 4a
-    Note that in Konnov2015 the collision efficiency for O2 was 1.5, but Konnov2019 updated the rate
-    for the specific collider (see reaction index 13). THerefore, an efficiency of 0 was given here for O2.""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 4a
+Note that in Konnov2015 the collision efficiency for O2 was 1.5, but Konnov2019 updated the rate
+for the specific collider (see reaction index 13). THerefore, an efficiency of 0 was given here for O2.
+""",
 )
 
 entry(
-    index = 12,
-    label = "H2O + H2O <=> H + OH + H2O",
-    kinetics = Arrhenius(A=(1e+26, 'cm^3/(mol*s)'), n=-2.44, Ea=(120160, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'),
-                    Tmax=(3400, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 4b
-                   Originally from Srinivasan and Michael, Int. J. Chem. Kinetic 38 (2006)""",
+    index=12,
+    label="H2O + H2O <=> H + OH + H2O",
+    kinetics=Arrhenius(A=(1e+26, 'cm^3/(mol*s)'), n=-2.44, Ea=(120160, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'),
+                       Tmax=(3400, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+Table 1, Reaction 4b
+Originally from Srinivasan and Michael, Int. J. Chem. Kinetic 38 (2006)
+""",
 )
 
 entry(
-    index = 13,
-    label = "H + OH + O2 <=> H2O + O2",
-    kinetics = Arrhenius(A=(2.56e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
-                         Tmax=(3000, 'K')),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 4""",
+    index=13,
+    label="H + OH + O2 <=> H2O + O2",
+    kinetics=Arrhenius(A=(2.56e+22, 'cm^6/(mol^2*s)', '*|/', 2), n=-1.835, Ea=(800, 'cal/mol'), Tmin=(300, 'K'),
+                       Tmax=(3000, 'K')),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""Table 1, Reaction 4""",
 )
 
 entry(
-    index = 14,
-    label = "H + O2 <=> HO2",
-    kinetics = Troe(
-        arrheniusHigh = Arrhenius(A=(4.66e+12, 'cm^3/(mol*s)', '*|/', 1.2), n=0.44, Ea=(0, 'cal/mol'), Tmin=(300, 'K'),
-                                  Tmax=(2000, 'K')),
-        arrheniusLow = Arrhenius(A=(1.225e+19, 'cm^6/(mol^2*s)', '*|/', 1.2), n=-1.2, Ea=(0.0, 'cal/mol'),
-                                 Tmin=(1000, 'K'), Tmax=(1430, 'K')), T3=(1752, 'K'), T1=(1e-10, 'K'), T2=(1e+30, 'K'),
-        efficiencies = {'[H][H]': 1.5, 'O=C=O': 3.61, '[He]': 0.57, '[Ar]': 0.72, 'O': 16.6},),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 6
-                   The value of T3 was calculated with the first factor of the Lindemann model and an Fcent 
-                   value of 0.5 specified in the Konnov 2019 paper.""",
+    index=14,
+    label="H + O2 <=> HO2",
+    kinetics=Troe(
+        arrheniusHigh=Arrhenius(A=(4.66e+12, 'cm^3/(mol*s)', '*|/', 1.2), n=0.44, Ea=(0, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+        arrheniusLow=Arrhenius(A=(1.225e+19, 'cm^6/(mol^2*s)', '*|/', 1.2), n=-1.2, Ea=(0.0, 'cal/mol'), Tmin=(1000, 'K'), Tmax=(1430, 'K')),
+        T1=(1e-10, 'K'), T2=(1e+30, 'K'), T3=(1752, 'K'),
+        efficiencies={'[H][H]': 1.5, 'O=C=O': 3.61, '[He]': 0.57, '[Ar]': 0.72, 'O': 16.6}, ),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""
+Table 1, Reaction 6
+The value of T3 was calculated with the first factor of the Lindemann model and an Fcent 
+value of 0.5 specified in the Konnov 2019 paper.
+""",
 )
 
 entry(
-    index = 15,
-    label = "H + O2 <=> OH + O",
-    kinetics = Arrhenius(A=(1.04e+14, 'cm^3/(mol*s)'), n=0, Ea=(15286, 'cal/mol'), T0=(1, 'K'), Tmin=(1100, 'K'),
-                         Tmax=(3370, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 8
-                   Originally based on Hong et al., Proc. Comb. Inst. 33:309-316 (2011)""",
+    index=15,
+    label="H + O2 <=> OH + O",
+    kinetics=Arrhenius(A=(1.04e+14, 'cm^3/(mol*s)'), n=0, Ea=(15286, 'cal/mol'), T0=(1, 'K'), Tmin=(1100, 'K'),
+                       Tmax=(3370, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+Table 1, Reaction 8
+Originally based on Hong et al., Proc. Comb. Inst. 33:309-316 (2011)
+""",
 )
 
 entry(
-    index = 16,
-    label = "OH + OH <=> H2O + O",
-    kinetics = Arrhenius(A=(2.668e+06,'cm^3/(mol*s)', '*|/', 1.4), n=1.82, Ea=(-1647, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(200, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 5""",
+    index=16,
+    label="OH + OH <=> H2O + O",
+    kinetics=Arrhenius(A=(2.668e+06, 'cm^3/(mol*s)', '*|/', 1.4), n=1.82, Ea=(-1647, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(200, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""Table 1, Reaction 5""",
 )
 
 entry(
-    index = 17,
-    label = "OH + HO2 <=> H2O + O2",
-    kinetics = Arrhenius(A=(2.14e+06, 'cm^3/(mol*s)', '*|/', 2), n=1.65, Ea = (2180, 'cal/mol'), Tmin=(200, 'K'),
-                         Tmax=(2500, 'K')),
-    shortDesc = u"""[Konnov2019]""",
-    longDesc = u"""Konnov (2019) https://doi.org/10.1016/j.combustflame.2019.01.032, Table 1, Reaction 7""",
+    index=17,
+    label="OH + HO2 <=> H2O + O2",
+    kinetics=Arrhenius(A=(2.14e+06, 'cm^3/(mol*s)', '*|/', 2), n=1.65, Ea=(2180, 'cal/mol'), Tmin=(200, 'K'),
+                       Tmax=(2500, 'K')),
+    shortDesc=u"""[Konnov2019]""",
+    longDesc=u"""Table 1, Reaction 7""",
 )
 
 entry(
-    index = 18,
-    label = "O + O <=> O2",
-    kinetics = ThirdBody(
+    index=18,
+    label="O + O <=> O2",
+    kinetics=ThirdBody(
         arrheniusLow=Arrhenius(A=(1e+17, 'cm^6/(mol^2*s)'), n=-1, Ea=(0, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'),
-                         Tmax=(5000, 'K')),
+                               Tmax=(5000, 'K')),
         efficiencies={'[Ar]': 0.0, '[He]': 0.0, 'N#N': 2.0, '[N]=O': 2.0, '[N]': 2.0, 'O': 5.0, '[O-][O+]=O': 8.0,
                       '[O]': 28.8, '[O][O]': 8.0}),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 2""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 2""",
 )
 
 entry(
-    index = 19,
-    label = "O + O + Ar <=> O2 + Ar",
-    kinetics = Arrhenius(A=(1.886e+13, 'cm^6/(mol^2*s)'), n=0, Ea=(-1788, 'cal/mol'), T0 = (1, 'K')),
-    shortDesc = u"""Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986)""",
+    index=19,
+    label="O + O + Ar <=> O2 + Ar",
+    kinetics=Arrhenius(A=(1.886e+13, 'cm^6/(mol^2*s)'), n=0, Ea=(-1788, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Tsang1986]""",
 )
 
 entry(
-    index = 20,
-    label = "O + O + He <=> O2 + He",
-    kinetics = Arrhenius(A=(1.886e+13, 'cm^6/(mol^2*s)'), n=0, Ea=(-1788, 'cal/mol'), T0 = (1, 'K')),
-    shortDesc = u"""Tsang and Hampson J. Phys. Chem. Ref. Data, 15:1087 (1986)""",
+    index=20,
+    label="O + O + He <=> O2 + He",
+    kinetics=Arrhenius(A=(1.886e+13, 'cm^6/(mol^2*s)'), n=0, Ea=(-1788, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Tsang1986]""",
 )
 
 entry(
-    index = 21,
-    label = "H2O + O <=> H + HO2",
-    kinetics = Arrhenius(A=(2.2e+08, 'cm^3/(mol*s)'), n=2, Ea=(61600, 'cal/mol'), T0=(1, 'K'), Tmin=(1500, 'K'),
-                    Tmax=(4000, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 13""",
+    index=21,
+    label="H2O + O <=> H + HO2",
+    kinetics=Arrhenius(A=(2.2e+08, 'cm^3/(mol*s)'), n=2, Ea=(61600, 'cal/mol'), T0=(1, 'K'), Tmin=(1500, 'K'),
+                       Tmax=(4000, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 13""",
 )
 
 entry(
-    index = 22,
-    label = "H2O + OH <=> H2 + HO2",
-    kinetics = Arrhenius(A=(7.9e+09, 'cm^3/(mol*s)'), n=0.43, Ea=(71700, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X22""",
+    index=22,
+    label="H2O + OH <=> H2 + HO2",
+    kinetics=Arrhenius(A=(7.9e+09, 'cm^3/(mol*s)'), n=0.43, Ea=(71700, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X22""",
 )
 
 entry(
@@ -240,244 +253,264 @@ entry(
 )
 
 entry(
-    index = 24,
-    label = "H2O2 + H <=> HO2 + H2",
-    kinetics = Arrhenius(A=(5.02e+06, 'cm^3/(mol*s)'), n=2.07, Ea=(4300, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2400, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 17""",
+    index=24,
+    label="H2O2 + H <=> HO2 + H2",
+    kinetics=Arrhenius(A=(5.02e+06, 'cm^3/(mol*s)'), n=2.07, Ea=(4300, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2400, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 17""",
 )
 
 entry(
-    index = 25,
-    label = "H2O2 + H <=> H2O + OH",
-    kinetics = Arrhenius(A=(2.03e+07, 'cm^3/(mol*s)'), n=2.02, Ea=(2620, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2400, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 18""",
+    index=25,
+    label="H2O2 + H <=> H2O + OH",
+    kinetics=Arrhenius(A=(2.03e+07, 'cm^3/(mol*s)'), n=2.02, Ea=(2620, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2400, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 18""",
 )
 
 entry(
-    index = 26,
-    label = "H2O2 + O <=> HO2 + OH",
-    kinetics = Arrhenius(A=(9.55e+06, 'cm^3/(mol*s)'), n=2, Ea=(3970, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 19
-                   Originally from Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986)""",
+    index=26,
+    label="H2O2 + O <=> HO2 + OH",
+    kinetics=Arrhenius(A=(9.55e+06, 'cm^3/(mol*s)'), n=2, Ea=(3970, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+Table 1, Reaction 19
+Originally from Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986)
+""",
 )
 
 entry(
-    index = 27,
-    label = "H2O2 + OH <=> HO2 + H2O",
-    kinetics = MultiArrhenius(
+    index=27,
+    label="H2O2 + OH <=> HO2 + H2O",
+    kinetics=MultiArrhenius(
         arrhenius=[Arrhenius(A=(1.74e+12, 'cm^3/(mol*s)'), n=0, Ea=(318, 'cal/mol'), Tmin=(280, 'K'), Tmax=(1640, 'K')),
                    Arrhenius(A=(7.59e+13, 'cm^3/(mol*s)'), n=0, Ea=(7269, 'cal/mol'), T0=(1, 'K'))]),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 20
-                   Originally from Hong et al., J. Phys. Chem. A, 114:5718 (2010)""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+Table 1, Reaction 20
+Originally from Hong et al., J. Phys. Chem. A, 114:5718 (2010)
+""",
 )
 
 entry(
-    index = 28,
-    label = "O + H2 <=> OH + H",
-    kinetics = Arrhenius(A=(50800, 'cm^3/(mol*s)'), n=2.67, Ea=(6292, 'cal/mol'), Tmin=(297, 'K'), Tmax=(2495, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 7""",
+    index=28,
+    label="O + H2 <=> OH + H",
+    kinetics=Arrhenius(A=(50800, 'cm^3/(mol*s)'), n=2.67, Ea=(6292, 'cal/mol'), Tmin=(297, 'K'), Tmax=(2495, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 7""",
 )
 
 entry(
-    index = 29,
-    label = "H2 + OH <=> H2O + H",
-    kinetics = Arrhenius(A=(2.14e+08, 'cm^3/(mol*s)'), n=1.52, Ea=(3450, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 9
-                   Originally based on Michael and Sutherland, J. Phys. Chem. 92:3853 (1988)""",
+    index=29,
+    label="H2 + OH <=> H2O + H",
+    kinetics=Arrhenius(A=(2.14e+08, 'cm^3/(mol*s)'), n=1.52, Ea=(3450, 'cal/mol'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+    Table 1, Reaction 9
+    Originally based on Michael and Sutherland, J. Phys. Chem. 92:3853 (1988)
+    """,
 )
 
 entry(
-    index = 30,
-    label = "HO2 + O <=> OH + O2",
-    kinetics = Arrhenius(A=(2.85e+10, 'cm^3/(mol*s)'), n=1, Ea=(-723.9, 'cal/mol'), Tmin=(150, 'K'), Tmax=(1600, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 11
-                   Originally taken from Fernandez-Ramos and Varandas, J. Phys. Chem. A 106:4077-4083 (2002)""",
+    index=30,
+    label="HO2 + O <=> OH + O2",
+    kinetics=Arrhenius(A=(2.85e+10, 'cm^3/(mol*s)'), n=1, Ea=(-723.9, 'cal/mol'), Tmin=(150, 'K'), Tmax=(1600, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+    Table 1, Reaction 11
+    Originally taken from Fernandez-Ramos and Varandas, J. Phys. Chem. A 106:4077-4083 (2002)
+    """,
 )
 
 entry(
-    index = 31,
-    label = "H + HO2 <=> OH + OH",
-    kinetics = Arrhenius(A=(7.079e+13, 'cm^3/(mol*s)'), n=0, Ea=(295, 'cal/mol'), Tmin=(300, 'K'), Tmax=(1000, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 12
-                   Originally taken by Mueller et al., Int. J. Chem. Kinetic. 31:113 (1999)""",
+    index=31,
+    label="H + HO2 <=> OH + OH",
+    kinetics=Arrhenius(A=(7.079e+13, 'cm^3/(mol*s)'), n=0, Ea=(295, 'cal/mol'), Tmin=(300, 'K'), Tmax=(1000, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+    Table 1, Reaction 12
+    Originally taken by Mueller et al., Int. J. Chem. Kinetic. 31:113 (1999)
+    """,
 )
 
 entry(
-    index = 32,
-    label = "H2 + O2 <=> H + HO2",
-    kinetics = Arrhenius(A=(740000, 'cm^3/(mol*s)'), n=2.43, Ea=(53500, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2300, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 14""",
+    index=32,
+    label="H2 + O2 <=> H + HO2",
+    kinetics=Arrhenius(A=(740000, 'cm^3/(mol*s)'), n=2.43, Ea=(53500, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2300, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 14""",
 )
 
 entry(
-    index = 33,
-    label = "HO2 + HO2 <=> H2O2 + O2",
-    kinetics = Arrhenius(A=(1.93E-02, 'cm^3/(mol*s)'), n=4.12, Ea=(-9857, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Klippenstein2022]""",
-    longDesc = u"""CASPT2""",
+    index=33,
+    label="HO2 + HO2 <=> H2O2 + O2",
+    kinetics=Arrhenius(A=(1.93E-02, 'cm^3/(mol*s)'), n=4.12, Ea=(-9857, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Klippenstein2022]""",
+    longDesc=u"""CASPT2""",
 )
 
 entry(
-    index = 34,
-    label = "HO2 + HO2 <=> H2O + O3",
-    kinetics = Arrhenius(A=(100, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X4""",
+    index=34,
+    label="HO2 + HO2 <=> H2O + O3",
+    kinetics=Arrhenius(A=(100, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X4""",
 )
 
 entry(
-    index = 35,
-    label = "O2 + O <=> O3",
-    kinetics = ThirdBody(
+    index=35,
+    label="O2 + O <=> O3",
+    kinetics=ThirdBody(
         arrheniusLow=Arrhenius(A=(6.53e+17, 'cm^6/(mol^2*s)'), n=-1.5, Ea=(0, 'cal/mol'), T0=(1, 'K'),
                                Tmin=(100, 'K'), Tmax=(1000, 'K')),
         efficiencies={'[Ar]': 0.0, '[He]': 0.0, '[O-][O+]=O': 2.5, '[O]': 4.0, '[O][O]': 0.95}),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 21b""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 21b""",
 )
 
 entry(
-    index = 36,
-    label = "O2 + O + Ar <=> O3 + Ar",
-    kinetics = MultiArrhenius(
+    index=36,
+    label="O2 + O + Ar <=> O3 + Ar",
+    kinetics=MultiArrhenius(
         arrhenius=[Arrhenius(A=(4.29e+17, 'cm^6/(mol^2*s)'), n=-1.5, Ea=(0, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(80, 'K'), Tmax=(1500, 'K')),
+                             Tmin=(80, 'K'), Tmax=(1500, 'K')),
                    Arrhenius(A=(5.1e+21, 'cm^6/(mol^2*s)'), n=-3.2, Ea=(0, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(80, 'K'), Tmax=(1500, 'K'))]),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 21a""",
+                             Tmin=(80, 'K'), Tmax=(1500, 'K'))]),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 21a""",
 )
 
 entry(
-    index = 37,
-    label = "O2 + O + He <=> O3 + He",
-    kinetics = MultiArrhenius(
+    index=37,
+    label="O2 + O + He <=> O3 + He",
+    kinetics=MultiArrhenius(
         arrhenius=[Arrhenius(A=(4.29e+17, 'cm^6/(mol^2*s)'), n=-1.5, Ea=(0, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(80, 'K'), Tmax=(1500, 'K')),
+                             Tmin=(80, 'K'), Tmax=(1500, 'K')),
                    Arrhenius(A=(5.1e+21, 'cm^6/(mol^2*s)'), n=-3.2, Ea=(0, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(80, 'K'), Tmax=(1500, 'K'))]),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Duplicated reaction of Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, 
-               Reaction 21a using He as a collider instead of Ar since it is expected to behave similarly as Ar in terms
-               of energy transfer.""",
+                             Tmin=(80, 'K'), Tmax=(1500, 'K'))]),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+Duplicated reaction of Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, 
+Reaction 21a using He as a collider instead of Ar since it is expected to behave similarly as Ar in terms
+of energy transfer.
+""",
 )
 
 entry(
-    index = 38,
-    label = "O3 + O <=> O2 + O2",
-    kinetics = Arrhenius( A=(4.82e+12, 'cm^3/(mol*s)'), n=0, Ea=(4094, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(200, 'K'), Tmax=(400, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 22a""",
+    index=38,
+    label="O3 + O <=> O2 + O2",
+    kinetics=Arrhenius(A=(4.82e+12, 'cm^3/(mol*s)'), n=0, Ea=(4094, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(200, 'K'), Tmax=(400, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 22a""",
 )
 
 entry(
-    index = 39,
-    label = "O3 + H <=> OH + O2",
-    kinetics = Arrhenius(A=(8.43e+13, 'cm^3/(mol*s)'), n=0, Ea=(934, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(200, 'K'), Tmax=(430, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 36""",
+    index=39,
+    label="O3 + H <=> OH + O2",
+    kinetics=Arrhenius(A=(8.43e+13, 'cm^3/(mol*s)'), n=0, Ea=(934, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(200, 'K'), Tmax=(430, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 36""",
 )
 
 entry(
-   index = 40,
-   label = "O3 + H <=> O + HO2 ",
-   kinetics = Arrhenius(A=(100, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
-   shortDesc = u"""[Konnov2015]""",
-   longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X15 
-                  Data wasn't available from konnov 2015.""",
+    index=40,
+    label="O3 + H <=> O + HO2",
+    kinetics=Arrhenius(A=(100, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""
+    Table 2, Reaction X15 
+    No data was given, the rate is very low.
+    """,
 )
 
 entry(
-    index = 43,
-    label = "O3 + OH <=> HO2 + O2",
-    kinetics = Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(1870, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(220, 'K'), Tmax=(450, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 37""",
+    index=41,
+    label="O3 + OH <=> HO2 + O2",
+    kinetics=Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(1870, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(220, 'K'), Tmax=(450, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 37""",
 )
 entry(
-    index = 44,
-    label = "O3 + HO2 <=> OH + O2 + O2",
-    kinetics = Arrhenius(A=(5.85e-4, 'cm^3/(mol*s)'), n=4.57, Ea=(-1377, 'cal/mol'), T0=(1, 'K'),
-                               Tmin=(250, 'K'), Tmax=(340, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 38""",
-)
-
-entry(
-    index = 45,
-    label = "O3 + H2 <=> OH + HO2",
-    kinetics = Arrhenius(A=(6e+10, 'cm^3/(mol*s)'), n=0, Ea=(20000, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X18""",
+    index=42,
+    label="O3 + HO2 <=> OH + O2 + O2",
+    kinetics=Arrhenius(A=(5.85e-4, 'cm^3/(mol*s)'), n=4.57, Ea=(-1377, 'cal/mol'), T0=(1, 'K'),
+                       Tmin=(250, 'K'), Tmax=(340, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 38""",
 )
 
 entry(
-    index = 46,
-    label = "H2 + O2 <=> OH + OH",
-    kinetics = Arrhenius(A=(2.04e+12, 'cm^3/(mol*s)'), n=0.44, Ea=(69155, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X1""",
+    index=43,
+    label="O3 + H2 <=> OH + HO2",
+    kinetics=Arrhenius(A=(6e+10, 'cm^3/(mol*s)'), n=0, Ea=(20000, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X18""",
 )
 
 entry(
-    index = 47,
-    label = "H2 + O2 <=> O + H2O",
-    kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(69545, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X2""",
+    index=44,
+    label="H2 + O2 <=> OH + OH",
+    kinetics=Arrhenius(A=(2.04e+12, 'cm^3/(mol*s)'), n=0.44, Ea=(69155, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X1""",
 )
 
 entry(
-    index = 48,
-    label = "H2 + O2 + O2 <=> HO2 + HO2",
-    kinetics = Arrhenius(A=(2e+17, 'cm^6/(mol^2*s)'), n=0, Ea=(25830, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X3""",
+    index=45,
+    label="H2 + O2 <=> O + H2O",
+    kinetics=Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(69545, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X2""",
 )
 
 entry(
-   index = 49,
-   label = "O + OH <=> HO2",
-   kinetics = ThirdBody(
+    index=46,
+    label="H2 + O2 + O2 <=> HO2 + HO2",
+    kinetics=Arrhenius(A=(2e+17, 'cm^6/(mol^2*s)'), n=0, Ea=(25830, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X3""",
+)
+
+entry(
+    index=47,
+    label="O + OH <=> HO2",
+    kinetics=ThirdBody(
         arrheniusLow=Arrhenius(A=(1e+15, 'cm^6/(mol^2*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'))),
-   shortDesc = u"""[Konnov2015]""",
-   longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X13""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 2, Reaction X13""",
 )
 
 entry(
-    index = 50,
-    label = "HO2 + H <=> H2O2",
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(6.0E+14, 'cm^6/(mol^2*s)'), n=1.25, Ea=(-270, 'cal/mol'), T0 = (1, 'K'))),
-    shortDesc = u"""Mousavipour et al., Bull. Chem. Soc. Jpn., 80:1901 (2007)""",
-    longDesc = u"""Taken BurkeH2O2 library Reaction X2 in Burke at el. (Table III), p. 1909 in Mousavipour et al. 
-                   Declared 'negligible' by Burke at el. We want to teach RMG that this reaction matters.""",
+    index=48,
+    label="HO2 + H <=> H2O2",
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(6.0E+14, 'cm^6/(mol^2*s)'), n=1.25, Ea=(-270, 'cal/mol'), T0=(1, 'K'))),
+    shortDesc=u"""[Hosein2007]""",
+    longDesc = u"""
+Reaction X2 in Burke at el. (Table III),
+p. 1909 in Hosein2007
+Declared 'negligible' by Burke at el.
+The original rate Arrhenius(A=(7.20E+09, 'cm^6/(mol^2*s)'), n=1.25, Ea=(-270, 'cal/mol'), T0 = (1, 'K')) was
+multiplied by the inverse of ~1.2E-05 mol cm^-3 which is the density of an ideal gas at 1000 K,
+so that a ThirdBody kinetics format could be written here
+""",
 )
 
 entry(
-    index = 51,
-    label = "H2O2 + O <=> H2O + O2",
-    kinetics = Arrhenius(A=(8.43E+11, 'cm^3/(mol*s)'), n=0.00, Ea=(3.970E+03, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""Baulch et al., J. Phys. Chem. Ref. Data, 34:757 (2005)""",
-    longDesc = u"""Added from the BurkeH2O2 library Reaction X5 in Burke at el. (Table III), Upper limit""",
+    index=49,
+    label="H2O2 + O <=> H2O + O2",
+    kinetics=Arrhenius(A=(8.43E+11, 'cm^3/(mol*s)'), n=0.00, Ea=(3.970E+03, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Baulch2005]""",
+    longDesc=u"""Added from the BurkeH2O2 library Reaction X5 in Burke at el. (Table III), Upper limit""",
 )
 
 entry(
-    index = 52,
-    label = "HO2 + HO2 <=> O2 + OH + OH",
-    kinetics = Arrhenius(A=(6.41E17, 'cm^3/(mol*s)'), n=-1.54, Ea=(16971, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Klippenstein2022]""",
-    longDesc = u"""CASPT2""",
+    index=50,
+    label="HO2 + HO2 <=> O2 + OH + OH",
+    kinetics=Arrhenius(A=(6.41E17, 'cm^3/(mol*s)'), n=-1.54, Ea=(16971, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Klippenstein2022]""",
+    longDesc=u"""CASPT2""",
 )

--- a/input/kinetics/libraries/primaryH2O2/reactions.py
+++ b/input/kinetics/libraries/primaryH2O2/reactions.py
@@ -8,7 +8,10 @@ Based on:
 [Konnov2015] A.A. Konnov, "On the role of excited species in hydrogen combustion", Combustion and Flame 2015, 
 162, 3755-3772, DOI: 10.1016/j.combustflame.2015.07.014
 [Konnov2019] A.A. Konnov, "Yet another kinetic mechanism for hydrogen combustion", Combustion and Flame 2019, 
-203, 14-22, DOI: 10.1016/j.combustflame.2019.01.032 
+203, 14-22, DOI: 10.1016/j.combustflame.2019.01.032
+[Klippenstein2022] S.J. Klippenstein, R. Sivaramakrishnan, U. Burke, K.P. Somers, H.J. Curran, L. Cai, H. Pitsch,
+M. Pelucchi, T. Faravelli, P. Glarborg, "HO2 + HO2: High level theory and the role of singlet channels",
+Combustion and Flame 2022, 243, 111975, DOI: 10.1016/j.combustflame.2021.111975
 """
 
 entry(
@@ -224,20 +227,16 @@ entry(
 )
 
 entry(
-    index = 23,
-    label = "H2O2 <=> OH + OH",
-    kinetics = Troe(
-        arrheniusHigh=Arrhenius(A=(2e+12, 's^-1'), n=0.9, Ea=(48750, 'cal/mol'), T0=(1, 'K'),
-                                Tmin=(500, 'K'), Tmax=(1500, 'K')),
-        arrheniusLow=Arrhenius(A=(2.49e+24, 'cm^3/(mol*s)'), n=-2.3, Ea=(48750, 'cal/mol'), T0=(1, 'K'),
-                                Tmin=(500, 'K'), Tmax=(1500, 'K')),
-        alpha=0.42,
-        T3=(1e+30, 'K'),
-        T1=(1e+30, 'K'),
+    index=23,
+    label="H2O2 <=> OH + OH",
+    kinetics=Troe(
+        arrheniusHigh=Arrhenius(A=(2e+12, 's^-1'), n=0.9, Ea=(48750, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1500, 'K')),
+        arrheniusLow=Arrhenius(A=(2.49e+24, 'cm^3/(mol*s)'), n=-2.3, Ea=(48750, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1500, 'K')),
+        alpha=0.42, T3=(1e+30, 'K'), T1=(1e+30, 'K'),
         efficiencies={'N#N': 1.5, 'O': 7.5, 'OO': 7.7, '[H][H]': 3.7, '[He]': 0.65, '[O][O]': 1.2, '[C-]#[O+]': 2.8,
                       'O=C=O': 1.6, }),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 6""",
+    shortDesc=u"""[Konnov2015]""",
+    longDesc=u"""Table 1, Reaction 6""",
 )
 
 entry(
@@ -322,28 +321,13 @@ entry(
 entry(
     index = 33,
     label = "HO2 + HO2 <=> H2O2 + O2",
-    duplicate = True,
-    kinetics = MultiArrhenius(
-        arrhenius=[Arrhenius(A=(1.03e+14, 'cm^3/(mol*s)'), n=0, Ea=(11040, 'cal/mol'), T0=(1, 'K'),
-                                Tmin=(300, 'K'), Tmax=(1250, 'K')),
-                   Arrhenius(A=(1.94e+11, 'cm^3/(mol*s)'), n=0, Ea=(-1409, 'cal/mol'), T0=(1, 'K'),
-                                Tmin=(300, 'K'), Tmax=(1250, 'K'))]),
-    shortDesc = u"""[Konnov2015]""",
-    longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 16.""",
+    kinetics = Arrhenius(A=(1.93E-02, 'cm^3/(mol*s)'), n=4.12, Ea=(-9857, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Klippenstein2022]""",
+    longDesc = u"""CASPT2""",
 )
 
 entry(
-   index = 34,
-   label = "HO2 + HO2 <=> H2O2 + O2",
-   duplicate = True,
-   kinetics = ThirdBody(
-       arrheniusLow = Arrhenius(A=(6.84e+14, 'cm^6/(mol^2*s)'), n=0, Ea=(-1950, 'cal/mol'), T0=(1, 'K'))),
-   shortDesc = u"""[Konnov2015]""",
-   longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 2, Reaction X6""",
-)
-
-entry(
-    index = 35,
+    index = 34,
     label = "HO2 + HO2 <=> H2O + O3",
     kinetics = Arrhenius(A=(100, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Konnov2015]""",
@@ -351,7 +335,7 @@ entry(
 )
 
 entry(
-    index = 36,
+    index = 35,
     label = "O2 + O <=> O3",
     kinetics = ThirdBody(
         arrheniusLow=Arrhenius(A=(6.53e+17, 'cm^6/(mol^2*s)'), n=-1.5, Ea=(0, 'cal/mol'), T0=(1, 'K'),
@@ -362,7 +346,7 @@ entry(
 )
 
 entry(
-    index = 37,
+    index = 36,
     label = "O2 + O + Ar <=> O3 + Ar",
     kinetics = MultiArrhenius(
         arrhenius=[Arrhenius(A=(4.29e+17, 'cm^6/(mol^2*s)'), n=-1.5, Ea=(0, 'cal/mol'), T0=(1, 'K'),
@@ -374,7 +358,7 @@ entry(
 )
 
 entry(
-    index = 38,
+    index = 37,
     label = "O2 + O + He <=> O3 + He",
     kinetics = MultiArrhenius(
         arrhenius=[Arrhenius(A=(4.29e+17, 'cm^6/(mol^2*s)'), n=-1.5, Ea=(0, 'cal/mol'), T0=(1, 'K'),
@@ -388,7 +372,7 @@ entry(
 )
 
 entry(
-    index = 39,
+    index = 38,
     label = "O3 + O <=> O2 + O2",
     kinetics = Arrhenius( A=(4.82e+12, 'cm^3/(mol*s)'), n=0, Ea=(4094, 'cal/mol'), T0=(1, 'K'),
                                Tmin=(200, 'K'), Tmax=(400, 'K')),
@@ -397,7 +381,7 @@ entry(
 )
 
 entry(
-    index = 40,
+    index = 39,
     label = "O3 + H <=> OH + O2",
     kinetics = Arrhenius(A=(8.43e+13, 'cm^3/(mol*s)'), n=0, Ea=(934, 'cal/mol'), T0=(1, 'K'),
                                Tmin=(200, 'K'), Tmax=(430, 'K')),
@@ -406,7 +390,7 @@ entry(
 )
 
 entry(
-   index = 41,
+   index = 40,
    label = "O3 + H <=> O + HO2 ",
    kinetics = Arrhenius(A=(100, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
    shortDesc = u"""[Konnov2015]""",
@@ -415,7 +399,7 @@ entry(
 )
 
 entry(
-    index = 42,
+    index = 43,
     label = "O3 + OH <=> HO2 + O2",
     kinetics = Arrhenius(A=(1e+12, 'cm^3/(mol*s)'), n=0, Ea=(1870, 'cal/mol'), T0=(1, 'K'),
                                Tmin=(220, 'K'), Tmax=(450, 'K')),
@@ -423,7 +407,7 @@ entry(
     longDesc = u"""Konnov (2015) https://doi.org/10.1016/j.combustflame.2015.07.014, Table 1, Reaction 37""",
 )
 entry(
-    index = 43,
+    index = 44,
     label = "O3 + HO2 <=> OH + O2 + O2",
     kinetics = Arrhenius(A=(5.85e-4, 'cm^3/(mol*s)'), n=4.57, Ea=(-1377, 'cal/mol'), T0=(1, 'K'),
                                Tmin=(250, 'K'), Tmax=(340, 'K')),
@@ -432,7 +416,7 @@ entry(
 )
 
 entry(
-    index = 44,
+    index = 45,
     label = "O3 + H2 <=> OH + HO2",
     kinetics = Arrhenius(A=(6e+10, 'cm^3/(mol*s)'), n=0, Ea=(20000, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Konnov2015]""",
@@ -440,7 +424,7 @@ entry(
 )
 
 entry(
-    index = 45,
+    index = 46,
     label = "H2 + O2 <=> OH + OH",
     kinetics = Arrhenius(A=(2.04e+12, 'cm^3/(mol*s)'), n=0.44, Ea=(69155, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Konnov2015]""",
@@ -448,7 +432,7 @@ entry(
 )
 
 entry(
-    index = 46,
+    index = 47,
     label = "H2 + O2 <=> O + H2O",
     kinetics = Arrhenius(A=(3e+13, 'cm^3/(mol*s)'), n=0, Ea=(69545, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Konnov2015]""",
@@ -456,7 +440,7 @@ entry(
 )
 
 entry(
-    index = 47,
+    index = 48,
     label = "H2 + O2 + O2 <=> HO2 + HO2",
     kinetics = Arrhenius(A=(2e+17, 'cm^6/(mol^2*s)'), n=0, Ea=(25830, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Konnov2015]""",
@@ -464,7 +448,7 @@ entry(
 )
 
 entry(
-   index = 48,
+   index = 49,
    label = "O + OH <=> HO2",
    kinetics = ThirdBody(
         arrheniusLow=Arrhenius(A=(1e+15, 'cm^6/(mol^2*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'))),
@@ -473,7 +457,7 @@ entry(
 )
 
 entry(
-    index = 49,
+    index = 50,
     label = "HO2 + H <=> H2O2",
     kinetics = ThirdBody(
         arrheniusLow = Arrhenius(A=(6.0E+14, 'cm^6/(mol^2*s)'), n=1.25, Ea=(-270, 'cal/mol'), T0 = (1, 'K'))),
@@ -483,9 +467,17 @@ entry(
 )
 
 entry(
-    index = 50,
+    index = 51,
     label = "H2O2 + O <=> H2O + O2",
     kinetics = Arrhenius(A=(8.43E+11, 'cm^3/(mol*s)'), n=0.00, Ea=(3.970E+03, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""Baulch et al., J. Phys. Chem. Ref. Data, 34:757 (2005)""",
     longDesc = u"""Added from the BurkeH2O2 library Reaction X5 in Burke at el. (Table III), Upper limit""",
+)
+
+entry(
+    index = 52,
+    label = "HO2 + HO2 <=> O2 + OH + OH",
+    kinetics = Arrhenius(A=(6.41E17, 'cm^3/(mol*s)'), n=-1.54, Ea=(16971, 'cal/mol'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Klippenstein2022]""",
+    longDesc = u"""CASPT2""",
 )

--- a/input/kinetics/libraries/primaryNitrogenLibrary/dictionary.txt
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/dictionary.txt
@@ -41,6 +41,12 @@ H2O
 2 H u0 p0 c0 {1,S}
 3 H u0 p0 c0 {1,S}
 
+H2O2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
 N
 multiplicity 4
 1 N u3 p1 c0
@@ -52,6 +58,11 @@ N2
 NH
 multiplicity 3
 1 N u2 p1 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+
+NH(S)
+multiplicity 1
+1 N u0 p2 c0 {2,S}
 2 H u0 p0 c0 {1,S}
 
 NH2
@@ -127,12 +138,26 @@ multiplicity 2
 1 N u1 p1 c0 {2,D}
 2 O u0 p2 c0 {1,D}
 
-H2NO
+NH2O
 multiplicity 2
 1 N u0 p1 c0 {2,S} {3,S} {4,S}
 2 O u1 p2 c0 {1,S}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
+
+NHOH
+multiplicity 2
+1 N u1 p1 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+
+H2NOH
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
 
 NH2OH
 1 N u0 p1 c0 {2,S} {3,S} {4,S}
@@ -140,6 +165,22 @@ NH2OH
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {1,S}
 5 H u0 p0 c0 {2,S}
+
+NH3O
+1 N u0 p0 c+1 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p3 c-1 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+
+NH2NHO
+multiplicity 2
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 N u0 p1 c0 {1,S} {3,S} {6,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
 
 N2O
 1 N u0 p2 c-1 {2,D}
@@ -175,13 +216,6 @@ HON
 2 N u0 p2 c-1 {1,D}
 3 H u0 p0 c0 {1,S}
 
-HNOH
-multiplicity 2
-1 N u1 p1 c0 {2,S} {3,S}
-2 H u0 p0 c0 {1,S}
-3 O u0 p2 c0 {1,S} {4,S}
-4 H u0 p0 c0 {3,S}
-
 HNO2
 1 N u0 p0 c+1 {2,S} {3,S} {4,D}
 2 H u0 p0 c0 {1,S}
@@ -194,6 +228,13 @@ NH2NO
 3 O u0 p2 c0 {2,D}
 4 H u0 p0 c0 {1,S}
 5 H u0 p0 c0 {1,S}
+
+HNOO
+multiplicity 3
+1 N u1 p1 c0 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
 
 HNO3
 1 N u0 p0 c+1 {2,D} {3,S} {4,S}
@@ -255,13 +296,6 @@ multiplicity 2
 2 N u0 p1 c0 {1,D} {3,S}
 3 O u1 p2 c0 {2,S}
 4 H u0 p0 c0 {1,S}
-
-NNOH
-multiplicity 2
-1 N u1 p1 c0 {2,D}
-2 N u0 p1 c0 {1,D} {3,S}
-3 O u0 p2 c0 {2,S} {4,S}
-4 H u0 p0 c0 {3,S}
 
 HNNO2
 multiplicity 2
@@ -346,6 +380,16 @@ NHNHNH
 4 H u0 p0 c0 {3,S}
 5 N u0 p1 c0 {3,D} {6,S}
 6 H u0 p0 c0 {5,S}
+
+NHNH2NH
+multiplicity 2
+1 N u0 p0 c+1 {2,S} {3,S} {4,S} {5,S}
+2 N u1 p1 c0 {1,S} {6,S}
+3 N u0 p2 c-1 {1,S} {7,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
 
 cN3H3
 1 N u0 p1 c0 {2,S} {3,S} {4,S}
@@ -990,3 +1034,12 @@ NH2OOH
 4 H u0 p0 c0 {1,S}
 5 H u0 p0 c0 {1,S}
 6 H u0 p0 c0 {3,S}
+
+HONHOO
+multiplicity 2
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {4,S} {6,S}
+3 O u1 p2 c0 {1,S}
+4 N u0 p1 c0 {1,S} {2,S} {5,S}
+5 H u0 p0 c0 {4,S}
+6 H u0 p0 c0 {2,S}

--- a/input/kinetics/libraries/primaryNitrogenLibrary/dictionary.txt
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/dictionary.txt
@@ -982,3 +982,11 @@ multiplicity 2
 2 N u0 p1 c0 {1,D} {4,S}
 3 H u0 p0 c0 {1,S}
 4 H u0 p0 c0 {2,S}
+
+NH2OOH
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}

--- a/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
@@ -56,6 +56,7 @@ Reference legend:
 [Friedrichs2015]  N. Faßheber,  N. Lamoureux,  G. Friedrichs, Phys. Chem. Chem. Phys., 2015, 17, 15876-15886, doi: 10.1039/C5CP01414J
 [Glarborg2018] P. Glarborg, J.A. Miller, B. Ruscic, S.J. Klippenstein, Progress in Energy and Combustion Science, 2018, 67, 31-68, doi: 10.1016/j.pecs.2018.01.002
 [Glarborg2021] P. Glarborg, Ahren W. Jasper, J. Phys. Chem. A, 2021, 125, 7, 2021, 1505-1516, doi: 10.1021/acs.jpca.0c11011
+[Glarborg2022] P. Glarborg, Combustion and Flame, 2022, 112311, doi: 10.1016/j.combustflame.2022.112311
 [GlarGim] (RMG's Nitrogen_Glarborg_Gimenez_et_al library) Gimenez Lopeza et al., Proceedings of the Combustion Institute, 2009, 32(1), 367-375, doi: 10.1016/j.proci.2008.06.188
 [GlarZha] (RMG's Nitrogen_Glarborg_Zhang_et_al library) Kuiwen Zhang et al. Proceedings of the Combustion Institute, 2013, 34, 617-624, doi: 10.1016/j.proci.2012.06.010
 [Goldsmith2019] X. Chen, M.E. Fuller, C.F. Goldsmith, Reaction CHemistry and Engineering, 2019, 4, 323-333, doi: 10.1039/C8RE00201K
@@ -81,6 +82,7 @@ Reference legend:
 [Klemm1990] J.W. Sutherland, P.M. Patterson, R.B. Klemm, J. Phys. Chem., 1990, 94(6), 2471-2475, doi: 10.1021/j100369a049
 [Klippenstein2009a] S.J. Klippenstein, L.B. Harding, B. Ruscic, R. Sivaramakrishnan, N.K. Srinivasan, M.-C. Su, J.V. Michael, J. Phys. Chem. A, 2009, 113(38), 10241-10259, doi: 10.1021/jp905454k
 [Klippenstein2009b] S.J. Klippenstein, L.B. Harding, Proc. Comb. Inst., 2009, 32, 149-155, doi: 10.1016/j.proci.2008.06.135
+[Klippenstein2022] S.J. Klippenstein, P. Glarborg, Combustion and Flame, 2022, 236, 111787, doi: 10.1016/j.combustflame.2021.111787
 [Lin1990] C-Y. Lin, H-T. Wang, M.C. Lin, C.F. Melius, Int. J. Chem. Kin., 1990, 22(5), 455-482, doi: 10.1002/kin.550220504
 [Lin1993] Y. He, C.H. Wu, M.C. Lin, C.F. Melius, in: R. Burn, L.Z. Dumitrescu (Ed.) Shock Waves @ Marseille II (Proceedings Marseille France), 1993, 89-94, doi: 10.1007/978-3-642-78832-1
 [Lin1996a] A.M. Mebel, E.W.G. Diau, M.C. Lin, K.Morokuma, J. Phys. Chem., 1996, 100, 7517-7525, doi: 10.1021/jp953644f
@@ -119,6 +121,7 @@ Reference legend:
 [Lin2013b] W.-S. Teng, L.V. Moskaleva, H.-L. Chen, M.C. Lin, J. Phys. Chem. A, 2013, 117(28), 5775-5784, doi: 10.1021/jp402903t
 [Lin2014a] P. Raghunath, Y.H. Lin, M.C. Lin, Computational and Theoretical Chemistry, 2014, 1046, 73-80, doi: 10.1016/j.comptc.2014.07.011
 [Lin2014b] P. Raghunath, N.T. Nghia, M.C. Lin, Advances in Quantum Chemistry, 2014, 69, 253-301, doi: 10.1016/B978-0-12-800345-9.00007-6
+[Luo2019] Y. Shang, J. Shi, H. Ning, R. Zhang, H. Wang, S. Luo, Fuel, 2019, 243, 288-297, doi: 10.1016/j.fuel.2019.01.112
 [Marshall2013] S.J. Klippenstein, L.B. Harding, P. Glarborg, Y. Gao, H. Hu, P. Marshall, J. Phys. Chem. A, 2013, 117, 9011-9022, doi: 10.1021/jp4068069
 [Marshall2014] I.M. Alecu, P. Marshall, J. Phys. Chem. A, 2014, 118(48), 11405-11416, doi: 10.1021/jp509301t
 [Miller1992] J.A. Miller, C.F. Melius, Simp. (Int.) Comb., 1992, 24(1), 719-726, doi: 10.1016/S0082-0784(06)80088-3
@@ -137,6 +140,7 @@ Reference legend:
 [Stagni2020] A. Stagni, C. Cavallotti, O. Herbinet, T. Faravelli, Reaction Chemistry & Engineering, 2020, 5, 696-711, doi: 10.1039/c9re00429g
 [Staton2019] T.L. Nguyen, J.F. Staton, IJCK 2019, doi: 10.1002/kin.21255
 [Troe1975] K. Glanzer, J. Troe, Berichte der Bunsengesellschaft fur physikalische Chemie, 1975, 79(5), 465-469, doi: 10.1002/bbpc.19750790514
+[Troe1998] D. Fulle, H.F. Hamann, H. Hippler, J. Troe, J. Chem. Phys., 1998, 108, 5391-5397, doi: 10.1063/1.475971
 [Varandas2005] P.J.S.B. Caridade, S.P.J. Rodrigues, F. Sousa, A.J.C. Varandas, J. Phys. Chem. A ,2005, 109, 2356-2363, doi: 10.1021/jp045102g
 [Wang1982] O.I. Smith, S. Tseregounis, S-N. Wang, Int. J. Chem. Kin., 1982, 14(6), 679-697, doi: 10.1002/kin.550140610
 [Yamaguchi1999] Y. Yamaguchi, Y. Teng, S. Shimomura, K. Tabata, E. Suzuki, J. Phys. Chem. A, 1999, 103(41), 8272-8278, doi: 10.1021/jp990985a
@@ -1948,6 +1952,7 @@ entry(
         T1=(1e+30, 'K'),
         efficiencies={'N#N': 1.0, '[Ar]': 0.5, '[O][O]': 0.61, 'N': 2.93},
     ),
+    elementary_high_p=True,
     shortDesc=u"""[Glarborg2021]""",
     longDesc=
 u"""
@@ -1961,9 +1966,9 @@ level of theory Only High Pressure Limit rate was taken; low limit and 1 atm rat
 Also available from [Klippenstein2009a]: 
     label = "NH2 + NH2 <=> N2H4",
      kinetics = Troe(
-       arrheniusHigh = Arrhenius(A=(9.33e-10, 's^-1'), n=-0.414, Ea=(66, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), 
+       arrheniusHigh = Arrhenius(A=(9.33e-10, 'cm^3/(mol*s)'), n=-0.414, Ea=(66, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), 
        Tmax=(2500, 'K')), 
-       arrheniusLow = Arrhenius(A=(2.7e+10, 'cm^3/(mol*s)'), n=-5.49, Ea=(1987, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K')
+       arrheniusLow = Arrhenius(A=(2.7e+10, 'cm^6/(mol^2*s)'), n=-5.49, Ea=(1987, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K')
        , Tmax=(2500, 'K')),
        alpha=0.31, T3=(1e-30, 'K'), T1=(1e+30, 'K'), efficiencies={}),
 Table 3, p. 10245, T range: 300-2500 K, calculated at the CCSD(T) and CAS+1+2+QC level
@@ -3121,18 +3126,22 @@ calculations done at the UMP2/6-311G-(d,p)//UMP2/6-311G(d,p) level of theory
 
 entry(
     index = 169,
-    label = "NH3 + NO2 <=> NH2 + HONO",
+    label = "NH2 + HONO <=> NH3 + NO2",
     degeneracy = 1,
+    kinetics = Arrhenius(A=(6.4e+03, 'cm^3/(mol*s)'), n=2.340, Ea=(-3200, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc = u"""[Glarborg2022]""",
+    longDesc =
+u"""
+Part of the "Thermal de-NOx" mechanism
+Glarborg slightly adjusted the rate by Lin to agree with a rate experiment
+
+Available in reverse from [Lin1996a]
     kinetics = MultiArrhenius(
         arrhenius = [
             Arrhenius(A=(2.36e+01, 'cm^3/(mol*s)'), n=3.41, Ea=(22290, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
             Arrhenius(A=(1.88e+01, 'cm^3/(mol*s)'), n=3.52, Ea=(32598, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
         ],
     ),
-    shortDesc = u"""[Lin1996a]""",
-    longDesc =
-u"""
-Part of the "Thermal de-NOx" mechanism
 k2b, k2c on p. 7523-7524
 T range: 300-5000 K
 calculations done at the UMP2/6-311G-(d,p)//UMP2/6-311G(d,p) level of theory
@@ -3196,24 +3205,25 @@ calculations done at the CCSD(T)/6-311+G(3df,2p)//B3LYP/6-311+G(3df,2p) level of
 entry(
     index = 172,
     label='NH2 + NO2  <=> N2O + H2O',
-    kinetics=Arrhenius(A=(2.2e+11, 'cm^3/(mol*s)'), n=0.11, Ea=(-1186, 'cal/mol'),
+    kinetics=Arrhenius(A=(4.3e+17, 'cm^3/(mol*s)'), n=-1.874, Ea=(588, 'cal/mol'),
                        T0=(1, 'K')),
-    shortDesc=u"""[Glarborg2018]""",
+    shortDesc=u"""[Glarborg2022]""",
     longDesc=
-u"""Reaction 67, Table 9, Source:[Glarborg2018]. Thermochemistry updated using the Active Thermochemical Tables (ATcT) approach.
+u"""
+Part of the "Thermal de-NOx" mechanism
+
+Reaction 67, Table 9, Source:[Glarborg2018]. Thermochemistry updated using the Active Thermochemical Tables (ATcT) approach.
 Rate parameters for the gas-phase reaction is surveyed, based on available information from experiments and high-level of theory.
 Also was evaluated against experimental data. 
         
-Previously taken from [Marshall2013]
-        
-Part of the "Thermal de-NOx" mechanism
-        k1a 3 on p. 9019
-        T range: 300-2000 K
-        calculations done at the RQCISD(T)/CBS(QZ,5Z)//B3LYP/6-311++G(d,p) level of theory
-        +UCCSD(T)/cc-pVTZ rovibrational analysis with UCCSD-(T)/CBS(aug-cc-pVQZ′,aug-cc-pV5Z′) energies,
-        CCSDT(Q)/cc-pVDZ higher order corrections, CCSD(T,full)/CBS-(TZ,QZ) core−valence corrections,
-        CI/aug-cc-pcVTZ relativistic corrections, HF/cc-pVTZ diagonal Born−Oppenheimer corrections,
-        and B3LYP/6-311++G(d,p) anharmonic ZPE corrections
+Also available from [Marshall2013]
+k1a 3 on p. 9019
+T range: 300-2000 K
+calculations done at the RQCISD(T)/CBS(QZ,5Z)//B3LYP/6-311++G(d,p) level of theory
++UCCSD(T)/cc-pVTZ rovibrational analysis with UCCSD-(T)/CBS(aug-cc-pVQZ′,aug-cc-pV5Z′) energies,
+CCSDT(Q)/cc-pVDZ higher order corrections, CCSD(T,full)/CBS-(TZ,QZ) core−valence corrections,
+CI/aug-cc-pcVTZ relativistic corrections, HF/cc-pVTZ diagonal Born−Oppenheimer corrections,
+and B3LYP/6-311++G(d,p) anharmonic ZPE corrections
 """,
 )
 
@@ -3224,20 +3234,21 @@ entry(
         T0=(1, 'K')),
     shortDesc = u"""[Glarborg2018]""",
     longDesc =
-u"""Reaction 68, Table 9, Source:[Glarborg2018]. Thermochemistry updated using the Active Thermochemical Tables (ATcT) approach.
+u"""
+Part of the "Thermal de-NOx" mechanism
+
+Reaction 68, Table 9, Source:[Glarborg2018]. Thermochemistry updated using the Active Thermochemical Tables (ATcT) approach.
 Rate parameters for the gas-phase reaction is surveyed, based on available information from experiments and high-level of theory.
 Also was evaluated against experimental data. 
         
-Previously taken from [Marshall2013]
-        
-Part of the "Thermal de-NOx" mechanism
-        k1a 3 on p. 9019
-        T range: 300-2000 K
-        calculations done at the RQCISD(T)/CBS(QZ,5Z)//B3LYP/6-311++G(d,p) level of theory
-        +UCCSD(T)/cc-pVTZ rovibrational analysis with UCCSD-(T)/CBS(aug-cc-pVQZ′,aug-cc-pV5Z′) energies,
-        CCSDT(Q)/cc-pVDZ higher order corrections, CCSD(T,full)/CBS-(TZ,QZ) core−valence corrections,
-        CI/aug-cc-pcVTZ relativistic corrections, HF/cc-pVTZ diagonal Born−Oppenheimer corrections,
-        and B3LYP/6-311++G(d,p) anharmonic ZPE corrections
+Also available from [Marshall2013]
+k1a 3 on p. 9019
+T range: 300-2000 K
+calculations done at the RQCISD(T)/CBS(QZ,5Z)//B3LYP/6-311++G(d,p) level of theory
++UCCSD(T)/cc-pVTZ rovibrational analysis with UCCSD-(T)/CBS(aug-cc-pVQZ′,aug-cc-pV5Z′) energies,
+CCSDT(Q)/cc-pVDZ higher order corrections, CCSD(T,full)/CBS-(TZ,QZ) core−valence corrections,
+CI/aug-cc-pcVTZ relativistic corrections, HF/cc-pVTZ diagonal Born−Oppenheimer corrections,
+and B3LYP/6-311++G(d,p) anharmonic ZPE corrections
 """,
 )
 
@@ -3340,11 +3351,16 @@ entry(
     index = 179,
     label = "HNO + NO2 <=> HONO + NO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.42e+04, 'cm^3/(mol*s)'), n=2.64, Ea=(4042, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
-    shortDesc = u"""[Lin1998f]""",
+    kinetics = Arrhenius(A=(7.847e+02, 'cm^3/(mol*s)'), n=3.1, Ea=(3882, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Luo2019]""",
     longDesc =
 u"""
 Part of the "NO2 decomposition" subset
+Based on a shock tube measurement
+
+Also available from [Lin1998f]
+    kinetics = Arrhenius(A=(4.42e+04, 'cm^3/(mol*s)'), n=2.64, Ea=(4042, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
 T range: 300-5000 K
 calculations done at the B3LYP/6-311G-(d,p)//B3LYP/6-311G(d,p) level of theory
 This route produces the cis-HONO, two other routes that produce the trans-HONO product exist, yet their rates are much smaller
@@ -4777,11 +4793,16 @@ indicate transition states and A-factors similar to radical addition reactions.
 entry(
     index = 268,
     label = 'NH2 + HO2 <=> HNO + H2O',
-    kinetics = Arrhenius(A=(2.5e+12, 'cm^3/(mol*s)'), n=0.0, Ea=(0, 'cal/mol'),
-        T0=(1, 'K')),
-    shortDesc = u"""[Glarborg2021]""",
+    kinetics = Arrhenius(A=(1.02e+12, 'cm^3/(mol*s)'), n=0.166, Ea=(-1864, 'cal/mol'),
+                          T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc = u"""[Klippenstein2022]""",
     longDesc =
 u"""
+R1b
+CASPT2/CBS//CASPT2/cc-pVTZ-F12
+
+Also available from [Glarborg2021]:
+kinetics = Arrhenius(A=(2.5e+12, 'cm^3/(mol*s)'), n=0.0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
 Reaction 1b, Table 2. Experimental work re-interpreted using direct measurements from 
 [Altinay&Macdonald2015]. Estimation by theoretical study of the singlet surface and previews studies of the three
 important branching reactions.
@@ -4790,8 +4811,7 @@ important branching reactions.
 entry(
     index = 269,
     label = 'HNO + O2 <=> NO + HO2',
-    kinetics = Arrhenius(A=(2.0e+13, 'cm^3/(mol*s)'), n=0.0, Ea=(16000, 'cal/mol'),
-        T0=(1, 'K')),
+    kinetics = Arrhenius(A=(2.0e+13, 'cm^3/(mol*s)'), n=0.0, Ea=(16000, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Glarborg2021]""",
     longDesc =
 u"""
@@ -4830,11 +4850,16 @@ Optimized and characterized the stationary points of the PESs with the CCSD meth
 entry(
     index = 272,
     label = 'NH2 + HO2 <=> NH3 + O2',
-    kinetics = Arrhenius (A=(2.179e+06, 'cm^3/(mol*s)'), n=2.080, Ea=(-4760, 'cal/mol'),
-                          T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1700, 'K')),
-    shortDesc = u"""[Sarathy2022]""",
+    kinetics = Arrhenius (A=(6.04e+18, 'cm^3/(mol*s)'), n=-1.91, Ea=(608, 'cal/mol'),
+                          T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc = u"""[Klippenstein2022]""",
     longDesc =
 u"""
+R1a
+CASPT2/CBS//CASPT2/cc-pVTZ-F12
+
+Also available from [Sarathy2022]:
+kinetics = Arrhenius (A=(2.179e+06, 'cm^3/(mol*s)'), n=2.080, Ea=(-4760, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1700, 'K')),
 Table S2, Reaction R4, triplet surface.
 Optimized and characterized the stationary points of the PESs with the CCSD method (Detailed in Table 1).
 """,
@@ -4843,11 +4868,17 @@ Optimized and characterized the stationary points of the PESs with the CCSD meth
 entry(
     index = 273,
     label = 'NH2 + HO2 <=> H2NO + OH',
-    kinetics = Arrhenius(A=(3.489e+03, 'cm^3/(mol*s)'), n=2.639, Ea=(23938, 'cal/mol'),
-                         T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K')),
-    shortDesc = u"""[Sarathy2022]""",
+    kinetics = Arrhenius(A=(2.19e+09, 'cm^3/(mol*s)'), n=0.791, Ea=(-2838, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc = u"""[Klippenstein2022]""",
     longDesc =
 u"""
+R1c
+CASPT2/CBS//CASPT2/cc-pVTZ-F12
+
+Also available from [Sarathy2022]:
+kinetics = Arrhenius(A=(3.489e+03, 'cm^3/(mol*s)'), n=2.639, Ea=(23938, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K')),
 Table S2, Reaction R5, triplet surface.
 Optimized and characterized the stationary points of the PESs with the CCSD(T) method (Detailed in Table 1).
 """,
@@ -5495,4 +5526,119 @@ entry(
     u"""
     Computed at the ANL1 level of theory
     """,
+)
+
+entry(
+    index=320,
+    label='H2NO + OH <=> HNO + H2O',
+    kinetics=Arrhenius(A=(2.14e+15, 'cm^3/(mol*s)'), n=-0.751, Ea=(-922, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2022]""",
+    longDesc=
+u"""
+CASPT2/CBS//CASPT2/cc-pVTZ-F12
+
+Also available from [Glarborg2022]
+Based on an experimental measurement at 298-373 K from https://doi.org/10.1002/kin.550240805
+    kinetics = Arrhenius(A=(1.7e+12, 'cm^3/(mol*s)'), n=0.0, Ea=(-520, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(373, 'K')),
+""",
+)
+
+entry(
+    index=321,
+    label='H2NO + OH <=> NH2OOH',
+    kinetics=PDepArrhenius(
+        pressures=([0.1, 1, 10, 100, 300], 'bar'),
+        arrhenius=[
+            Arrhenius(A=(6.07E+24, 'cm^3/(mol*s)'), n=-5.64, Ea=(2715, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.37E+26, 'cm^3/(mol*s)'), n=-5.84, Ea=(2589, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(2.18E+28, 'cm^3/(mol*s)'), n=-6.07, Ea=(3036, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.98E+29, 'cm^3/(mol*s)'), n=-6.02, Ea=(3835, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.48E+29, 'cm^3/(mol*s)'), n=-5.82, Ea=(4215, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+        ]),
+    shortDesc=u"""[Klippenstein2022]""",
+    longDesc=
+u"""
+CASPT2/CBS//CASPT2/cc-pVTZ-F12
+Note that the rate expression at 300 bar may be of limited validity due to the effect of non-binary collisions
+""",
+)
+
+entry(
+    index=322,
+    label='NO + OH <=> HONO',
+    kinetics=Troe(
+        arrheniusHigh=Arrhenius(A=(1.1e+14, 'cm^3/(mol*s)'), n=0.3, Ea=(0.0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow=Arrhenius(A=(3.4e+23, 'cm^6/(mol^2*s)'), n=-2.5, Ea=(0.0, 'cal/mol'), T0=(1, 'K')),
+        alpha=0.75, T3=(1e-30, 'K'), T1=(1e+30, 'K'), T2=(1e+30, 'K'),
+        efficiencies={'[Ar]': 1.1, 'N#N': 2.0, 'N': 4.0}),
+    shortDesc=u"""[Troe1998]""",
+    longDesc=
+u"""
+Fit to experimental measurement
+""",
+)
+
+entry(
+    index=323,
+    label='HNO + H <=> H2NO',
+    kinetics=Lindemann(
+        arrheniusHigh=Arrhenius(A=(5.5e+13, 'cm^3/(mol*s)'), n=0, Ea=(3250, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow=Arrhenius(A=(1.5e+19, 'cm^6/(mol^2*s)'), n=-1.632, Ea=(0.0, 'cal/mol'), T0=(1, 'K'))),
+    shortDesc=u"""[Glarborg2022]""",
+    longDesc=
+u"""
+arrheniusHigh is based on a 1993 calculation from https://doi.org/10.1063/1.465700
+arrheniusLow is based on [DeanBozz2000]
+""",
+)
+
+entry(
+    index=324,
+    label='H2NO + NH2 <=> NH3 + HNO',
+    kinetics=Arrhenius(A=(1.8e+06, 'cm^3/(mol*s)'), n=1.94, Ea=(-580, 'cal/mol'), T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(373, 'K')),
+    shortDesc=u"""[DeanBozz2000]""",
+    longDesc=
+u"""
+This is the recommended rate in [Glarborg2022]
+""",
+)
+
+entry(
+    index=325,
+    label='H2NO + NO2 <=> HNO + HONO',
+    kinetics=Arrhenius(A=(8.0e+11, 'cm^3/(mol*s)'), n=0.0, Ea=(6000, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Glarborg2022]""",
+    longDesc=
+u"""
+est.
+""",
+)
+
+entry(
+    index=326,
+    label="NO + H <=> HNO",
+    degeneracy=1,
+    elementary_high_p=True,
+    kinetics=Troe(
+        arrheniusHigh=Arrhenius(A=(1.5e+15, 'cm^3/(mol*s)'), n=-0.41, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusLow=Arrhenius(A=(2.4e+14, 'cm^6/(mol^2*s)'), n=0.206, Ea=(-1550, 'cal/mol'), T0=(1, 'K')),
+        alpha=0.82, T3=(1e-30, 'K'), T1=(1e+30, 'K'), T2=(1e+30, 'K'), efficiencies={'N#N': 1.6}),
+    shortDesc=u"""[Glarborg2022]""",
+    longDesc=
+u"""
+Recommended rate by Glarborg2022 (also by the NOx2018 library)
+based on: https://doi.org/10.1002/kin.10137
+""",
+)
+
+entry(
+    index=327,
+    label='NO2 + H <=> NO + OH',
+    kinetics=Arrhenius(A=(1.3e+14, 'cm^3/(mol*s)'), n=0.0, Ea=(362, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Glarborg2022]""",
+    longDesc=
+u"""
+Recommended by Glarborg2022 (also by the NOx2018 library)
+""",
 )

--- a/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
@@ -40,13 +40,16 @@ Reference legend:
 [Baulch1992a] D.L. Baulch, C.J. Cobos, R.A. Cox, C. Esser, P. Frank, Th. Just, J.A. Kerr, M.J. Philling, J. Troe, R.W. Walker, J. Warnatz, "Evaluated Kinetic Data for Combustion Modelling", Journal of Physical and Chemical Reference Data, 1992, 21(3), 411, doi: 10.1063/1.555908
 [Baulch1992b] R. Atkinson, D.L. Baulch, R.A. Cox, R.F. Hampson, J.A. Kerr, J. Troe, "Evaluated Kinetic and Photochemical Data for Atmospheric Chemistry: Supplement IV", Journal of Physical and Chemical Reference Data, 1992, 21, 1125, doi: 10.1063/1.555918
 [Baulch1994] D.L. Baulch et al., Journal of Physical and Chemical Reference Data, 1994, 23, 847, doi: 10.1063/1.555953
+[Baulch2005] D.L. Baulch et al., Journal of Physical and Chemical Reference Data, 2005, 34, 757-1397, doi: 10.1063/1.1748524
 [Baulch2009] D.L. Baulch et al., Journal of Physical and Chemical Reference Data, 2009
 [Bozzelli1994] J.W. Bozzelli, A.Y. Chang, A.M. Dean, Symp. (Int.) Comb., 1994, 25(1), 965-974, doi: 10.1016/S0082-0784(06)80733-2
 [Bozzelli1996] P. Glarborg, D. Kubel, K. Dam-Johansen, H-M. Chiang, J.W. Bozzelli, Int. J. Chem. Kin., 1996, 28(10), 773-790, doi: 10.1002/(SICI)1097-4601(1996)28:10<773::AID-KIN8>3.0.CO;2-K
 [Bozzelli2010] R. Asatryan, J.W. Bozzelli, G. da Silva, S. Swinnen, M.T. Nguyen, J. Phys. Chem. A 2010, 114, 6235-6249, doi: 10.1021/jp101640p 
 [Carl2002] S.A. Carl, Q. Sun, L. Vereecken, J. Peeters, J. Phys. Chem. A 2002, 106(51), 12242-12247, doi: 10.1021/jp014135i
-[Cohen1991] N. Cohen, K. R. Westberg, Journal of Physical and Chemical Reference Data, 1991, 20, 1211,; doi: 10.1063/1.555901
+[Cavallotti2023] A. Stagni, C. Cavallotti, Proc. Comb. Inst. 2023, 39(1), 633-641, doi: 10.1016/j.proci.2022.08.024
+[Cohen1991] N. Cohen, K. R. Westberg, Journal of Physical and Chemical Reference Data, 1991, 20, 1211, doi: 10.1063/1.555901
 [Cohen1992] Cohen, N. (1992). Chemical Kinetic Data Sheets for High-Temperature Chemical Reactions, Vol. III., Aerospace Corporation Report ATR-91 (7189)-2.
+[Dagaut1998] P. Dagaut, F. Lecomte, S. Chevailler, M. Cathonnet, Combat. Sci. Tech. 1998, 139, 329-363, doi: 10.1080/00102209808952093
 [DeanBozz2000] (RMG's Nitrogen_Dean_and_Bozzelli library) Anthony M. Dean, Joseph W. Bozzelli, Combustion Chemistry of Nitrogen, in: Gas-Phase Combustion Chemistry, Editor: W.C. Gardiner, 2000, 125-341, doi: 10.1007/978-1-4612-1310-9_2
 [DeRuyck2001] A.A. Konnov, J. De Ruyck, Comb. Flame, 2001, 125(4), 1258-1264, doi: 10.1016/S0010-2180(01)00250-4
 [Dievart2020] P. Dievart, L. Catoire, J. Phys. Chem. A, 2020, 124(30), 6214-6236, doi: 10.1021/acs.jpca.0c03144
@@ -57,10 +60,13 @@ Reference legend:
 [Glarborg2018] P. Glarborg, J.A. Miller, B. Ruscic, S.J. Klippenstein, Progress in Energy and Combustion Science, 2018, 67, 31-68, doi: 10.1016/j.pecs.2018.01.002
 [Glarborg2021] P. Glarborg, Ahren W. Jasper, J. Phys. Chem. A, 2021, 125, 7, 2021, 1505-1516, doi: 10.1021/acs.jpca.0c11011
 [Glarborg2022] P. Glarborg, Combustion and Flame, 2022, 112311, doi: 10.1016/j.combustflame.2022.112311
+[Glarborg2023] Y. Gao, I.M. Alecu, H. Hashemi, P. Glarborg, P. Marshall, Proc. Comb. Inst. 2023, 39, 571-579, doi: 10.1016/j.proci.2022.07.045
 [GlarGim] (RMG's Nitrogen_Glarborg_Gimenez_et_al library) Gimenez Lopeza et al., Proceedings of the Combustion Institute, 2009, 32(1), 367-375, doi: 10.1016/j.proci.2008.06.188
 [GlarZha] (RMG's Nitrogen_Glarborg_Zhang_et_al library) Kuiwen Zhang et al. Proceedings of the Combustion Institute, 2013, 34, 617-624, doi: 10.1016/j.proci.2012.06.010
-[Goldsmith2019] X. Chen, M.E. Fuller, C.F. Goldsmith, Reaction CHemistry and Engineering, 2019, 4, 323-333, doi: 10.1039/C8RE00201K
+[Goldsmith2019] X. Chen, M.E. Fuller, C.F. Goldsmith, Reaction Chemistry and Engineering, 2019, 4, 323-333, doi: 10.1039/C8RE00201K
 [Green2014] K. Prozument, Y.V. Suleimanov, B. Buesser, J.M. Oldham, W.H. Green, A.G. Suits, R.W. Field, J. Phys. Chem. Lett. 2014, 5(21), 3641-3648, doi: 10.1021/jz501758p
+[GrinbergDana2019] A. Grinberg Dana, K.B. Moore, A.W. Jasper, W.H. Green, J. Phys. Chem. A, 2019, 123(22), 4679-4692, doi: 10.1021/acs.jpca.9b02217
+[GrinbergDana2024] J.M. Velasco, K. Kaplan, M. Keslin, A. Grinberg Dana, internal computations for the NH3 modeling paper
 [GRI] (RMG's GRI-Mech3.0-N library) GRI-Mech 3.0, http://www.me.berkeley.edu/gri_mech/
 [Hanson1981] T.R. Roose, R.K. Hanson, C.H. Kruger, Symposium (International) on Combustion, 1981, 18(1), 853-862, doi: 10.1016/S0082-0784(81)80089-6
 [Hanson1984a] M.Y. Louge, R.K. Hanson, Int. J. Chem. Kin., 1984, 16(3), 231-250, doi: 10.1002/kin.550160306
@@ -77,18 +83,23 @@ Reference legend:
 [Herron1991] W. Tsang, J.T. Herron, Journal of Physical and Chemical Reference Data, 1991, 20, 609, doi: 10.1063/1.555890
 [Hindelang1993] M.L. Thoma, F.J. Hindelang in: R. Burn, L.Z. Dumitrescu (Ed.) Shock Waves @ Marseille II (Proceedings Marseille France), 1993, 59-64, doi: 10.1007/978-3-642-78832-1
 [Howard1988] J.F. Gleason, C.J. Howard, J. Phys. Chem., 1988, 92(12), 3414-3417, doi: 10.1021/j100323a021
+[Huynh2019] T.V.-T Mai, H.T. Nguyen, L.K. Huynh, Phys. Chem. Chem. Phys., 2019, 21, 23733, doi: 10.1039/c9cp04585f
 [Hwang2003] D. Hwang, A. M. Mebel, J. Phys. Chem. A, 2003, 107, 2865-2875, doi: 10.1021/jp0270349
+[Kanno2020] N. Kanno, T. Kito, Int. K. Chem. Kin., 2020, 52(8), 548-555, doi: 10.1002/kin.21370
 [Klemm1985] J.V. Michael, J.W. Sutherland, R.B. Klemm, Int. J. Chem. Kin., 1985, 17(3), 315-326, doi: 10.1002/kin.550170308
 [Klemm1990] J.W. Sutherland, P.M. Patterson, R.B. Klemm, J. Phys. Chem., 1990, 94(6), 2471-2475, doi: 10.1021/j100369a049
+[Klippenstein2000] J.A. Miller, S.J. Klippenstein, J. Phys. Chem. A, 2020, 104, 2061-2069, doi: 10.1021/jp992836y
 [Klippenstein2009a] S.J. Klippenstein, L.B. Harding, B. Ruscic, R. Sivaramakrishnan, N.K. Srinivasan, M.-C. Su, J.V. Michael, J. Phys. Chem. A, 2009, 113(38), 10241-10259, doi: 10.1021/jp905454k
 [Klippenstein2009b] S.J. Klippenstein, L.B. Harding, Proc. Comb. Inst., 2009, 32, 149-155, doi: 10.1016/j.proci.2008.06.135
 [Klippenstein2022] S.J. Klippenstein, P. Glarborg, Combustion and Flame, 2022, 236, 111787, doi: 10.1016/j.combustflame.2021.111787
+[Klippenstein2023] S.J. Klippenstein, C.R. Mulvihill, P. Glarborg, J. Phys. Chem. A, 2023, doi: 10.1021/acs.jpca.3c05181
 [Lin1990] C-Y. Lin, H-T. Wang, M.C. Lin, C.F. Melius, Int. J. Chem. Kin., 1990, 22(5), 455-482, doi: 10.1002/kin.550220504
 [Lin1993] Y. He, C.H. Wu, M.C. Lin, C.F. Melius, in: R. Burn, L.Z. Dumitrescu (Ed.) Shock Waves @ Marseille II (Proceedings Marseille France), 1993, 89-94, doi: 10.1007/978-3-642-78832-1
 [Lin1996a] A.M. Mebel, E.W.G. Diau, M.C. Lin, K.Morokuma, J. Phys. Chem., 1996, 100, 7517-7525, doi: 10.1021/jp953644f
 [Lin1996b] A.M. Mebel, M.C. Lin, K. Morokuma, C.F. Melius, Int. J. Chem. Kin., 1996, 28(9), 693-703, doi: 10.1002/(SICI)1097-4601(1996)28:9<693::AID-KIN8>3.0.CO;2-Q
 [Lin1997a] C.C. Hsu, M.C. Lin, A.M. Mebel, C.F. Melius, J. Phys. Chem. A, 1997, 101(1), 60-66, doi: 10.1021/jp962286t
 [Lin1997b] J.W. Boughton, S. Kristyan, M.C. Lin, Chemical Physics, 1997, 214(2-3), 219-227, doi: 10.1016/S0301-0104(96)00313-8
+[Lin1997c] A.G. Thaxton, C.-C. Hsu, M.C. Lin, Int. J. Chem. Kin., 1997, 29(4), 245-251, doi: 10.1002/(SICI)1097-4601(1997)29:4<245::AID-KIN2>3.0.CO;2-U
 [Lin1998a] D. Chakraborty, J. Park, M.C. Lin, Chemical Phisics, 1998, 231(1), 39-49, doi: 10.1016/S0301-0104(98)00033-0
 [Lin1998b] J. Park, N.D. Giles, J. Moore, M.C. Lin, J. Phys. Chem. A, 1998, 102(49), 10099-10105, doi: 10.1021/jp983139t
 [Lin1998c] A.M. Mebel, M.C. Lin, C.F. Melius, J. Phys. Chem. A, 1998, 102(10), 1803-1807, doi: 10.1021/jp973449w
@@ -113,6 +124,7 @@ Reference legend:
 [Lin2007b] S. Xu, M.C. Lin, J. Phys. Chem. A, 2007, 111, 6730-6740, doi: 10.1021/jp069038+
 [Lin2009a] S. Xu, M.C. Lin, Proceedings of the Combustion Institute, 2009, 32, 99-106, doi: 10.1016/j.proci.2008.07.011
 [Lin2009b] S-Y. Tzeng, P-H. Chen, N.S. Wang, L.C. Lee, Z.F. Xu, M.C. Lin, J. Phys. Chem. A, 2009, 113, 6314-6325, doi: 10.1021/jp901903n
+[Lin2009c] S. Xu, M.C. Lin, Int. J. Chem. Kin., 2009, 41(11), 667-677, doi: 10.1002/kin.20453
 [Lin2010a] S. Xu, M.C. Lin, J. Phys. Chem. A, 2010, 114, 5195-5204, doi: 10.1021/jp911048p
 [Lin2010b] R.S. Zhu, S.C. Xu, M.C. Lin, Chem. Phys. Letters, 2010, 488(4-6), 121-125, doi: 10.1016/j.cplett.2010.02.003
 [Lin2010c] S. Xu, M.C. Lin, Int. J. Chem. Kin., 2010, 42(2), 69-78, doi: 10.1002/kin.20463
@@ -121,14 +133,18 @@ Reference legend:
 [Lin2013b] W.-S. Teng, L.V. Moskaleva, H.-L. Chen, M.C. Lin, J. Phys. Chem. A, 2013, 117(28), 5775-5784, doi: 10.1021/jp402903t
 [Lin2014a] P. Raghunath, Y.H. Lin, M.C. Lin, Computational and Theoretical Chemistry, 2014, 1046, 73-80, doi: 10.1016/j.comptc.2014.07.011
 [Lin2014b] P. Raghunath, N.T. Nghia, M.C. Lin, Advances in Quantum Chemistry, 2014, 69, 253-301, doi: 10.1016/B978-0-12-800345-9.00007-6
+[Lin2020] T.V. Pham, T.J. Tsay, M.C. Lin, Int. J. Chem. Kin., 2020, 52(10), 632-644, doi: 10.1002/kin.21388
 [Luo2019] Y. Shang, J. Shi, H. Ning, R. Zhang, H. Wang, S. Luo, Fuel, 2019, 243, 288-297, doi: 10.1016/j.fuel.2019.01.112
 [Marshall2013] S.J. Klippenstein, L.B. Harding, P. Glarborg, Y. Gao, H. Hu, P. Marshall, J. Phys. Chem. A, 2013, 117, 9011-9022, doi: 10.1021/jp4068069
 [Marshall2014] I.M. Alecu, P. Marshall, J. Phys. Chem. A, 2014, 118(48), 11405-11416, doi: 10.1021/jp509301t
+[Marshall2023] P. Marshal, P. Glarborg, The Journal of Physical Chemistry A, 2023, 127(11), 2601-2607, doi: 10.1021/acs.jpca.2c08921
+[Mei2019] B. Mei, X. Zhang, S. Ma, M. Cui H. Guo, Z. Cao, Y. Li, Combustion and Flame, 2019, 210, 236-246, doi: 10.1016/j.combustflame.2019.08.033
 [Miller1992] J.A. Miller, C.F. Melius, Simp. (Int.) Comb., 1992, 24(1), 719-726, doi: 10.1016/S0082-0784(06)80088-3
 [Miller1999] P. Glarborg, A.B. Bendtsen, J.A. Miller, Int. J. Chem. Kin., 1999, 31(9), 591-602, doi: 10.1002/(SICI)1097-4601(1999)31:9<591::AID-KIN1>3.0.CO;2-E
 [Miller2008] L.B. Harding, S.J. Klippenstein, J.A. Miller, J. Phys. Chem. A, 2008, 112 (3), pp 522-532, doi: 10.1021/jp077526r
 [Miller2011] S.J. Klippenstein, L.B. Harding, P. Glarborg, J.A. Miller, Comb. Flame, 2011, 158(4), 774-789, doi: 10.1016/j.combustflame.2010.12.013
 [Morley1976] C. Morley, Combustion and Flame, 1976, 27, 189-204, doi: 10.1016/0010-2180(76)90022-5
+[Mousavipour2009] S. Hosein Mousavipour, F. Pirhadi, A. HabibAgahi, J. Phys. Chem. A, 2009, 113(46), 12961-12971, doi: 10.1021/jp905197h
 [Page1992] M.R. Soto, M. Page, J. Chem. Phys., 1992, 97, 7287, doi: 10.1063/1.463501
 [Palmer1977] H. Freund, H.B. Palmer, Int. J. Chem. Kin., 1977, 9(6), 887-905, doi: 10.1002/kin.550090605
 [Perry1984] R.A. Perry, Chem. Phys. Lett., 1984, 106(3), 223-228, doi: 10.1016/0009-2614(84)80230-4
@@ -136,13 +152,17 @@ Reference legend:
 [Pritchard2001] W-T. Chan, S.M. Heck, H.O. Pritchard, Phys. Chem. Chem. Phys., 2001, 3, 56-62, doi: 10.1039/b006088g
 [Rabinowitz2010] S.M. Hwang, J.A. Cooke, K.J. De Witt, M.J. Rabinowitz, Int. J. Chem. Kin., 2010, 42(3), 168-180, doi: 10.1002/kin.20472
 [Salimian1984] S. Salimian, R.K. Hanson, C.H. Kruger, Int. J. CHem. Kin., 1984, 16(6), 725-739, doi: 10.1002/kin.550160609
+[Sarathy2020] Y. Li, S. Mani Sarathy, Int. J. Hydrogen Energy, 2020, 45, 23624-23637, doi: 10.1016/j.ijhydene.2020.06.083
 [Sarathy2022] J.E. Chavarrio Cans, M. Monge-Palacios, X. Zhang, S. Mani Sarathy, Combustion and Flame, 2022, 235, 111708, doi: 10.1016/j.combustflame.2021.111708
 [Stagni2020] A. Stagni, C. Cavallotti, O. Herbinet, T. Faravelli, Reaction Chemistry & Engineering, 2020, 5, 696-711, doi: 10.1039/c9re00429g
 [Staton2019] T.L. Nguyen, J.F. Staton, IJCK 2019, doi: 10.1002/kin.21255
 [Troe1975] K. Glanzer, J. Troe, Berichte der Bunsengesellschaft fur physikalische Chemie, 1975, 79(5), 465-469, doi: 10.1002/bbpc.19750790514
-[Troe1998] D. Fulle, H.F. Hamann, H. Hippler, J. Troe, J. Chem. Phys., 1998, 108, 5391-5397, doi: 10.1063/1.475971
+[Troe1998] D. Fulle, H.F. Hamann, H. Hippler, J. Troe, J. Chem. Phys. 1998, 108, 5391-5397, doi: 10.1063/1.475971
+[Troe2023] C.J. Cobos, P. Glarborg, P. Marshall, J. Troe, Comb. Flame 2023, 257, 112374, doi: 10.1016/j.combustflame.2022.112374
 [Varandas2005] P.J.S.B. Caridade, S.P.J. Rodrigues, F. Sousa, A.J.C. Varandas, J. Phys. Chem. A ,2005, 109, 2356-2363, doi: 10.1021/jp045102g
+[Wagner1998] J. Deppe, G. Friedrichs, A. Ibrahim, H.-J. Romming, H.Gg. Wagner, Berichte der Bunsengesellschaft für physikalische Chemie, 1998, 1474-1485, doi: 10.1002/bbpc.199800016
 [Wang1982] O.I. Smith, S. Tseregounis, S-N. Wang, Int. J. Chem. Kin., 1982, 14(6), 679-697, doi: 10.1002/kin.550140610
+[Xu2021] Y. Li, S. Javoy, R. Mevel, X. Xu, Phys. Chem. Chem. Phys., 2021, 23, 585, doi: 10.1039/d0cp05131d
 [Yamaguchi1999] Y. Yamaguchi, Y. Teng, S. Shimomura, K. Tabata, E. Suzuki, J. Phys. Chem. A, 1999, 103(41), 8272-8278, doi: 10.1021/jp990985a
 [Yang2012] Y. Guan, B. Yang, J. Comp. Chem., 2012, 33(23), 1870-1879, doi: 10.1002/jcc.23020
 """
@@ -199,6 +219,7 @@ u"""
 Part of the "Thermal (Zeldovich) NO" mechanism
 5.4 on p. 398
 T range: 1750-4200 K
+Also available from Han 2008 (https://doi.org/10.1142/S021963360800399X)
 [DeanBozz2000] (p. 231) give A = 6.4e+12 cm^3/(mol*s); n = 0.1; Ea = 21300 cal/mol, citing [Cohen1991]
 But [Cohen1991] says that this rate "cannot be fixed more precisely" than an upper boundary of 4.1e+10 (p. 95, k2a)
 [GRI] used a fit to low and high T expressions from Atkinson et al., (1989) J. Phys. Chem. Ref. Data 18 88 and Hanson et al., Combustion Chemistry , Springer-Verlag, N.Y., p. 361
@@ -1154,7 +1175,7 @@ Done at the CCSD(T)/6-311+G(3df,2p)//CCSD/6-311++G(d,p) level of theory
 
 entry(
     index = 54,
-    label = "O + HNCN <=> NH + NCO",
+    label = "HNCN + O <=> NH + NCO",
     degeneracy = 1,
     duplicate = True,
     kinetics = MultiArrhenius(
@@ -1175,7 +1196,7 @@ Done at the CCSD(T)/6-311+G(3df,2p)//CCSD/6-311++G(d,p) level of theory
 
 entry(
     index = 55,
-    label = "O + HNCN <=> OH + NCN",
+    label = "HNCN + O <=> OH + NCN",
     degeneracy = 4,
     duplicate = True,
     kinetics = MultiArrhenius(
@@ -1199,7 +1220,7 @@ Added as a training reaction to H_Abstraction (k8 only)
 
 entry(
     index = 56,
-    label = "O + HNCN <=> HN(O)CN",
+    label = "HNCN + O <=> HN(O)CN",
     degeneracy = 1,
     kinetics = Arrhenius(A=(9.45e+39, 'cm^3/(mol*s)'), n=-10.47, Ea=(5316, 'cal/mol'), T0=(1, 'K'),
                          Tmin=(300, 'K'), Tmax=(3000, 'K')),
@@ -1216,7 +1237,7 @@ Done at the CCSD(T)/6-311+G(3df,2p)//CCSD/6-311++G(d,p) level of theory
 
 entry(
     index = 57,
-    label = "O + HNCN <=> CN + HNO",
+    label = "HNCN + O <=> CN + HNO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.32e+10, 'cm^3/(mol*s)'), n=0.62, Ea=(189, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin2009a]""",
@@ -1365,48 +1386,56 @@ Shock Tube
 
 entry(
     index = 66,
-    label = "NCO + H2 <=> HNCO + H",
+    label = "HNCO + H <=> NCO + H2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(8.61e+12, 'cm^3/(mol*s)','+|-',1.46e+12), n=0, Ea=(9000, 'cal/mol'), T0=(1, 'K'), Tmin=(592, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Perry1985]""",
+    kinetics = Arrhenius(A=(1.46e+05, 'cm^3/(mol*s)'), n=2.53, Ea=(12941, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
     longDesc =
 u"""
 Part of the "Prompt NO, NCN subset" mechanism
-k6
-T range: 592-913(-2000) K
-Ea uncertainty: 17%
-Shock Tube
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+
+Also available in reverse from [Perry1985], k6, Ea uncertainty: 17%, Shock Tube:
+    kinetics = Arrhenius(A=(8.61e+12, 'cm^3/(mol*s)','+|-',1.46e+12), n=0, Ea=(9000, 'cal/mol'), T0=(1, 'K'), Tmin=(592, 'K'), Tmax=(2000, 'K')),
 """,
 )
 
 entry(
-    index = 67,
-    label = "N2O <=> N2 + O",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(4.0e+14, 'cm^3/(mol*s)'), n=0, Ea=(56099, 'cal/mol'), T0 = (1, 'K'), Tmin=(1000, 'K'), Tmax=(3000, 'K'))),
-    shortDesc = u"""[DeanBozz2000]""",
-    longDesc =
+    index=67,
+    label="N2O <=> N2 + O",
+    kinetics=Lindemann(
+        arrheniusHigh=Arrhenius(A=(7.9e+11, 's^-1'), n=0, Ea=(61540, 'cal/mol'),
+                                T0=(1, 'K'), Tmin=(925, 'K'), Tmax=(2500, 'K')),
+        arrheniusLow=Arrhenius(A=(9.3e+14, 'cm^3/(mol*s)'), n=0, Ea=(60050, 'cal/mol'),
+                               T0=(1, 'K'), Tmin=(925, 'K'), Tmax=(2500, 'K'))),
+    shortDesc=u"""[Lin2020]""",
+    longDesc=
 u"""
 Part of the "N2O Pathway"
-Rate taken from:
+CCSD(T)/CBS(TQ5)//CCSD(T)/aug-cc-pVTZ+d
+
+Also available from D&B
+Originally took the rate from:
 Johnsson, J.E., Glarborg, P., & Dam-Johansen, K. (1992). 24th Symposium (International) on Combustion, p. 917
-As reported by Dean & Bozzelli, see 2.5.3 on p. 143
+see 2.5.3 on p. 143
 Measured in a flow reactor with Ar as bath gas.
 T range: 1000-3000 K
 """,
 )
 
 entry(
-    index = 68,
-    label = "O + N2O <=> N2 + O2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.4e+12, 'cm^3/(mol*s)'), n=0, Ea=(10810, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[DeanBozz2000]""",
-    longDesc =
+    index=68,
+    label="N2O + O <=> N2 + O2",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(1.66e+12, 'cm^3/(mol*s)'), n=0, Ea=(11650, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(988, 'K'), Tmax=(3340, 'K')),
+    shortDesc=u"""[Lin2020]""",
+    longDesc=
 u"""
 Part of the "N2O Pathway"
-Rate taken from:
+k3
+
+Also available from D&B, originally taken from:
 Davidson, D.E, DiRosa, M.D., Chang, A.Y., & Hanson, R.K. (1991). 18th International Symposium on Shock Waves, Sendai, p. 813
 As reported by Dean & Bozzelli, see 2.5.4 on p. 145
 """,
@@ -1414,7 +1443,7 @@ As reported by Dean & Bozzelli, see 2.5.4 on p. 145
 
 entry(
     index = 69,
-    label = "O + N2O <=> NO + NO",
+    label = "N2O + O <=> NO + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.9e+13, 'cm^3/(mol*s)'), n=0, Ea=(23151, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[DeanBozz2000]""",
@@ -1427,38 +1456,36 @@ As reported by Dean & Bozzelli, see 2.5.4 on p. 145
 """,
 )
 
-entry(
-    index = 70,
-    label = "H + N2O <=> HNNO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(8.5e+13, 'cm^3/(mol*s)'), n=0, Ea=(9082, 'cal/mol'), T0=(1, 'K')),
-    elementary_high_p = True,
-    shortDesc = u"""[DeanBozz2000]""",
-    longDesc =
-u"""
-Part of the "N2O Pathway"
-See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163
-""",
-)
+# entry(
+#     index = 70,
+#     label = "N2O + H <=> NNOH",
+#     degeneracy = 1,
+#     kinetics = Arrhenius(A=(1.0e+0, 'cm^3/(mol*s)'), n=0, Ea=(1000, 'kcal/mol'), T0=(1, 'K')),
+#     elementary_high_p = True,
+#     shortDesc = u"""NPS""",
+#     longDesc =
+# u"""
+# The NNOH species does not exist
+# see A.M. Mebel, C.C. Hsu, M.C. Lin, K. Morokuma, J. Chem. Phys. 103, 5640-5649, 1995, DOI: 10.1063/1.470546
+#
+# However, a rate was given later by D&B:
+# See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163:
+#     Arrhenius(A=(1.3e+14, 'cm^3/(mol*s)'), n=0, Ea=(18403, 'cal/mol'), T0=(1, 'K')
+#
+# We could not optimize NNOH at neither of wb97xd/Def2TZVP, CBS-QB3, M062X/Def2TZVP.
+#
+# NNOH
+# multiplicity 2
+# 1 N u1 p1 c0 {2,D}
+# 2 N u0 p1 c0 {1,D} {3,S}
+# 3 O u0 p2 c0 {2,S} {4,S}
+# 4 H u0 p0 c0 {3,S}
+# """,
+# )
 
 entry(
     index = 71,
-    label = "H + N2O <=> NNOH",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.3e+14, 'cm^3/(mol*s)'), n=0, Ea=(18403, 'cal/mol'), T0=(1, 'K')),
-    elementary_high_p = True,
-    shortDesc = u"""[DeanBozz2000]""",
-    longDesc =
-u"""
-Part of the "N2O Pathway"
-See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163
-""",
-)
-
-entry(
-    index = 72,
     label = "HNNO <=> NH + NO",
-    degeneracy = 1,
     kinetics = ThirdBody(
         arrheniusLow = Arrhenius(A=(4.0e+15, 'cm^3/(mol*s)'), n=0, Ea=(49952, 'cal/mol'), T0 = (1, 'K'))),
     shortDesc = u"""[DeanBozz2000]""",
@@ -1470,7 +1497,7 @@ See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163
 )
 
 entry(
-    index = 73,
+    index = 72,
     label = "HNNO <=> N2 + OH",
     degeneracy = 1,
     kinetics = ThirdBody(
@@ -1484,7 +1511,7 @@ See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163
 )
 
 entry(
-    index = 74,
+    index = 73,
     label = "N2O + NO <=> N2 + NO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.26e+05, 'cm^3/(mol*s)'), n=2.23, Ea=(46286, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
@@ -1499,7 +1526,7 @@ calculations done at the B3LYP/6-311G(d,p)//B3LYP/6-311G(d,p) level of theory
 )
 
 entry(
-    index = 75,
+    index = 74,
     label = "N2O + OH <=> N2 + HO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.29e-02, 'cm^3/(mol*s)'), n=4.72, Ea=(36565, 'cal/mol'), T0=(1, 'K'), Tmin=(1000, 'K'), Tmax=(5000, 'K')),
@@ -1516,7 +1543,7 @@ For the low T range (300-1000 K) the recommended rate for both "N2O + OH <=> N2 
 )
 
 entry(
-    index = 76,
+    index = 75,
     label = "N2O + OH <=> HNO + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.18e-04, 'cm^3/(mol*s)'), n=4.33, Ea=(25039, 'cal/mol'), T0=(1, 'K'), Tmin=(1000, 'K'), Tmax=(5000, 'K')),
@@ -1531,7 +1558,7 @@ calculations done at the B3LYP/6-311G(d,p)//B3LYP/6-311G(d,p) level of theory
 )
 
 entry(
-    index = 77,
+    index = 76,
     label = "HNNO <=> O + NNH",
     degeneracy = 1,
     kinetics = ThirdBody(
@@ -1545,7 +1572,7 @@ See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163
 )
 
 entry(
-    index = 78,
+    index = 77,
     label = "NNH + O <=> N2O + H",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.9e+14, 'cm^3/(mol*s)'), n=-0.274, Ea=(-22, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
@@ -1561,7 +1588,7 @@ T range: 300-4000 K, k1d, QRRK
 )
 
 entry(
-    index = 79,
+    index = 78,
     label = "NNH + O <=> N2 + OH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.2e+13, 'cm^3/(mol*s)'), n=0.145, Ea=(-217, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
@@ -1574,7 +1601,7 @@ calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 +
 )
 
 entry(
-    index = 80,
+    index = 79,
     label = "NNH + O <=> NH + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.2e+11, 'cm^3/(mol*s)','+|-',2.6e+11), n=0.388, Ea=(-409, 'cal/mol','+|-',102), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
@@ -1590,28 +1617,25 @@ k1, T range: 1200-2500 K, Uncertainty: A 50%, Ea 25%
 )
 
 entry(
-    index = 81,
-    label = "N2 + H <=> NNH",
+    index = 80,
+    label = "NNH <=> N2 + H",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(7.6e+15, 'cm^3/(mol*s)'), n=-0.64, Ea=(15333, 'cal/mol'), T0=(1, 'K'),
+    kinetics = Arrhenius(A=(7.68e+07, 's^-1'), n=1.73, Ea=(4282, 'cal/mol'), T0=(1, 'K'),
                          Tmin=(300, 'K'), Tmax=(25000, 'K')),
     elementary_high_p = True,
-    shortDesc = u"""[Varandas2005]""",
+    shortDesc = u"""[Sarathy2020]""",
     longDesc =
 u"""
 Part of the "NNH Pathway"
-T range: 300-25000 K
-reaction -3 in [Varandas2005]
-Fits to a total of 972 MRCI energies (based on the aug-cc-pVQZ basis set of Dunning27), scaled by the DMBE-SEC
-method to account for excitations higher than singles and doubles and the incompleteness of the one-electron basis set.
-The paper reports a HO-RR rate, and a sum-over-states rate (where vib-rot aren't assumed to be independent).
-The sum-over-states rate was taken here.
-Added as a training reaction to R_Addition_MultipleBond
+
+Also available in reverse from [Varandas2005], reaction -3:
+    kinetics = Arrhenius(A=(7.6e+15, 'cm^3/(mol*s)'), n=-0.64, Ea=(15333, 'cal/mol'), T0=(1, 'K'),
+                         Tmin=(300, 'K'), Tmax=(25000, 'K')),
 """,
 )
 
 entry(
-    index = 82,
+    index = 81,
     label = "N + NH <=> N2 + H",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.41e+11, 'cm^3/(mol*s)'), n=0.51, Ea=(18, 'cal/mol'), T0=(1, 'K')),
@@ -1627,38 +1651,6 @@ method to account for excitations higher than singles and doubles and the incomp
 
 entry(
     index = 83,
-    label = "N + NH <=> N + N + H",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(7.75e+14, 'cm^3/(mol*s)'), n=-0.20, Ea=(54159, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Varandas2005]""",
-    longDesc =
-u"""
-Part of the "NNH Pathway"
-reaction 1 in [Varandas2005]
-Fits to a total of 972 MRCI energies (based on the aug-cc-pVQZ basis set of Dunning27), scaled by the DMBE-SEC
-method to account for excitations higher than singles and doubles and the incompleteness of the one-electron basis set.
-The fragmentation channel (N + NH <=> N + N + H) opens up at ~3000 K, and even at very high T (25000 K) its rate is
-an order of magnitude lower than N + NH <=> N2 + H. Although probably insignificant, it is brought here for completeness.
-""",
-)
-
-entry(
-    index = 84,
-    label = "N + H2 <=> NH + H",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.60e+14, 'cm^3/(mol*s)'), n=0, Ea=(25138, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Hanson1990b]""",
-    longDesc =
-u"""
-Part of the "NNH Pathway"
-See [Hanson1990b] R2; p. 860
-Shock Tube
-Added as a training reaction to H_Abstraction
-""",
-)
-
-entry(
-    index = 85,
     label = "NNH + O2 <=> N2 + HO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.6e+14, 'cm^3/(mol*s)'), n=-0.385, Ea=(-13, 'cal/mol'),
@@ -1675,7 +1667,7 @@ calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 +
 )
 
 entry(
-    index = 86,
+    index = 84,
     label = "NNH + H <=> H2 + N2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.4e+08, 'cm^3/(mol*s)'), n=1.5, Ea=(-894, 'cal/mol'), T0=(1, 'K')),
@@ -1689,8 +1681,8 @@ DHT estimate
 )
 
 entry(
-    index = 87,
-    label = "NNH + OH <=> H2O + N2",
+    index = 85,
+    label = "NNH + OH <=> N2 + H2O",
     degeneracy = 1,
     kinetics = MultiArrhenius(
         arrhenius = [
@@ -1708,7 +1700,7 @@ calculated using  QRRK / DHT
 )
 
 entry(
-    index = 88,
+    index = 86,
     label='NH2 + H <=> NH3',
     kinetics=Troe(
         arrheniusHigh=Arrhenius(A=(1.6e+14, 'cm^3/(mol*s)'), n=0.0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
@@ -1734,29 +1726,31 @@ and is ~40 times lower in rate, and can be neglected.
 )
 
 entry(
-    index = 89,
-    label = "NH2 + H <=> NH + H2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(4.00e+13, 'cm^3/(mol*s)'), n=0, Ea=(3650, 'cal/mol'), T0=(1, 'K'), Tmin=(2200, 'K'), Tmax=(2800, 'K')),
-    shortDesc = u"""[Hanson1990a]""",
-    longDesc =
+    index=87,
+    label="NH2 + H <=> NH + H2",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(1.09e+05, 'cm^3/(mol*s)'), n=2.59, Ea=(1812, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Sarathy2020]""",
+    longDesc=
 u"""
 Part of the "NHx" subset
-R9 in Table 1, p. 521
-T range: 2200-2800 K
-Shock Tube
-Train!
+Table 6 (given in s^-1 units, probably an error?)
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+
+Also available from [Hanson1990a], R9 in Table 1, p. 521:
+    kinetics = Arrhenius(A=(4.00e+13, 'cm^3/(mol*s)'), n=0, Ea=(3650, 'cal/mol'), T0=(1, 'K'), Tmin=(2200, 'K'), Tmax=(2800, 'K')),
 """,
 )
 
 entry(
-    index = 90,
-    label = "HNCO <=> NH + CO",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(3.26e+35, 'cm^3/(mol*s)'), n=-5.11, Ea=(110000, 'cal/mol'), T0 = (1, 'K'), Tmin=(1830, 'K'), Tmax=(3340, 'K'))),
-    shortDesc = u"""[Hanson1989]""",
-    longDesc =
+    index=88,
+    label="HNCO <=> NH + CO",
+    degeneracy=1,
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(3.26e+35, 'cm^3/(mol*s)'), n=-5.11, Ea=(110000, 'cal/mol'),
+                               T0=(1, 'K'), Tmin=(1830, 'K'), Tmax=(3340, 'K'))),
+    shortDesc=u"""[Hanson1989]""",
+    longDesc=
 u"""
 Part of the "NHx" subset
 T range: 1830-3340 K
@@ -1767,14 +1761,14 @@ Measured in Ar
 )
 
 entry(
-    index = 91,
-    label = "H + NCO <=> HNCO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(2.80e+12, 'cm^3/(mol*s)'), n=0.493, Ea=(-294, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(200, 'K'), Tmax=(2500, 'K')),
-    elementary_high_p = True,
-    shortDesc = u"""[Klippenstein2009b]""",
-    longDesc =
+    index=89,
+    label="H + NCO <=> HNCO",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(2.80e+12, 'cm^3/(mol*s)'), n=0.493, Ea=(-294, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K')),
+    elementary_high_p=True,
+    shortDesc=u"""[Klippenstein2009b]""",
+    longDesc=
 u"""
 Part of the "NHx" subset
 T range: 200-2500 K
@@ -1789,7 +1783,7 @@ Added as a training reaction to R_Recombination
 )
 
 entry(
-    index = 92,
+    index = 90,
     label = "H + NCO <=> NCOH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(7.00e+11, 'cm^3/(mol*s)'), n=0.493, Ea=(-294, 'cal/mol'), T0=(1, 'K'),
@@ -1811,13 +1805,15 @@ Added as a training reaction to R_Recombination
 )
 
 entry(
-    index = 93,
-    label = "NH <=> N + H",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(2.65e+14, 'cm^3/(mol*s)'), n=0, Ea=(75500, 'cal/mol'), T0 = (1, 'K'), Tmin=(3140, 'K'), Tmax=(3320, 'K'))),
-    shortDesc = u"""[Hanson1989]""",
-    longDesc =
+    index=91,
+    label="NH <=> N + H",
+    degeneracy=1,
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(2.65e+14, 'cm^3/(mol*s)'), n=0, Ea=(75500, 'cal/mol'),
+                               T0=(1, 'K'), Tmin=(3140, 'K'), Tmax=(3320, 'K')),
+        efficiencies={'[N]': 0}),
+    shortDesc=u"""[Hanson1989]""",
+    longDesc=
 u"""
 Part of the "NHx" subset
 T range: 3140-3320 K
@@ -1828,7 +1824,24 @@ Measured in Ar
 )
 
 entry(
-    index = 94,
+    index=92,
+    label="N + NH <=> N + N + H",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(7.75e+14, 'cm^3/(mol*s)'), n=-0.20, Ea=(54159, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Varandas2005]""",
+    longDesc=
+u"""
+Part of the "NNH Pathway"
+reaction 1 in [Varandas2005]
+Fits to a total of 972 MRCI energies (based on the aug-cc-pVQZ basis set of Dunning27), scaled by the DMBE-SEC
+method to account for excitations higher than singles and doubles and the incompleteness of the one-electron basis set.
+The fragmentation channel (N + NH <=> N + N + H) opens up at ~3000 K, and even at very high T (25000 K) its rate is
+an order of magnitude lower than N + NH <=> N2 + H. Although probably insignificant, it is brought here for completeness.
+""",
+)
+
+entry(
+    index = 93,
     label = "N2H4 + NO <=> N2H3 + HNO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.44e+01, 'cm^3/(mol*s)'), n=3.16, Ea=(30488, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -1845,7 +1858,7 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 95,
+    index = 94,
     label = "N2H4 + NO <=> NH2 + NH2NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.03e+01, 'cm^3/(mol*s)'), n=2.98, Ea=(35609, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -1861,9 +1874,8 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 96,
+    index = 95,
     label = "N2H4 + NO2 <=> N2H3 + HNO2",
-    degeneracy = 1,
     kinetics = Arrhenius(A=(2.41e-02, 'cm^3/(mol*s)'), n=4.14, Ea=(7947, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
     shortDesc = u"""[Lin2014a]""",
     longDesc =
@@ -1878,7 +1890,7 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 97,
+    index = 96,
     label = "N2H3 + HNO <=> NH2NHNO + H",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.65e-02, 'cm^3/(mol*s)'), n=3.82, Ea=(17780, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -1894,8 +1906,8 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 98,
-    label = "N2H3 + HNO <=> N2H2 + HNOH",
+    index = 97,
+    label = "N2H3 + HNO <=> N2H2 + NHOH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.85e-17, 'cm^3/(mol*s)'), n=8.15, Ea=(904, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
     shortDesc = u"""[Lin2014a]""",
@@ -1910,7 +1922,7 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 99,
+    index = 98,
     label = "N2H3 + HONO <=> NH2NHNO + OH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.69e+00, 'cm^3/(mol*s)'), n=2.94, Ea=(15379, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -1926,7 +1938,7 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 100,
+    index = 99,
     label = "N2H3 + HONO <=> N2H2 + H2O + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.79e-08, 'cm^3/(mol*s)'), n=5.51, Ea=(11112, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -1942,20 +1954,24 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 101,
-    label='NH2 + NH2 <=> N2H4',
+    index = 100,
+    label='N2H4 <=> NH2 + NH2',
     kinetics=Troe(
-        arrheniusHigh=Arrhenius(A=(5.6e+14, 'cm^3/(mol*s)'), n=-0.414, Ea=(66, 'cal/mol'), T0=(1, 'K')),
-        arrheniusLow=Arrhenius(A=(1.6e34, 'cm^6/(mol^2*s)'), n=-5.49, Ea=(1987, 'cal/mol'), T0=(1, 'K')),
-        alpha=0.31,
-        T3=(1e-30, 'K'),
-        T1=(1e+30, 'K'),
-        efficiencies={'N#N': 1.0, '[Ar]': 0.5, '[O][O]': 0.61, 'N': 2.93},
+        arrheniusHigh=Arrhenius(A=(7.6e+16, 's^-1'), n=-1.0, Ea=(66770, 'cal/mol'), T0=(1000, 'K')),
+        arrheniusLow=Arrhenius(A=(6.1e+20, 'cm^3/(mol*s)'), n=-7.3, Ea=(68540, 'cal/mol'), T0=(1000, 'K')),
+        alpha=0.29,
+        T3=(1460, 'K'),
+        T1=(21, 'K'),
+        T2=(13400, 'K'),
+        efficiencies={'N#N': 2.0, '[Ar]': 1.0, '[O][O]': 1.22, 'N': 5.86},  # [Glarborg2021] efficiencies time 2
     ),
     elementary_high_p=True,
-    shortDesc=u"""[Glarborg2021]""",
+    shortDesc=u"""[Troe2023]""",
     longDesc=
 u"""
+T range: 1100-2500 K, computed for Ar as bath gas
+
+Also available from [Glarborg2021]:
 Reaction 3, Table 2 taken form [Glarborg2021]. Experimental work re-interpreted using direct measurements from 
 [Altinay&Macdonald2015]. Original values taken from [Klippenstein2009a], computed with the CCSD(T) method employing 
 either the aug-cc-pvdz or aug-cc-pvtz basis set, adopted by [Glarborg2021] and calculated the relative third-body 
@@ -1976,7 +1992,7 @@ Table 3, p. 10245, T range: 300-2500 K, calculated at the CCSD(T) and CAS+1+2+QC
 )
 
 entry(
-    index = 102,
+    index = 101,
     label = "N2H4 <=> N2H3 + H",
     degeneracy = 1,
     kinetics = Lindemann(
@@ -1995,7 +2011,7 @@ Only High Pressure Limit rate was taken low limit and 1 atm rate are also availa
 )
 
 entry(
-    index = 103,
+    index = 102,
     label = "ONONO2 <=> NO2 + NO2",
     degeneracy = 1,
     kinetics = Lindemann(
@@ -2014,7 +2030,7 @@ Only High Pressure Limit rate was taken low limit and 1 atm rate are also availa
 )
 
 entry(
-    index = 104,
+    index = 103,
     label = "ONONO2 <=> NO + NO3",
     degeneracy = 1,
     kinetics = Lindemann(
@@ -2033,23 +2049,27 @@ Only High Pressure Limit rate was taken low limit and 1 atm rate are also availa
 )
 
 entry(
-    index = 105,
-    label = "N2H4 + NO2 <=> N2H3 + HONO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(3.23e+00, 'cm^3/(mol*s)'), n=3.56, Ea=(763, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Lin2014b]""",
-    longDesc =
-u"""
-Part of the "N2H4 + N2O4" subset
-p. 267
-calculations done at the G2M(CC2)//B3LYP/6-311þþG(3df,2p) level of theoty
-Also available from [Lin2014a], calculated at the CCSD(T)/CBS//CCSD level of theoty:
-    kinetics = Arrhenius(A=(8.25e+01, 'cm^3/(mol*s)'), n=3.13, Ea=(8863, 'cal/mol'), T0=(1, 'K')),
-""",
+    index=104,
+    label="N2H4 + NO2 <=> N2H3 + HONO",
+    kinetics=MultiArrhenius(
+        arrhenius=[
+            Arrhenius(A=(8.25e+01, 'cm^3/(mol*s)'), n=3.13, Ea=(8863, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+            Arrhenius(A=(3.28e-02, 'cm^3/(mol*s)'), n=4.00, Ea=(12917, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Lin2014a]""",
+    longDesc=
+    u"""
+    Part of the "N2H4 + N2O4" subset
+    p. 78
+    k3 + k5 (cis + tans HONO)
+    Also available from [Lin2014b]:
+        kinetics = Arrhenius(A=(3.23e+00, 'cm^3/(mol*s)'), n=3.56, Ea=(763, 'cal/mol'), T0=(1, 'K'))
+    """,
 )
 
 entry(
-    index = 106,
+    index = 105,
     label = "N2H4 + NO3 <=> N2H3 + HNO3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.28e+04, 'cm^3/(mol*s)'), n=2.53, Ea=(-2947, 'cal/mol'), T0=(1, 'K'),
@@ -2072,7 +2092,7 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 107,
+    index = 106,
     label = "N2H4 + NO3 <=> HONO + N2H3O",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3.46e+03, 'cm^3/(mol*s)'), n=2.51, Ea=(-7452, 'cal/mol'), T0=(1, 'K'),
@@ -2099,7 +2119,7 @@ and the moment of inertia and harmonic vibrational frequencies were obtained by 
 )
 
 entry(
-    index = 108,
+    index = 107,
     label = "N2H4 + N2O4 <=> HONO + NH2NHNO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.39e+02, 'cm^3/(mol*s)'), n=2.62, Ea=(13112, 'cal/mol'), T0=(1, 'K'),
@@ -2115,7 +2135,7 @@ calculations done at the G2M(CC3)//B3LYP level of theoty
 )
 
 entry(
-    index = 109,
+    index = 108,
     label = "N2H4 + ONONO2 <=> HNO3 + NH2NHNO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.7e+14, 'cm^3/(mol*s)','+|-',6.1e+13), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'),
@@ -2134,7 +2154,7 @@ in this pathway is negligable. The summation of the two constant rate coefficien
 )
 
 entry(
-    index = 110,
+    index = 109,
     label = "NH2NHNO <=> N2H3 + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.24e+15, 's^-1'), n=-0.15, Ea=(35611, 'cal/mol'), T0=(1, 'K'),
@@ -2150,7 +2170,7 @@ calculations done at the CCSD(T)/6-311þG(3df,2p) level of theoty
 )
 
 entry(
-    index = 111,
+    index = 110,
     label = "N2H3 + NO2 <=> N2H2 + HONO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.40e+55, 'cm^3/(mol*s)'), n=-16.7, Ea=(-14397, 'cal/mol'), T0=(1, 'K'),
@@ -2168,7 +2188,7 @@ The Low T (300-800 K) rate is:
 )
 
 entry(
-    index = 112,
+    index = 111,
     label = "N2H3 + NO2 <=> N2H2 + HNO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.12e+07, 'cm^3/(mol*s)'), n=-0.2, Ea=(-2736, 'cal/mol'), T0=(1, 'K'),
@@ -2186,7 +2206,7 @@ The Low T (300-1500 K) rate is:
 )
 
 entry(
-    index = 113,
+    index = 112,
     label = "N2H3 + NO2 <=> N2H3O + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.14e+00, 'cm^3/(mol*s)'), n=2.8, Ea=(-8853, 'cal/mol'), T0=(1, 'K'),
@@ -2204,7 +2224,7 @@ The Low T (300-1000 K) rate is:
 )
 
 entry(
-    index = 114,
+    index = 113,
     label = "N2H3 + N2O4 <=> NH2NHNO2 + NO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.10e+10, 'cm^3/(mol*s)'), n=0.87, Ea=(11772, 'cal/mol'), T0=(1, 'K'),
@@ -2219,7 +2239,7 @@ calculations done at the CCSD(T)/6-311þþG(3df,2p)//B3LYP/6-311þþG(3df,2p) le
 )
 
 entry(
-    index = 115,
+    index = 114,
     label = "N2H3 + N2O4 <=> N2H2 + HONO + NO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(8.55e+10, 'cm^3/(mol*s)'), n=0.74, Ea=(11707, 'cal/mol'), T0=(1, 'K'),
@@ -2234,7 +2254,7 @@ calculations done at the CCSD(T)/6-311þþG(3df,2p)//B3LYP/6-311þþG(3df,2p) le
 )
 
 entry(
-    index = 116,
+    index = 115,
     label = "N2H3 + N2O4 <=> NH2NHONO + NO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.54e+13, 'cm^3/(mol*s)'), n=0.76, Ea=(15960, 'cal/mol'), T0=(1, 'K'),
@@ -2249,7 +2269,7 @@ calculations done at the CCSD(T)/6-311þþG(3df,2p)//B3LYP/6-311þþG(3df,2p) le
 )
 
 entry(
-    index = 117,
+    index = 116,
     label = "N2H3 + N2O4 <=> N2H3O + N2O3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3.69e+11, 'cm^3/(mol*s)'), n=0.87, Ea=(8047.4, 'cal/mol'), T0=(1, 'K'),
@@ -2264,7 +2284,7 @@ calculations done at the CCSD(T)/6-311þþG(3df,2p)//B3LYP/6-311þþG(3df,2p) le
 )
 
 entry(
-    index = 118,
+    index = 117,
     label = "N2H3O <=> NH3 + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.86e+22, 's^-1'), n=-2.80, Ea=(79296, 'cal/mol'), T0=(1, 'K'),
@@ -2281,24 +2301,32 @@ calculations done at the CCSD(T)/6-311þG(3df,2p)//CCSD/6-311þþG(d,p) level of
 )
 
 entry(
-    index = 119,
-    label = "N2H3O <=> NH2 + HNO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(9.12e+33, 's^-1'), n=-6.68, Ea=(35217, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    index = 118,
+    label = "NH2 + HNO <=> N2H3O",
+    kinetics = PDepArrhenius(
+        pressures = ([1, 10, 100, 760, 7600, 76000], 'torr'),
+        arrhenius = [
+            Arrhenius(A=(2.17e+32, 'cm^3/(mol*s)'), n=-8.34, Ea=(-3237, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.86e+33, 'cm^3/(mol*s)'), n=-8.33, Ea=(-3239, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(2.04e+34, 'cm^3/(mol*s)'), n=-8.34, Ea=(-3309, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.92e+35, 'cm^3/(mol*s)'), n=-8.36, Ea=(-3474, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(2.85e+36, 'cm^3/(mol*s)'), n=-8.40, Ea=(-3821, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(5.22e+37, 'cm^3/(mol*s)'), n=-8.46, Ea=(-4416, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+        ],
+    ),
     elementary_high_p = True,
-    shortDesc = u"""[Lin2014b]""",
+    shortDesc = u"""[Lin2009c]""",
     longDesc =
 u"""
-Part of the "N2H4 + N2O4" subset
-k15, p. 284
-T range: 300-3000 K, P = 1 atm
-calculations done at the CCSD(T)/6-311þG(3df,2p)//CCSD/6-311þþG(d,p) level of theoty
+k2, Table II
+CCSD(T)/6-311+G(3df.2p)//CCSD/6-311++G(d,p)
+
+Also available from [Lin2014b], k15, p. 284, T range: 300-3000 K, P = 1 atm, CCSD(T)/6-311þG(3df,2p)//CCSD/6-311þþG(d,p)
 """,
 )
 
 entry(
-    index = 120,
+    index = 119,
     label = "N2H3O <=> NH2NO + H",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.57e+34, 's^-1'), n=-6.63, Ea=(44953, 'cal/mol'), T0=(1, 'K'),
@@ -2315,7 +2343,7 @@ calculations done at the CCSD(T)/6-311þG(3df,2p)//CCSD/6-311þþG(d,p) level of
 )
 
 entry(
-    index = 121,
+    index = 120,
     label = "N2H2 + NO2 <=> HONO + NNH",
     degeneracy = 1,
     kinetics = MultiArrhenius(
@@ -2335,7 +2363,7 @@ conformer-dup: rates summed for trans/cis-N2H2
 )
 
 entry(
-    index = 122,
+    index = 121,
     label = "N2H2 + N2O4 <=> HONO + NO2 + NNH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(8.79e+00, 'cm^3/(mol*s)'), n=3.10, Ea=(28787, 'cal/mol'), T0=(1, 'K'),
@@ -2351,7 +2379,7 @@ calculations done at the B3LYP/6-311þþG(3df,2p) level
 )
 
 entry(
-    index = 123,
+    index = 122,
     label = "N2H2 + N2O4 <=> HONO + HNO2 + N2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.38e-02, 'cm^3/(mol*s)'), n=3.90, Ea=(13360, 'cal/mol'), T0=(1, 'K'),
@@ -2363,6 +2391,17 @@ Part of the "N2H4 + N2O4" subset
 k20, p. 288
 T range: 300-2500 K
 calculations done at the B3LYP/6-311þþG(3df,2p) level
+""",
+)
+
+entry(
+    index = 123,
+    label = "N2H2 + O <=> NNH + OH",
+    kinetics = Arrhenius(A=(1.11e08, 'cm^3/(mol*s)'), n=1.62, Ea=(805, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
+    longDesc =
+u"""
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
 """,
 )
 
@@ -2536,7 +2575,7 @@ calculations done at the MP2(frozen core)/6-311++G(2d,p) level of theory
 )
 
 entry(
-    index = 1000,
+    index = 134,
     label = "CH3 + NO2 <=> CH3O + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.0e+13, 'cm^3/(mol*s)'), n=-0.2, Ea=(0, 'cal/mol'), T0=(1, 'K')),
@@ -2549,7 +2588,7 @@ T: 1000 - 1400 K
 )
 
 entry(
-    index = 134,
+    index = 135,
     label = "CH3O + CH4 <=> CH3OH + CH3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.5e+13, 'cm^3/(mol*s)'), n=0, Ea=(16900, 'cal/mol'), T0=(1, 'K')),
@@ -2564,7 +2603,7 @@ calculations done at the MP2(frozen core)/6-311++G(2d,p) level of theory
 )
 
 entry(
-    index = 135,
+    index = 136,
     label = "CH3O + NO2 <=> CH2O + HNO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.5e+10, 'cm^3/(mol*s)'), n=0, Ea=(6700, 'cal/mol'), T0=(1, 'K')),
@@ -2579,7 +2618,7 @@ calculations done at the MP2(frozen core)/6-311++G(2d,p) level of theory
 )
 
 entry(
-    index = 136,
+    index = 137,
     label = "CH3O + NO <=> CH2O + HNO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.3e+11, 'cm^3/(mol*s)'), n=0, Ea=(5600, 'cal/mol'), T0=(1, 'K')),
@@ -2594,7 +2633,7 @@ calculations done at the MP2(frozen core)/6-311++G(2d,p) level of theory
 )
 
 entry(
-    index = 137,
+    index = 138,
     label = "CH4 + NO <=> CH3 + HNO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(7.0e+14, 'cm^3/(mol*s)'), n=0, Ea=(65600, 'cal/mol'), T0=(1, 'K')),
@@ -2609,7 +2648,7 @@ calculations done at the MP2(frozen core)/6-311++G(2d,p) level of theory
 )
 
 entry(
-    index = 138,
+    index = 139,
     label = "CH4 + NO <=> CH3 + HON",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.8e+15, 'cm^3/(mol*s)'), n=0, Ea=(76300, 'cal/mol'), T0=(1, 'K')),
@@ -2624,34 +2663,17 @@ calculations done at the MP2(frozen core)/6-311++G(2d,p) level of theory
 )
 
 entry(
-    index = 139,
-    label='NH2 + HNO <=> NH3 + NO',
-    kinetics=Arrhenius(A=(5.9e+02, 'cm^3/(mol*s)'), n=2.950, Ea=(-3469, 'cal/mol'), T0=(1, 'K')),
-    shortDesc=u"""[Glarborg2021]""",
-    longDesc=
-u"""Reaction 7, Table 2, Source: [Glarborg2021], Experimental work re-interpreted using direct measurments from 
-[Altinay&Macdonald2015]. New parameters obtained with the predicted rate expressions by [ShuchengXu & M.C.Lin2009] 
-the potential energy surface of this reaction has been computed by single-point calculations at the 
-CCSD(T)/6-311+G(3df,2p) level based on geometries optimized at the CCSD/6-311++G(d,p) level.
-Previously taken from [Lin1996a] in reverse.
-Reaction Part of the "Thermal de-NOx" mechanism
-        k1 on p. 7519
-        T range: 300-5000 K
-        calculations done at the UMP2/6-311G-(d,p)//UMP2/6-311G(d,p) level of theory
-        Added as a training reaction to H_Abstraction
-""",
-)
-
-entry(
     index = 140,
     label = 'NH2 + NO <=> NNH + OH',
     kinetics = Arrhenius(A=(4.3e+10, 'cm^3/(mol*s)'), n=0.294, Ea=(-866, 'cal/mol'),
         T0=(1, 'K')),
     shortDesc =u"""[Glarborg2021]""",
     longDesc =
-u"""Reaction 5a, Table 2,Source: [Glarborg2021]. Experimental work re-interpreted using direct measurements from 
-[Altinay&Macdonald2015]. Original information taken from [Song&Golden2001] Shock tube experiments  were  
-performed behind reflected shockwaves in a stainless steel shock tube.  Rates were calculated using their branching 
+u"""
+Reaction 5a, Table 2
+Experimental work re-interpreted using direct measurements from [Altinay&Macdonald2015].
+Original information taken from [Song&Golden2001] Shock tube experiments were  
+performed behind reflected shockwaves in a stainless steel shock tube. Rates were calculated using their branching 
 ratio results data and the overall rate coefficient.
 
 Previously taken from [Lin1999a] 
@@ -2667,13 +2689,14 @@ entry(
         T0=(1, 'K')),
     shortDesc = u"""[Glarborg2021]""",
     longDesc =
-u"""Reaction 5b, Table 2,Source: [Glarborg2021]. Experimental work re-interpreted using direct measurements from 
-[Altinay&Macdonald2015]. Original information taken from [Song&Golden2001] Shock tube experiments  were  
-performed behind reflected shockwaves in a stainless steel shock tube.  Rates were calculated using their branching 
-ratio results data and the overall rate coefficient.
+u"""
+Reaction 5b, Table 2. Experimental work re-interpreted using direct measurements from [Altinay&Macdonald2015].
+Original information taken from [Song&Golden2001]. Shock tube experiments were performed behind reflected shockwaves
+in a stainless steel shock tube. Rates were calculated using their branching ratio results data and the overall rate
+coefficient.
 
-Previously taken from [Lin1999a].
-Part of the "Thermal de-NOx" mechanism k1b T range: 300-2500 K
+Also available from [Lin1999a].
+Part of the "Thermal de-NOx" mechanism
 """,
 )
 
@@ -2681,15 +2704,16 @@ entry(
     index = 142,
     label = "NH2 + NO <=> N2O + H2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(7e+13, 'cm^3/(mol*s)','*|/',2), n=0, Ea=(15700, 'cal/mol'), T0=(1, 'K'), Tmin=(1680, 'K'), Tmax=(2850, 'K')),
-    shortDesc = u"""[Hanson1981]""",
+    kinetics = Arrhenius(A=(4.52e+01, 'cm^3/(mol*s)'), n=2.056, Ea=(1879, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Klippenstein2000]""",
     longDesc =
 u"""
 Part of the "Thermal de-NOx" mechanism
-k2
-Uncertainty: +100%, -70%
-T range: 1680-2850 K
-Shocktube measurement
+
+Fitted to a three-param Arrhenius expression manually from Fig. 12 in [Klippenstein2000]
+
+Also available from [Hanson1981], k2, Uncertainty: +100%, -70%, Shocktube measurement (ref 35 in [Klippenstein2000]),
+but [Klippenstein2000] claim that the [Hanson1981] rate is too high by 2-3 orders of magnitude.
 """,
 )
 
@@ -2702,9 +2726,12 @@ entry(
     longDesc =
 u"""
 Part of the "Thermal de-NOx" mechanism
-calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC electronic structure calculations level
+
+Miller2011 applied VRC-TST with CASPT2(7e,6o)/aug-cc-pVDZ energies:
+    kinetics = Arrhenius(A=(1.8e+14, 'cm^3/(mol*s)','*|/',3), n=-0.351, Ea=(-244, 'cal/mol'), T0=(1, 'K')),
 Also available from [Hanson1981], k3, Shock Tube, Uncertainty: +200%, -70%, T range: 1680-2850 K:
     kinetics = Arrhenius(A=(8e+13, 'cm^3/(mol*s)'), n=0, Ea=(29400, 'cal/mol'), T0=(1, 'K'), Tmin=(1680, 'K'), Tmax=(2850, 'K')),
+Also available from [Baulch2005], p. 937
 """,
 )
 
@@ -2717,7 +2744,7 @@ entry(
     longDesc =
 u"""
 Part of the "Thermal de-NOx" mechanism
-calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC electronic structure calculations level
+calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC level
 Also availabvle from [Bozzelli1994]:
     kinetics = Arrhenius(A=(6.1e+13, 'cm^3/(mol*s)'), n=-0.50, Ea=(120, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(4000, 'K')),
 T range: 300-4000 K, k2a, QRRK
@@ -2726,14 +2753,14 @@ T range: 300-4000 K, k2a, QRRK
 
 entry(
     index = 145,
-    label="NH2 + O2 <=> H2NO + O",
+    label="NH2 + O2 <=> NH2O + O",
     degeneracy=1,
     kinetics=Arrhenius(A=(2.6e+11, 'cm^3/(mol*s)'), n=0.4872, Ea=(29050, 'cal/mol'), T0=(1, 'K')),
     shortDesc=u"""[Miller2011]""",
     longDesc=
     u"""
     Part of the "Thermal de-NOx" mechanism
-    calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC electronic structure calculations level
+    calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC level
 """,
 )
 
@@ -2746,7 +2773,7 @@ entry(
     longDesc=
     u"""
     Part of the "Thermal de-NOx" mechanism
-    calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC electronic structure calculations level
+    calculated at the (CCSD(T) and QCISD(T)) and multireference CASPT2 and CAS + 1 + 2 + QC level
 """,
 )
 
@@ -2774,30 +2801,32 @@ entry(
     index = 148,
     label = "NH2 + OH <=> NH + H2O",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.84e+06, 'cm^3/(mol*s)'), n=1.97, Ea=(-2246, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Klippenstein2009a]""",
+    kinetics = Arrhenius(A=(4.04e+04, 'cm^3/(mol*s)'), n=2.52, Ea=(-616, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(600, 'K'), Tmax=(2000, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
     longDesc =
 u"""
 Part of the "Thermal de-NOx" mechanism
-Table 3, p. 10245
-T range: 300-2500 K
-calculated at the (CCSD(T) and CAS+1+2+QC level
-Train!
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+
+Both [Sarathy2020] and [Klippenstein2009a] reduced Ea by 2 kcal/mol
+since the computed rates were significantly lower than experimental data.
+
+Also available from [Klippenstein2009a], Table 3, p. 10245, calculated at the CCSD(T) and CAS+1+2+QC level:
+    kinetics = Arrhenius(A=(2.84e+06, 'cm^3/(mol*s)'), n=1.97, Ea=(-2246, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
 """,
 )
 
 entry(
     index = 149,
     label='NH3 + O <=> NH2 + OH',
-    kinetics=Arrhenius(A=(4.43e+02, 'cm^3/(mol*s)'), n=3.180, Ea=(6739.9, 'cal/mol'), T0=(1, 'K'),
-                       Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics=Arrhenius(A=(4.430e+02, 'cm^3/(mol*s)'), n=3.180, Ea=(6739.9, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc=u"""[Stagni2020]""",
     longDesc=
-u"""Reaction 4, Table 1, Source: [Stagni2020].The rate of reaction was calculated with CCSD(T) level of theory 
-performed using Molpro 2010. Electronic structure calculations were performed determining structures and vibrational 
-frequencies at the M06-2X/aug-cc-pVTZ level and energies at the unrestricted CCSDĲT)/aug-cc-pVTZ level, corrected for
-basis set size effect with the change of density fitted (DF) MP2 energies computed using aug-cc-pVQZ and aug-cc-pVTZ 
-basis sets.
+u"""
+Reaction 4, Table 1
+CCSD(T)/aug-cc-pVTZ//M06-2X/aug-cc-pVTZ
     
 Previously taken from [Klippenstein2009a].
 
@@ -2812,9 +2841,10 @@ Part of the "Thermal de-NOx" mechanism Table 3, p. 10245
 
 entry(
     index = 150,
-    label = "NH2OH + OH <=> HNOH + H2O",
+    label = "NH2OH + OH <=> NHOH + H2O",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.54e+04, 'cm^3/(mol*s)'), n=2.61, Ea=(-3537, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(1.54e+04, 'cm^3/(mol*s)'), n=2.61, Ea=(-3537, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2828,9 +2858,10 @@ Train!
 
 entry(
     index = 151,
-    label = "NH2OH + OH <=> H2NO + H2O",
+    label = "NH2OH + OH <=> NH2O + H2O",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.53e+05, 'cm^3/(mol*s)'), n=2.28, Ea=(-1296, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(1.53e+05, 'cm^3/(mol*s)'), n=2.28, Ea=(-1296, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2844,9 +2875,10 @@ Train!
 
 entry(
     index = 152,
-    label = "NH2OH + NH2 <=> HNOH + NH3",
+    label = "NH2OH + NH2 <=> NHOH + NH3",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.08e-01, 'cm^3/(mol*s)'), n=4.00, Ea=(-97, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(1.08e-01, 'cm^3/(mol*s)'), n=4.00, Ea=(-97, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2860,9 +2892,10 @@ Train!
 
 entry(
     index = 153,
-    label = "NH2OH + NH2 <=> H2NO + NH3",
+    label = "NH2OH + NH2 <=> NH2O + NH3",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(9.45e+00, 'cm^3/(mol*s)'), n=3.42, Ea=(-1013, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(9.45e+00, 'cm^3/(mol*s)'), n=3.42, Ea=(-1013, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2876,9 +2909,10 @@ Train!
 
 entry(
     index = 154,
-    label = "NH2OH + NH <=> HNOH + NH2",
+    label = "NH2OH + NH <=> NHOH + NH2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.91e-03, 'cm^3/(mol*s)'), n=4.40, Ea=(1564, 'cal/mol'), T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(2.91e-03, 'cm^3/(mol*s)'), n=4.40, Ea=(1564, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2892,9 +2926,10 @@ Train!
 
 entry(
     index = 155,
-    label = "NH2OH + NH <=> H2NO + NH2",
+    label = "NH2OH + NH <=> NH2O + NH2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.46e-03, 'cm^3/(mol*s)'), n=4.60, Ea=(2424, 'cal/mol'), T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(1.46e-03, 'cm^3/(mol*s)'), n=4.60, Ea=(2424, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2902,49 +2937,15 @@ Part of the "Thermal de-NOx" mechanism
 Table 3, p. 10245
 T range: 400-2500 K
 calculated at the (CCSD(T) and CAS+1+2+QC level
-Train!
 """,
 )
 
 entry(
     index = 156,
-    label = "NH + OH <=> H2O + N",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(1.59e+07, 'cm^6/(mol^2*s)'), n=1.737, Ea=(-576, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K'))),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
-u"""
-Part of the "Thermal de-NOx" mechanism
-Table 3, p. 10245
-T range: 200-2500 K
-calculated at the (CCSD(T) and CAS+1+2+QC level
-Train!
-""",
-)
-
-entry(
-    index = 157,
-    label = "NH + OH <=> HNO + H",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(3.25e+14, 'cm^6/(mol^2*s)'), n=-0.376, Ea=(-46, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K'))),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
-u"""
-Part of the "Thermal de-NOx" mechanism
-Table 3, p. 10245
-T range: 200-2500 K
-calculated at the (CCSD(T) and CAS+1+2+QC level
-""",
-)
-
-entry(
-    index = 158,
     label = "NH + NH <=> N2H2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(6.26e+13, 'cm^3/(mol*s)'), n=-0.036, Ea=(-161, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(200, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(6.26e+13, 'cm^3/(mol*s)'), n=-0.036, Ea=(-161, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K')),
     elementary_high_p = True,
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
@@ -2958,10 +2959,11 @@ Train!
 )
 
 entry(
-    index = 159,
+    index = 157,
     label = "NH + NH <=> NH2 + N",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(5.66e-01, 'cm^3/(mol*s)'), n=3.88, Ea=(342, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(5.66e-01, 'cm^3/(mol*s)'), n=3.88, Ea=(342, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2009a]""",
     longDesc =
 u"""
@@ -2974,17 +2976,17 @@ Train!
 )
 
 entry(
-    index = 160,
-    label = "NH2 + NH <=> N2H2 + H",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(4.26e+14, 'cm^6/(mol^2*s)'), n=-0.272, Ea=(-78, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K'))),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
+    index=158,
+    label="NH2 + NH <=> N2H2 + H",
+    degeneracy=1,
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(4.26e+14, 'cm^6/(mol^2*s)'), n=-0.272, Ea=(-78, 'cal/mol'),
+                               T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K'))),
+    shortDesc=u"""[Klippenstein2009a]""",
+    longDesc=
 u"""
 Part of the "Thermal de-NOx" mechanism
 Table 3, p. 10245
-T range: 200-2500 K
 calculated at the (CCSD(T) and CAS+1+2+QC level
 Also available from [Hanson1990a]:
     kinetics = Arrhenius(A=(1.50e+15, 'cm^3/(mol*s)'), n=-0.5, Ea=(0, 'cal/mol'), T0=(1, 'K')),
@@ -2993,12 +2995,13 @@ R11 in Table 1, p. 521, T range: 2200-2800 K, Shock Tube
 )
 
 entry(
-    index = 161,
-    label = "NH2 + NH <=> NH3 + N",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(9.58e+03, 'cm^3/(mol*s)'), n=2.46, Ea=(107, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
+    index=159,
+    label="NH2 + NH <=> NH3 + N",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(9.58e+03, 'cm^3/(mol*s)'), n=2.46, Ea=(107, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2009a]""",
+    longDesc=
 u"""
 Part of the "Thermal de-NOx" mechanism
 Table 3, p. 10245
@@ -3009,13 +3012,31 @@ Train!
 )
 
 entry(
-    index = 162,
-    label = "NH2 + NH2 <=> N2H2 + H2",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(1.74e+08, 'cm^6/(mol^2*s)'), n=1.02, Ea=(11784, 'cal/mol'), T0 = (1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K'))),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
+    index=160,
+    label="NH2 + NH2 <=> N2H2 + H2",
+    degeneracy=1,
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(1.74e+08, 'cm^6/(mol^2*s)'), n=1.02, Ea=(11784, 'cal/mol'),
+                               T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K'))),
+    shortDesc=u"""[Klippenstein2009a]""",
+    longDesc=
+u"""
+Part of the "Thermal de-NOx" mechanism
+Table 3, p. 10245
+T range: 500-2500 K
+calculated at the CCSD(T) and CAS+1+2+QC level
+""",
+)
+
+entry(
+    index=161,
+    label="NH2 + NH2 <=> H2NN(S) + H2",
+    degeneracy=1,
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(7.17e+04, 'cm^6/(mol^2*s)'), n=1.88, Ea=(8803, 'cal/mol'),
+                               T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K'))),
+    shortDesc=u"""[Klippenstein2009a]""",
+    longDesc=
 u"""
 Part of the "Thermal de-NOx" mechanism
 Table 3, p. 10245
@@ -3025,33 +3046,18 @@ calculated at the (CCSD(T) and CAS+1+2+QC level
 )
 
 entry(
-    index = 163,
-    label = "NH2 + NH2 <=> H2NN(S) + H2",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(7.17e+04, 'cm^6/(mol^2*s)'), n=1.88, Ea=(8803, 'cal/mol'), T0 = (1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K'))),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
-u"""
-Part of the "Thermal de-NOx" mechanism
-Table 3, p. 10245
-T range: 500-2500 K
-calculated at the (CCSD(T) and CAS+1+2+QC level
-""",
-)
-
-entry(
-    index = 164,
-    label = "NH2 + NH2 <=> NH3 + NH",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(5.64e+00, 'cm^3/(mol*s)'), n=3.53, Ea=(552, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Klippenstein2009a]""",
-    longDesc =
+    index=162,
+    label="NH2 + NH2 <=> NH3 + NH",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(5.64e+00, 'cm^3/(mol*s)'), n=3.53, Ea=(552, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2009a]""",
+    longDesc=
 u"""
 Part of the "Thermal de-NOx" mechanism
 Table 3, p. 10245
 T range: 300-2500 K
-calculated at the (CCSD(T) and CAS+1+2+QC level
+calculated at the CCSD(T) and CAS+1+2+QC level
 Also available from [Hanson1990a]:
     kinetics = Arrhenius(A=(5.00e+13, 'cm^3/(mol*s)'), n=0, Ea=(10000, 'cal/mol'), T0=(1, 'K')),
 R12 in Table 1, p. 521, T range: 2200-2800 K, Shock Tube
@@ -3062,10 +3068,9 @@ Train both!!!
 )
 
 entry(
-    index = 165,
+    index = 163,
     label='NH3 + H <=> NH2 + H2',
-    kinetics=Arrhenius(A=(6.4e+05, 'cm^3/(mol*s)'), n=2.390, Ea=(10171, 'cal/mol'),
-                       T0=(1, 'K')),
+    kinetics=Arrhenius(A=(6.4e+05, 'cm^3/(mol*s)'), n=2.390, Ea=(10171, 'cal/mol'), T0=(1, 'K')),
     shortDesc=u"""[Glarborg2021]""",
     longDesc=
 u"""Reaction 10, Table 2,Source: [Glarborg2021]. Experimental work re-interpreted using direct measurements from 
@@ -3087,10 +3092,9 @@ Tmin=(300, 'K'), Tmax=(2500, 'K'))
 )
 
 entry(
-    index = 167,
+    index = 164,
     label='NH3 + OH <=> NH2 + H2O ',
-    kinetics=Arrhenius(A=(2.0e+06, 'cm^3/(mol*s)'), n=2.040, Ea=(566, 'cal/mol'),
-                       T0=(1, 'K')),
+    kinetics=Arrhenius(A=(2.0e+06, 'cm^3/(mol*s)'), n=2.040, Ea=(566, 'cal/mol'), T0=(1, 'K')),
     shortDesc= u"""[Glarborg2021]""",
     longDesc=
 u"""Reaction 12, Table 2,Source: [Glarborg2021]. Experimental work re-interpreted using direct measurements from 
@@ -3110,10 +3114,11 @@ Part of the "Thermal de-NOx" mechanism
 )
 
 entry(
-    index = 168,
+    index = 165,
     label = "NH3 + NO2 <=> NH2 + HNO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.91e+00, 'cm^3/(mol*s)'), n=3.41, Ea=(29880, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
+    kinetics = Arrhenius(A=(4.91e+00, 'cm^3/(mol*s)'), n=3.41, Ea=(29880, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
     shortDesc = u"""[Lin1996a]""",
     longDesc =
 u"""
@@ -3125,14 +3130,15 @@ calculations done at the UMP2/6-311G-(d,p)//UMP2/6-311G(d,p) level of theory
 )
 
 entry(
-    index = 169,
-    label = "NH2 + HONO <=> NH3 + NO2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(6.4e+03, 'cm^3/(mol*s)'), n=2.340, Ea=(-3200, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Glarborg2022]""",
-    longDesc =
+    index=166,
+    label="NH2 + HONO <=> NH3 + NO2",
+    kinetics=Arrhenius(A=(6.4e+03, 'cm^3/(mol*s)'), n=2.340, Ea=(-3200, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Glarborg2022]""",
+    longDesc=
 u"""
 Part of the "Thermal de-NOx" mechanism
+Also available from [Lin1997c]
 Glarborg slightly adjusted the rate by Lin to agree with a rate experiment
 
 Available in reverse from [Lin1996a]
@@ -3152,18 +3158,18 @@ conformer-dup: cis/trans-HONO
 )
 
 entry(
-    index = 170,
+    index = 167,
     label = "NH3 + NO3 <=> HNO3 + NH2",
     degeneracy = 1,
     kinetics = PDepArrhenius(
-        pressures = ([1, 10, 100, 760, 7600, 76000], 'torr'),
-        arrhenius = [
-            Arrhenius(A=(2.57e+00, 'cm^3/(mol*s)'), n=3.61, Ea=(964, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(5.67e+00, 'cm^3/(mol*s)'), n=3.53, Ea=(1598, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(4.61e+00, 'cm^3/(mol*s)'), n=3.56, Ea=(1691, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(4.06e+00, 'cm^3/(mol*s)'), n=3.57, Ea=(1689, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(3.85e+00, 'cm^3/(mol*s)'), n=3.58, Ea=(1679, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(3.63e+00, 'cm^3/(mol*s)'), n=3.59, Ea=(1669, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+        pressures=([1, 10, 100, 760, 7600, 76000], 'torr'),
+        arrhenius=[
+            Arrhenius(A=(2.57e+00, 'cm^3/(mol*s)'), n=3.61, Ea=(964, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(5.67e+00, 'cm^3/(mol*s)'), n=3.53, Ea=(1598, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(4.61e+00, 'cm^3/(mol*s)'), n=3.56, Ea=(1691, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(4.06e+00, 'cm^3/(mol*s)'), n=3.57, Ea=(1689, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(3.85e+00, 'cm^3/(mol*s)'), n=3.58, Ea=(1679, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(3.63e+00, 'cm^3/(mol*s)'), n=3.59, Ea=(1669, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
         ],
     ),
     shortDesc = u"""[Lin2010c]""",
@@ -3178,18 +3184,18 @@ k-1 was addopted here due to the strange T dependence of k+1
 )
 
 entry(
-    index = 171,
-    label = "HNO3 + NH2 <=> H2NO + HONO",
+    index = 168,
+    label = "HNO3 + NH2 <=> NH2O + HONO",
     degeneracy = 1,
     kinetics = PDepArrhenius(
         pressures = ([1, 10, 100, 760, 7600, 76000], 'torr'),
         arrhenius = [
-            Arrhenius(A=(8.91e+04, 'cm^3/(mol*s)'), n=2.00, Ea=(24641, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(1.36e+07, 'cm^3/(mol*s)'), n=1.40, Ea=(26390, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(5.09e+08, 'cm^3/(mol*s)'), n=0.99, Ea=(28353, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(1.73e+08, 'cm^3/(mol*s)'), n=1.17, Ea=(29562, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(7.17e+04, 'cm^3/(mol*s)'), n=2.19, Ea=(29870, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-            Arrhenius(A=(3.46e-02, 'cm^3/(mol*s)'), n=4.04, Ea=(28946, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(8.91e+04, 'cm^3/(mol*s)'), n=2.00, Ea=(24641, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.36e+07, 'cm^3/(mol*s)'), n=1.40, Ea=(26390, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(5.09e+08, 'cm^3/(mol*s)'), n=0.99, Ea=(28353, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.73e+08, 'cm^3/(mol*s)'), n=1.17, Ea=(29562, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(7.17e+04, 'cm^3/(mol*s)'), n=2.19, Ea=(29870, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(3.46e-02, 'cm^3/(mol*s)'), n=4.04, Ea=(28946, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
         ],
     ),
     shortDesc = u"""[Lin2010c]""",
@@ -3203,10 +3209,9 @@ calculations done at the CCSD(T)/6-311+G(3df,2p)//B3LYP/6-311+G(3df,2p) level of
 )
 
 entry(
-    index = 172,
+    index = 169,
     label='NH2 + NO2  <=> N2O + H2O',
-    kinetics=Arrhenius(A=(4.3e+17, 'cm^3/(mol*s)'), n=-1.874, Ea=(588, 'cal/mol'),
-                       T0=(1, 'K')),
+    kinetics=Arrhenius(A=(4.3e+17, 'cm^3/(mol*s)'), n=-1.874, Ea=(588, 'cal/mol'), T0=(1, 'K')),
     shortDesc=u"""[Glarborg2022]""",
     longDesc=
 u"""
@@ -3228,10 +3233,9 @@ and B3LYP/6-311++G(d,p) anharmonic ZPE corrections
 )
 
 entry(
-    index = 173,
-    label = 'NH2 + NO2 <=> H2NO + NO',
-    kinetics = Arrhenius(A=(8.6e+11, 'cm^3/(mol*s)'), n=0.11, Ea=(-1186, 'cal/mol'),
-        T0=(1, 'K')),
+    index = 170,
+    label = 'NH2 + NO2 <=> NH2O + NO',
+    kinetics = Arrhenius(A=(8.6e+11, 'cm^3/(mol*s)'), n=0.11, Ea=(-1186, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""[Glarborg2018]""",
     longDesc =
 u"""
@@ -3253,7 +3257,7 @@ and B3LYP/6-311++G(d,p) anharmonic ZPE corrections
 )
 
 entry(
-    index = 174,
+    index = 171,
     label = "NH2 + NO2 <=> HNNO + OH",
     degeneracy = 1,
     duplicate = True,
@@ -3279,12 +3283,12 @@ conformer-dup: cis/trans-HNNO
 )
 
 entry(
-    index = 175,
+    index = 172,
     label = "NO2 <=> NO + O",
     degeneracy = 1,
     kinetics = Lindemann(
-        arrheniusHigh = Arrhenius(A=(3.98e+14, 's^-1'), n=0, Ea=(71700, 'cal/mol'), T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(2100, 'K')),
-        arrheniusLow = Arrhenius(A=(3.98e+15, 'cm^3/(mol*s)'), n=0, Ea=(60000, 'cal/mol'), T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(2100, 'K'))),
+        arrheniusHigh=Arrhenius(A=(3.98e+14, 's^-1'), n=0, Ea=(71700, 'cal/mol'), T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(2100, 'K')),
+        arrheniusLow=Arrhenius(A=(3.98e+15, 'cm^3/(mol*s)'), n=0, Ea=(60000, 'cal/mol'), T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(2100, 'K'))),
     elementary_high_p = True,
     shortDesc = u"""[Hanson1997]""",
     longDesc =
@@ -3297,10 +3301,11 @@ Added as a training reaction to Birad_R_Recombination
 )
 
 entry(
-    index = 176,
+    index = 173,
     label = "NO2 + NO2 <=> NO + NO + O2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.51e+12, 'cm^3/(mol*s)'), n=0, Ea=(27600, 'cal/mol'), T0=(1, 'K'), Tmin=(625, 'K'), Tmax=(2100, 'K')),
+    kinetics = Arrhenius(A=(4.51e+12, 'cm^3/(mol*s)'), n=0, Ea=(27600, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(625, 'K'), Tmax=(2100, 'K')),
     shortDesc = u"""[Lin1998b]""",
     longDesc =
 u"""
@@ -3311,10 +3316,11 @@ Shock tube measurement by [Hanson1997], and rate improvement by [Lin1998b]
 )
 
 entry(
-    index = 177,
+    index = 174,
     label = "NO2 + NO2 <=> NO3 + NO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.00e+13, 'cm^3/(mol*s)'), n=0, Ea=(25800, 'cal/mol'), T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(2100, 'K')),
+    kinetics = Arrhenius(A=(1.00e+13, 'cm^3/(mol*s)'), n=0, Ea=(25800, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(2100, 'K')),
     shortDesc = u"""[Hanson1997]""",
     longDesc =
 u"""
@@ -3325,7 +3331,7 @@ Shock tube measurement
 )
 
 entry(
-    index = 178,
+    index = 175,
     label = "HONO + NO2 <=> HNO3 + NO",
     degeneracy = 1,
     duplicate = True,
@@ -3348,7 +3354,7 @@ Also available from [Lin1998b] (although cited as "unpublished work"):
 )
 
 entry(
-    index = 179,
+    index = 176,
     label = "HNO + NO2 <=> HONO + NO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(7.847e+02, 'cm^3/(mol*s)'), n=3.1, Ea=(3882, 'cal/mol'),
@@ -3368,7 +3374,7 @@ This route produces the cis-HONO, two other routes that produce the trans-HONO p
 )
 
 entry(
-    index = 180,
+    index = 177,
     label = "N2O + H <=> N2 + OH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(6.4e+07, 'cm^3/(mol*s)'), n=1.835, Ea=(13492, 'cal/mol'), T0=(1, 'K')),
@@ -3384,10 +3390,11 @@ T range: 700-2500 K, Review and recommendation, p. 660, 14,4
 )
 
 entry(
-    index = 181,
+    index = 178,
     label = "N2O + CO <=> N2 + CO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(3.2e+11, 'cm^3/(mol*s)'), n=0, Ea=(20330, 'cal/mol'), T0=(1, 'K'), Tmin=(700, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(3.2e+11, 'cm^3/(mol*s)'), n=0, Ea=(20330, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(700, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Herron1991]""",
     longDesc =
 u"""
@@ -3398,10 +3405,11 @@ Review and recommendation, p. 662, 14,8
 )
 
 entry(
-    index = 182,
+    index = 179,
     label = "NO2 + HCO <=> CO + HONO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.24e+23, 'cm^3/(mol*s)'), n=-3.29, Ea=(2355, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    kinetics = Arrhenius(A=(1.24e+23, 'cm^3/(mol*s)'), n=-3.29, Ea=(2355, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
     shortDesc = u"""[Lin1990]""",
     longDesc =
 u"""
@@ -3412,10 +3420,11 @@ k2, p. 471
 )
 
 entry(
-    index = 183,
+    index = 180,
     label = "HONO + H <=> H2 + NO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.01e+08, 'cm^3/(mol*s)'), n=1.55, Ea=(6614, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3500, 'K')),
+    kinetics = Arrhenius(A=(2.01e+08, 'cm^3/(mol*s)'), n=1.55, Ea=(6614, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3500, 'K')),
     shortDesc = u"""[Lin1997a]""",
     longDesc =
 u"""
@@ -3427,11 +3436,12 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 184,
+    index = 181,
     label = "NO <=> N + O",
     degeneracy = 1,
     kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(9.6e+14, 'cm^3/(mol*s)'), n=0, Ea=(148000, 'cal/mol'), T0 = (1, 'K'), Tmin=(2400, 'K'), Tmax=(6200, 'K')),
+        arrheniusLow = Arrhenius(A=(9.6e+14, 'cm^3/(mol*s)'), n=0, Ea=(148000, 'cal/mol'),
+                                 T0=(1, 'K'), Tmin=(2400, 'K'), Tmax=(6200, 'K')),
         efficiencies={'N#N': 1.5, 'O=C=O': 2.5}),
     shortDesc = u"""[Herron1991]""",
     longDesc =
@@ -3444,10 +3454,11 @@ This reaction is not expected to be important except at the highest temperatures
 )
 
 entry(
-    index = 185,
+    index = 182,
     label = "NO2 + HCO <=> H + CO2 + NO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(8.39e+15, 'cm^3/(mol*s)'), n=-0.75, Ea=(1930, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    kinetics = Arrhenius(A=(8.39e+15, 'cm^3/(mol*s)'), n=-0.75, Ea=(1930, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
     shortDesc = u"""[Lin1990]""",
     longDesc =
 u"""
@@ -3458,27 +3469,11 @@ k2, p. 471
 )
 
 entry(
-    index = 186,
-    label = "HNO + H <=> NO + H2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(4.46e+11, 'cm^3/(mol*s)'), n=0.720, Ea=(655, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-    shortDesc = u"""[Page1992]""",
-    longDesc =
-u"""
-Part of the "NOx" subset
-T range: 200-3000 K
-calculations done at the CASSCF//(CASSCF and CISD) levels of theory
-Also available (in reverse direction) from Tando and Asaba 1976, as reported by [Herron1991] in T range: 2020-3250 K:
-    kinetics = Arrhenius(A=(1.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(56500, 'cal/mol'), T0=(1, 'K')),
-Added as a training reaction to H_Abstraction
-""",
-)
-
-entry(
-    index = 187,
+    index = 183,
     label = "HONO + H <=> OH + HNO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(5.64e+10, 'cm^3/(mol*s)'), n=0.86, Ea=(4970, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3500, 'K')),
+    kinetics = Arrhenius(A=(5.64e+10, 'cm^3/(mol*s)'), n=0.86, Ea=(4970, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3500, 'K')),
     shortDesc = u"""[Lin1997a]""",
     longDesc =
 u"""
@@ -3489,24 +3484,11 @@ G2 and BAC-MP4
 )
 
 entry(
-    index = 188,
-    label = "HONO + H <=> H2O + NO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(8.13e+06, 'cm^3/(mol*s)'), n=1.89, Ea=(3847, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3500, 'K')),
-    shortDesc = u"""[Lin1997a]""",
-    longDesc =
-u"""
-Part of the "NOx" subset
-T range: 300-3500 K
-G2 and BAC-MP4
-""",
-)
-
-entry(
-    index = 189,
+    index = 184,
     label = "HONO + HONO <=> H2O + NO2 + NO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(3.49e-01, 'cm^3/(mol*s)'), n=3.64, Ea=(12140, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
+    kinetics = Arrhenius(A=(3.49e-01, 'cm^3/(mol*s)'), n=3.64, Ea=(12140, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(5000, 'K')),
     shortDesc = u"""[Lin1998c]""",
     longDesc =
 u"""
@@ -3517,10 +3499,11 @@ G2M
 )
 
 entry(
-    index = 190,
+    index = 185,
     label = "HNO3 + H <=> H2 + NO3",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(5.56e+08, 'cm^3/(mol*s)'), n=1.53, Ea=(16400, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(5.56e+08, 'cm^3/(mol*s)'), n=1.53, Ea=(16400, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin1997b]""",
     longDesc =
 u"""
@@ -3532,10 +3515,11 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 191,
+    index = 186,
     label = "HNO3 + H <=> OH + HONO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(3.82e+05, 'cm^3/(mol*s)'), n=2.30, Ea=(6977, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(3.82e+05, 'cm^3/(mol*s)'), n=2.30, Ea=(6977, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin1997b]""",
     longDesc =
 u"""
@@ -3547,10 +3531,11 @@ RRKM
 )
 
 entry(
-    index = 192,
+    index = 187,
     label = "HNO3 + H <=> H2O + NO2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(6.08e+01, 'cm^3/(mol*s)'), n=3.29, Ea=(6286, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(6.08e+01, 'cm^3/(mol*s)'), n=3.29, Ea=(6286, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin1997b]""",
     longDesc =
 u"""
@@ -3561,85 +3546,74 @@ RRKM
 )
 
 entry(
-    index = 193,
-    label = "HNNO2 <=> N2O + OH",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(7.43e+12, 's^-1'), n=0, Ea=(32220, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(500, 'K'), Tmax=(2000, 'K')),
-    elementary_high_p = True,
-    shortDesc = u"""[Lin1998d]""",
-    longDesc =
-u"""
-Part of the "NOx" subset
-T range: 500-2000 K
-calculations done at the B3LYP/6-311D(d,p)//B3LYP/6-311D(d,p) level of theory
-k1b_inf, p. 8892
-k_inf was taken. the study also reports k_200atm and k_1atm.
-""",
+    index=188,
+    label="HNNO2 <=> NO2 + NH",
+    kinetics=Arrhenius(A=(1.00e+15, 's^-1'), n=0, Ea=(38160, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K')),
+    elementary_high_p=True,
+    shortDesc=u"""[Lin1998d]""",
+    longDesc=
+    u"""
+    Part of the "NOx" subset
+    k1a,inf
+    B3LYP/6-311D(d,p)//B3LYP/6-311D(d,p)
+
+    [Lin1998d] gave k1a,inf and k1a,1atm. We can fit it into Lindemann form:
+    kinetics=Lindemann(
+        arrheniusHigh=Arrhenius(A=(1.00e+15, 's^-1'), n=0, Ea=(38160, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K')),
+        # arrheniusLow=Arrhenius(A=(6.09e+44, 's^-1'), n=-9.92, Ea=(46900, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K'))),  # given in s^-1 units, converted below
+        arrheniusLow=Arrhenius(A=(5.06e+40, 'cm^3/(mol*s)'), n=-9.92, Ea=(46900, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K'))),
+    arrheniusLow (k1a,1atm) was given in s^-1 units, here multiplied by P/RT where P=1bar to get to cm^3/(mol*s) units
+    P/RT = 12.0e+03 cm^3/(mol*K) / T
+    """,
 )
 
 entry(
-    index = 194,
-    label = "NH + NO2 <=> HNNO2",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.42e+16, 'cm^3/(mol*s)'), n=-0.75, Ea=(1226, 'cal/mol'), T0=(1, 'K'),
-                         Tmin=(500, 'K'), Tmax=(3000, 'K')),
-    elementary_high_p = True,
-    shortDesc = u"""[Lin1998d]""",
-    longDesc =
-u"""
-Part of the "NOx" subset
-T range: 500-3000 K
-calculations done at the B3LYP/6-311D(d,p)//B3LYP/6-311D(d,p) level of theory
-k3a, p. 8893
-No stabilization at low pressures, only K3a_inf is given (k3a_low = 0)
-reverse rate also available from the same study (k1a)
-Added as a training reaction to Birad_R_Recombination
-""",
+    index=189,
+    label="HNNO2 <=> N2O + OH",
+    kinetics=Arrhenius(A=(7.43e+12, 's^-1'), n=0, Ea=(32220, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K')),
+    elementary_high_p=True,
+    shortDesc=u"""[Lin1998d]""",
+    longDesc=
+    u"""
+    Part of the "NOx" subset
+    k1b,inf
+
+    [Lin1998d] gave k1a,inf and k1a,1atm. We can fit it into Lindemann form:
+    kinetics=Lindemann(
+        arrheniusHigh=Arrhenius(A=(7.43e+12, 's^-1'), n=0, Ea=(32220, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K')),
+        # arrheniusLow=Arrhenius(A=(1.36e+54, 's^-1'), n=-13.16, Ea=(44241, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K'))),  # given in s^-1 units, converted below
+        arrheniusLow=Arrhenius(A=(1.13e+50, 'cm^3/(mol*s)'), n=-13.16, Ea=(44241, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K'))),
+    arrheniusLow (k1a,1atm) was given in s^-1 units, here multiplied by P/RT where P=1bar to get to cm^3/(mol*s) units
+    P/RT = 12.0e+03 cm^3/(mol*K) / T
+    
+    """,
 )
 
 entry(
-    index = 195,
-    label = "NH + NO2 <=> N2O + OH",
-    degeneracy = 1,
-    kinetics = ThirdBody(
-        arrheniusLow = Arrhenius(A=(2.08e+13, 'cm^6/(mol^2*s)'), n=-0.49, Ea=(715, 'cal/mol'), T0 = (1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K'))),
-    shortDesc = u"""[Lin1998d]""",
-    longDesc =
+    index=190,
+    label="NO2 + NH <=> HNO + NO",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(1.25e+06, 'cm^3/(mol*s)'), n=1.96, Ea=(2345, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[Lin1998d]""",
+    longDesc=
 u"""
 Part of the "NOx" subset
-T range: 500-3000 K
-calculations done at the B3LYP/6-311D(d,p)//B3LYP/6-311D(d,p) level of theory
-k3b, p. 8893
-No production of N2O at the high pressure limit (k3b_inf = 0)
-""",
-)
-
-entry(
-    index = 196,
-    label = "NH + NO2 <=> HNO + NO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.25e+06, 'cm^3/(mol*s)'), n=1.96, Ea=(2345, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
-    shortDesc = u"""[Lin1998d]""",
-    longDesc =
-u"""
-Part of the "NOx" subset
-T range: 300-3000 K
 calculations done at the B3LYP/6-311D(d,p)//B3LYP/6-311D(d,p) level of theory
 k4, p. 8894
 """,
 )
 
 entry(
-    index = 197,
-    label = "HCO + HNO <=> CH2O + NO",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(5.83e-01, 'cm^3/(mol*s)'), n=3.84, Ea=(115, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
-    shortDesc = u"""[Lin2004]""",
-    longDesc =
+    index=191,
+    label="HCO + HNO <=> CH2O + NO",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(5.83e-01, 'cm^3/(mol*s)'), n=3.84, Ea=(115, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[Lin2004]""",
+    longDesc=
 u"""
 Part of the "NOx" subset
-T range: 200-3000 K
 calculations done at the G2M//BH&HLYP/6-311G(d, p) level of theory
 k1, p. 211
 Added as a training reaction to H_Abstraction
@@ -3647,10 +3621,11 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 198,
-    label = "HCO + HNO <=> H2NO + CO",
+    index = 192,
+    label = "HCO + HNO <=> NH2O + CO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(4.90e+01, 'cm^3/(mol*s)'), n=3.27, Ea=(1755, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(4.90e+01, 'cm^3/(mol*s)'), n=3.27, Ea=(1755, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin2004]""",
     longDesc =
 u"""
@@ -3662,17 +3637,18 @@ k2, p. 211
 )
 
 entry(
-    index = 199,
-    label = "HCO + HNO <=> HNOH + CO",
+    index = 193,
+    label = "HCO + HNO <=> NHOH + CO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.31e+13, 'cm^3/(mol*s)'), n=-0.205, Ea=(3647, 'cal/mol'), T0=(1, 'K'), Tmin=(1000, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(1.31e+13, 'cm^3/(mol*s)'), n=-0.205, Ea=(3647, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(1000, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin2004]""",
     longDesc =
 u"""
 Part of the "NOx" subset
 T range: 1000-3000 K
 calculations done at the G2M//BH&HLYP/6-311G(d, p) level of theory
-k4(HNOH+CO), p. 213
+k4(NHOH+CO), p. 213
 The Low T (200-400 K) rate is:
     kinetics = Arrhenius(A=(1.04e-07, 'cm^3/(mol*s)'), n=6.23, Ea=(-3291, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(400, 'K')),
 
@@ -3682,10 +3658,11 @@ The Low T (400-1000 K) rate is:
 )
 
 entry(
-    index = 200,
+    index = 194,
     label = "HCO + NO <=> HNO + CO",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(1.04e+08, 'cm^3/(mol*s)'), n=1.47, Ea=(-1765, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(1.04e+08, 'cm^3/(mol*s)'), n=1.47, Ea=(-1765, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin2005c]""",
     longDesc =
 u"""
@@ -3699,10 +3676,11 @@ The Low T (200-500 K) rate is:
 )
 
 entry(
-    index = 201,
+    index = 195,
     label = "NH3 + HNO3 <=> H2NNO2 + H2O",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(8.1e-01, 'cm^3/(mol*s)'), n=3.47, Ea=(43060, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    kinetics = Arrhenius(A=(8.1e-01, 'cm^3/(mol*s)'), n=3.47, Ea=(43060, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
     shortDesc = u"""[Lin1998e]""",
     longDesc =
 u"""
@@ -3713,7 +3691,7 @@ calculations done at the G2M//PMP4/6-311G(d, p) level of theory
 )
 
 entry(
-    index = 202,
+    index = 196,
     label = "NH3 + HNO3 <=> H2NONO + H2O",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.32e+01, 'cm^3/(mol*s)'), n=3.50, Ea=(44930, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
@@ -3727,7 +3705,7 @@ calculations done at the G2M//PMP4/6-311G(d, p) level of theory
 )
 
 entry(
-    index = 203,
+    index = 197,
     label = "CH2O + NO2 <=> HCO + HONO",
     degeneracy = 3,
     kinetics = Arrhenius(A=(1.42e-07, 'cm^3/(mol*s)'), n=5.64, Ea=(9221, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
@@ -3744,7 +3722,7 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 204,
+    index = 198,
     label = "CH2O + NO2 <=> HCO + HNO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.07e-01, 'cm^3/(mol*s)'), n=4.22, Ea=(19852, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
@@ -3759,7 +3737,7 @@ calculations done at the G2M//B3LYP/6−311+G(d,p) and G2M//MPW1PW91/6−311+G(3
 )
 
 entry(
-    index = 205,
+    index = 199,
     label = "HONO + O3 <=> HNO3 + O2",
     degeneracy = 1,
     duplicate = True,
@@ -3780,7 +3758,7 @@ conformer-dup: rate are for both cis-HONO and trans-HONO reactants
 )
 
 entry(
-    index = 206,
+    index = 200,
     label = "O3 <=> O2 + O",
     degeneracy = 1,
     kinetics = ThirdBody(
@@ -3795,7 +3773,7 @@ Shock Tube
 )
 
 entry(
-    index = 207,
+    index = 201,
     label = "HONO + NH3 <=> NH2NO + H2O",
     degeneracy = 1,
     duplicate = True,
@@ -3816,7 +3794,7 @@ conformer-dup: rate are for both cis-HONO and trans-HONO reactants
 )
 
 entry(
-    index = 208,
+    index = 202,
     label = "HNO3 + OH <=> H2O + NO3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(8.73e+00, 'cm^3/(mol*s)'), n=3.50, Ea=(-1667, 'cal/mol'), T0=(1, 'K'), Tmin=(750, 'K'), Tmax=(1500, 'K')),
@@ -3832,9 +3810,8 @@ Added as a training reaction to H_Abstraction
 )
 
 entry(
-    index = 209,
-    label = "OH + NO2 <=> HNO3",
-    degeneracy = 1,
+    index = 203,
+    label = "NO2 + OH <=> HNO3",
     kinetics = Lindemann(
         arrheniusHigh = Arrhenius(A=(2.85e+15, 'cm^3/(mol*s)'), n=-0.82, Ea=(-42, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
         arrheniusLow = Arrhenius(A=(1.20e+42, 'cm^6/(mol^2*s)'), n=-8.8, Ea=(3118, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K'))),
@@ -3843,16 +3820,15 @@ entry(
     longDesc =
 u"""
 Part of the "NOx" subset
-k_inf_a on p. 44
-T range: 200-2000 K
 Also available from [Lin1998a] at the B3LYP/6-311G(d,p)//B3LYP/6-311G(d,p) level of theory, T range: 300-2000 K (k_inf_a on p. 44):
     kinetics = Arrhenius(A=(1.45e+13, 'cm^3/(mol*s)'), n=0, Ea=(-477, 'cal/mol'), T0=(1, 'K')),
+Also available from J. Troe, J. Phys. Chem. A, 2012, 116(24), 6387-6393, doi: 10.1021/jp212095n for 220-430 K
 """,
 )
 
 entry(
-    index = 210,
-    label = "OH + NO2 <=> HOONO",
+    index = 204,
+    label = "NO2 + OH <=> HOONO",
     degeneracy = 1,
     kinetics = Lindemann(
         arrheniusHigh = Arrhenius(A=(1.03e+14, 'cm^3/(mol*s)'), n=-0.24, Ea=(-200, 'cal/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
@@ -3868,7 +3844,7 @@ T range: 200-2000 K
 )
 
 entry(
-    index = 211,
+    index = 205,
     label = "NO2 + OH <=> NO + HO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.00e+06, 'cm^3/(mol*s)'), n=2.00, Ea=(3000, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -3884,11 +3860,13 @@ Probably not the best fit... but deviated only by ~5% above 1000 K (larger devia
 
 Also available from [Troe1975]:
     kinetics = Arrhenius(A=(4.5e+12, 'cm^3/(mol*s)','+|-',1e+12), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'), Tmin=(1350, 'K'), Tmax=(1700, 'K')),
+
+Also available from Baulch et al., J.Phys. Chem. Ref. Data, 2005, 34: 757-1397
 """,
 )
 
 entry(
-    index = 212,
+    index = 206,
     label = "NO2 + CO <=> NO + CO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(8.91e+13, 'cm^3/(mol*s)'), n=0, Ea=(67200, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2000, 'K')),
@@ -3902,42 +3880,45 @@ Shock tube measurement
 )
 
 entry(
-    index = 213,
-    label = "NH + O2 <=> HNO + O",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(4.61e+05, 'cm^3/(mol*s)'), n=2.0, Ea=(6500, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3300, 'K')),
-    shortDesc = u"""[Miller1992]""",
-    longDesc =
+    index=207,
+    label="HNCO + O <=> NCO + OH",
+    kinetics=Arrhenius(A=(3.63e+03, 'cm^3/(mol*s)'), n=2.88, Ea=(10107, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Sarathy2020]""",
+    longDesc=
 u"""
-Part of the "NOx" subset
-T range: 300-3300 K
-k3
-BAC-MP4
+Part of the "Prompt NO, NCN subset" mechanism
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
 """,
 )
 
 entry(
-    index = 214,
-    label = "NH + O2 <=> NO + OH",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(1.28e+06, 'cm^3/(mol*s)'), n=1.5, Ea=(100, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3300, 'K')),
-    shortDesc = u"""[Miller1992]""",
-    longDesc =
+    index=208,
+    label="NH + O2 <=> NO + OH",
+    kinetics=Arrhenius(A=(1.28e+06, 'cm^3/(mol*s)'), n=1.5, Ea=(100, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3300, 'K')),
+    shortDesc=u"""[Miller1992]""",
+    longDesc=
 u"""
 Part of the "NOx" subset
-T range: 300-3300 K
 k4
 BAC-MP4
+
+Also available from R. Talipov et al., J. Phys. Chem. A 2009, 113(23), 6468-6476, doi: 10.1021/jp902527a
+which suggests a significantly lower rate (see rate coefficient on NIST kinetics)
+Experimental data (though old) agree with the [Miller1992] rate.
+
+NOx2018 suggest a different rate, similar to ours but lower above 1100 K, we can consider shifting to that:
+NH+O2=HNO+O                          2.4E13   0.000   13850
+! Baulch DL Bowman CT Cobos CJ Cox RA Just Th Kerr JA Pilling MJ Stocker D Troe J Tsang W Walker RW Warnatz J JPCRD 34:757-1397 2005
+! Final value used in P. Glarborg, J.A. Miller, B. Ruscic, S.J. Klippenstein, Prog. Energy Combust. Sci. 67 (2018) 31-68 
 """,
 )
 
 entry(
-    index = 215,
-    label = "N2O5 + H2O <=> HNO3 + HNO3",
-    degeneracy = 1,
-    kinetics = Arrhenius(A=(5.73e+07, 'cm^3/(mol*s)'), n=3.354, Ea=(15700, 'cal/mol'), T0=(298, 'K'), Tmin=(180, 'K'), Tmax=(1800, 'K')),
-    shortDesc = u"""[Marshall2014]""",
-    longDesc =
+    index=209,
+    label="N2O5 + H2O <=> HNO3 + HNO3",
+    kinetics=Arrhenius(A=(5.73e+07, 'cm^3/(mol*s)'), n=3.354, Ea=(15700, 'cal/mol'), T0=(298, 'K'), Tmin=(180, 'K'), Tmax=(1800, 'K')),
+    shortDesc=u"""[Marshall2014]""",
+    longDesc=
 u"""
 Part of the "NOx" subset
 p. 11413
@@ -3947,7 +3928,7 @@ calculations done at the CCSD(T)-F12a/cc-pVTZ-F12//M06-2X/MG3S level of theory
 )
 
 entry(
-    index = 216,
+    index = 210,
     label = "CN + OH <=> NCO + H",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.00e+13, 'cm^3/(mol*s)'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K'), Tmin=(1250, 'K'), Tmax=(1863, 'K')),
@@ -3962,7 +3943,7 @@ Shock Tube
 )
 
 entry(
-    index = 217,
+    index = 211,
     label = "HCN + O <=> NH + CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.4e+08, 'cm^3/(mol*s)'), n=1.21, Ea=(7650, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
@@ -3976,37 +3957,74 @@ Review and reccomendation, p. 653, 13,3(b)
 )
 
 entry(
-    index = 218,
-    label = "HCN + H <=> H2 + CN",
+    index = 212,
+    label = "HCN + H <=> CN + H2",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(3.8e+14, 'cm^3/(mol*s)'), n=0, Ea=(24600, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(1000, 'K')),
-    shortDesc = u"""[Herron1991]""",
+    kinetics = Arrhenius(A=(2.09e+09, 'cm^3/(mol*s)'), n=1.92, Ea=(26229, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
     longDesc =
 u"""
 Part of the "HCN" subset
-T range: 300-1000 K
-Reviewed by Bailch et al. 1981, as reported by [Herron1991] p. 654
-Added as a training reaction to H_Abstraction
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+
+Also available from [Herron1991], Reviewed by Bailch et al. 1981, as reported by [Herron1991] p. 654
 """,
 )
 
 entry(
-    index = 219,
-    label = "HCN + OH <=> H2O + CN",
+    index = 213,
+    label = "HCN + OH <=> CN + H2O",
     degeneracy = 1,
-    kinetics = Arrhenius(A=(2.2e+07, 'cm^3/(mol*s)'), n=1.5, Ea=(7724, 'cal/mol'), T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(2840, 'K')),
-    shortDesc = u"""[Herron1991]""",
+    kinetics = Arrhenius(A=(7.69e+03, 'cm^3/(mol*s)'), n=2.78, Ea=(13054, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
     longDesc =
 u"""
 Part of the "HCN" subset
-T range: 298-2840 K
-Review and reccomendation, p. 656, 13,5(a)
-Added as a training reaction to H_Abstraction
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+
+Also available from [Herron1991], review and recommendation, p. 656, 13,5(a)
 """,
 )
 
 entry(
-    index = 220,
+    index = 214,
+    label = "HCN + HO2 <=> CN + H2O2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.61e+04, 'cm^3/(mol*s)'), n=2.54, Ea=(41604, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
+    longDesc =
+u"""
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 215,
+    label = "HCN + O2 <=> CN + HO2",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(4.56e+08, 'cm^3/(mol*s)'), n=2.29, Ea=(88454, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
+    longDesc =
+u"""
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 216,
+    label = "HNCO + OH <=> NCO + H2O",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.15e+00, 'cm^3/(mol*s)'), n=3.64, Ea=(1182, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
+    longDesc =
+u"""
+Part of the "Prompt NO, NCN subset" mechanism
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 217,
     label = "HCN + OH <=> H + NCOH",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3.2e+04, 'cm^3/(mol*s)'), n=2.45, Ea=(12120, 'cal/mol'), T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(2840, 'K')),
@@ -4020,7 +4038,7 @@ Review and reccomendation, p. 656, 13,5(b)
 )
 
 entry(
-    index = 221,
+    index = 218,
     label = "HCN + OH <=> NH2 + CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(7.83e-04, 'cm^3/(mol*s)'), n=4.00, Ea=(4000, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
@@ -4036,7 +4054,7 @@ as reported by [Hanson1996] (4d in Table 1, p. 249)
 )
 
 entry(
-    index = 222,
+    index = 219,
     label = "HCN + OH <=> H + HNCO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(5.6e-06, 'cm^3/(mol*s)'), n=4.71, Ea=(-493, 'cal/mol'), T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(2840, 'K')),
@@ -4050,7 +4068,32 @@ Review and reccomendation, p. 656, 13,5(c)
 )
 
 entry(
-    index = 223,
+    index = 220,
+    label = "HCN + O <=> CN + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(1.57e+08, 'cm^3/(mol*s)'), n=1.82, Ea=(27825, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
+    longDesc =
+u"""
+Part of the "Prompt NO" mechanism
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 221,
+    label = "HCN <=> HNC",
+    kinetics = Arrhenius(A=(8.98e+10, 's^-1'), n=0.92, Ea=(42512, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
+    longDesc =
+u"""
+Part of the "HCN" subset
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+""",
+)
+
+entry(
+    index = 222,
     label = "CH4 + NO2 <=> HONO + CH3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.71e+13, 'cm^3/(mol*s)'), n=0, Ea=(32450, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1650, 'K')),
@@ -4069,7 +4112,7 @@ Train!
 )
 
 entry(
-    index = 224,
+    index = 223,
     label = "CH4 + NO2 <=> HNO2 + CH3",
     degeneracy = 1,
     kinetics = Arrhenius(A=(1.985e+13, 'cm^3/(mol*s)'), n=0, Ea=(36685, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1650, 'K')),
@@ -4087,7 +4130,7 @@ Train!
 )
 
 entry(
-    index = 225,
+    index = 224,
     label = "C2H5ONO <=> CH3CHO + HNO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(9.85e+15, 's^-1'), n=0, Ea=(41760, 'cal/mol'), T0=(1, 'K'),
@@ -4103,7 +4146,6 @@ Here, the rate was estimated as follows:
 The A factor is taken from the reaction C2H5ONO <=> C2H5O + NO
 The latter is given in reverse in the Nitrogen_Glarborg_Zhang_et_al library:
     entry(
-        index = 669,
         label = "CH3CH2O + NO <=> CH3CH2ONO",
         degeneracy = 1,
         kinetics = Troe(
@@ -4131,7 +4173,7 @@ K(T) = 1.0E+16 * exp(-42 kcal/mol / RT)  s^-1
 )
 
 entry(
-    index = 226,
+    index = 225,
     label = "HCCO + NO <=> HCNO + CO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(8.43e+12, 'cm^3/(mol*s)','+|-',1.2e+12), n=0, Ea=(636, 'cal/mol','+|-',60),
@@ -4146,7 +4188,7 @@ x5 slower than the respective Dean & Bozzelli rate
 )
 
 entry(
-    index = 227,
+    index = 226,
     label = "HCCO + NO <=> HCN + CO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(3.45e+17, 'cm^3/(mol*s)','*|/',1.56), n=-1.65, Ea=(782, 'cal/mol','+|-',75),
@@ -4163,7 +4205,7 @@ x4 slower than the respective Dean & Bozzelli rate at 1000 K
 )
 
 entry(
-    index = 228,
+    index = 227,
     label = "C3H8 + NO2 <=> iC3H7 + HONO",
     degeneracy = 2,
     kinetics = Arrhenius(A=(1.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(33.8, 'kcal/mol'),
@@ -4178,7 +4220,7 @@ Rate for trans-HONO was taken
 )
 
 entry(
-    index = 229,
+    index = 228,
     label = "C3H8 + NO2 <=> iC3H7 + HNO2",
     degeneracy = 2,
     kinetics = Arrhenius(A=(3.0e+13, 'cm^3/(mol*s)'), n=0, Ea=(30.3, 'kcal/mol'),
@@ -4192,7 +4234,7 @@ Table 2
 )
 
 entry(
-    index = 230,
+    index = 229,
     label = "tC4H10 + NO2 <=> tC4H9 + HONO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.1e+13, 'cm^3/(mol*s)'), n=0, Ea=(31.9, 'kcal/mol'),
@@ -4207,7 +4249,7 @@ Rate for trans-HONO was taken
 )
 
 entry(
-    index = 231,
+    index = 230,
     label = "tC4H10 + NO2 <=> tC4H9 + HNO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.8e+14, 'cm^3/(mol*s)'), n=0, Ea=(27.6, 'kcal/mol'),
@@ -4221,7 +4263,7 @@ Table 2
 )
 
 entry(
-    index = 232,
+    index = 231,
     label = "C6H6 + NO2 <=> C6H5 + HONO",
     degeneracy = 1,
     kinetics = Arrhenius(A=(4.3e+14, 'cm^3/(mol*s)'), n=0, Ea=(43.0, 'kcal/mol'),
@@ -4236,7 +4278,7 @@ Rate for trans-HONO was taken
 )
 
 entry(
-    index = 233,
+    index = 232,
     label = "C6H6 + NO2 <=> C6H5 + HNO2",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.5e+14, 'cm^3/(mol*s)'), n=0, Ea=(42.2, 'kcal/mol'),
@@ -4250,7 +4292,7 @@ Table 2
 )
 
 entry(
-    index = 234,
+    index = 233,
     label = 'N2H4 + NH <=> N2H3 + NH2',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(6.09e+01, 'cm^3/(mol*s)'), n=3.61, Ea=(24.3, 'kJ/mol'),
@@ -4262,13 +4304,12 @@ Calculated by alongd (xq1330)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.2035, dn = +|- 0.0225658, dEa = +|- 0.225133 kJ/mol
 Added as training reaction to H-Abstraction
 """,
 )
 
 entry(
-    index = 235,
+    index = 234,
     label = 'N2H4 + H2NN(S) <=> N4',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(4.73e-01, 'cm^3/(mol*s)'), n=3.55, Ea=(50.6, 'kJ/mol'),
@@ -4280,12 +4321,11 @@ Calculated by alongd (xq1340)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.23644, dn = +|- 0.0264761, dEa = +|- 0.200697 kJ/mol
 """,
 )
 
 entry(
-    index = 236,
+    index = 235,
     label = 'N2H4 + H2NN(S) <=> N4c23',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(2.29e+00, 'cm^3/(mol*s)'), n=2.96, Ea=(55.4, 'kJ/mol'),
@@ -4297,12 +4337,11 @@ Calculated by alongd (xq1341)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.23663, dn = +|- 0.0264574, dEa = +|- 0.202208 kJ/mol
 """,
 )
 
 entry(
-    index = 237,
+    index = 236,
     label = 'N4 <=> NH3 + NH2NHN',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(3.00e+12, 's^-1'), n=0.83, Ea=(178.7, 'kJ/mol'),
@@ -4314,13 +4353,12 @@ Calculated by alongd (xq1343)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 2.33413, dn = +|- 0.105743, dEa = +|- 0.801565 kJ/mol
 Added as training reaction to 1,2_NH3_elimination
 """,
 )
 
 entry(
-    index = 238,
+    index = 237,
     label = 'N4c23 <=> NH3 + NH2NNH',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(4.30e+13, 's^-1'), n=0.26, Ea=(38.7, 'kJ/mol'),
@@ -4332,13 +4370,12 @@ Calculated by alongd (xq1344)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.173, dn = +|- 0.0199062, dEa = +|- 0.150895 kJ/mol
 Added as training reaction to 1,2_NH3_elimination
 """,
 )
 
 entry(
-    index = 239,
+    index = 238,
     label = 'N2H3 + N2H3 <=> N2H4 + H2NN(S)',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.11e-01, 'cm^3/(mol*s)'), n=3.21, Ea=(-1.5, 'kJ/mol'),
@@ -4350,12 +4387,11 @@ Calculated by alongd (xq1342b)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.02199, dn = +|- 0.00271314, dEa = +|- 0.0205664 kJ/mol
 """,
 )
 
 entry(
-    index = 240,
+    index = 239,
     label = 'NH2NHN <=> NH3 + N2',
     elementary_high_p = True,
     allow_max_rate_violation=True,
@@ -4368,13 +4404,12 @@ Calculated by alongd (xq1444)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 2.36471, dn = +|- 0.107367, dEa = +|- 0.813875 kJ/mol
 Added as training reaction to 1,2_NH3_elimination
 """,
 )
 
 entry(
-    index = 241,
+    index = 240,
     label = 'NH2NNH <=> NH3 + N2',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(4.90e+09, 's^-1'), n=1.34, Ea=(142.2, 'kJ/mol'),
@@ -4386,30 +4421,12 @@ Calculated by alongd (xq1445)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.61639, dn = +|- 0.0584997, dEa = +|- 0.583637 kJ/mol
 Added as training reaction to 1,3_NH3_elimination
 """,
 )
 
 entry(
-    index = 242,
-    label = 'N2H3 + NH2 <=> H2NN(T) + NH3',
-    kinetics = Arrhenius(A=(3.10e+00, 'cm^3/(mol*s)'), n=3.43, Ea=(-8.2, 'kJ/mol'),
-        T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K')),
-    shortDesc = u"""CCSD(T)-F12a/aug-cc-pVTZ//wB97x-D3/6-311++G(3df,3pd)""",
-    longDesc =
-u"""
-Calculated by alongd (xq1453)
-opt, freq: wB97x-D3/6-311++G(3df,3pd)
-sp: CCSD(T)-F12a/aug-cc-pVTZ
-rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.13644, dn = +|- 0.0159552, dEa = +|- 0.120945 kJ/mol
-Added as training reaction to H-Abstraction
-""",
-)
-
-entry(
-    index = 244,
+    index = 241,
     label = 'N3 <=> H2NN(S) + NH3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.04e+10, 's^-1'), n=1.14, Ea=(177.1, 'kJ/mol'),
@@ -4426,7 +4443,7 @@ Added as training reaction to 1,2_NH3_elimination
 )
 
 entry(
-    index = 245,
+    index = 242,
     label = 'NH2NHN <=> NH2NNH',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.50e+08, 's^-1'), n=1.44, Ea=(168.1, 'kJ/mol'),
@@ -4438,12 +4455,11 @@ Calculated by alongd (xq1458)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.73206, dn = +|- 0.0669199, dEa = +|- 0.667643 kJ/mol
 """,
 )
 
 entry(
-    index = 246,
+    index = 243,
     label = 'N3 <=> N2H2 + NH3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.40e+09, 's^-1'), n=0.92, Ea=(213.3, 'kJ/mol'),
@@ -4460,7 +4476,7 @@ Added as training reaction to 1,3_NH3_elimination
 )
 
 entry(
-    index = 247,
+    index = 244,
     label = 'N3c <=> N2H2 + NH3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(6.57e+11, 's^-1'), n=0.57, Ea=(41.2, 'kJ/mol'),
@@ -4476,7 +4492,7 @@ rotors: B3LYP/6-311++G(3df,3pd)
 )
 
 entry(
-    index = 248,
+    index = 245,
     label = 'N3 <=> N3c',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(7.94e+09, 's^-1'), n=0.85, Ea=(103.9, 'kJ/mol'),
@@ -4492,7 +4508,7 @@ rotors: B3LYP/6-311++G(3df,3pd)
 )
 
 entry(
-    index = 249,
+    index = 246,
     label = 'N4 <=> NH2NNH + NH3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(7.70e+10, 's^-1'), n=0.84, Ea=(214.1, 'kJ/mol'),
@@ -4504,13 +4520,12 @@ Calculated by alongd (xq1472)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 3.06808, dn = +|- 0.139852, dEa = +|- 1.06012 kJ/mol
 Added as training reaction to 1,3_NH3_elimination
 """,
 )
 
 entry(
-    index = 250,
+    index = 247,
     label = 'H2NN(T) <=> H2NN(S)',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1e+12, 's^-1'), n=0, Ea=(0, 'cal/mol'), T0=(1, 'K')),
@@ -4522,7 +4537,7 @@ An estimated rate for the fast H2NN(T) transition into the stable H2NN(S) form
 )
 
 entry(
-    index = 251,
+    index = 248,
     label = 'H2NN(S) <=> N2H2',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(3.77e+07, 's^-1'), n=1.75, Ea=(179.2, 'kJ/mol'),
@@ -4533,12 +4548,11 @@ u"""
 Calculated by alongd (xc1097)
 opt, freq: B3LYP/6-311G(2d,d,p)
 sp: CCSD(T)-F12/cc-pVTZ
-Fitted to 51 data points; dA = *|/ 2.61343, dn = +|- 0.117033, dEa = +|- 1.16761 kJ/mol
 """,
 )
 
 entry(
-    index = 252,
+    index = 249,
     label = 'N4c12 <=> N4c23',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.74e+10, 's^-1'), n=0.91, Ea=(74.4, 'kJ/mol'),
@@ -4550,12 +4564,11 @@ Calculated by alongd (xq1476)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 2.65741, dn = +|- 0.121925, dEa = +|- 0.924226 kJ/mol
 """,
 )
 
 entry(
-    index = 253,
+    index = 250,
     label = 'N4 <=> N4c12',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(7.90e+11, 's^-1'), n=0.59, Ea=(158.6, 'kJ/mol'),
@@ -4567,12 +4580,11 @@ Calculated by alongd (xq1476)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.24889, dn = +|- 0.0277259, dEa = +|- 0.210171 kJ/mol
 """,
 )
 
 entry(
-    index = 254,
+    index = 251,
     label = 'NH2NNH <=> NHNHNH',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.47e+09, 's^-1'), n=1.03, Ea=(258.0, 'kJ/mol'),
@@ -4584,12 +4596,11 @@ Calculated by alongd (xq1481)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.0909, dn = +|- 0.0108533, dEa = +|- 0.0822714 kJ/mol
 """,
 )
 
 entry(
-    index = 255,
+    index = 252,
     label = 'cN3H3 <=> NHNHNH',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(1.23e+12, 's^-1'), n=0.56, Ea=(132.2, 'kJ/mol'),
@@ -4601,73 +4612,97 @@ Calculated by alongd (xq1481)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.0909, dn = +|- 0.0108533, dEa = +|- 0.0822714 kJ/mol
 """,
 )
 
 entry(
-    index = 256,
-    label = 'N2H4 <=> NH3NH',
-    elementary_high_p = True,
-    kinetics = Arrhenius(A=(1.34e+11, 's^-1'), n=0.86, Ea=(64.5, 'kcal/mol'),
-        T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Bozzelli2010]""",
-    longDesc =
-u"""
-Tautomerization of Hydrazine into iminoammonium
-CCSD(T)//CBS-QB3
-Table 3, R2
-""",
+    index=253,
+    label='N2H4 <=> NH3NH',
+    elementary_high_p=True,
+    kinetics=Arrhenius(A=(1.34e+11, 's^-1'), n=0.86, Ea=(64.5, 'kcal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Bozzelli2010]""",
+    longDesc=
+    u"""
+    Tautomerization of Hydrazine into iminoammonium
+    CCSD(T)//CBS-QB3
+    Table 3, R2
+    """,
 )
 
 entry(
-    index = 257,
-    label = 'N2H4 <=> H2NN(S) + H2',
-    elementary_high_p = True,
-    kinetics = Arrhenius(A=(5.38e+09, 's^-1'), n=1.255, Ea=(75.3, 'kcal/mol'),
-        T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Bozzelli2010]""",
-    longDesc =
-u"""
-CCSD(T)//CBS-QB3
-Table 3, R3
-""",
+    index=254,
+    label='N2H4 <=> H2NN(S) + H2',
+    elementary_high_p=True,
+    kinetics=Arrhenius(A=(5.38e+09, 's^-1'), n=1.255, Ea=(75.3, 'kcal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Bozzelli2010]""",
+    longDesc=
+    u"""
+    CCSD(T)//CBS-QB3
+    Table 3, R3
+    """,
 )
 
 entry(
-    index = 258,
-    label = 'N2H4 <=> N2H2 + H2',
-    elementary_high_p = True,
-    kinetics = Arrhenius(A=(8.70e+12, 's^-1'), n=0, Ea=(52.9, 'kcal/mol'),
-        T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Bozzelli2010]""",
-    longDesc =
-u"""
-CCSD(T)//CBS-QB3
-Table 3, R3
-Employed a lower TS1 calculated at CBS-QB3.
-Also, a rate constant with a higher TS1 was showed in Table 3.
-    kinetics = Arrhenius(A=(8.70e+12, 's^-1'), n=0.0, Ea=(92.9, 'kcal/mol'),
-        T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
-""",
+    index=255,
+    label='N2H4 <=> N2H2 + H2',
+    elementary_high_p=True,
+    kinetics=Arrhenius(A=(8.70e+12, 's^-1'), n=0, Ea=(52.9, 'kcal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Bozzelli2010]""",
+    longDesc=
+    u"""
+    CCSD(T)//CBS-QB3
+    Table 3, R3
+    Employed a lower TS1 calculated at CBS-QB3.
+    Also, a rate constant with a higher TS1 was showed in Table 3.
+        kinetics = Arrhenius(A=(8.70e+12, 's^-1'), n=0.0, Ea=(92.9, 'kcal/mol'),
+            T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    """,
+)
+
+entry(
+    index=256,
+    label="N2H4 + NH2 <=> N2H3 + NH3",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(3.79e+01, 'cm^3/(mol*s)'), n=3.44, Ea=(-574, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Glarborg2023]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12b/cc-pVTZ-F12//M062X/6-311+G(2df,2p)
+    R1
+    """,
+)
+
+entry(
+    index=257,
+    label="N2H4 + H <=> NH3 + NH2",
+    degeneracy=1,
+    kinetics=Arrhenius(A=(3.01e+05, 'cm^3/(mol*s)'), n=2.07, Ea=(8012, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Glarborg2023]""",
+    longDesc=
+    u"""
+    CCSD(T)-F12b/cc-pVTZ-F12//M062X/6-311+G(2df,2p)
+    """,
+)
+
+entry(
+    index=258,
+    label='NH3NH <=> NH3 + NH',
+    elementary_high_p=True,
+    kinetics=Arrhenius(A=(1.10e+09, 's^-1'), n=1.64, Ea=(20.7, 'kcal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Bozzelli2010]""",
+    longDesc=
+    u"""
+    CCSD(T)//CBS-QB3
+    Table 3, R5
+    """,
 )
 
 entry(
     index = 259,
-    label = 'NH3NH <=> NH3 + NH',
-    elementary_high_p = True,
-    kinetics = Arrhenius(A=(1.10e+09, 's^-1'), n=1.64, Ea=(20.7, 'kcal/mol'),
-        T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
-    shortDesc = u"""[Bozzelli2010]""",
-    longDesc =
-u"""
-CCSD(T)//CBS-QB3
-Table 3, R5
-""",
-)
-
-entry(
-    index = 260,
     label = 'NH3NH <=> N2H2 + H2',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(5.75e+10, 's^-1'), n=1.01, Ea=(33.8, 'kcal/mol'),
@@ -4685,7 +4720,7 @@ Also, the reaction path to cis-N2H2 was calculated (Table 3, R7).
 )
 
 entry(
-    index = 261,
+    index = 260,
     label = 'NH3NH <=> N2H3 + H',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(3.37e+2, 's^-1'), n=2.82, Ea=(2.2, 'kcal/mol'),
@@ -4699,7 +4734,7 @@ See Table 3, R8
 )
 
 entry(
-    index = 262,
+    index = 261,
     label = 'N2H2 + H2 <=> N2 + H2 + H2',
     kinetics = Arrhenius(A=(3.22e+6, 'cm^3/(mol*s)'), n=1.80, Ea=(21.4, 'kcal/mol'),
         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
@@ -4713,7 +4748,7 @@ cis-N2H2 and H2 forms a six-membered ring structure in transition state.
 )
 
 entry(
-    index = 263,
+    index = 262,
     label = 'NH3NH + H2 <=> NH3 + NH3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(9.03e+5, 'cm^3/(mol*s)'), n=2.59, Ea=(22.9, 'kcal/mol'),
@@ -4727,7 +4762,7 @@ See Table 4, R12
 )
 
 entry(
-    index = 264,
+    index = 263,
     label = 'NH2 + N2H2(T) <=> NH + N2H3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(4.22e-02, 'cm^3/(mol*s)'), n=4.05, Ea=(52.1, 'kJ/mol'),
@@ -4739,12 +4774,11 @@ Calculated by alongd (xq1485)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.35051, dn = +|- 0.0366059, dEa = +|- 0.365208 kJ/mol
 """,
 )
 
 entry(
-    index = 265,
+    index = 264,
     label = 'H2NN(S) + NH3 <=> N2H2 + NH3',
     elementary_high_p = True,
     kinetics = Arrhenius(A=(2.07e-01, 'cm^3/(mol*s)'), n=3.64, Ea=(31.1, 'kJ/mol'),
@@ -4756,12 +4790,11 @@ Calculated by alongd (xq1507)
 opt, freq: wB97x-D3/6-311++G(3df,3pd)
 sp: CCSD(T)-F12a/aug-cc-pVTZ
 rotors: B3LYP/6-311++G(3df,3pd)
-Fitted to 51 data points; dA = *|/ 1.10125, dn = +|- 0.0117499, dEa = +|- 0.117226 kJ/mol
 """,
 )
 
 entry(
-    index = 266,
+    index = 265,
     label = 'H2NN(S) + O <=> NH2 + NO',
     kinetics = Arrhenius(A=(3.2e+09, 'cm^3/(mol*s)'), n=1.03, Ea=(684.38, 'cal/mol'),
         T0=(1, 'K')),
@@ -4776,7 +4809,7 @@ indicate transition states and A-factors similar to radical addition reactions.
 )
 
 entry(
-    index = 267,
+    index = 266,
     label = 'H2NN(S) + O <=> OH + NNH',
     kinetics = Arrhenius(A=(3.3e+08, 'cm^3/(mol*s)'), n=1.5, Ea=(226.45, 'cal/mol'),
         T0=(1, 'K')),
@@ -4791,10 +4824,10 @@ indicate transition states and A-factors similar to radical addition reactions.
 )
 
 entry(
-    index = 268,
+    index = 267,
     label = 'NH2 + HO2 <=> HNO + H2O',
-    kinetics = Arrhenius(A=(1.02e+12, 'cm^3/(mol*s)'), n=0.166, Ea=(-1864, 'cal/mol'),
-                          T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    kinetics = Arrhenius(A=(1.02e+12, 'cm^3/(mol*s)'), n=0.166, Ea=(-938, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Klippenstein2022]""",
     longDesc =
 u"""
@@ -4808,34 +4841,10 @@ Reaction 1b, Table 2. Experimental work re-interpreted using direct measurements
 important branching reactions.
 """,
 )
-entry(
-    index = 269,
-    label = 'HNO + O2 <=> NO + HO2',
-    kinetics = Arrhenius(A=(2.0e+13, 'cm^3/(mol*s)'), n=0.0, Ea=(16000, 'cal/mol'), T0=(1, 'K')),
-    shortDesc = u"""[Glarborg2021]""",
-    longDesc =
-u"""
-Reaction 8, Table 2. Experimental work re-interpreted using direct measurements from 
-[Altinay&Macdonald2015]. Original data based on [DeanBozz2000]""",
-)
 
 entry(
-    index = 270,
-    label = 'H2NO + O2 <=> HNO + HO2',
-    duplicate=True,
-    kinetics = Arrhenius (A=(1.110e0, 'cm^3/(mol*s)'), n=3.489, Ea=(13900, 'cal/mol'),
-                          T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1700, 'K')),
-    shortDesc = u"""[Sarathy2022]""",
-    longDesc =
-u"""
-Table S2, Reaction R1, doublet surface.
-Optimized and characterized the stationary points of the PESs with the ROCCSD method (Detailed in Table 1).
-""",
-)
-
-entry(
-    index = 271,
-    label = 'H2NO + O2 <=> HNO(T) + HO2',
+    index = 268,
+    label = 'NH2O + O2 <=> HNO(T) + HO2',
     duplicate = True,
     kinetics = Arrhenius(A=(4.429e+03, 'cm^3/(mol*s)'), n=2.578, Ea=(29877, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(3000, 'K')),
@@ -4848,30 +4857,31 @@ Optimized and characterized the stationary points of the PESs with the CCSD meth
 )
 
 entry(
-    index = 272,
-    label = 'NH2 + HO2 <=> NH3 + O2',
-    kinetics = Arrhenius (A=(6.04e+18, 'cm^3/(mol*s)'), n=-1.91, Ea=(608, 'cal/mol'),
-                          T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Klippenstein2022]""",
-    longDesc =
+    index=269,
+    label='NH2 + HO2 <=> NH3 + O2',
+    kinetics=Arrhenius(A=(2.179e+06, 'cm^3/(mol*s)'), n=2.080, Ea=(-4760, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1700, 'K')),
+    shortDesc=u"""[Sarathy2022]""",
+    longDesc=
 u"""
+W3X-L
+
+Also available from [Klippenstein2022]:
+kinetics=MultiArrhenius(
+arrhenius=[Arrhenius(A=(6.04e+18, 'cm^3/(mol*s)'), n=-1.91, Ea=(306, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+           Arrhenius(A=(5.91e+07, 'cm^3/(mol*s)'), n=1.59, Ea=(-1373, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K'))]),
 R1a
 CASPT2/CBS//CASPT2/cc-pVTZ-F12
-
-Also available from [Sarathy2022]:
-kinetics = Arrhenius (A=(2.179e+06, 'cm^3/(mol*s)'), n=2.080, Ea=(-4760, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(1700, 'K')),
-Table S2, Reaction R4, triplet surface.
-Optimized and characterized the stationary points of the PESs with the CCSD method (Detailed in Table 1).
 """,
 )
 
 entry(
-    index = 273,
-    label = 'NH2 + HO2 <=> H2NO + OH',
-    kinetics = Arrhenius(A=(2.19e+09, 'cm^3/(mol*s)'), n=0.791, Ea=(-2838, 'cal/mol'),
-                         T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Klippenstein2022]""",
-    longDesc =
+    index=270,
+    label='NH2 + HO2 <=> NH2O + OH',
+    kinetics=Arrhenius(A=(2.19e+09, 'cm^3/(mol*s)'), n=0.791, Ea=(-1428, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2022]""",
+    longDesc=
 u"""
 R1c
 CASPT2/CBS//CASPT2/cc-pVTZ-F12
@@ -4885,7 +4895,7 @@ Optimized and characterized the stationary points of the PESs with the CCSD(T) m
 )
 
 entry(
-    index = 274,
+    index = 271,
     label = 'NH2 + HO2 <=> NH3 + O2(S)',
     duplicate=True,
     kinetics = Arrhenius(A=(2.851e+01, 'cm^3/(mol*s)'), n=2.937, Ea=(1241, 'cal/mol'),
@@ -4899,7 +4909,7 @@ Optimized and characterized the stationary points of the PESs with the CCSD meth
 )
 
 entry(
-    index = 275,
+    index = 272,
     label = 'NO + HO2 <=> HNO3',
     kinetics = Lindemann(
         arrheniusHigh = Arrhenius(A=(2.85e+15, 'cm^3/(mol*s)'), n=-0.82, Ea=(-41.7, 'cal/mol'),
@@ -4916,7 +4926,7 @@ He was used as the 3rd body collider in these computations.
 )
 
 entry(
-    index = 276,
+    index = 273,
     label = 'NO + HO2 <=> HOONO',
     kinetics = Lindemann(
         arrheniusHigh = Arrhenius(A=(1.03e+14, 'cm^3/(mol*s)'), n=-0.24, Ea=(-198.7, 'cal/mol'),
@@ -4933,7 +4943,7 @@ He was used as the 3rd body collider in these computations.
 )
 
 entry(
-    index = 277,
+    index = 274,
     label = 'CH3NHNH2 + H <=> CH3NHNH + H2',
     kinetics = Arrhenius(A=(1.080e+06, 'cm^3/(mol*s)'), n=2.310, Ea=(1182, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -4946,7 +4956,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 278,
+    index = 275,
     label = 'CH3NHNH2 + H <=> CH3NNH2 + H2',
     kinetics = Arrhenius(A=(7.270e+06, 'cm^3/(mol*s)'), n=2.030, Ea=(858.1, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -4959,7 +4969,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 279,
+    index = 276,
     label = 'CH3NHNH2 + H <=> CH2NHNH2 + H2',
     kinetics = Arrhenius(A=(1.170e+04, 'cm^3/(mol*s)'), n=3.080, Ea=(1605, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -4972,7 +4982,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 280,
+    index = 277,
     label = 'CH3NHNH2 + NH2 <=> CH3NHNH + NH3',
     kinetics = Arrhenius(A=(1.402e+03, 'cm^3/(mol*s)'), n=2.741, Ea=(1030, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -4985,7 +4995,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 281,
+    index = 278,
     label = 'CH3NHNH2 + NH2 <=> CH3NNH2 + NH3',
     kinetics = Arrhenius(A=(3.092e+02, 'cm^3/(mol*s)'), n=2.884, Ea=(688, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -4998,7 +5008,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 282,
+    index = 279,
     label = 'CH3NHNH2 + NH2 <=> CH2NHNH2 + NH3',
     kinetics = Arrhenius(A=(2.805e-02, 'cm^3/(mol*s)'), n=4.083, Ea=(1724, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5011,7 +5021,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 283,
+    index = 280,
     label = 'CH3NHNH2 + CH3 <=> CH3NHNH + CH4',
     kinetics = Arrhenius(A=(1.180e+01, 'cm^3/(mol*s)'), n=3.550, Ea=(3542.0, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5024,7 +5034,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 284,
+    index = 281,
     label = 'CH3NHNH2 + CH3 <=> CH3NNH2 + CH4',
     kinetics = Arrhenius(A=(9.480e+00, 'cm^3/(mol*s)'), n=3.390, Ea=(8824.1, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5037,7 +5047,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 285,
+    index = 282,
     label = 'CH3NHNH2 + CH3 <=> CH2NHNH2 + CH4',
     kinetics = Arrhenius(A=(4.300e-02, 'cm^3/(mol*s)'), n=4.320, Ea=(5814.0, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5050,7 +5060,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 286,
+    index = 283,
     label = 'CH3NHNH2 + NH <=> CH3NHNH + NH2',
     kinetics = Arrhenius(A=(9.556e+01, 'cm^3/(mol*s)'), n=3.278, Ea=(3688.8, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5063,7 +5073,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 287,
+    index = 284,
     label = 'CH3NHNH2 + NH <=> CH3NNH2 + NH2',
     kinetics = Arrhenius(A=(4.096e+00, 'cm^3/(mol*s)'), n=3.630, Ea=(1941, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5076,7 +5086,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 288,
+    index = 285,
     label = 'CH3NHNH2 + NH <=> CH2NHNH2 + NH2',
     kinetics = Arrhenius(A=(4.340e-01, 'cm^3/(mol*s)'), n=4.161, Ea=(6582.8, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5089,7 +5099,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 289,
+    index = 286,
     label = 'CH3NHNH2 <=> CH3NH + NH2',
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(8.413e+25, 's^-1'), n=-3.151, Ea=(64498.8, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5104,7 +5114,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 290,
+    index = 287,
     label = 'CH3NNH + H <=> CH3NN + H2',
     kinetics = Arrhenius(A=(7.570e+07, 'cm^3/(mol*s)'), n=1.815, Ea=(707.2, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5117,7 +5127,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 291,
+    index = 288,
     label = 'CH3NNH + CH3 <=> CH3NN + CH4',
     kinetics = Arrhenius(A=(4.402e+02, 'cm^3/(mol*s)'), n=3.139, Ea=(-415.9, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5130,7 +5140,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 292,
+    index = 289,
     label = 'CH3NNH + NH2 <=> CH3NN + NH3',
     kinetics = Arrhenius(A=(2.338e+02, 'cm^3/(mol*s)'), n=2.945, Ea=(-4162.0, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5143,7 +5153,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 293,
+    index = 290,
     label = 'CH3NNH + H <=> CH2NNH + H2',
     kinetics = Arrhenius(A=(5.320e+03, 'cm^3/(mol*s)'), n=3.162, Ea=(9821.6, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5156,7 +5166,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 294,
+    index = 291,
     label = 'CH3NNH + CH3 <=> CH2NNH + CH4',
     kinetics = Arrhenius(A=(4.736e-02, 'cm^3/(mol*s)'), n=4.243, Ea=(13944, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5169,7 +5179,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 295,
+    index = 292,
     label = 'CH3NNH + NH2 <=> CH2NNH + NH3',
     kinetics = Arrhenius(A=(1.581e-02, 'cm^3/(mol*s)'), n=4.296, Ea=(9291.6, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5182,7 +5192,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 296,
+    index = 293,
     label = 'CH2NNH2 + H <=> CH2NNH + H2',
     kinetics = Arrhenius(A=(2.713e+04, 'cm^3/(mol*s)'), n=2.751, Ea=(2485.8, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5195,7 +5205,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 297,
+    index = 294,
     label = 'CH2NNH2 + CH3 <=> CH2NNH + CH4',
     kinetics = Arrhenius(A=(1.715e-03, 'cm^3/(mol*s)'), n=4.415, Ea=(3546.4, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5208,7 +5218,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 298,
+    index = 295,
     label = 'CH2NNH2 + NH2 <=> CH2NNH + NH3',
     kinetics = Arrhenius(A=(3.809e-01, 'cm^3/(mol*s)'), n=3.704, Ea=(-263.9, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5221,7 +5231,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 299,
+    index = 296,
     label = 'CH2NNH2 + H <=> CHNNH2 + H2',
     kinetics = Arrhenius(A=(8.712e+02, 'cm^3/(mol*s)'), n=3.417, Ea=(5302.9, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5234,7 +5244,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 300,
+    index = 297,
     label = 'CH2NNH2 + CH3 <=> CHNNH2 + CH4',
     kinetics = Arrhenius(A=(1.492e+00, 'cm^3/(mol*s)'), n=3.649, Ea=(8270.6, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5247,7 +5257,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 301,
+    index = 298,
     label = 'CH2NNH2 + NH2 <=> CHNNH2 + NH3',
     kinetics = Arrhenius(A=(2.686e-04, 'cm^3/(mol*s)'), n=4.531, Ea=(2242.2, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5260,7 +5270,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 302,
+    index = 299,
     label = 'CH3NH <=> CH2NH + H',
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(1.236e+04, 's^-1'), n=3.022, Ea=(31798.1, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5275,7 +5285,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 303,
+    index = 300,
     label = 'CH2NH2 <=> CH2NH + H',
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(7.920e+04, 's^-1'), n=2.555, Ea=(38704.2, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5290,7 +5300,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 304,
+    index = 301,
     label = 'CH3NH <=> CH2NH2',
     kinetics = PDepArrhenius(
         pressures = ([0.001, 0.010, 0.100, 1.000, 10.00, 100.0], 'atm'),
@@ -5312,7 +5322,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 # entry(
-#     index = 305,
+#     index = 302,
 #     label = 'CH2NH + H <=> H2CN + H2',
 #     kinetics = Arrhenius(A=(2.400e+08, 'cm^3/(mol*s)'), n=2.445, Ea=(1534, 'cal/mol'),
 #                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5327,7 +5337,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 # )
 
 entry(
-    index = 306,
+    index = 303,
     label = 'CH2NH + H <=> CHNH + H2',
     kinetics = Arrhenius(A=(3.679e+04, 'cm^3/(mol*s)'), n=2.738, Ea=(3760.2, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5340,12 +5350,13 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 307,
+    index = 304,
     label = 'N2H3 <=> N2H2 + H',
     kinetics = Troe(
         arrheniusHigh = Arrhenius(A=(1.275e+11, 's^-1'), n=0.819, Ea=(48065.2, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
         arrheniusLow = Arrhenius(A=(3.840e+40, 'cm^3/(mol*s)'), n=-6.880, Ea=(54463.0, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-        alpha=0.842, T1=(28, 'K'), T2=(7298, 'K'), T3=(80000, 'K'), efficiencies={'[Ar]': 1.00, 'N#N': 2.00, 'CNN': 5.00}),
+        alpha=0.842, T1=(28, 'K'), T2=(7298, 'K'), T3=(80000, 'K'),
+        efficiencies={'[Ar]': 1.00, 'N#N': 2.00, 'CNN': 5.00}),
     shortDesc = u"""[Dievart2020]""",
     longDesc =
 u"""
@@ -5355,7 +5366,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 308,
+    index = 305,
     label = 'N2H3 + H <=> N2H2 + H2',
     kinetics = Arrhenius(A=(7.476e+03, 'cm^3/(mol*s)'), n=2.796, Ea=(4684.4, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5368,7 +5379,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 309,
+    index = 306,
     label = 'N2H3 + H <=> H2NN(S) + H2',
     kinetics = Arrhenius(A=(6.243e+06, 'cm^3/(mol*s)'), n=1.890, Ea=(246.6, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5381,7 +5392,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 310,
+    index = 307,
     label = 'N2H3 + CH3 <=> N2H2 + CH4',
     kinetics = Arrhenius(A=(1.395e+01, 'cm^3/(mol*s)'), n=3.290, Ea=(505.7, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5394,7 +5405,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 311,
+    index = 308,
     label = 'N2H3 + CH3 <=> H2NN(S) + CH4',
     kinetics = Arrhenius(A=(4.065e+01, 'cm^3/(mol*s)'), n=3.045, Ea=(1859, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5407,7 +5418,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 312,
+    index = 309,
     label = 'N2H3 + NH2 <=> N2H2 + NH3',
     kinetics = Arrhenius(A=(6.075e-01, 'cm^3/(mol*s)'), n=3.574, Ea=(1194, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5420,8 +5431,9 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 313,
+    index = 310,
     label = 'N2H3 + NH2 <=> H2NN(S) + NH3',
+    duplicate = True,
     kinetics = Arrhenius(A=(1.111e+01, 'cm^3/(mol*s)'), n=3.080, Ea=(211.0, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
     shortDesc = u"""[Dievart2020]""",
@@ -5433,20 +5445,44 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 314,
-    label = 'N2H2 + H <=> NNH + H2',
-    kinetics = Arrhenius(A=(3.886e+08, 'cm^3/(mol*s)'), n=1.732, Ea=(738.2, 'cal/mol'),
-                         T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-    shortDesc = u"""[Dievart2020]""",
+    index=311,
+    label="N2H3 + NH2 <=> H2NN(S) + NH3",
+    duplicate=True,
+    kinetics=Chebyshev(
+        coeffs=[
+            [11.8587, -0.720541, -0.135785, 0.00199697],
+            [0.303136, 0.802251, 0.110296, -0.0164717],
+            [-0.0197441, 0.0133575, 0.0483838, 0.0121341],
+            [0.0146729, -0.0808526, -0.0112121, 0.00442436],
+            [0.0408972, -0.0273676, -0.0129358, -0.00137426],
+            [0.0287508, 0.00134059, -0.00304271, -0.0013336]],
+        kunits='cm^3/(mol*s)', Tmin=(300, 'K'), Tmax=(3000, 'K'), Pmin=(0.01, 'bar'), Pmax=(100, 'bar'),
+    ),
+    shortDesc=u"""[GrinbergDana2019]""",
+    longDesc=
+    u"""
+    PDep route, showed to be more dominant than the direct H Abstraction route in the "NH3-1" paper.
+    """,
+)
+
+entry(
+    index = 312,
+    label = 'N2H2 + H <=> NNH + H2',   # add our pdep, take DnC comment there
+    kinetics = Arrhenius(A=(4.82e+08, 'cm^3/(mol*s)'), n=1.76, Ea=(739, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""[Sarathy2020]""",
     longDesc =
 u"""
-Table 9
-Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
+CCSD(T)/cc-pVTZ and cc-pVQZ // M062X/6-311++G(d,p)
+Direct H Abstraction route
+
+PDep route also available from [Dievart2020], Table 9, Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory:
+    kinetics = Arrhenius(A=(3.886e+08, 'cm^3/(mol*s)'), n=1.732, Ea=(738.2, 'cal/mol'),
+                         T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
 """,
 )
 
 entry(
-    index = 315,
+    index = 313,
     label = 'N2H2 + CH3 <=> NNH + CH4',
     kinetics = Arrhenius(A=(1.855e+03, 'cm^3/(mol*s)'), n=3.045, Ea=(904.8, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5459,7 +5495,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 316,
+    index = 314,
     label = 'N2H2 + NH2 <=> NNH + NH3',
     kinetics = Arrhenius(A=(2.711e+05, 'cm^3/(mol*s)'), n=2.226, Ea=(-1034, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5472,7 +5508,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index = 317,
+    index = 315,
     label = 'CH4 + NH2 <=> CH3 + NH3',
     kinetics = Arrhenius(A=(1.402e+00, 'cm^3/(mol*s)'), n=3.793, Ea=(7961.5, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5490,7 +5526,7 @@ G2M//B3LYP/6-311G(d,p) level of theory
 )
 
 entry(
-    index = 318,
+    index = 316,
     label = 'C2H6 + NH2 <=> C2H5 + NH3',
     kinetics = Arrhenius(A=(1.405e+01, 'cm^3/(mol*s)'), n=3.619, Ea=(5816.0, 'cal/mol'),
                          T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
@@ -5503,7 +5539,7 @@ Calculated at the CCSD(T)/CSB//M06-2x-D3/aug-cc-pVTZ level of theory
 )
 
 entry(
-    index=319,
+    index=317,
     label='HNO2 <=> HONO',
     kinetics = PDepArrhenius(
         pressures=([1.000E-01, 2.154E-01, 4.641E-01, 1.000E+00, 2.154E+00,
@@ -5529,12 +5565,14 @@ entry(
 )
 
 entry(
-    index=320,
-    label='H2NO + OH <=> HNO + H2O',
-    kinetics=Arrhenius(A=(2.14e+15, 'cm^3/(mol*s)'), n=-0.751, Ea=(-922, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    index=318,
+    label='NH2O + OH <=> HNO + H2O',
+    kinetics=Arrhenius(A=(2.14e+15, 'cm^3/(mol*s)'), n=-0.751, Ea=(-464, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
     shortDesc=u"""[Klippenstein2022]""",
     longDesc=
 u"""
+p. 6
 CASPT2/CBS//CASPT2/cc-pVTZ-F12
 
 Also available from [Glarborg2022]
@@ -5545,27 +5583,27 @@ Based on an experimental measurement at 298-373 K from https://doi.org/10.1002/k
 )
 
 entry(
-    index=321,
-    label='H2NO + OH <=> NH2OOH',
+    index=319,
+    label='NH2O + OH <=> NH2OOH',
     kinetics=PDepArrhenius(
         pressures=([0.1, 1, 10, 100, 300], 'bar'),
         arrhenius=[
-            Arrhenius(A=(6.07E+24, 'cm^3/(mol*s)'), n=-5.64, Ea=(2715, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-            Arrhenius(A=(3.37E+26, 'cm^3/(mol*s)'), n=-5.84, Ea=(2589, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-            Arrhenius(A=(2.18E+28, 'cm^3/(mol*s)'), n=-6.07, Ea=(3036, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-            Arrhenius(A=(1.98E+29, 'cm^3/(mol*s)'), n=-6.02, Ea=(3835, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
-            Arrhenius(A=(1.48E+29, 'cm^3/(mol*s)'), n=-5.82, Ea=(4215, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(6.07E+24, 'cm^3/(mol*s)'), n=-5.64, Ea=(1366, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.37E+26, 'cm^3/(mol*s)'), n=-5.84, Ea=(1303, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(2.18E+28, 'cm^3/(mol*s)'), n=-6.07, Ea=(1528, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.98E+29, 'cm^3/(mol*s)'), n=-6.02, Ea=(1930, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.48E+29, 'cm^3/(mol*s)'), n=-5.82, Ea=(2121, 'cal/mol'), T0=(1, 'K'), Tmin=(250, 'K'), Tmax=(2500, 'K')),
         ]),
     shortDesc=u"""[Klippenstein2022]""",
     longDesc=
 u"""
 CASPT2/CBS//CASPT2/cc-pVTZ-F12
-Note that the rate expression at 300 bar may be of limited validity due to the effect of non-binary collisions
+(The rate expression at 300 bar may be of limited validity due to the effect of non-binary collisions)
 """,
 )
 
 entry(
-    index=322,
+    index=320,
     label='NO + OH <=> HONO',
     kinetics=Troe(
         arrheniusHigh=Arrhenius(A=(1.1e+14, 'cm^3/(mol*s)'), n=0.3, Ea=(0.0, 'cal/mol'), T0=(1, 'K')),
@@ -5580,50 +5618,14 @@ Fit to experimental measurement
 )
 
 entry(
-    index=323,
-    label='HNO + H <=> H2NO',
-    kinetics=Lindemann(
-        arrheniusHigh=Arrhenius(A=(5.5e+13, 'cm^3/(mol*s)'), n=0, Ea=(3250, 'cal/mol'), T0=(1, 'K')),
-        arrheniusLow=Arrhenius(A=(1.5e+19, 'cm^6/(mol^2*s)'), n=-1.632, Ea=(0.0, 'cal/mol'), T0=(1, 'K'))),
-    shortDesc=u"""[Glarborg2022]""",
-    longDesc=
-u"""
-arrheniusHigh is based on a 1993 calculation from https://doi.org/10.1063/1.465700
-arrheniusLow is based on [DeanBozz2000]
-""",
-)
-
-entry(
-    index=324,
-    label='H2NO + NH2 <=> NH3 + HNO',
-    kinetics=Arrhenius(A=(1.8e+06, 'cm^3/(mol*s)'), n=1.94, Ea=(-580, 'cal/mol'), T0=(1, 'K'), Tmin=(298, 'K'), Tmax=(373, 'K')),
-    shortDesc=u"""[DeanBozz2000]""",
-    longDesc=
-u"""
-This is the recommended rate in [Glarborg2022]
-""",
-)
-
-entry(
-    index=325,
-    label='H2NO + NO2 <=> HNO + HONO',
-    kinetics=Arrhenius(A=(8.0e+11, 'cm^3/(mol*s)'), n=0.0, Ea=(6000, 'cal/mol'), T0=(1, 'K')),
-    shortDesc=u"""[Glarborg2022]""",
-    longDesc=
-u"""
-est.
-""",
-)
-
-entry(
-    index=326,
+    index=321,
     label="NO + H <=> HNO",
     degeneracy=1,
     elementary_high_p=True,
     kinetics=Troe(
-        arrheniusHigh=Arrhenius(A=(1.5e+15, 'cm^3/(mol*s)'), n=-0.41, Ea=(0, 'cal/mol'), T0=(1, 'K')),
+        arrheniusHigh=Arrhenius(A=(1.5e+15, 'cm^3/(mol*s)'), n=-0.410, Ea=(0, 'cal/mol'), T0=(1, 'K')),
         arrheniusLow=Arrhenius(A=(2.4e+14, 'cm^6/(mol^2*s)'), n=0.206, Ea=(-1550, 'cal/mol'), T0=(1, 'K')),
-        alpha=0.82, T3=(1e-30, 'K'), T1=(1e+30, 'K'), T2=(1e+30, 'K'), efficiencies={'N#N': 1.6}),
+        alpha=0.82, T3=(1e-30, 'K'), T1=(1e+30, 'K'), T2=(1e+30, 'K'), efficiencies={'N#N': 1.6, 'N': 4}),
     shortDesc=u"""[Glarborg2022]""",
     longDesc=
 u"""
@@ -5633,7 +5635,7 @@ based on: https://doi.org/10.1002/kin.10137
 )
 
 entry(
-    index=327,
+    index=322,
     label='NO2 + H <=> NO + OH',
     kinetics=Arrhenius(A=(1.3e+14, 'cm^3/(mol*s)'), n=0.0, Ea=(362, 'cal/mol'), T0=(1, 'K')),
     shortDesc=u"""[Glarborg2022]""",
@@ -5641,4 +5643,1586 @@ entry(
 u"""
 Recommended by Glarborg2022 (also by the NOx2018 library)
 """,
+)
+
+entry(
+    index=323,
+    label='N + HO2 <=> O2 + NH',
+    kinetics=Arrhenius(A=(27.7894, 'cm^3/(mol*s)'), n=3.47248, Ea=(5.49367, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x1
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=324,
+    label='HO2 + NH <=> N + H2O2',
+    kinetics=Arrhenius(A=(0.211726, 'cm^3/(mol*s)'), n=4.02063, Ea=(15.4615, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x2
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=325,
+    label='N + HNO2 <=> NO2 + NH',
+    kinetics=Arrhenius(A=(0.0284234, 'cm^3/(mol*s)'), n=4.42306, Ea=(13.72, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x3
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=326,
+    label='N + HNO <=> NO + NH',
+    kinetics=Arrhenius(A=(9.14196e+06, 'cm^3/(mol*s)'), n=2.17825, Ea=(7.62254, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x4
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=327,
+    label='N + N2H2 <=> NH + NNH',
+    kinetics=Arrhenius(A=(2.18748, 'cm^3/(mol*s)'), n=3.96904, Ea=(16.2408, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x5
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=328,
+    label='N + NH2OH <=> NH + NH2O',
+    kinetics=Arrhenius(A=(4.47106e-05, 'cm^3/(mol*s)'), n=5.05219, Ea=(28.4545, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x6
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=329,
+    label='NH + HNNO <=> N + NH2NO',
+    kinetics=Arrhenius(A=(4.6901e-38, 'cm^3/(mol*s)'), n=14.1294, Ea=(4.17644, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x7
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=330,
+    label='N + NHOH <=> NH + HNO',
+    kinetics=Arrhenius(A=(30.8138, 'cm^3/(mol*s)'), n=3.39795, Ea=(22.6251, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x8
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=331,
+    label='NH + NHOH <=> NH2OH + N',
+    kinetics=Arrhenius(A=(2.85669e-06, 'cm^3/(mol*s)'), n=5.32063, Ea=(14.7829, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x9
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=332,
+    label='N2H3 + NH <=> N2H4 + N',
+    kinetics=Arrhenius(A=(0.000418231, 'cm^3/(mol*s)'), n=4.35534, Ea=(22.4657, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x10
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=333,
+    label='H2NN(T) + NH <=> N2H3 + N',
+    kinetics=Arrhenius(A=(0.015648, 'cm^3/(mol*s)'), n=4.16309, Ea=(11.1711, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x12
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=334,
+    label='N + NH3O <=> NH + NH2O',
+    kinetics=Arrhenius(A=(93489,'cm^3/(mol*s)'), n=2.70273, Ea=(6.99122,'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x13
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=335,
+    label='NH + O2 <=> O + HNO(T)',
+    kinetics=Arrhenius(A=(4.61e+05, 'cm^3/(mol*s)'), n=2.0, Ea=(6500, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3300, 'K')),
+    shortDesc=u"""[Miller1992]""",
+    longDesc=
+    u"""
+    Part of the "NOx" subset
+    k3
+    BAC-MP4
+    
+    Also studied by 10.1021/jp902527a
+    """,
+)
+
+entry(
+    index=336,
+    label='NH + HO2 <=> NH2 + O2',
+    duplicate = True,
+    kinetics=MultiArrhenius(
+        arrhenius=[
+            Arrhenius(A=(2.17541e-26, 'cm^3/(mol*s)'), n=11.1378, Ea=(75.2695, 'kJ/mol'),
+                      T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),  # m = 2
+            Arrhenius(A=(3947.27, 'cm^3/(mol*s)'), n=2.95763, Ea=(-5.69126, 'kJ/mol'),
+                      T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),  # m = 4
+        ],
+    ),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x16
+    Combining doublet and quartet surfaces
+    The doublet rate is insignificant relative to the quartet rate
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=337,
+    label='NH + H2O2 <=> HO2 + NH2',
+    kinetics=Arrhenius(A=(0.000171391, 'cm^3/(mol*s)'), n=4.92081, Ea=(14.0127, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x17
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=338,
+    label='NH + HNO2 <=> NO2 + NH2',
+    kinetics=Arrhenius(A=(73.1449, 'cm^3/(mol*s)'), n=3.4912, Ea=(-2.15416, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x19
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=339,
+    label='NH2O + NH <=> HNO + NH2',
+    kinetics=Arrhenius(A=(4251.49, 'cm^3/(mol*s)'), n=2.55939, Ea=(3.73373, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x20
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=340,
+    label='NH + NHOH <=> HNO + NH2',
+    kinetics=Arrhenius(A=(218124, 'cm^3/(mol*s)'), n=2.23762, Ea=(10.844, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x21
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=341,
+    label='NH + N2H3 <=> NH2 + H2NN(T)',
+    kinetics=Arrhenius(A=(0.154773, 'cm^3/(mol*s)'), n=3.93965, Ea=(7.28875, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x23
+    This is the multiplicity 4 surface, could not find a TS on the multiplicity 2 surface.
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=342,
+    label='NH + HO2 <=> O2 + NH2',
+    duplicate=True,
+    kinetics=MultiArrhenius(
+        arrhenius=[
+            Arrhenius(A=(2.39523e-26, 'cm^3/(mol*s)'), n=11.126, Ea=(74.9584, 'kJ/mol'),
+                      T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),  # m = 2
+            Arrhenius(A=(4342.52, 'cm^3/(mol*s)'), n=2.94613, Ea=(-5.79413, 'kJ/mol'),
+                      T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),  # m = 4
+        ],
+    ),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x24
+    Combining doublet and quartet surfaces
+    The doublet rate is insignificant relative to the quartet rate
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=343,
+    label='HNNO + NH2 <=> NH + NH2NO',
+    kinetics=Arrhenius(A=(1.27732e-07, 'cm^3/(mol*s)'), n=5.52596, Ea=(42.4149, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x27
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=344,
+    label='HO2 + NH3 <=> H2O2 + NH2',
+    kinetics=Arrhenius(A=(0.132333, 'cm^3/(mol*s)'), n=4.13768, Ea=(77.0269, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x29
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=345,
+    label='N2H3 + H <=> H2NN(T) + H2',
+    kinetics=Arrhenius(A=(4.33362e+07, 'cm^3/(mol*s)'), n=1.78415, Ea=(3.69912, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x30
+    CCSD(T)-F12/cc-pvtz-f12//wb97xd/def2tzvp
+    """,
+)
+
+entry(
+    index=346,
+    label='HO2 + N2H3 <=> H2O2 + H2NN(T)',
+    kinetics=Arrhenius(A=(0.00201841, 'cm^3/(mol*s)'), n=4.04044, Ea=(12.2982, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x32
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=347,
+    label='HO2 + N2H4 <=> H2O2 + N2H3',
+    kinetics=Arrhenius(A=(0.00431241, 'cm^3/(mol*s)'), n=4.18584, Ea=(8.85035, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x33
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=348,
+    label='NHOH + N2H3 <=> N2H4 + HNO',
+    kinetics=Arrhenius(A=(3.63865, 'cm^3/(mol*s)'), n=3.21359, Ea=(-2.75823, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x38
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/Def2TZVP
+    """,
+)
+
+entry(
+    index=349,
+    label='NNH + N2H4 <=> N2H2 + N2H3',
+    kinetics=Arrhenius(A=(8.90238e-06, 'cm^3/(mol*s)'), n=5.00138, Ea=(85.1537, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x39
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=350,
+    label='NHOH + N2H4 <=> NH2OH + N2H3',
+    kinetics=Arrhenius(A=(1.16857e-06, 'cm^3/(mol*s)'), n=4.9734, Ea=(20.0134, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x41
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=351,
+    label='HNNO + N2H4 <=> NH2NO + N2H3',
+    kinetics=Arrhenius(A=(0.946419, 'cm^3/(mol*s)'), n=3.53388, Ea=(35.23, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x42
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=352,
+    label='NH2OH + N2H3 <=> NH2O + N2H4',
+    kinetics=Arrhenius(A=(0.284206, 'cm^3/(mol*s)'), n=3.40875, Ea=(35.7095, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x43
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=353,
+    label='H2NN(T) + NH2OH <=> NH2O + N2H3',
+    kinetics=Arrhenius(A=(0.0436834, 'cm^3/(mol*s)'), n=3.62578, Ea=(0.357605, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x46
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=354,
+    label='H2NN(T) + NH2OH <=> NHOH + N2H3',
+    kinetics=Arrhenius(A=(0.00222861, 'cm^3/(mol*s)'), n=4.08146, Ea=(10.7837, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x48
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=355,
+    label='H2NN(T) + NH2NO <=> HNNO + N2H3',
+    kinetics=Arrhenius(A=(1.98585e-12, 'cm^3/(mol*s)'), n=6.64611, Ea=(4.94275, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x50
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=356,
+    label='HNO + NNH <=> NO + N2H2',
+    kinetics=Arrhenius(A=(6.14893e-05,'cm^3/(mol*s)'), n=4.69717, Ea=(15.0533,'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x51
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=357,
+    label='HNO + NH2O <=> NO + NH2OH',
+    kinetics=Arrhenius(A=(2.05244, 'cm^3/(mol*s)'), n=3.41689, Ea=(-3.88395, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x52
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=358,
+    label='HNO + NHOH <=> NO + NH2OH',
+    kinetics=Arrhenius(A=(0.156126, 'cm^3/(mol*s)'), n=3.85677, Ea=(-7.82899, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x53
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=359,
+    label='HNO + NH2O <=> NO + NH3O',
+    kinetics=Arrhenius(A=(0.000260618, 'cm^3/(mol*s)'), n=4.2297, Ea=(29.7365, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x54
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=360,
+    label='HNO + HNNO <=> NO + NH2NO',
+    kinetics=Arrhenius(A=(515.701, 'cm^3/(mol*s)'), n=3.01312, Ea=(25.5287, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x55
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=361,
+    label='HNO + NO2 <=> NO + HNO2',
+    kinetics=Arrhenius(A=(175.432, 'cm^3/(mol*s)'), n=3.22162, Ea=(31.3428, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x56
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=362,
+    label='NH2O + NO <=> HNO + HNO',
+    kinetics=Arrhenius(A=(0.0176994, 'cm^3/(mol*s)'), n=4.03806, Ea=(84.6598, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x60
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/Def2TZVP
+    ** include, JIM MILLER ESTIMATED, USED BY P. Glarborg, J.A. Miller, B. Ruscic, S.J. Klippenstein, Prog. Energy Combust. Sci. 67 (2018) 31-68.
+    """,
+)
+
+entry(
+    index=363,
+    label='NO2 + N2H2 <=> HNO2 + NNH',
+    kinetics=Arrhenius(A=(0.000226061, 'cm^3/(mol*s)'), n=4.91241, Ea=(18.8216, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x63
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=364,
+    label='NO2 + HNO2 <=> NO2 + HONO',
+    kinetics=Arrhenius(A=(1.74489e-21, 'cm^3/(mol*s)'), n=9.44235, Ea=(70.3648, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x64
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=365,
+    label='NO2 + NH3O <=> HNO2 + NH2O',
+    kinetics=Arrhenius(A=(159.337, 'cm^3/(mol*s)'), n=3.29524, Ea=(19.5154, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x65
+    CCSD(T)-F12/cc-pvtz-f12//wb97xd/def2tzvp
+    """,
+)
+
+entry(
+    index=366,
+    label='HONO + H2NN(T) <=> NO2 + N2H3',
+    kinetics=Arrhenius(A=(0.00955069, 'cm^3/(mol*s)'), n=4.02649, Ea=(12.2148, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x66
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=367,
+    label='HO2 + HONO <=> NO2 + H2O2',
+    kinetics=Arrhenius(A=(4.05386e-06, 'cm^3/(mol*s)'), n=5.04565, Ea=(38.7712, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x67
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=368,
+    label='HNO2 + HO2 <=> NO2 + H2O2',
+    kinetics=Arrhenius(A=(0.00213862, 'cm^3/(mol*s)'), n=4.53665, Ea=(0.871945, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x68
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=369,
+    label='HONO + NHOH <=> NO2 + NH2OH',
+    kinetics=Arrhenius(A=(2731.65, 'cm^3/(mol*s)'), n=2.31076, Ea=(18.3768, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x69
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=370,
+    label='HNO2 + NH2O <=> NO2 + NH2OH',
+    kinetics=Arrhenius(A=(4.95354e-05, 'cm^3/(mol*s)'), n=4.886, Ea=(5.21725, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x71
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=371,
+    label='HNO2 + HNNO <=> NO2 + NH2NO',
+    kinetics=Arrhenius(A=(6.49987e-13, 'cm^3/(mol*s)'), n=7.22365, Ea=(49.3044, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x72
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=372,
+    label='HONO + HNNO <=> NO2 + NH2NO',
+    kinetics=Arrhenius(A=(2.88652e-12, 'cm^3/(mol*s)'), n=6.51918, Ea=(41.6434, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x73
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=373,
+    label='HONO + H <=> NO + H2O',
+    kinetics=Arrhenius(A=(502.962, 'cm^3/(mol*s)'), n=3.30766, Ea=(41.3964, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x74
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=374,
+    label='NO2 + NH2OH <=> HONO + NH2O',
+    kinetics=Arrhenius(A=(1.28207e-07, 'cm^3/(mol*s)'), n=5.41152, Ea=(23.5494, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x76
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pVTZ
+    """,
+)
+
+entry(
+    index=375,
+    label='NNH + HO2 <=> N2H2 + O2',
+    kinetics=Arrhenius(A=(8.30235e-06, 'cm^3/(mol*s)'), n=4.80917, Ea=(5.18822, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x82
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=376,
+    label='NH2O + HO2 <=> NH3O + O2',
+    kinetics=Arrhenius(A=(1.61201e-05, 'cm^3/(mol*s)'), n=4.51311, Ea=(8.62701, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x83
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=377,
+    label='HNNO + HO2 <=> NH2NO + O2',
+    kinetics=Arrhenius(A=(7.88453, 'cm^3/(mol*s)'), n=3.43698, Ea=(5.53848, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x84
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=378,
+    label='NHOH + O2 <=> HNO + HO2',
+    kinetics=Arrhenius(A=(0.000376483, 'cm^3/(mol*s)'), n=4.61521, Ea=(75.8714, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x85
+    CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/Def2TZVP
+    ** include, JIM MILLER ESTIMATED, USED BY S.J. Klippenstein et al. 
+    """,
+)
+
+entry(
+    index=379,
+    label='HO2 + N2H2 <=> NNH + H2O2',
+    kinetics=Arrhenius(A=(3.36973, 'cm^3/(mol*s)'), n=3.53454, Ea=(-1.79879, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x88
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=380,
+    label='NH2O + N2H2 <=> NNH + NH2OH',
+    kinetics=Arrhenius(A=(0.000204599, 'cm^3/(mol*s)'), n=4.61138, Ea=(11.4773, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x89
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=381,
+    label='NNH + H2NN(S) <=> NNH + N2H2',
+    kinetics=Arrhenius(A=(0.84716, 'cm^3/(mol*s)'), n=3.91169, Ea=(6.1594, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x91
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=382,
+    label='NNH + NH3O <=> NH2O + N2H2',
+    kinetics=Arrhenius(A=(0.0137156,'cm^3/(mol*s)'), n=4.37867, Ea=(35.6236,'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x92
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=383,
+    label='HNNO + N2H2 <=> NNH + NH2NO',
+    kinetics=Arrhenius(A=(3.8865e-11, 'cm^3/(mol*s)'), n=6.78593, Ea=(-0.745059, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x93
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=384,
+    label='NHOH + N2H2 <=> NNH + NH2OH',
+    kinetics=Arrhenius(A=(0.000587998, 'cm^3/(mol*s)'), n=4.5746, Ea=(1.07353, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x94
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=385,
+    label='NH2O + NH3O <=> NH2O + NH2OH',
+    kinetics=Arrhenius(A=(0.93416, 'cm^3/(mol*s)'), n=3.47676, Ea=(-7.87813, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x100
+    CBS-QB3
+    """,
+)
+
+entry(
+    index=386,
+    label='NHOH + NH3O <=> NH2O + NH2OH',
+    kinetics=Arrhenius(A=(9.10472, 'cm^3/(mol*s)'), n=3.66473, Ea=(-5.31092, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x101
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=387,
+    label='HNNO + NH2OH <=> NH2O + NH2NO',
+    kinetics=Arrhenius(A=(1.91127e-12, 'cm^3/(mol*s)'), n=6.6384, Ea=(24.1922, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x103
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=388,
+    label='NHOH + NH2NO <=> HNNO + NH2OH',
+    kinetics=Arrhenius(A=(1.01102e-10, 'cm^3/(mol*s)'), n=6.24238, Ea=(15.2554, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x104
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=389,
+    label='N2H3O + HNO <=> NH2NO + NH2O',
+    kinetics=Arrhenius(A=(1.94018e-06, 'cm^3/(mol*s)'), n=5.14382, Ea=(5.70077, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x107
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/Def2-TZVP
+    """,
+)
+
+entry(
+    index=390,
+    label='NH + N2H3 <=> NH3 + NNH',
+    kinetics=Arrhenius(A=(40824.2, 'cm^3/(mol*s)'), n=2.38262, Ea=(-3.05802, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x108
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=391,
+    label='NO + H2NN(S) <=> NHOH + N2',
+    kinetics=Arrhenius(A=(1.42556, 'cm^3/(mol*s)'), n=3.42359, Ea=(1.9558, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x109
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=392,
+    label='HNO + HO2 <=> HONHOO',
+    kinetics=Arrhenius(A=(3.35255, 'cm^3/(mol*s)'), n=2.96577, Ea=(5.53239,'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x111
+    RMG Family: HO2 Elimination from Peroxy Radical
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=393,
+    label='HNO2 + NH2O <=> HONO + NHOH',
+    kinetics=Arrhenius(A=(0.855685,'cm^3/(mol*s)'), n=3.38223, Ea=(-8.58211, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x112
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=394,
+    label='NH + H <=> H2 + N',
+    kinetics=Arrhenius(A=(1.06816e+08, 'cm^3/(mol*s)'), n=1.64895, Ea=(1.98218, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x113
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+
+    Also available experimentally from [Hanson1990b], R2, p. 860, shock tube.
+    """,
+)
+
+entry(
+    index=395,
+    label='N2H3 + NH2 <=> H2NN(T) + NH3',
+    kinetics=Arrhenius(A=(7.15894, 'cm^3/(mol*s)'), n=3.26667, Ea=(-6.93272, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x116
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=396,
+    label='HNO + O2 <=> NO + HO2',
+    kinetics=Arrhenius(A=(1.90122e-05, 'cm^3/(mol*s)'), n=5.12075, Ea=(31.0018, 'kJ/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+    shortDesc=u"""[GrinbergDana2024]""",
+    longDesc=
+    u"""
+    x118
+    CCSD(T)-F12/cc-pvtz-f12//B2PLYPD3/aug-cc-pvtz
+    """,
+)
+
+entry(
+    index=397,
+    label='NH2 + O <=> HNO + H',
+    kinetics=Arrhenius(A=(2.78e+13, 'cm^3/(mol*s)'), n=-0.065, Ea=(-188, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc=
+u"""
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=398,
+    label='NH2 + O <=> NH + OH',
+    kinetics=Arrhenius(A=(3.09e+3, 'cm^3/(mol*s)'), n=2.84, Ea=(-2780, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc=
+u"""
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=399,
+    label='NH2 + O <=> NO + H2',
+    kinetics=Arrhenius(A=(2.38e+12, 'cm^3/(mol*s)'), n=0.112, Ea=(-347, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc=
+u"""
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=400,
+    label="NH + OH <=> HNO + H",
+    kinetics=Arrhenius(A=(1.51e+14, 'cm^3/(mol*s)'), n=-0.314, Ea=(-308, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc=
+u"""
+ANL1
+Part of the "Thermal de-NOx" mechanism
+Table 5
+
+Also available from Klippenstein2009a
+Table 3, p. 10245
+""",
+)
+
+entry(
+    index=401,
+    label='NH + OH <=> NO + H2',
+    kinetics=Arrhenius(A=(3.43e+13, 'cm^3/(mol*s)'), n=-0.303, Ea=(-336, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc=
+u"""
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=402,
+    label="NH + OH <=> H2O + N",
+    kinetics=Arrhenius(A=(2.61e+7, 'cm^3/(mol*s)'), n=1.66, Ea=(-945, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc =
+u"""
+Part of the "Thermal de-NOx" mechanism
+ANL1
+Table 5
+
+Also available from Klippenstein2009a:
+Table 3, p. 10245
+    kinetics = ThirdBody(
+        arrheniusLow = Arrhenius(A=(1.59e+07, 'cm^6/(mol^2*s)'), n=1.737, Ea=(-576, 'cal/mol'), T0 = (1, 'K'), Tmin=(200, 'K'), Tmax=(2500, 'K'))),
+calculated at the (CCSD(T) and CAS+1+2+QC level
+""",
+)
+
+entry(
+    index=403,
+    label="HNO + H <=> NO + H2",
+    kinetics=Arrhenius(A=(1.66e+10, 'cm^3/(mol*s)'), n=1.18, Ea=(-446, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc =
+u"""
+Part of the "NOx" subset
+ANL1
+Table 5
+
+Also available from Page1992:
+calculations done at the CASSCF//(CASSCF and CISD) levels of theory
+Also available (in reverse direction) from Tando and Asaba 1976, as reported by [Herron1991] in T range: 2020-3250 K:
+    kinetics = Arrhenius(A=(1.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(56500, 'cal/mol'), T0=(1, 'K')),
+""",
+)
+
+entry(
+    index=404,
+    label="HNO + H <=> NHOH",
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'bar'),
+        arrhenius=[
+            Arrhenius(A=(7.01e+18, 'cm^3/(mol*s)'), n=-3.18, Ea=(2600, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(7.09e+22, 'cm^3/(mol*s)'), n=-3.95, Ea=(2487, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(4.89e+24, 'cm^3/(mol*s)'), n=-4.14, Ea=(3141, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.57e+24, 'cm^3/(mol*s)'), n=-3.79, Ea=(3702, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.03e+24, 'cm^3/(mol*s)'), n=-3.36, Ea=(4710, 'cal/mol'), T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2500, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc =
+u"""
+Part of the "NOx" subset
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=405,
+    label='HNO + H <=> NH2O',
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'bar'),
+        arrhenius=[
+            Arrhenius(A=(5.67e+23, 'cm^3/(mol*s)'), n=-4.59, Ea=(5690, 'cal/mol'), T0=(1, 'K'), Tmin=(600, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(5.69e+25, 'cm^3/(mol*s)'), n=-4.80, Ea=(4233, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(2.68e+27, 'cm^3/(mol*s)'), n=-4.94, Ea=(4849, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(2.55e+27, 'cm^3/(mol*s)'), n=-4.63, Ea=(5539, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(4.84e+25, 'cm^3/(mol*s)'), n=-3.87, Ea=(5867, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc=
+u"""
+ANL1
+Table 5
+
+Also available from Glarborg2022:
+arrheniusHigh is based on a 1993 calculation from https://doi.org/10.1063/1.465700
+arrheniusLow is based on [DeanBozz2000]
+""",
+)
+
+entry(
+    index=406,
+    label="NHOH <=> NO + H2",
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'bar'),
+        arrhenius=[
+            Arrhenius(A=(8.49e+25, 's^-1'), n=-4.99, Ea=(53140, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(4.21e+27, 's^-1'), n=-5.20, Ea=(55170, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.47e+28, 's^-1'), n=-5.12, Ea=(56560, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.29e+27, 's^-1'), n=-4.69, Ea=(57520, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(5.76e+24, 's^-1'), n=-3.95, Ea=(58190, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc =
+u"""
+Part of the "NOx" subset
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=407,
+    label="NHOH <=> NH2O",
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'bar'),
+        arrhenius=[
+            Arrhenius(A=(2.30e+25, 's^-1'), n=-5.13, Ea=(39080, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.47e+26, 's^-1'), n=-5.15, Ea=(41210, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.45e+27, 's^-1'), n=-5.13, Ea=(43280, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(7.74e+27, 's^-1'), n=-4.93, Ea=(45060, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(3.39e+26, 's^-1'), n=-4.26, Ea=(45960, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc =
+u"""
+Part of the "NOx" subset
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=408,
+    label="NH2O <=> NO + H2",
+    kinetics=PDepArrhenius(
+        pressures=([0.01, 0.1, 1, 10, 100], 'bar'),
+        arrhenius=[
+            Arrhenius(A=(1.57e+27, 's^-1'), n=-5.28, Ea=(61560, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.79e+28, 's^-1'), n=-5.32, Ea=(63290, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.42e+28, 's^-1'), n=-5.05, Ea=(64350, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(4.66e+26, 's^-1'), n=-4.39, Ea=(64830, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+            Arrhenius(A=(1.65e+23, 's^-1'), n=-3.18, Ea=(64220, 'cal/mol'), T0=(1, 'K'), Tmin=(500, 'K'), Tmax=(2500, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Klippenstein2023]""",
+    longDesc =
+u"""
+Part of the "NOx" subset
+ANL1
+Table 5
+""",
+)
+
+entry(
+    index=409,
+    label="NH2O + HO2 <=> HNO + H2O2",
+    kinetics=Arrhenius(A=(5.41e+04, 'cm^3/(mol*s)'), n=2.16, Ea=(-3597, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Cavallotti2023]""",
+    longDesc =
+u"""
+CASPT2
+Table 4
+""",
+)
+
+entry(
+    index=410,
+    label="NH2O + NO2 <=> HNO + HONO",
+    kinetics=Arrhenius(A=(7.95, 'cm^3/(mol*s)'), n=2.95, Ea=(-3293, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Cavallotti2023]""",
+    longDesc =
+u"""
+CASPT2
+Table 4
+""",
+)
+
+entry(
+    index=411,
+    label="NH2O + O2 <=> HNO + HO2",
+    kinetics=Arrhenius(A=(1.73e05, 'cm^3/(mol*s)'), n=2.19, Ea=(18010, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Cavallotti2023]""",
+    longDesc =
+u"""
+CASPT2
+Table 4
+
+Also available from NOx2018:
+    kinetics=Arrhenius(A=(2.3e02, 'cm^3/(mol*s)'), n=2.994, Ea=(18900, 'cal/mol'), T0=(1, 'K')),
+""",
+)
+
+entry(
+    index=412,
+    label="NH2O + NH2 <=> HNO + NH3",
+    kinetics=Arrhenius(A=(9.49e+12, 'cm^3/(mol*s)'), n=-0.08, Ea=(-1644, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(400, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Cavallotti2023]""",
+    longDesc =
+u"""
+CASPT2
+Table 4
+""",
+)
+
+entry(
+    index=413,
+    label="HNO <=> HNO(T)",
+    kinetics=Arrhenius(A=(1e-5, 's^-1'), n=0, Ea=(10000, 'kcal/mol'), T0=(1, 'K')),
+    shortDesc=u"""est.""",
+    longDesc =
+u"""
+RMG estimates this spin-forbidden reaction with a high rate coefficient
+""",
+)
+
+entry(
+    index=414,
+    label="HNO + HNO <=> HNO + HNO(T)",
+    kinetics=Arrhenius(A=(1e-5, 'cm^3/(mol*s)'), n=0, Ea=(10000, 'kcal/mol'), T0=(1, 'K')),
+    shortDesc=u"""est.""",
+    longDesc =
+u"""
+RMG estimates this spin-forbidden reaction with a high rate coefficient
+""",
+)
+
+entry(
+    index=415,
+    label="HNO + HNO <=> HNO(T) + HNO(T)",
+    kinetics=Arrhenius(A=(1e-5, 'cm^3/(mol*s)'), n=0, Ea=(10000, 'kcal/mol'), T0=(1, 'K')),
+    shortDesc=u"""est.""",
+    longDesc =
+u"""
+RMG estimates this spin-forbidden reaction with a high rate coefficient
+""",
+)
+
+entry(
+    index=416,
+    label="HNO + HNO(T) <=> HNO(T) + HNO(T)",
+    kinetics=Arrhenius(A=(1e-5, 'cm^3/(mol*s)'), n=0, Ea=(10000, 'kcal/mol'), T0=(1, 'K')),
+    shortDesc=u"""est.""",
+    longDesc =
+u"""
+RMG estimates this spin-forbidden reaction with a high rate coefficient
+""",
+)
+
+entry(
+    index=417,
+    label="HNO + NHOH <=> HNO(T) + NHOH",
+    kinetics=Arrhenius(A=(1e-5, 'cm^3/(mol*s)'), n=0, Ea=(10000, 'kcal/mol'), T0=(1, 'K')),
+    shortDesc=u"""est.""",
+    longDesc =
+u"""
+RMG estimates this spin-forbidden reaction with a high rate coefficient
+""",
+)
+
+entry(
+    index=418,
+    label='N2H4 + H <=> N2H3 + H2',
+    kinetics=Arrhenius(A=(2.76e+05, 'cm^3/(mol*s)'), n=2.56, Ea=(1218, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(2000, 'K')),
+    shortDesc=u"""[Kanno2020]""",
+    longDesc=
+    u"""
+    Table 4
+    CBS-QB3//DSD-BLYP-D3(BJ)/Def2-TZVP
+    """,
+)
+
+entry(
+    index=419,
+    label='N2H4 + OH <=> N2H3 + H2O',
+    kinetics=PDepArrhenius(
+        pressures=([1, 760, 7600], 'torr'),
+        arrhenius=[
+            Arrhenius(A=(3.49e+08, 'cm^3/(mol*s)'), n=1.544, Ea=(-5.45, 'kJ/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(2.48e+08, 'cm^3/(mol*s)'), n=1.585, Ea=(-5.86, 'kJ/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.62e+08, 'cm^3/(mol*s)'), n=1.637, Ea=(-6.39, 'kJ/mol'), T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(3000, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Huynh2019]""",
+    longDesc=
+    u"""
+    CCSD(T)/CBS//M06-2X/6-311++G(3df,2p)
+    Fitted Arrhenius expressions to raw data given seperately for each of the three pressures in Table S4
+    """,
+)
+
+entry(
+    index=420,
+    label='NH + O2 <=> NO2 + H',
+    kinetics=Arrhenius(A=(2.3e+10, 'cm^3/(mol*s)'), n=0, Ea=(2482, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[DeanBozz2000]""",
+    longDesc=
+    u"""
+    """,
+)
+
+entry(
+    index=421,
+    label="NH + O2 <=> HNOO",
+    degeneracy=1,
+    elementary_high_p=True,
+    kinetics=PDepArrhenius(
+        pressures=([0.1, 1, 10], 'atm'),
+        arrhenius=[
+            Arrhenius(A=(3.5e+23, 'cm^3/(mol*s)'), n=-5, Ea=(2275, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(3.7e+24, 'cm^3/(mol*s)'), n=-5, Ea=(2295, 'cal/mol'), T0=(1, 'K')),
+            Arrhenius(A=(5.4e+25, 'cm^3/(mol*s)'), n=-5.05, Ea=(2454, 'cal/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc=u"""[DeanBozz2000]""",
+    longDesc=
+    u"""
+    """,
+)
+
+entry(
+    index=422,
+    label="N2O + H <=> HNNO",
+    kinetics=Arrhenius(A=(8.5e+13, 'cm^3/(mol*s)'), n=0, Ea=(9082, 'cal/mol'), T0=(1, 'K')),
+    elementary_high_p=True,
+    shortDesc=u"""[DeanBozz2000]""",
+    longDesc=
+    u"""
+    Part of the "N2O Pathway"
+    See [DeanBozz2000] 2.6.3, p. 158, and Table 2.6 on p. 163
+    """,
+)
+
+entry(
+    index=423,
+    label="NH2 + OH <=> NH2O + H",
+    kinetics=Arrhenius(A=(6.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(77.1, 'kJ/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Mousavipour2009]""",
+    longDesc=
+    u"""
+    R3
+    CCSD(full)/Aug-cc-pVTZ//B3LYP/6-311++G(3df,3p)
+    Passes through NH2OH*, should be re-computed as PDep
+    This work only gives Arrhenius expressions, unclear whether for 1 bar or as high-P-limit
+    """,
+)
+
+entry(
+    index=424,
+    label="NH2 + OH <=> NHOH + H",
+    duplicate=True,
+    kinetics=MultiArrhenius(
+        arrhenius=[
+            Arrhenius(A=(6.4e+13, 'cm^3/(mol*s)'), n=0, Ea=(131.1, 'kJ/mol'), T0=(1, 'K')),
+            Arrhenius(A=(5.0e+11, 'cm^3/(mol*s)'), n=0, Ea=(107.9, 'kJ/mol'), T0=(1, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Mousavipour2009]""",
+    longDesc=
+    u"""
+    R4 & R5 (cis & trans NHOH)
+    CCSD(full)/Aug-cc-pVTZ//B3LYP/6-311++G(3df,3p)
+    Passes through NH2OH*, should be re-computed as PDep
+    This work only gives Arrhenius expressions, unclear whether for 1 bar or as high-P-limit
+    """,
+)
+
+entry(
+    index=425,
+    label="NO2 + O <=> NO + O2",
+    duplicate=True,
+    kinetics=MultiArrhenius(
+        arrhenius=[
+            Arrhenius(A=(2.589e+15, 'cm^3/(mol*s)'), n=-1.035, Ea=(226, 'J/mol'), T0=(1, 'K'), Tmin=(221, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(4.242e+16, 'cm^3/(mol*s)'), n=-0.861, Ea=(50917, 'J/mol'), T0=(1, 'K'), Tmin=(221, 'K'), Tmax=(3000, 'K')),
+        ],
+    ),
+    shortDesc=u"""[Xu2021]""",
+    longDesc=
+    u"""
+    low-T experiments and high-T W3X-L calculations
+    """,
+)
+
+entry(
+    index=426,
+    label="NH2 <=> NH + H",
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(1.2e+15, 'cm^3/(mol*s)'), n=0, Ea=(318, 'kJ/mol'),
+                               T0=(1, 'K'), Tmin=(2200, 'K'), Tmax=(4000, 'K'))),
+    shortDesc=u"""[Wagner1998]""",
+    longDesc=
+    u"""
+    R5a
+    Experimental
+    """,
+)
+
+entry(
+    index=427,
+    label='NH2 + HNO <=> NH3 + NO',
+    duplicate=True,
+    kinetics=Arrhenius(A=(5.9e+02, 'cm^3/(mol*s)'), n=2.950, Ea=(-3469, 'cal/mol'), T0=(1, 'K')),
+    shortDesc=u"""[Glarborg2021]""",
+    longDesc=
+u"""
+Reaction 7, Table 2, Source: [Glarborg2021], Experimental work re-interpreted using direct measurments from 
+[Altinay&Macdonald2015]. New parameters obtained with the predicted rate expressions by [ShuchengXu & M.C.Lin2009] 
+the potential energy surface of this reaction has been computed by single-point calculations at the 
+CCSD(T)/6-311+G(3df,2p) level based on geometries optimized at the CCSD/6-311++G(d,p) level.
+Previously taken from [Lin1996a] in reverse.
+Reaction Part of the "Thermal de-NOx" mechanism
+        k1 on p. 7519
+        T range: 300-5000 K
+        calculations done at the UMP2/6-311G-(d,p)//UMP2/6-311G(d,p) level of theory
+        Added as a training reaction to H_Abstraction
+""",
+)
+
+entry(
+    index=428,
+    label='NH2 + HNO <=> NH3 + NO',
+    duplicate=True,
+    kinetics=PDepArrhenius(
+        pressures=([1, 10, 100, 760, 7600, 76000], 'torr'),
+        arrhenius=[
+            Arrhenius(A=(2.18e-18, 'cm^3/(mol*s)'), n=8.17, Ea=(9064, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(7.71e-17, 'cm^3/(mol*s)'), n=7.79, Ea=(6576, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(2.14e-12, 'cm^3/(mol*s)'), n=6.56, Ea=(3279, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(7.83e-08, 'cm^3/(mol*s)'), n=5.29, Ea=(469, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(5.70e-05, 'cm^3/(mol*s)'), n=4.49, Ea=(-1157, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.31e-03, 'cm^3/(mol*s)'), n=4.11, Ea=(-1938, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+        ],
+    ),
+    elementary_high_p = True,
+    shortDesc=u"""[Lin2009c]""",
+    longDesc=
+u"""
+k3, Table II
+CCSD(T)/6-311+G(3df.2p)//CCSD/6-311++G(d,p)
+""",
+)
+
+entry(
+    index=429,
+    label='NH2 + HNO <=> NH2NO + H',
+    duplicate=True,
+    kinetics=PDepArrhenius(
+        pressures=([1, 10, 100, 760, 7600, 76000], 'torr'),
+        arrhenius=[
+            Arrhenius(A=(2.39e+03, 'cm^3/(mol*s)'), n=2.70, Ea=(256, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(7.29e+03, 'cm^3/(mol*s)'), n=2.56, Ea=(18, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(4.07e+04, 'cm^3/(mol*s)'), n=2.36, Ea=(-354, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(2.43e+05, 'cm^3/(mol*s)'), n=2.15, Ea=(-759, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.21e+06, 'cm^3/(mol*s)'), n=1.97, Ea=(-1166, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+            Arrhenius(A=(1.95e+06, 'cm^3/(mol*s)'), n=1.92, Ea=(-1312, 'cal/mol'), T0=(1, 'K'), Tmin=(300, 'K'), Tmax=(3000, 'K')),
+        ],
+    ),
+    elementary_high_p = True,
+    shortDesc=u"""[Lin2009c]""",
+    longDesc=
+u"""
+k5, Table II
+CCSD(T)/6-311+G(3df.2p)//CCSD/6-311++G(d,p)
+""",
+)
+
+entry(
+    index=430,
+    label="N2 <=> N + N",
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(1.89e+18, 'cm^3/(mol*s)'), n=-0.8, Ea=(224.95, 'kcal/mol'), T0=(1, 'K')),
+        efficiencies={'O': 16.25, '[C-]#[O+]': 18.75, 'O=C=O': 3.75, 'C': 16.25, 'CC': 16.25}),
+    shortDesc=u"""[Dagaut1998]""",
+    longDesc=
+    u"""
+    R1 Table I
+    Ultimate source is unclear.
+    """,
+)
+
+entry(
+    index=431,
+    label="HNO + HNO <=> N2O + H2O",
+    kinetics=Arrhenius(A=(8.4e+8, 'cm^3/(mol*s)'), n=0.0, Ea=(3102, 'cal/mol'),
+                       T0=(1, 'K'), Tmin=(450, 'K'), Tmax=(520, 'K')),
+    shortDesc=u"""[Herron1991]""",
+    longDesc=
+    u"""
+    based on experimental observations by He et al., 10.1021/j100330a028, https://www.osti.gov/biblio/5992224
+    """,
+)
+
+entry(
+    index=432,
+    label="N2H2 <=> NNH + H",
+    kinetics=ThirdBody(
+        arrheniusLow=Arrhenius(A=(3.8e+13, 'cm^3/(mol*s)'), n=1.2, Ea=(293000, 'kJ/mol'), T0=(1, 'K'))),
+    shortDesc = u"""[Mei2019]""",
+    longDesc =
+u"""
+Reinterpreted rate coefficient based on the Miller and Bowman's work (https://doi.org/10.1016/0360-1285(89)90017-8)
+with updated energies by Klippenstein et al. [Klippenstein2009a].
+Actual rate is in their SI:
+N2H2+M=NNH+H+M  3.80E+13 1.2 70100 ! PW ZXY_20190214 estimated from 1979 Miller PECS and the PES calculated by SJK2009 JPCA
+""",
+)
+
+entry(
+    index=433,
+    label="NH3 + NH2 <=> N2H3 + H2",
+    kinetics=Arrhenius(A=(1.3e+13, 'cm^3/(mol*s)'), n=0.0, Ea=(58.8, 'kcal/mol'),
+                       T0=(1, 'K'), Tmin=(1000, 'K'), Tmax=(2500, 'K')),
+    shortDesc=u"""[Marshall2023]""",
+    longDesc=
+    u"""
+    CBS-APNO//M062X/6-311++G(2df,2p)
+    This is the upper bound for the rate coefficient
+    """,
 )

--- a/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
+++ b/input/kinetics/libraries/primaryNitrogenLibrary/reactions.py
@@ -4875,7 +4875,7 @@ entry(
                                   T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
         arrheniusLow = Arrhenius(A=(1.20e+42, 'cm^6/(mol^2*s)'), n=-8.8, Ea=(3117.9, 'cal/mol'),
                                  T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K'))),
-    elementary_high_p = False,
+    elementary_high_p = True,
     shortDesc = u"""[Lin2003d]""",
     longDesc =
 u"""
@@ -4892,7 +4892,7 @@ entry(
                                   T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K')),
         arrheniusLow = Arrhenius(A=(1.14e+50, 'cm^6/(mol^2*s)'), n=-12.3, Ea=(5136.9, 'cal/mol'),
                                  T0=(1, 'K'), Tmin=(200, 'K'), Tmax=(2000, 'K'))),
-    elementary_high_p = False,
+    elementary_high_p = True,
     shortDesc = u"""[Lin2003d]""",
     longDesc =
 u"""

--- a/input/thermo/libraries/NH3.py
+++ b/input/thermo/libraries/NH3.py
@@ -1,0 +1,2262 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "NH3"
+shortDesc = "Ammonia oxidation"
+longDesc = """
+Written by Alon Grinberg Dana,
+Based on 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ computations
+with enthalpies from ATcT  v. 1.130 where available.
+"""
+
+entry(
+    index=1,
+    label="N",
+    molecule="""
+multiplicity 4
+1 N u3 p1 c0
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.5, 4.40191e-13, -7.53247e-16, 5.07597e-19, -1.16114e-22, 56076.4, 4.17947], Tmin=(298, 'K'), Tmax=(2023.39, 'K')),
+        NASAPolynomial(coeffs=[2.5, 1.12586e-09, -7.88843e-13, 2.44938e-16, -2.84351e-20, 56076.4, 4.17947], Tmin=(2023.39, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(466.246, 'kJ/mol'), Cp0=(20.7862, 'J/(mol*K)'), CpInf=(20.7862, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(472.440, 'kJ/mol'),
+    S298=(153.171, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([20.7862, 20.7862, 20.7862, 20.7862, 20.7862, 20.7862, 20.7862, 20.7862, 20.7862], 'J/(mol*K)'),
+    Cp0=(20.7862, 'J/(mol*K)'),
+    CpInf=(20.7862, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=2,
+    label="NH(S)",
+    molecule="""
+multiplicity 1
+1 N u0 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.60037, -0.000534387, 6.06544e-07, 2.40431e-10, -2.16168e-13, 60210.6, 0.274904], Tmin=(298, 'K'), Tmax=(1016.57, 'K')),
+        NASAPolynomial(coeffs=[3.37342, -0.000144347, 7.73144e-07, -3.55512e-10, 5.00787e-14, 60282.7, 1.50133], Tmin=(1016.57, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(500.705, 'kJ/mol'), Cp0=(29.1007, 'J/(mol*K)'), CpInf=(37.4151, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(509.39, 'kJ/mol'),
+    S298=(171.743, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([29.0839, 29.0587, 29.1119, 29.269, 29.8957, 30.7503, 32.8289, 34.3866, 35.288], 'J/(mol*K)'),
+    Cp0=(29.1007, 'J/(mol*K)'),
+    CpInf=(37.4151, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=3,
+    label="NH(T)",
+    molecule="""
+multiplicity 3
+1 N u2 p1 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.60703, -0.000582915, 7.15283e-07, 1.58499e-10, -1.95045e-13, 42096.9, 1.34837], Tmin=(298, 'K'), Tmax=(1018.46, 'K')),
+        NASAPolynomial(coeffs=[3.35047, -8.48743e-05, 7.32289e-07, -3.43917e-10, 4.88775e-14, 42175.6, 2.72055], Tmin=(1018.46, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(350.104, 'kJ/mol'), Cp0=(29.1007, 'J/(mol*K)'), CpInf=(37.4151, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(358.79, 'kJ/mol'),
+    S298=(180.898, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([29.0824, 29.0587, 29.1169, 29.2825, 29.9315, 30.8004, 32.8894, 34.4385, 35.3262], 'J/(mol*K)'),
+    Cp0=(29.1007, 'J/(mol*K)'),
+    CpInf=(37.4151, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=4,
+    label="NH2",
+    molecule="""
+multiplicity 2
+1 N u1 p1 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.17563, -0.00169104, 5.10754e-06, -3.25458e-09, 7.05524e-13, 21166, -0.0947707], Tmin=(298, 'K'), Tmax=(1159.03, 'K')),
+        NASAPolynomial(coeffs=[2.96198, 0.00249753, -3.13356e-07, -1.36462e-10, 3.29417e-14, 21447.3, 5.93948], Tmin=(1159.03, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(176.099, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(186.03, 'kJ/mol'),
+    S298=(194.473, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([33.6462, 34.3101, 35.266, 36.4685, 39.246, 41.9191, 47.4293, 51.0909, 53.1949], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=5,
+    label="NH3",
+    molecule="""
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.02402, -0.00171864, 1.05396e-05, -8.56127e-09, 2.31612e-12, -6679.15, 0.316593], Tmin=(298, 'K'), Tmax=(951.008, 'K')),
+        NASAPolynomial(coeffs=[2.1289, 0.00625227, -2.03265e-06, 2.51927e-10, -6.70266e-16, -6318.69, 9.36423], Tmin=(951.008, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-55.5883, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-45.556, 'kJ/mol',),
+    S298=(192.286, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([35.3396, 37.6552, 40.4923, 43.6023, 49.6031, 54.8092, 64.6581, 70.8086, 74.4798], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=6,
+    label="N2",
+    molecule="""
+1 N u0 p1 c0 {2,T}
+2 N u0 p1 c0 {1,T}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.57917, -0.00092269, 2.52013e-06, -1.59938e-09, 3.37289e-13, -1044.86, 2.81354], Tmin=(298, 'K'), Tmax=(1224.73, 'K')),
+        NASAPolynomial(coeffs=[2.85431, 0.00144431, -3.78377e-07, -2.18841e-11, 1.53369e-14, -867.277, 6.45765], Tmin=(1224.73, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-8.63946, 'kJ/mol'), Cp0=(29.1007, 'J/(mol*K)'), CpInf=(37.4151, 'J/(mol*K)'))
+    ,
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 is exact
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(0.0, 'kJ/mol',),
+    S298=(191.465, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([29.0347, 29.2669, 29.6493, 30.162, 31.3996, 32.5611, 34.6758, 35.7636, 36.2178], 'J/(mol*K)'),
+    Cp0=(29.1007, 'J/(mol*K)'),
+    CpInf=(37.4151, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=7,
+    label="NNH",
+    molecule="""
+multiplicity 2
+1 N u1 p1 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.95201, -0.00112385, 8.04654e-06, -7.44027e-09, 2.23831e-12, 28790.3, 4.48518], Tmin=(298, 'K'), Tmax=(876.559, 'K')),
+        NASAPolynomial(coeffs=[2.59685, 0.00505955, -2.53369e-06, 6.05725e-10, -5.62358e-14, 29027.9, 10.8447], Tmin=(876.559, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(239.281, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(249.23, 'kJ/mol'),
+    S298=(224.169, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([34.6139, 36.2864, 38.3125, 40.4409, 44.173, 47.1274, 51.9156, 54.2885, 55.5058], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=8,
+    label="N2H2",
+    molecule="""
+1 N u0 p1 c0 {2,D} {3,S}
+2 N u0 p1 c0 {1,D} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.90363, -0.00277548, 1.71597e-05, -1.59688e-08, 4.88596e-12, 22888.6, 4.17493], Tmin=(298, 'K'), Tmax=(858.612, 'K')),
+        NASAPolynomial(coeffs=[1.18583, 0.009886, -4.96016e-06, 1.20622e-09, -1.14888e-13, 23355.3, 16.8724],  Tmin=(858.612, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(190.102, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(199.97, 'kJ/mol'),
+    S298=(217.988, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([35.2366, 38.4647, 42.4773, 46.6858, 53.9989, 59.817, 69.3669, 74.2705, 76.9546], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=9,
+    label="N2H2(T)",
+    molecule="""
+multiplicity 3
+1 N u1 p1 c0 {2,S} {3,S}
+2 N u1 p1 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.80462, 0.00602849, 3.95609e-06, -8.62046e-09, 3.61111e-12, 44228.5, 10.2844], Tmin=(298, 'K'), Tmax=(866.507, 'K')),
+        NASAPolynomial(coeffs=[2.53086, 0.00945813, -5.73027e-06, 1.71661e-09, -2.03545e-13, 44194.6, 11.0968], Tmin=(866.507, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(366.831, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'),
+        CpInf=(78.9875, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(377.074, 'kJ/mol'),
+    S298=(234.184, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([39.6793, 44.7435, 49.5678, 53.7002, 59.9985, 64.6321, 71.4662, 74.7812, 76.8449], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(78.9875, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=10,
+    label="H2NN(S)",
+    molecule="""
+1 N u0 p0 c+1 {2,D} {3,S} {4,S}
+2 N u0 p2 c-1 {1,D}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.81477, -0.00187204, 1.62016e-05, -1.58152e-08, 5.01782e-12, 34969.2, 4.44255], Tmin=(298, 'K'), Tmax=(830.377, 'K')),
+        NASAPolynomial(coeffs=[1.36937, 0.00990746, -5.07663e-06, 1.26764e-09, -1.25188e-13, 35375.3, 15.7857], Tmin=(830.377, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(290.494, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(300.46, 'kJ/mol'),
+    S298=(217.902, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([36.0598, 39.5746, 43.755, 47.9949, 55.2547, 60.9869, 70.283, 74.9856, 77.5189], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=11,
+    label="H2NN(T)",
+    molecule="""
+multiplicity 3
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 N u2 p1 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.04506, 0.00470387, 4.86932e-06, -8.53561e-09, 3.46826e-12, 42828.9, 9.41533], Tmin=(298, 'K'), Tmax=(838.109, 'K')),
+        NASAPolynomial(coeffs=[2.592, 0.00845899, -4.70219e-06, 1.34563e-09, -1.55637e-13, 42848.9, 11.1873], Tmin=(838.109, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(355.382, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(365.612, 'kJ/mol'),
+    S298=(235.406, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([39.0515, 43.5863, 47.9629, 51.801, 57.9468, 62.6902, 70.3347, 74.5841, 77.3535], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=12,
+    label="N2H3",
+    molecule="""
+multiplicity 2
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 N u1 p1 c0 {1,S} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.4704, 0.0102434, -2.24608e-06, -2.64426e-09, 1.46424e-12, 25803.2, 11.5301], Tmin=(298, 'K'), Tmax=(873.911, 'K')),
+        NASAPolynomial(coeffs=[2.54229, 0.0110855, -5.70181e-06, 1.52552e-09, -1.67311e-13, 25745.9, 10.937],  Tmin=(873.911, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(213.536, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(108.088, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+Rotor scan not smooth, need to consider a strongly-coupled inversion mode
+
+ThermoData(
+    H298=(224.24, 'kJ/mol'),
+    S298=(237.266, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([43.9292, 50.5402, 56.4966, 61.7058, 70.4242, 77.2517, 88.513, 94.9756, 99.1945], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(108.088, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=13,
+    label="N2H4",
+    molecule="""
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 N u0 p1 c0 {1,S} {5,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.35889, 0.0117876, 7.52133e-07, -7.2024e-09, 3.25471e-12, 10513.5, 11.6062], Tmin=(298, 'K'), Tmax=(867.229, 'K')),
+        NASAPolynomial(coeffs=[2.1854, 0.0146696, -7.83336e-06, 2.16554e-09, -2.43776e-13, 10465.3, 11.9671], Tmin=(867.229, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(86.2821, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(97.56, 'kJ/mol'),
+    S298=(237.245, 'J/(mol*K)'), # c=1
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([48.1822, 56.75, 64.4017, 71.1699, 82.4016, 91.0855, 105.125, 113.069, 118.318], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=14,
+    label="NH3NH",
+    molecule="""
+1 N u0 p0 c+1 {2,S} {3,S} {4,S} {5,S}
+2 N u0 p2 c-1 {1,S} {6,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.40007, 0.00605245, 7.56422e-06, -9.63729e-09, 3.18472e-12, 32468.1, 7.40385], Tmin=(298, 'K'), Tmax=(835.206, 'K')),
+        NASAPolynomial(coeffs=[1.78544, 0.0137859, -6.32582e-06, 1.45068e-09, -1.34464e-13, 32737.8, 14.9026], Tmin=(835.206, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(269.545, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(281.023, 'kJ/mol'),
+    S298=(239.749, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([46.9974, 53.9847, 60.8924, 67.3473, 78.5492, 87.6979, 103.514, 112.385, 117.413], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=15,
+    label="N3H",
+    molecule="""
+1 N u0 p2 c-1 {2,D}
+2 N u0 p0 c+1 {1,D} {3,D}
+3 N u0 p1 c0 {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.74276, 0.0108092, -8.34987e-06, 3.50729e-09, -6.22863e-13, 33838.7, 10.2512], Tmin=(298, 'K'), Tmax=(1193.09, 'K')),
+        NASAPolynomial(coeffs=[3.75119, 0.00742842, -4.0995e-06, 1.13236e-09, -1.25236e-13, 33598.1, 5.20806], Tmin=(1193.09, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(280.682, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(291.58, 'kJ/mol'),
+    S298=(239.1, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([44.2453, 49.4604, 53.6725, 57.2887, 63.0867, 67.3409, 73.6203, 76.8927, 79.1299], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=16,
+    label="N3H5",
+    molecule="""
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 N u0 p1 c0 {1,S} {3,S} {6,S}
+3 N u0 p1 c0 {2,S} {7,S} {8,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.27949, 0.0221769, -1.43802e-05, 5.20758e-09, -8.24357e-13, 21673.1, 8.66556], Tmin=(298, 'K'), Tmax=(1224.34, 'K')),
+        NASAPolynomial(coeffs=[4.54305, 0.0180488, -9.3226e-06, 2.45368e-09, -2.62032e-13, 21363.7, 2.31386], Tmin=(1224.34, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(180.079, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'),
+        CpInf=(174.604, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(195.541, 'kJ/mol'),
+    S298=(277.401, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([72.9684, 84.4757, 94.4758, 103.263, 117.7, 128.708, 146.165, 155.963, 162.411], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(174.604, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=17,
+    label="NO",
+    molecule="""
+multiplicity 2
+1 N u1 p1 c0 {2,D}
+2 O u0 p2 c0 {1,D}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.54726, -0.000976042, 3.57791e-06, -2.83595e-09, 7.41777e-13, 9921.91, 4.62453], Tmin=(298, 'K'), Tmax=(1010.73, 'K')),
+        NASAPolynomial(coeffs=[2.75583, 0.00215604, -1.07029e-06, 2.29919e-10, -1.6545e-14, 10081.9, 8.45118], Tmin=(1010.73, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(82.5046, 'kJ/mol'), Cp0=(29.1007, 'J/(mol*K)'), CpInf=(37.4151, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(91.143, 'kJ/mol'),
+    S298=(205.185, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([29.1848, 29.639, 30.2811, 31.0423, 32.5281, 33.7023, 35.5187, 36.2781, 36.5925], 'J/(mol*K)'),
+    Cp0=(29.1007, 'J/(mol*K)'),
+    CpInf=(37.4151, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=18,
+    label="HNO(S)",
+    molecule="""
+1 N u0 p1 c0 {2,D} {3,S}
+2 O u0 p2 c0 {1,D}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.04892, -0.00203371, 9.1381e-06, -7.68952e-09, 2.1349e-12, 11684, 3.72802], Tmin=(298, 'K'), Tmax=(947.955, 'K')),
+        NASAPolynomial(coeffs=[2.28668, 0.00540271, -2.62961e-06, 5.86811e-10, -4.79003e-14, 12018.1, 12.1356], Tmin=(947.955, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(97.1133, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(106.98, 'kJ/mol'),
+    S298=(220.593, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([33.9253, 35.3633, 37.2635, 39.4024, 43.3578, 46.5106, 51.6233, 54.09, 55.3123], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=19,
+    label="HNO(T)",
+    molecule="""
+multiplicity 3
+1 N u1 p1 c0 {2,S} {3,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.9029, -0.000720791, 7.98867e-06, -8.20547e-09, 2.72225e-12, 21384.6, 5.26094], Tmin=(298, 'K'), Tmax=(797.947, 'K')),
+        NASAPolynomial(coeffs=[2.76701, 0.00497317, -2.71477e-06, 7.36833e-10, -7.93508e-14, 21565.9, 10.4846], Tmin=(797.947, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(177.678, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(187.668, 'kJ/mol'),
+    S298=(229.222, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([35.0004, 36.8737, 38.9327, 40.9764, 44.5361, 47.226, 51.5718, 53.8883, 55.2562], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=20,
+    label="HON(S)",
+    molecule="""
+1 N u0 p2 c-1 {2,D}
+2 O u0 p1 c+1 {1,D} {3,S}
+3 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.87944, -0.00103045, 8.89067e-06, -9.07581e-09, 3.0217e-12, 32654.2, 4.42294], Tmin=(298, 'K'), Tmax=(790.668, 'K')),
+        NASAPolynomial(coeffs=[2.66917, 0.00509258, -2.72596e-06, 7.19359e-10, -7.55345e-14, 32845.5, 9.9775], Tmin=(790.668, 'K'), Tmax=(3000, 'K'))],
+                Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(271.348, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(281.249, 'kJ/mol'),
+    S298=(220.65, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([34.5515, 36.4022, 38.5912, 40.7405, 44.362, 47.1941, 51.7277, 54.0203, 55.3133], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=21,
+    label="HON(T)",
+    molecule="""
+multiplicity 3
+1 N u2 p1 c0 {2,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.62076, 0.00100623, 5.86889e-06, -7.6479e-09, 2.90357e-12, 24700.4, 6.62511], Tmin=(298, 'K'), Tmax=(840.198, 'K')),
+        NASAPolynomial(coeffs=[3.06606, 0.00477133, -2.86016e-06, 8.70968e-10, -1.05115e-13, 24753.9, 8.96844], Tmin=(840.198, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(205.045, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(215.03, 'kJ/mol'),
+    S298=(230.74, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([35.5185, 37.766, 40.0513, 42.1275, 45.3492, 47.7332, 51.5332, 53.647, 55.0837], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=22,
+    label="NH2O",
+    molecule="""
+multiplicity 2
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 O u1 p2 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.07928, 0.00227378, 4.54857e-06, -4.93461e-09, 1.48515e-12, 6352.15, 3.76557], Tmin=(298, 'K'), Tmax=(914.757, 'K')),
+        NASAPolynomial(coeffs=[2.98935, 0.00703992, -3.26708e-06, 7.61529e-10, -7.16286e-14, 6551.55, 8.92673], Tmin=(914.757, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(52.9039, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(64.02, 'kJ/mol'),
+    S298=(231.513, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([41.9816, 45.2358, 48.4661, 51.5984, 57.2998, 61.9654, 69.8886, 74.3812, 77.0853], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=23,
+    label="NHOH",
+    molecule="""
+multiplicity 2
+1 N u1 p1 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {4,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.07284, 0.00442232, 5.37198e-06, -8.99621e-09, 3.6302e-12, 10216.3, 9.07206], Tmin=(298, 'K'), Tmax=(839.264, 'K')),
+        NASAPolynomial(coeffs=[2.59974, 0.00835128, -4.64222e-06, 1.33526e-09, -1.55318e-13, 10236.7, 10.9204], Tmin=(839.264, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(84.2354, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(94.45, 'kJ/mol'),
+    S298=(233.325, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([38.867, 43.3346, 47.6713, 51.4871, 57.5699, 62.2706, 69.9013, 74.2066, 77.0521], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=24,
+    label="NH2OH",
+    molecule="""
+1 N u0 p1 c0 {2,S} {3,S} {4,S}
+2 O u0 p2 c0 {1,S} {5,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.45498, 0.00912211, 5.52546e-06, -1.28325e-08, 5.37895e-12, -6389.62, 11.3877], Tmin=(298, 'K'), Tmax=(901.673, 'K')),
+        NASAPolynomial(coeffs=[2.33175, 0.0137315, -8.90135e-06, 2.83138e-09, -3.49572e-13, -6532.55, 11.0537], Tmin=(901.673, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(-54.3299, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-43.46, 'kJ/mol'),
+    S298=(234.76, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([44.8708, 52.3121, 59.3393, 65.323, 74.0483, 80.2019, 88.9773, 93.3877, 96.694], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=25,
+    label="NH3O",
+    molecule="""
+1 N u0 p0 c+1 {2,S} {3,S} {4,S} {5,S}
+2 O u0 p3 c-1 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.72113, -0.00211582, 2.34595e-05, -2.38341e-08, 7.81597e-12, 6037.76, 5.19934], Tmin=(298, 'K'), Tmax=(807.523, 'K')),
+        NASAPolynomial(coeffs=[0.301436, 0.0148247, -8.01035e-06, 2.14848e-09, -2.28548e-13, 6590.01, 20.9661], Tmin=(807.523, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(49.8408, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(108.088, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(60.0, 'kJ/mol'),
+    S298=(221.292, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([38.4778, 44.0343, 50.1571, 56.256, 66.9449, 75.0582, 88.1808, 95.1716, 99.2691], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(108.088, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=26,
+    label="NO2",
+    molecule="""
+multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 N u0 p1 c0 {1,S} {3,D}
+3 O u0 p2 c0 {2,D}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.44844, 0.00226387, 6.15116e-06, -9.07133e-09, 3.4916e-12, 2931.62, 8.34207], Tmin=(298, 'K'), Tmax=(882.308, 'K')),
+        NASAPolynomial(coeffs=[2.86852, 0.00676166, -4.67235e-06, 1.50729e-09, -1.85984e-13, 2961.22, 10.6551], Tmin=(882.308, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(23.9105, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(34.071, 'kJ/mol'),
+    S298=(239.979, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([37.1699, 40.2433, 43.2638, 45.9116, 49.7122, 52.1859, 55.2851, 56.378, 57.0702], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=27,
+    label="cNOO",
+    molecule="""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 N u1 p1 c0 {1,S} {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.2074, 0.0124306, -1.4031e-05, 7.58575e-09, -1.60229e-12, 41307.8, 13.6722], Tmin=(298, 'K'), Tmax=(1120.15, 'K')),
+        NASAPolynomial(coeffs=[4.5525, 0.00405638, -2.81708e-06, 9.11697e-10, -1.12752e-13, 40782.4, 2.09241], Tmin=(1120.15, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(342.271, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(352.6, 'kJ/mol'),
+    S298=(244.388, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([40.4759, 44.7168, 47.9996, 50.2095, 53.1141, 54.9062, 56.6267, 57.1019, 57.713], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=28,
+    label="NHOO(S)",
+    molecule="""
+1 N u0 p2 c-1 {2,S} {4,S}
+2 O u0 p1 c+1 {1,S} {3,D}
+3 O u0 p2 c0 {2,D}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.43236, 0.0153851, -8.68908e-06, -1.50068e-09, 2.0642e-12, 27088.3, 17.3107], Tmin=(298, 'K'), Tmax=(936.892, 'K')),
+        NASAPolynomial(coeffs=[3.69261, 0.0100996, -7.21442e-06, 2.42225e-09, -3.09392e-13, 26473.2, 5.53141], Tmin=(936.892, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(223.308, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(78.9875, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(233.80, 'kJ/mol'),
+    S298=(246.614, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([43.6981, 51.0261, 57.4357, 62.2967, 68.431, 72.3426, 76.7918, 78.475, 80.1063], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(78.9875, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=29,
+    label="NHOO(T)",
+    molecule="""
+multiplicity 3
+1 N u1 p1 c0 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.96153, 0.0022846, 3.2891e-05, -7.09302e-08, 4.39506e-11, 41138, 8.37658], Tmin=(10, 'K'), Tmax=(566.683, 'K')),
+        NASAPolynomial(coeffs=[4.36262, 0.00820607, -5.9509e-06, 2.02036e-09, -2.56656e-13, 40952, 5.42939], Tmin=(566.683, 'K'), Tmax=(3000, 'K')), ],
+        Tmin=(10, 'K'), Tmax=(3000, 'K'), E0=(342.026, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(78.9875, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(354.121, 'kJ/mol'),
+    S298=(270.619, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([50.2858, 55.9027, 59.9243, 62.7499, 66.9165, 69.6877, 73.1807, 75.0595, 76.7195], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(78.9875, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=30,
+    label="ONHO(T)",
+    molecule="""
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 N u0 p1 c0 {1,S} {3,S} {4,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.90454, 0.0151069, -1.39704e-05, 6.59807e-09, -1.25459e-12, 31530.2, 16.2771], Tmin=(298, 'K'), Tmax=(1203.84, 'K')),
+        NASAPolynomial(coeffs=[4.24618, 0.00732633, -4.27568e-06, 1.22928e-09, -1.39655e-13, 30966.5, 4.54567], Tmin=(1203.84, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(260.764, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(271.532, 'kJ/mol'),
+    S298=(258.287, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([44.4976, 50.7278, 55.889, 59.8187, 65.7008, 69.8242, 75.3579, 77.9444, 79.8667], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=31,
+    label="HONO(S)",
+    molecule="""
+1 O u0 p2 c0 {2,S} {4,S}
+2 N u0 p1 c0 {1,S} {3,D}
+3 O u0 p2 c0 {2,D}
+4 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.95928, 0.0165219, -1.86802e-05, 1.12647e-08, -2.76569e-12, -10688.8, 14.5546], Tmin=(298, 'K'), Tmax=(948.023, 'K')),
+        NASAPolynomial(coeffs=[4.053, 0.00768787, -4.70275e-06, 1.43554e-09, -1.7367e-13, -11085.8, 4.56542], Tmin=(948.023, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(-89.8571, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-79.114, 'kJ/mol',),
+    S298=(248.643, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([45.8098, 51.9118, 56.401, 59.8886, 65.3399, 69.1903, 74.5339, 77.3021, 79.4347], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=32,
+    label="HONO(T)",
+    molecule="""
+multiplicity 3
+1 O u1 p2 c0 {2,S}
+2 N u1 p1 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.36961, 0.00784944, -6.32642e-06, 2.77539e-09, -5.16116e-13, 19098.3, 5.36276], Tmin=(298, 'K'), Tmax=(1133.99, 'K')),
+        NASAPolynomial(coeffs=[5.05279, 0.00543966, -3.1389e-06, 9.01486e-10, -1.03e-13, 18943.3, 1.98093], Tmin=(1133.99, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(159.165, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(78.9875, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(172.096, 'kJ/mol'),
+    S298=(268.878, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([51.7719, 55.367, 58.388, 60.9663, 65.0071, 67.8768, 71.9477, 74.1705, 75.8581], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(78.9875, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=33,
+    label="cNHOO",
+    molecule="""
+1 O u0 p2 c0 {2,S} {3,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 N u0 p1 c0 {1,S} {2,S} {4,S}
+4 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.18006, 0.0101071, -9.99705e-07, -6.10893e-09, 3.12219e-12, 31490.7, 14.2407], Tmin=(298, 'K'), Tmax=(906.597, 'K')),
+        NASAPolynomial(coeffs=[2.89754, 0.0102555, -6.72828e-06, 2.13559e-09, -2.63145e-13, 31224.4, 10.0985], Tmin=(906.597, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(260.456, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(270.80, 'kJ/mol'),
+    S298=(245.946, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([41.5125, 47.7211, 53.4143, 58.0371, 64.526, 69.0285, 75.0757, 77.7832, 79.7256], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=34,
+    label="HNO2",
+    molecule="""
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.36352, 0.00117404, 1.61593e-05, -2.00675e-08, 7.42513e-12, -6416.82, 8.58965], Tmin=(298, 'K'), Tmax=(839.373, 'K')),
+        NASAPolynomial(coeffs=[1.53117, 0.0122918, -7.97211e-06, 2.485e-09, -3.00495e-13, -6193.26, 16.6082], Tmin=(839.373, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(-53.9314, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-43.7, 'kJ/mol',),
+    S298=(238.267, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([39.0565, 44.1857, 49.4298, 54.2374, 61.6382, 66.7489, 74.0267, 77.2858, 79.2742], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=35,
+    label="NH2OO",
+    molecule="""
+multiplicity 2
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u1 p2 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[5.06329, 0.00178829, 1.30223e-05, -1.60113e-08, 5.91685e-12, 17464, 3.91391], Tmin=(298, 'K'), Tmax=(781.35, 'K')),
+        NASAPolynomial(coeffs=[3.41401, 0.011041, -6.29449e-06, 1.79609e-09, -2.0499e-13, 17697, 11.3057], Tmin=(781.35, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(145.771, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(159.125, 'kJ/mol'),
+    S298=(280.543, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([53.1439, 58.0059, 63.1178, 67.6716, 75.2266, 81.0401, 90.1727, 94.8317, 97.5783], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=36,
+    label="NHOOH",
+    molecule="""
+multiplicity 2
+1 N u1 p1 c0 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {5,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.9686, 0.00752346, 3.26852e-06, -7.94702e-09, 3.19104e-12, 17806.5, 8.69494], Tmin=(298, 'K'), Tmax=(901.989, 'K')),
+        NASAPolynomial(coeffs=[3.41474, 0.0118862, -7.15742e-06, 2.10233e-09, -2.43815e-13, 17828.8, 10.8799], Tmin=(901.989, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(147.99, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'),
+        CpInf=(99.7737, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(160.784, 'kJ/mol'),
+    S298=(279.597, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([52.6643, 58.7966, 64.512, 69.4675, 77.4134, 83.2176, 91.5125, 95.3007, 97.5678], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(99.7737, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=37,
+    label="HONOH",
+    molecule="""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {4,S}
+2 N u1 p1 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {5,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.95838, 0.0222963, -2.49871e-05, 1.36854e-08, -2.91388e-12, -1458.84, 16.2336], Tmin=(298, 'K'), Tmax=(1121.51, 'K')),
+        NASAPolynomial(coeffs=[6.28102, 0.00687946, -4.36772e-06, 1.42876e-09, -1.81778e-13, -2428.44, -5.11647], Tmin=(1121.51, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-13.3723, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(99.7737, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-0.665543, 'kJ/mol',),
+    S298=(274.714, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([56.0159, 63.9807, 69.889, 73.9757, 79.7937, 83.6851, 88.8169, 92.008, 94.9841], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(99.7737, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=38,
+    label="HONHO",
+    molecule="""
+multiplicity 2
+1 O u0 p3 c-1 {2,S}
+2 N u1 p0 c+1 {1,S} {3,S} {4,S}
+3 O u0 p2 c0 {2,S} {5,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.15375, 0.0124759, -6.22351e-06, -8.25338e-11, 7.51663e-13, -425.23, 11.4633], Tmin=(298, 'K'), Tmax=(971.537, 'K')),
+        NASAPolynomial(coeffs=[3.93071, 0.0109678, -6.5057e-06, 1.90246e-09, -2.2008e-13, -655.996, 7.32673], Tmin=(971.537, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-4.09814, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(8.4295, 'kJ/mol'),
+    S298=(273.32, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([52.7627, 59.4919, 65.484, 70.5636, 78.2241, 83.772, 91.9519, 95.8949, 98.3354], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=39,
+    label="NH2OOH",
+    molecule="""
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.61743, 0.0236206, -2.47082e-05, 1.36895e-08, -3.07366e-12, 9.04537, 12.8721], Tmin=(298, 'K'), Tmax=(1031.66, 'K')),
+        NASAPolynomial(coeffs=[5.82677, 0.0111774, -6.61631e-06, 1.99849e-09, -2.40625e-13, -653.149, -2.71116], Tmin=(1031.66, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-0.518348, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'),
+        CpInf=(124.717, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(13.6809, 'kJ/mol'),
+    S298=(281.365, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([64.8742, 74.4339, 81.2311, 86.6305, 95.1346, 101.229, 110.054, 114.982, 118.626], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(124.717, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=40,
+    label="N2O",
+    molecule="""
+1 N u0 p2 c-1 {2,D}
+2 N u0 p0 c+1 {1,D} {3,D}
+3 O u0 p2 c0 {2,D}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.88536, 0.00650105, -2.19073e-06, -1.54076e-09, 9.45436e-13, 8807.07, 8.16589], Tmin=(298, 'K'), Tmax=(976.024, 'K')),
+        NASAPolynomial(coeffs=[3.16776, 0.00667377, -4.5003e-06, 1.433e-09, -1.73897e-13, 8688.59, 6.48576], Tmin=(976.024, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(72.8193, 'kJ/mol'), Cp0=(29.1007, 'J/(mol*K)'), CpInf=(62.3585, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(82.593, 'kJ/mol'),
+    S298=(219.771, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([38.2555, 42.1148, 45.4102, 48.0968, 52.1693, 54.9117, 58.3067, 59.7901, 60.9366], 'J/(mol*K)'),
+    Cp0=(29.1007, 'J/(mol*K)'),
+    CpInf=(62.3585, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=41,
+    label="cNNO",
+    molecule="""
+1 N u0 p1 c0 {2,D} {3,S}
+2 N u0 p1 c0 {1,D} {3,S}
+3 O u0 p2 c0 {1,S} {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.81887, 0.00590123, -5.04223e-06, 2.16668e-09, -3.76745e-13, 40723.6, 5.75776], Tmin=(298, 'K'), Tmax=(1272.54, 'K')),
+        NASAPolynomial(coeffs=[4.63318, 0.00334175, -2.02543e-06, 5.86315e-10, -6.62876e-14, 40516.3, 1.63289], Tmin=(1272.54, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(338.532, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(58.2013, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(349.9, 'kJ/mol'),
+    S298=(241.679, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([43.1403, 45.8127, 47.8349, 49.5288, 52.11, 53.8461, 55.9649, 56.8226, 57.4447], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(58.2013, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=42,
+    label="HNNO",
+    molecule="""
+multiplicity 2
+1 O u0 p3 c-1 {2,S}
+2 N u1 p0 c+1 {1,S} {3,D}
+3 N u0 p1 c0 {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.22652, 0.00193049, 1.7626e-05, -2.24845e-08, 8.32227e-12, 23851.3, 10.2175], Tmin=(298, 'K'), Tmax=(856.031, 'K')),
+        NASAPolynomial(coeffs=[1.17257, 0.0145893, -9.91965e-06, 3.14513e-09, -3.82762e-13, 24090.8, 19.1523], Tmin=(856.031, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(197.615, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(78.9875, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+Did not use a "fine" DFT grid
+
+ThermoData(
+    H298=(207.975, 'kJ/mol'),
+    S298=(247.566, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([40.4359, 46.4029, 52.4379, 57.9053, 66.1002, 71.4701, 78.3416, 80.6907, 81.9072], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(78.9875, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=43,
+    label="NNHO",
+    molecule="""
+multiplicity 2
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 N u1 p1 c0 {2,D}
+4 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.00442, 0.0049756, 7.77865e-06, -1.25513e-08, 4.94409e-12, 36667.9, 11.2157], Tmin=(298, 'K'), Tmax=(868.824, 'K')),
+        NASAPolynomial(coeffs=[2.26136, 0.0109524, -6.95253e-06, 2.13807e-09, -2.56942e-13, 36700.5, 14.1409], Tmin=(868.824, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(304.083, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(314.539, 'kJ/mol'),
+    S298=(249.927, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([40.7911, 46.1714, 51.3893, 55.9525, 62.8104, 67.6941, 74.5841, 77.6688, 79.5715], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=44,
+    label="NH2NO",
+    molecule="""
+1 O u0 p2 c0 {3,D}
+2 N u0 p1 c0 {3,S} {4,S} {5,S}
+3 N u0 p1 c0 {1,D} {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.45286, 0.0131475, -9.05272e-06, 3.31346e-09, -5.10648e-13, 7613.55, 8.05399], Tmin=(298, 'K'), Tmax=(1332.32, 'K')),
+        NASAPolynomial(coeffs=[4.60865, 0.00967739, -5.14586e-06, 1.35852e-09, -1.43812e-13, 7305.58, 2.14637], Tmin=(1332.32, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(63.1087, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(76.10, 'kJ/mol'),
+    S298=(259.989, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([55.486, 62.0136, 67.6695, 72.5677, 80.4224, 86.1879, 94.7048, 99.1279, 102.066], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=45,
+    label="N2H3O",
+    molecule="""
+multiplicity 2
+1 O u0 p3 c-1 {2,S}
+2 N u1 p0 c+1 {1,S} {3,S} {4,S}
+3 N u0 p1 c0 {2,S} {5,S} {6,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.61874, 0.0151368, -3.93849e-06, -4.15926e-09, 2.28086e-12, 16472.1, 14.1009], Tmin=(298, 'K'), Tmax=(962.397, 'K')),
+        NASAPolynomial(coeffs=[2.931, 0.0165316, -1.03091e-05, 3.1609e-09, -3.75867e-13, 16287.3, 11.9586], Tmin=(962.397, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(136.062, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(148.685, 'kJ/mol'),
+    S298=(277.07, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([55.7533, 65.2439, 73.4606, 80.4352, 91.4434, 99.3367, 110.622, 116.589, 120.949], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=46,
+    label="NH2NOH",
+    molecule="""
+multiplicity 2
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 N u1 p1 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {6,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.81948, 0.0227117, -1.62501e-05, 3.7015e-09, 3.93916e-13, 15285.7, 17.1085], Tmin=(298, 'K'), Tmax=(1014.83, 'K')),
+        NASAPolynomial(coeffs=[4.82741, 0.0146562, -9.96086e-06, 3.2601e-09, -4.06393e-13, 14479.5, 1.58854], Tmin=(1014.83, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(125.651, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(124.717, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+NH2 rotor scan not smooth, need to consider a strongly-coupled inversion mode (OH rotor is smooth)
+
+ThermoData(
+    H298=(138.856, 'kJ/mol'),
+    S298=(278.986, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([60.4127, 71.2073, 80.0224, 86.7586, 96.5672, 103.071, 111.093, 115.157, 118.883], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(124.717, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=47,
+    label="NH2ONH2",
+    molecule="""
+1 N u0 p1 c0 {2,S} {4,S} {5,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 N u0 p1 c0 {2,S} {6,S} {7,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.80874, 0.030058, -3.0821e-05, 1.63883e-08, -3.46868e-12, 14264.7, 14.6239], Tmin=(298, 'K'), Tmax=(1110.21, 'K')),
+        NASAPolynomial(coeffs=[6.68631, 0.0124862, -7.08202e-06, 2.13462e-09, -2.59313e-13, 13181.5, -9.41792], Tmin=(1110.21, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(117.423, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(149.66, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(132.176, 'kJ/mol'),
+    S298=(271.509, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([70.0806, 82.3798, 91.4104, 98.1337, 108.669, 116.326, 127.924, 135.008, 140.345], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(149.66, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=48,
+    label="N2O2",
+    molecule="""
+1 O u0 p2 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 N u0 p1 c0 {2,S} {4,D}
+4 O u0 p2 c0 {3,D}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.66063, 0.0236523, -4.07459e-05, 3.20989e-08, -9.57389e-12, 18746.6, 6.81545], Tmin=(298, 'K'), Tmax=(829.986, 'K')),
+        NASAPolynomial(coeffs=[8.16, 0.00196827, -1.55749e-06, 6.21844e-10, -9.27433e-14, 17999.7, -14.053], Tmin=(829.986, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(156.24, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(78.9875, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130  ###**** note trans
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+This is cis-N2O2, trans-N2O2 is higher in energy.
+
+ThermoData(
+    H298=(171.17, 'kJ/mol'),
+    S298=(275.823, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([65.2315, 70.4384, 72.3074, 73.4635, 75.0276, 75.8914, 76.7608, 77.6623, 78.6564], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(78.9875, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=49,
+    label="NNO2(S)",
+    molecule="""
+multiplicity 1
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 N u0 p2 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.50564, 0.0155584, -1.31038e-05, 4.49117e-09, -3.52952e-13, 43468.3, 13.3739], Tmin=(298, 'K'), Tmax=(1035.33, 'K')),
+        NASAPolynomial(coeffs=[4.93254, 0.0084082, -5.96988e-06, 1.97431e-09, -2.46694e-13, 42846.4, 1.00507], Tmin=(1035.33, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(360.432, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(372.479, 'kJ/mol'),
+    S298=(263.92, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([50.7842, 57.5314, 62.8916, 66.8341, 72.3365, 75.769, 79.3031, 80.6367, 82.0467], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=50,
+    label="NNO2(T)",
+    molecule="""
+multiplicity 3
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 N u2 p1 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[0.928089, 0.0221956, -2.64351e-05, 1.50117e-08, -3.31969e-12, 54155, 20.9565], Tmin=(298, 'K'), Tmax=(1073.88, 'K')),
+        NASAPolynomial(coeffs=[5.06166, 0.0067988, -4.92872e-06, 1.66049e-09, -2.11512e-13, 53267.2, 0.719806], Tmin=(1073.88, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(448.368, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(459.058, 'kJ/mol'),
+    S298=(264.486, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([46.4353, 53.6931, 59.0586, 62.5326, 67.1378, 69.9115, 72.4426, 73.248, 74.5276], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=51,
+    label="cNNOO",
+    molecule="""
+1 N u0 p1 c0 {2,D} {4,S}
+2 N u0 p1 c0 {1,D} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {1,S} {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[0.879853, 0.0200966, -1.76664e-05, 6.12703e-09, -3.76974e-13, 40894.5, 19.9361], Tmin=(298, 'K'), Tmax=(974.474, 'K')),
+        NASAPolynomial(coeffs=[4.18491, 0.0098391, -6.9706e-06, 2.29439e-09, -2.87694e-13, 40093.3, 3.27042], Tmin=(974.474, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(337.797, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(348.419, 'kJ/mol'),
+    S298=(251.15, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([45.6698, 53.7324, 60.4607, 65.3245, 71.5521, 75.4741, 79.513, 80.6773, 81.9097], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=52,
+    label="NNOO",
+    molecule="""
+1 O u0 p3 c-1 {2,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 N u0 p0 c+1 {2,S} {4,T}
+4 N u0 p1 c0 {3,T}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.16972, 0.0170209, -2.04409e-05, 1.22897e-08, -2.93466e-12, 52048.4, 10.3229], Tmin=(298, 'K'), Tmax=(986.204, 'K')),
+        NASAPolynomial(coeffs=[5.77709, 0.00644552, -4.35586e-06, 1.4163e-09, -1.7827e-13, 51534.1, -2.21987], Tmin=(986.204, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(432.488, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(445.583, 'kJ/mol'),
+    S298=(271.454, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([55.9283, 61.9728, 65.8443, 68.7548, 73.0924, 75.909, 79.181, 80.6562, 81.9262], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=53,
+    label="ON2HO",
+    molecule="""
+multiplicity 2
+1 N u0 p2 c-1 {2,S} {4,S}
+2 N u0 p0 c+1 {1,S} {3,D} {5,S}
+3 O u0 p2 c0 {2,D}
+4 O u1 p2 c0 {1,S}
+5 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.31754, 0.0224442, -2.28344e-05, 1.16035e-08, -2.34034e-12, 20421, 14.2186], Tmin=(298, 'K'), Tmax=(1151.41, 'K')),
+        NASAPolynomial(coeffs=[6.03495, 0.00953069, -6.01227e-06, 1.86404e-09, -2.25777e-13, 19564.9, -4.24011], Tmin=(1151.41, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(168.856, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(182.324, 'kJ/mol'),
+    S298=(275.991, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([60.3896, 69.4949, 76.1488, 80.9942, 88.2759, 93.1974, 99.4702, 102.51, 104.799], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=54,
+    label="NHNO2",
+    molecule="""
+multiplicity 2
+1 N u0 p2 c-1 {2,S} {5,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 O u1 p2 c0 {2,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.39923, 0.0200345, -1.88548e-05, 8.79795e-09, -1.62817e-12, 26925, 15.3856], Tmin=(298, 'K'), Tmax=(1239.55, 'K')),
+        NASAPolynomial(coeffs=[5.75626, 0.00920116, -5.74483e-06, 1.74683e-09, -2.06016e-13, 26092.8, -1.53095], Tmin=(1239.55, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(222.922, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(235.963, 'kJ/mol'),
+    S298=(284.868, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([57.5536, 66.0476, 72.4724, 77.3203, 84.6212, 89.5173, 95.5916, 98.4055, 100.723], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=55,
+    label="NH2NO2",
+    molecule="""
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 N u0 p1 c0 {2,S} {5,S} {6,S}
+5 H u0 p0 c0 {4,S}
+6 H u0 p0 c0 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.67634, 0.0247611, -2.09598e-05, 8.57821e-09, -1.28769e-12, -696.412, 16.7862], Tmin=(298, 'K'), Tmax=(1058.83, 'K')),
+        NASAPolynomial(coeffs=[5.14237, 0.0137643, -8.35169e-06, 2.5102e-09, -2.96596e-13, -1547.94, -0.688597], Tmin=(1058.83, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-7.27489, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(6.10281, 'kJ/mol'),
+    S298=(273.195, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([61.8202, 72.8238, 81.6939, 88.5763, 99.063, 106.359, 116.211, 121.182, 124.806], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=56,
+    label="NH2ONO",
+    molecule="""
+1 N u0 p1 c0 {2,S} {5,S} {6,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 N u0 p1 c0 {2,S} {4,D}
+4 O u0 p2 c0 {3,D}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.69674, 0.0260916, -3.41614e-05, 2.4219e-08, -6.95122e-12, 10037.2, 6.9044], Tmin=(298, 'K'), Tmax=(828.998, 'K')),
+        NASAPolynomial(coeffs=[6.8686, 0.0107868, -6.46826e-06, 1.94821e-09, -2.34931e-13, 9511.29, -7.80306], Tmin=(828.998, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(83.8728, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(124.717, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(100.11, 'kJ/mol'),
+    S298=(286.213, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([75.0041, 83.8873, 89.5976, 94.3951, 101.983, 107.451, 115.376, 119.564, 122.174], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(124.717, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=57,
+    label="HON2HO",
+    molecule="""
+1 O u0 p2 c0 {2,S} {5,S}
+2 N u0 p1 c0 {1,S} {3,S} {6,S}
+3 N u0 p1 c0 {2,S} {4,D}
+4 O u0 p2 c0 {3,D}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.61618, 0.0204155, -2.21054e-05, 1.38771e-08, -3.71661e-12, 4136.34, 4.0168], Tmin=(298, 'K'), Tmax=(847.47, 'K')),
+        NASAPolynomial(coeffs=[6.40216, 0.0119858, -7.18519e-06, 2.14008e-09, -2.54263e-13, 3833.63, -4.30397], Tmin=(847.47, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(35.3116, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(124.717, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(51.9577, 'kJ/mol'),
+    S298=(295.438, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([75.5257, 83.6505, 89.6652, 94.8391, 103.05, 108.986, 117.558, 121.937, 124.669], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(124.717, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=58,
+    label="NH2cNOO",
+    molecule="""
+1 N u0 p1 c0 {2,S} {5,S} {6,S}
+2 N u0 p1 c0 {1,S} {3,S} {4,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {2,S} {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.69222, 0.0259304, -2.11989e-05, 7.26543e-09, -6.1547e-13, 36689.8, 17.7734], Tmin=(298, 'K'), Tmax=(1055.81, 'K')),
+        NASAPolynomial(coeffs=[5.64972, 0.0144395, -9.84922e-06, 3.2407e-09, -4.06394e-13, 35658.9, -2.45859], Tmin=(1055.81, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(303.582, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(317.384, 'kJ/mol'),
+    S298=(284.879, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([64.2108, 76.0259, 85.3891, 92.3074, 102.233, 108.783, 116.805, 120.863, 124.452], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=59,
+    label="cNH2NOO",
+    molecule="""
+1 N u0 p2 c-1 {2,S} {4,S}
+2 O u0 p2 c0 {1,S} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 N u0 p0 c+1 {1,S} {3,S} {5,S} {6,S}
+5 H u0 p0 c0 {4,S}
+6 H u0 p0 c0 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.48869, 0.0199535, -1.71324e-05, 8.19759e-09, -1.67381e-12, 17124.6, 8.97348], Tmin=(298, 'K'), Tmax=(1055.14, 'K')),
+        NASAPolynomial(coeffs=[5.24908, 0.01328, -7.64561e-06, 2.20372e-09, -2.53682e-13, 16753.1, 0.386112], Tmin=(1055.14, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(142.395, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'),
+        CpInf=(133.032, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(157.264, 'kJ/mol'),
+    S298=(283.551, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([67.5995, 76.7805, 83.8985, 90.0255, 99.7949, 106.91, 117.332, 122.811, 126.515], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(133.032, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=60,
+    label="NH2NO2H",
+    molecule="""
+multiplicity 2
+1 O u0 p3 c-1 {2,S}
+2 N u1 p0 c+1 {1,S} {3,S} {4,S}
+3 O u0 p2 c0 {2,S} {5,S}
+4 N u0 p1 c0 {2,S} {6,S} {7,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.84914, 0.0251024, -2.99752e-05, 2.18474e-08, -6.75647e-12, 8162.18, 9.26855], Tmin=(298, 'K'), Tmax=(756.898, 'K')),
+        NASAPolynomial(coeffs=[5.98752, 0.0138016, -7.57973e-06, 2.12182e-09, -2.41199e-13, 7838.47, -0.452322], Tmin=(756.898, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(68.3432, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(149.66, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(84.8018, 'kJ/mol'),
+    S298=(312.012, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([76.5726, 85.8304, 93.2681, 99.4322, 109.396, 117.217, 129.571, 136.123, 140.23], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(149.66, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=61,
+    label="N2H3OO",
+    molecule="""
+multiplicity 2
+1 N u0 p1 c0 {2,S} {5,S} {6,S}
+2 N u0 p1 c0 {1,S} {3,S} {7,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u1 p2 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {1,S}
+7 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.17919, 0.021183, -1.41801e-05, 4.69103e-09, -5.69292e-13, 26641.8, 13.584], Tmin=(298, 'K'), Tmax=(1127.37, 'K')),
+        NASAPolynomial(coeffs=[4.95718, 0.0160167, -8.82585e-06, 2.42348e-09, -2.65735e-13, 26168.4, 4.47117], Tmin=(1127.37, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(221.161, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(153.818, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(236.245, 'kJ/mol'),
+    S298=(311.122, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([69.7485, 80.35, 89.5262, 97.4326, 110.011, 119.143, 132.462, 139.517, 144.458], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(153.818, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=62,
+    label="NO3",
+    molecule="""
+multiplicity 2
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 O u1 p2 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.4283, 0.0165038, -1.45483e-05, 5.41129e-09, -5.80254e-13, 7579.69, 12.7513], Tmin=(298, 'K'), Tmax=(1046.36, 'K')),
+        NASAPolynomial(coeffs=[5.14525, 0.00833799, -6.02541e-06, 2.00922e-09, -2.51978e-13, 6889.55, -1.06038], Tmin=(1046.36, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(61.9905, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(83.1447, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//wB97xd/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(74.15, 'kJ/mol'),
+    S298=(256.953, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([51.6024, 58.5626, 64.0258, 67.9827, 73.425, 76.7446, 79.9253, 80.9943, 82.2969], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(83.1447, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=63,
+    label="HNO3",
+    molecule="""
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 O u0 p2 c0 {2,S} {5,S}
+5 H u0 p0 c0 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[0.575295, 0.0267557, -2.74413e-05, 1.39498e-08, -2.82692e-12, -17282.9, 21.916], Tmin=(298, 'K'), Tmax=(1138.23, 'K')),
+        NASAPolynomial(coeffs=[4.84502, 0.0117508, -7.66705e-06, 2.36787e-09, -2.83044e-13, -18254.9, 0.764279], Tmin=(1138.23, 'K'), Tmax=(2500, 'K'))],
+        Tmin=(298, 'K'), Tmax=(2500, 'K'), E0=(-145.815, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-134.19, 'kJ/mol',),
+    S298=(266.61, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([53.8927, 64.2395, 72.1265, 77.865, 86.3276, 91.8509, 98.0493, 100.203, 102.028], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=64,
+    label="N2O3",
+    molecule="""
+1 O u0 p2 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 N u0 p0 c+1 {2,S} {4,D} {5,S}
+4 O u0 p2 c0 {3,D}
+5 O u0 p3 c-1 {3,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[5.00769, 0.0152729, -1.237e-05, 3.97118e-09, -2.18399e-13, 8297.22, 3.71118], Tmin=(298, 'K'), Tmax=(1009.43, 'K')),
+        NASAPolynomial(coeffs=[7.15172, 0.00891867, -6.11032e-06, 1.93899e-09, -2.35681e-13, 7755.25, -7.19314], Tmin=(1009.43, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(69.3822, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(86.19, 'kJ/mol'),
+    S298=(301.625, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([71.3756, 78.1566, 83.3362, 87.5559, 93.6235, 97.2848, 100.678, 101.762, 103.133], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=65,
+    label="ONONO2",
+    molecule="""
+1 O u0 p2 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 N u0 p0 c+1 {3,S} {5,D} {6,S}
+5 O u0 p2 c0 {4,D}
+6 O u0 p3 c-1 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[5.19485, 0.0183156, -1.07462e-05, -2.2203e-10, 1.56645e-12, 2592.18, 6.65451], Tmin=(298, 'K'), Tmax=(958.431, 'K')),
+        NASAPolynomial(coeffs=[7.28082, 0.0134838, -9.24703e-06, 2.95239e-09, -3.61617e-13, 2014.4, -4.24875], Tmin=(958.431, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(21.8782, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(40.4, 'kJ/mol'),
+    S298=(342.823, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([80.9957, 90.0269, 97.4832, 103.57, 112.362, 117.726, 122.947, 124.886, 127.157], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=66,
+    label="N2O4",
+    molecule="""
+1 O u0 p3 c-1 {2,S}
+2 N u0 p0 c+1 {1,S} {3,D} {4,S}
+3 O u0 p2 c0 {2,D}
+4 N u0 p0 c+1 {2,S} {5,D} {6,S}
+5 O u0 p2 c0 {4,D}
+6 O u0 p3 c-1 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[2.9869, 0.0298811, -3.15564e-05, 1.65055e-08, -3.46588e-12, -658.459, 11.8976], Tmin=(298, 'K'), Tmax=(1084.54, 'K')),
+        NASAPolynomial(coeffs=[7.25107, 0.0141542, -9.80502e-06, 3.13503e-09, -3.8386e-13, -1583.4, -9.02068], Tmin=(1084.54, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-5.68565, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(128.874, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298 from ATcT 1.130
+S298 and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(10.90, 'kJ/mol'),
+    S298=(303.947, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([79.1064, 90.4791, 98.8874, 105.076, 114.023, 119.651, 125.257, 126.617, 127.94], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(128.874, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=67,
+    label="HONHOO",
+    molecule="""
+multiplicity 2
+1 O u0 p2 c0 {2,S} {5,S}
+2 N u0 p1 c0 {1,S} {3,S} {6,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u1 p2 c0 {3,S}
+5 H u0 p0 c0 {1,S}
+6 H u0 p0 c0 {2,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.61112, 0.02141, -1.84195e-05, 7.49572e-09, -1.11347e-12, 11736.3, 10.9168], Tmin=(298, 'K'), Tmax=(1059.15, 'K')),
+        NASAPolynomial(coeffs=[6.59936, 0.0119468, -7.59809e-06, 2.30869e-09, -2.72541e-13, 11001.1, -4.15401], Tmin=(1059.15, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(97.1849, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(124.717, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(113.2, 'kJ/mol'),
+    S298=(308.599, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([71.316, 80.4555, 87.9384, 93.9811, 102.589, 107.921, 115.011, 118.13, 119.853], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(124.717, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=68,
+    label="N2(T)",
+    molecule="""
+multiplicity 3
+1 N u1 p1 c0 {2,D}
+2 N u1 p1 c0 {1,D}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.47977, -0.000833406, 4.88592e-06, -5.03344e-09, 1.68853e-12, 85808.9, 4.68385], Tmin=(298, 'K'), Tmax=(794.109, 'K')),
+        NASAPolynomial(coeffs=[2.78528, 0.00266559, -1.72486e-06, 5.17673e-10, -5.94616e-14, 85919.1, 7.87409], Tmin=(794.109, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(713.406, 'kJ/mol'), Cp0=(29.1007, 'J/(mol*K)'), CpInf=(37.4151, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(722.052, 'kJ/mol'),
+    S298=(203.172, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([29.5168, 30.3084, 31.2694, 32.209, 33.7077, 34.7754, 36.1697, 36.6361, 36.8816], 'J/(mol*K)'),
+    Cp0=(29.1007, 'J/(mol*K)'),
+    CpInf=(37.4151, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=69,
+    label="ONNOH",
+    molecule="""
+multiplicity 2
+1 O u0 p2 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 N u1 p1 c0 {2,S} {4,S}
+4 O u0 p2 c0 {3,S} {5,S}
+5 H u0 p0 c0 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[1.57406, 0.0271331, -3.0653e-05, 1.64652e-08, -3.42209e-12, 19803.9, 17.4663], Tmin=(298, 'K'), Tmax=(1145.48, 'K')),
+        NASAPolynomial(coeffs=[7.04557, 0.00802583, -5.631e-06, 1.90185e-09, -2.43505e-13, 18550.4, -9.67349], Tmin=(1145.48, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(163.182, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(103.931, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(176.584, 'kJ/mol'),
+    S298=(276.847, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([61.2006, 70.7642, 77.6968, 82.3375, 88.6597, 92.5377, 96.5616, 98.5866, 100.985], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(103.931, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=70,
+    label="ONOOH",
+    molecule="""
+1 O u0 p2 c0 {2,D}
+2 N u0 p1 c0 {1,D} {3,S}
+3 O u0 p2 c0 {2,S} {4,S}
+4 O u0 p2 c0 {3,S} {5,S}
+5 H u0 p0 c0 {4,S}
+""",
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[4.81291, 0.0213907, -4.36423e-05, 5.23029e-08, -2.5312e-11, -3267.49, 2.58069], Tmin=(298, 'K'), Tmax=(505.037, 'K')),
+        NASAPolynomial(coeffs=[6.44835, 0.00843815, -5.17384e-06, 1.52501e-09, -1.77204e-13, -3432.69, -4.19219], Tmin=(505.037, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(298, 'K'), Tmax=(3000, 'K'), E0=(-26.2881, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(99.7737, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+ThermoData(
+    H298=(-9.78789, 'kJ/mol',),
+    S298=(289.746, 'J/(mol*K)'),
+    Tdata=([300, 400, 500, 600, 800, 1000, 1500, 2000, 2500], 'K'),
+    Cpdata=([70.7469, 75.546, 79.4249, 82.7731, 88.1058, 91.9644, 97.3891, 99.7385, 100.755], 'J/(mol*K)'),
+    Cp0=(33.2579, 'J/(mol*K)'),
+    CpInf=(99.7737, 'J/(mol*K)'),
+    Tmin=(298, 'K'),
+    Tmax=(3000, 'K'),
+)
+""",
+)
+
+entry(
+    index=71,
+    label="NH3N",
+    molecule="""
+multiplicity 2
+1 N u0 p0 c+1 {2,S} {3,S} {4,S} {5,S}
+2 N u1 p2 c-1 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 H u0 p0 c0 {1,S}
+""",
+    thermo=NASA(polynomials=[
+            NASAPolynomial(coeffs=[4.05422, -0.00474258, 4.75668e-05, -7.5359e-08, 4.1191e-11, 55593.2, 5.44064], Tmin=(10, 'K'), Tmax=(465.109, 'K')),
+            NASAPolynomial(coeffs=[2.11876, 0.0119021, -6.11171e-06, 1.57914e-09, -1.62693e-13, 55773.3, 13.2966], Tmin=(465.109, 'K'), Tmax=(3000, 'K'))],
+        Tmin=(10, 'K'), Tmax=(3000, 'K'), E0=(462.229, 'kJ/mol'), Cp0=(33.2579, 'J/(mol*K)'), CpInf=(108.088, 'J/(mol*K)')),
+    shortDesc=u"""""",
+    longDesc=u"""
+H298, S298, and Cp from a 1DHR RRHO CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ level of theory computation
+
+Enthalpy of formation (298 K)   =   113.035 kcal/mol
+Entropy of formation (298 K)    =    56.940 cal/(mol*K)
+=========== =========== =========== =========== ===========
+Temperature Heat cap.   Enthalpy    Entropy     Free energy
+(K)         (cal/mol*K) (kcal/mol)  (cal/mol*K) (kcal/mol)
+=========== =========== =========== =========== ===========
+       300      10.356     113.055      57.009      95.953
+       400      11.922     114.170      60.204      90.088
+       500      13.372     115.436      63.023      83.924
+       600      14.665     116.839      65.577      77.492
+       800      16.833     119.997      70.106      63.913
+      1000      18.532     123.541      74.052      49.489
+      1500      21.316     133.574      82.151      10.349
+      2000      22.865     144.654      88.515     -32.375
+      2400      23.673     153.970      92.759     -68.651
+=========== =========== =========== =========== ===========
+""",
+)

--- a/input/thermo/libraries/primaryNS.py
+++ b/input/thermo/libraries/primaryNS.py
@@ -3146,3 +3146,47 @@ entry(
     """,
 )
 
+entry(
+    index=71,
+    label="NH2NO2(T)",
+    molecule=
+    """
+    multiplicity 3
+    1 O u1 p2 c0 {4,S}
+    2 O u1 p2 c0 {4,S}
+    3 N u0 p1 c0 {4,S} {5,S} {6,S}
+    4 N u0 p1 c0 {1,S} {2,S} {3,S}
+    5 H u0 p0 c0 {3,S}
+    6 H u0 p0 c0 {3,S}
+    """,
+    thermo=NASA(polynomials=[
+        NASAPolynomial(coeffs=[3.93159, 0.00472342, 6.65323e-05, -1.66728e-07, 1.24546e-10, 33648, 10.8335],
+                       Tmin=(10, 'K'), Tmax=(452.447, 'K')),
+        NASAPolynomial(coeffs=[3.87696, 0.0166599, -1.10128e-05, 3.48307e-09, -4.19249e-13, 33535.8, 9.75816],
+                       Tmin=(452.447, 'K'), Tmax=(3000, 'K')),
+    ],
+        Tmin=(10, 'K'),
+        Tmax=(3000, 'K'),
+        E0=(279.758, 'kJ/mol'),
+        Cp0=(33.2579, 'J/(mol*K)'),
+        CpInf=(128.874, 'J/(mol*K)'),
+    ),
+    shortDesc="""""",
+    longDesc=
+    """
+    CBS-QB3
+    Bond corrections: {'N-O': 2, 'H-N': 2, 'N-N': 1}
+    1D rotors:
+    pivots: [1, 2], dihedral: [5, 1, 2, 3], rotor symmetry: 1, max scan energy: 10.84 kJ/mol
+
+    External symmetry: 1, optical isomers: 2
+
+    Geometry:
+    N       0.78155200   -0.22032600    0.24201200
+    N      -0.59021400    0.09619700    0.28452600
+    O      -1.09581700    0.91055300   -0.60374100
+    O      -1.39064200   -0.92035400    0.36029700
+    H       1.28981900    0.64340200    0.40847200
+    H       0.99998500   -0.57200700   -0.69195200
+    """,
+)


### PR DESCRIPTION
Added the `NH3` therno library based on CCSD(T)-F12/cc-pVTZ-F12//B2PLYPD3/aug-cc-pVTZ computations (enthalpies taken from ATcT where available)

Made significant modifications and additions to the kinetic `promaryNitrogenLibrary` based on updated literature and based on the submitted "NH3-1" paper

Also added several forbidden species and made two minor modifications to the `primaryNitrogenLibrary` kinetic library

We should still add PDep reactions calculated by us on the N2H3 surface, and later we expect to have updated reactions of the N2H4 surface.

Points for discussion:
- There are many non-phisical species in the H/N/O space (with legitimate Lewis structure and Molecule representation, but which do not exist, see [here](https://doi.org/10.1002/cphc.202200373)). Should we keep adding them to the forbidden structures file (they were originally suggested by RMG and many made it into the core in early model generation iterations), or should we consider another approach?
- The Dean&Bozzelli library has an unreasonable rate for `NH2 + OH <=> NH(S} + H2O`. One updated source that studies all `NH2/NH3 + OH` reaction at all multiplicities is [this](https://doi.org/10.1016/j.chemphys.2018.03.022), though it is very confusing, and some of the rates are still very high. This is currently unresolved.