### PR TITLE
update adsorption corrections

### DIFF
--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 name = "Surface Adsorption Corrections Pt(111)"
-shortDesc = u"Surface adsorption Pt(111), Blondal 2018"
+shortDesc = u"Surface adsorption Pt(111), Blondal 2018 & Kreitz 2023"
 longDesc = u"""
 Changes due to adsorbing on a surface.
 Here, Pt(111)
@@ -110,15 +110,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.71, 1.22, 1.49, 1.65, 1.81, 1.9, 1.98], 'cal/(mol*K)'),
-        H298=(-5.3, 'kcal/mol'),
-        S298=(-22.53, 'cal/(mol*K)'),
+        Cpdata=([7.39, 8.41, 8.91, 9.16, 9.4, 9.51, 9.6], 'J/(mol*K)'),
+        H298=(-49.08, 'kJ/mol'),
+        S298=(-123.53, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2O vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.189 eV.
-            Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = -0.18932 eV, gamma_O(X) = 0.000.
-            The two lowest frequencies, 49.5 and 68.6 cm-1, where replaced by the 2D gas model.
+    shortDesc=u"""Came from averaged H2O, HOOH, CH3OH, HCOOH, CH3CH2OH, CH3OCH3, CH3OCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.   
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method.    
 
  RO-R
    :
@@ -139,14 +141,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.09, 1.82, 2.2, 2.42, 2.65, 2.75, 2.86], 'cal/(mol*K)'),
-        H298=(-46.3, 'kcal/mol'),
-        S298=(-33.89, 'cal/(mol*K)'),
+        Cpdata=([6.67, 8.28, 9.16, 9.7, 10.33, 10.68, 11.17], 'J/(mol*K)'),
+        H298=(-194.2, 'kJ/mol'),
+        S298=(-157.49, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from OH single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.970 eV.
-            Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = -0.18039 eV, gamma_O(X) = 0.500.
+    shortDesc=u"""Came from averaged *OCH3, *OH, *OCH2CH3, HC*O3, HC*OO, *OCHCH2, *OOH, *OCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    R
    |
@@ -171,16 +176,20 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.51, 1.74, 1.85, 1.92, 2.0, 2.05, 2.1], 'cal/(mol*K)'),
-        H298=(-15.36, 'kcal/mol'),
-        S298=(-26.31, 'cal/(mol*K)'),
+        Cpdata=([6.32, 7.23, 7.68, 7.95, 8.29, 8.51, 8.71], 'J/(mol*K)'),
+        H298=(-63.01, 'kJ/mol'),
+        S298=(-110.35, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HO-OH vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.286 eV.
-            Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = -0.28574 eV, gamma_O(X) = 0.000.
-            The two lowest frequencies, 10.6 and 50.4 cm-1, where replaced by the 2D gas model.
-
+    shortDesc=u"""Came from HOOH vdW-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            
+            The two lowest frequencies, 12.0 and 47.7 cm-1, where replaced by the 2D gas model.  
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method.           
+            
  RO-OR
    :
 ***********
@@ -201,14 +210,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.98, 2.83, 3.18, 3.31, 3.32, 3.26, 3.14], 'cal/(mol*K)'),
-        H298=(-27.36, 'kcal/mol'),
-        S298=(-40.49, 'cal/(mol*K)'),
+        Cpdata=([8.69, 12.02, 13.4, 13.87, 13.89, 13.63, 13.13], 'J/(mol*K)'),
+        H298=(-107.21, 'kJ/mol'),
+        S298=(-167.43, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from O2 bidentate, twice single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.347 eV.
-            Linear scaling parameters: ref_adatom_O1 = -3.586 eV, ref_adatom_O2 = -3.586 eV, psi = 3.23943 eV, gamma_O1(X) = 0.500, gamma_O2(X) = 0.500.
+    shortDesc=u"""Came from O2-bi bidentate, twice single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    O--O
    |  |
@@ -230,14 +242,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([4.16, 4.53, 4.58, 4.53, 4.37, 4.24, 4.07], 'cal/(mol*K)'),
-        H298=(-33.05, 'kcal/mol'),
-        S298=(-36.35, 'cal/(mol*K)'),
+        Cpdata=([10.21, 11.38, 11.38, 11.02, 10.19, 9.56, 8.77], 'J/(mol*K)'),
+        H298=(-134.04, 'kJ/mol'),
+        S298=(-120.71, 'J/(mol*K)'),
     ),
     shortDesc=u"""Came from OOH single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.742 eV.
-            Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = 1.05105 eV, gamma_O(X) = 0.500.
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    OR
    |
@@ -259,14 +274,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.31, 0.21, 0.48, 0.63, 0.78, 0.86, 0.93], 'cal/(mol*K)'),
-        H298=(-93.14, 'kcal/mol'),
-        S298=(-30.95, 'cal/(mol*K)'),
+        Cpdata=([-2.44, 0.14, 1.49, 2.26, 3.07, 3.45, 3.84], 'J/(mol*K)'),
+        H298=(-382.56, 'kJ/mol'),
+        S298=(-140.6, 'J/(mol*K)'),
     ),
     shortDesc=u"""Came from O double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.030 eV.
-            Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = 0.00000 eV, gamma_O(X) = 1.000.
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    O
    ||
@@ -322,14 +340,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([2.18, 2.44, 2.67, 2.86, 3.13, 3.3, 3.56], 'cal/(mol*K)'),
-        H298=(-43.38, 'kcal/mol'),
-        S298=(-40.61, 'cal/(mol*K)'),
+        Cpdata=([1.44, 2.24, 2.93, 3.54, 4.49, 5.18, 6.35], 'J/(mol*K)'),
+        H298=(-182.55, 'kJ/mol'),
+        S298=(-149.81, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from O-CH3 single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.370 eV.
-            Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = 0.41957 eV, gamma_O(X) = 0.500.
+    shortDesc=u"""Came from averaged *OCH3, *OCH2CH3, and *OCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    CR3
    |
@@ -989,14 +1010,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-1.63, -0.71, -0.18, 0.14, 0.49, 0.67, 0.85], 'cal/(mol*K)'),
-        H298=(-158.52, 'kcal/mol'),
-        S298=(-31.82, 'cal/(mol*K)'),
+        Cpdata=([-7.34, -3.34, -1.0, 0.42, 1.97, 2.73, 3.51], 'J/(mol*K)'),
+        H298=(-657.91, 'kJ/mol'),
+        S298=(-133.84, 'J/(mol*K)'),
     ),
     shortDesc=u"""Came from C quadruple-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -6.750 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = 0.00000 eV, gamma_C(X) = 1.000.
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    C
  ||||
@@ -1018,17 +1042,20 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.8, 1.77, 2.28, 2.56, 2.8, 2.9, 2.96], 'cal/(mol*K)'),
-        H298=(-148.1, 'kcal/mol'),
-        S298=(-41.99, 'cal/(mol*K)'),
+        Cpdata=([3.31, 7.38, 9.53, 10.71, 11.76, 12.14, 12.4], 'J/(mol*K)'),
+        H298=(-613.35, 'kJ/mol'),
+        S298=(-163.77, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from C-C bidentate, twice double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -5.910 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_C2 = -6.750 eV, psi = 0.84219 eV, gamma_C1(X) = 0.500, gamma_C2(X) = 0.500.
+    shortDesc=u"""Came from CC-bi double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
-  C--C
-  |  |
+  C==C
+ ||  ||
 ***********
 """,
     metal = "Pt",
@@ -1046,16 +1073,19 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.98, 0.54, 1.55, 2.21, 2.95, 3.32, 3.69], 'cal/(mol*K)'),
-        H298=(-102.06, 'kcal/mol'),
-        S298=(-48.06, 'cal/(mol*K)'),
+        Cpdata=([2.94, 6.26, 8.08, 9.18, 10.4, 11.04, 11.77], 'J/(mol*K)'),
+        H298=(-429.79, 'kJ/mol'),
+        S298=(-168.79, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from C=CH2 double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -3.980 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.60024 eV, gamma_C(X) = 0.500.
+    shortDesc=u"""Came from averaged *CCH2, *CCCH2, *CCO on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
-   C
+   R
   ||
    C
   ||
@@ -1082,14 +1112,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.8, 1.58, 2.11, 2.48, 2.93, 3.2, 3.53], 'cal/(mol*K)'),
-        H298=(-141.26, 'kcal/mol'),
-        S298=(-45.92, 'cal/(mol*K)'),
+        Cpdata=([-1.91, 1.58, 4.18, 6.07, 8.47, 9.86, 11.63], 'J/(mol*K)'),
+        H298=(-594.9, 'kJ/mol'),
+        S298=(-174.23, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from C-CH3 triple-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -5.590 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.52567 eV, gamma_C(X) = 0.750.
+    shortDesc=u"""Came from averaged *CCH3, *CCH2CH3, *CCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    CR3
    |
@@ -1112,14 +1145,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-1.92, -0.35, 0.62, 1.22, 1.87, 2.19, 2.56], 'cal/(mol*K)'),
-        H298=(-148.64, 'kcal/mol'),
-        S298=(-40.0, 'cal/(mol*K)'),
+        Cpdata=([-1.12, 2.73, 5.33, 7.1, 9.21, 10.37, 11.81], 'J/(mol*K)'),
+        H298=(-571.12, 'kJ/mol'),
+        S298=(-176.66, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH triple-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -6.240 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -1.17590 eV, gamma_C(X) = 0.750.
+    shortDesc=u"""Came from averaged *CH, *CCH3, *COH, *CCHCH2, *CCH2CH3, CCHO, CCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    R
    |
@@ -1145,14 +1181,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.04, 1.3, 2.2, 2.83, 3.57, 3.92, 4.17], 'cal/(mol*K)'),
-        H298=(-53.12, 'kcal/mol'),
-        S298=(-31.36, 'cal/(mol*K)'),
+        Cpdata=([-5.41, -0.06, 4.05, 6.96, 10.38, 12.03, 13.24], 'J/(mol*K)'),
+        H298=(-221.27, 'kJ/mol'),
+        S298=(-175.96, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH-CH bidentate, twice double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -2.010 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_C2 = -6.750 eV, psi = 4.74337 eV, gamma_C1(X) = 0.500, gamma_C2(X) = 0.500.
+    shortDesc=u"""Came from CHCH-bi double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R-C--C-R
   ||  ||
@@ -1174,14 +1213,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-1.25, 0.39, 1.42, 2.06, 2.76, 3.1, 3.5], 'cal/(mol*K)'),
-        H298=(-93.47, 'kcal/mol'),
-        S298=(-42.7, 'cal/(mol*K)'),
+        Cpdata=([0.24, 3.87, 6.15, 7.64, 9.38, 10.32, 11.42], 'J/(mol*K)'),
+        H298=(-370.06, 'kJ/mol'),
+        S298=(-174.19, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH2 double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -3.640 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.26541 eV, gamma_C(X) = 0.500.
+    shortDesc=u"""Came from averaged *CH2, CH3*CCH3, CH3*COH, *CHCH2CH3, *CHCH3, *CHCHCH2-mono, *CHCHO-mono, *HCOH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R-C-R
   ||
@@ -1207,14 +1249,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.58, 2.74, 3.37, 3.72, 4.03, 4.14, 4.16], 'cal/(mol*K)'),
-        H298=(-27.48, 'kcal/mol'),
-        S298=(-41.46, 'cal/(mol*K)'),
+        Cpdata=([5.94, 10.72, 13.46, 15.04, 16.54, 17.1, 17.33], 'J/(mol*K)'),
+        H298=(-124.09, 'kJ/mol'),
+        S298=(-192.34, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH2-CH2 bidentate, twice single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.950 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_C2 = -6.750 eV, psi = 2.42761 eV, gamma_C1(X) = 0.250, gamma_C2(X) = 0.250.
+    shortDesc=u"""Came from averaged CH2CH2 and CH3CHCH2 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R2C--CR2
    |  |
@@ -1230,20 +1275,24 @@ entry(
     group =
 """
 1 * X u0 p0 c0 {2,S}
-2 C  u0 p0 c0 {1,S} {3,[S,D]} {4,[S,D]}
-3 R  u0 px c0 {2,[S,D]}
-4 R  u0 px c0 {2,[S,D]}
+2 C  u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 R  u0 px c0 {2,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.45, 0.61, 1.42, 2.02, 2.81, 3.26, 3.73], 'cal/(mol*K)'),
-        H298=(-46.05, 'kcal/mol'),
-        S298=(-32.73, 'cal/(mol*K)'),
+        Cpdata=([-1.16, 2.29, 4.74, 6.49, 8.69, 9.93, 11.24], 'J/(mol*K)'),
+        H298=(-212.02, 'kJ/mol'),
+        S298=(-176.19, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH3 single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.770 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.08242 eV, gamma_C(X) = 0.250.
+    shortDesc=u"""Came from averaged CH2CH2CH3, CH2CH2OH, CH2CH3, CH2CHCH2, CH2CHO, CH3, CH3CHCH3, CH3CHOH, H2COH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    CR3
    |
@@ -1270,15 +1319,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([2.01, 2.04, 2.05, 2.06, 2.07, 2.06, 2.05], 'cal/(mol*K)'),
-        H298=(-6.09, 'kcal/mol'),
-        S298=(-15.11, 'cal/(mol*K)'),
+        Cpdata=([9.04, 9.93, 10.39, 10.67, 10.97, 11.11, 11.2], 'J/(mol*K)'),
+        H298=(-29.6, 'kJ/mol'),
+        S298=(-137.34, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH3-CH3 vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.219 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.21852 eV, gamma_C(X) = 0.000.
-            The two lowest frequencies, 5.6 and 8.8 cm-1, where replaced by the 2D gas model.
+    shortDesc=u"""Came from averaged CH3CH3, CH3CH2CH3, CH3CH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R3C-CR3
     :
@@ -1302,15 +1353,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.98, 2.0, 2.01, 2.01, 2.02, 2.02, 2.01], 'cal/(mol*K)'),
-        H298=(-2.4, 'kcal/mol'),
-        S298=(-6.92, 'cal/(mol*K)'),
+        Cpdata=([8.55, 9.48, 9.93, 10.16, 10.36, 10.44, 10.48], 'J/(mol*K)'),
+        H298=(-41.27, 'kJ/mol'),
+        S298=(-125.91, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH4 vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.122 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.12206 eV, gamma_C(X) = 0.000.
-            The two lowest frequencies, 3.2 and 8.1 cm-1, where replaced by the 2D gas model.
+    shortDesc=u"""Came from averaged CH4, CH3CH3, CH3CH2CH3, CH3CH2OH, CH3OH, CH3OCH3, CH3OCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
   R3C-R
      :
@@ -1456,14 +1509,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.82, 2.68, 3.13, 3.36, 3.54, 3.6, 3.67], 'cal/(mol*K)'),
-        H298=(-111.88, 'kcal/mol'),
-        S298=(-43.75, 'cal/(mol*K)'),
+        Cpdata=([5.83, 9.83, 11.9, 12.95, 13.69, 13.91, 14.43], 'J/(mol*K)'),
+        H298=(-463.49, 'kJ/mol'),
+        S298=(-187.54, 'J/(mol*K)'),
     ),
     shortDesc=u"""Came from COH triple-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -4.260 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = 0.80370 eV, gamma_C(X) = 0.750.
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    OR
    |
@@ -1490,14 +1546,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-1.26, 0.53, 1.67, 2.4, 3.19, 3.57, 3.9], 'cal/(mol*K)'),
-        H298=(-76.71, 'kcal/mol'),
-        S298=(-53.04, 'cal/(mol*K)'),
+        Cpdata=([0.74, 6.17, 9.66, 11.87, 14.28, 15.41, 16.39], 'J/(mol*K)'),
+        H298=(-330.81, 'kJ/mol'),
+        S298=(-214.97, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2C-CH bidentate, single- and double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -2.770 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_C2 = -6.750 eV, psi = 2.29437 eV, gamma_C1(X) = 0.250, gamma_C2(X) = 0.500.
+    shortDesc=u"""Came from averaged CHCH2, CH2COH, CHCHCH3 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R2C--CR
    |  ||
@@ -1523,14 +1582,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.61, 1.45, 2.08, 2.53, 3.11, 3.43, 3.77], 'cal/(mol*K)'),
-        H298=(-47.26, 'kcal/mol'),
-        S298=(-42.06, 'cal/(mol*K)'),
+        Cpdata=([0.39, 3.93, 6.35, 8.02, 10.07, 11.2, 12.43], 'J/(mol*K)'),
+        H298=(-214.46, 'kJ/mol'),
+        S298=(-192.28, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2C-CH3 single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.750 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.06163 eV, gamma_C(X) = 0.250.
+    shortDesc=u"""Came from averaged CH2CH2CH3, CH2CH2OH, CH2CH3, CH3CHCH3, CH3CHOH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    R
    |
@@ -1621,14 +1683,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.91, 1.97, 2.0, 2.01, 2.02, 2.02, 2.01], 'cal/(mol*K)'),
-        H298=(-12.9, 'kcal/mol'),
-        S298=(-20.91, 'cal/(mol*K)'),
+        Cpdata=([6.0, 6.87, 7.39, 7.72, 8.09, 8.27, 8.39], 'J/(mol*K)'),
+        H298=(-73.08, 'kJ/mol'),
+        S298=(-122.36, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2C-O vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.184 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.18361 eV, gamma_C(X) = 0.000.
+    shortDesc=u"""Came from averaged H2CO, HCOOH, CH3CHO, OCO2H2, CH2CO on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R2C=O
     :
@@ -1652,14 +1717,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.84, 1.62, 2.2, 2.63, 3.19, 3.51, 3.84], 'cal/(mol*K)'),
-        H298=(-64.35, 'kcal/mol'),
-        S298=(-41.1, 'cal/(mol*K)'),
+        Cpdata=([-3.14, 0.0, 2.2, 3.74, 5.64, 6.69, 7.8], 'J/(mol*K)'),
+        H298=(-225.57, 'kJ/mol'),
+        S298=(-157.56, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2C-OH single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.890 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.19820 eV, gamma_C(X) = 0.250.
+    shortDesc=u"""Came from averaged H2COH, CH3CHOH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
     R
     |
@@ -1720,15 +1788,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.38, 1.68, 1.82, 1.9, 1.96, 1.98, 2.0], 'cal/(mol*K)'),
-        H298=(-11.09, 'kcal/mol'),
-        S298=(-28.83, 'cal/(mol*K)'),
+        Cpdata=([8.44, 9.53, 10.02, 10.25, 10.41, 10.45, 10.47], 'J/(mol*K)'),
+        H298=(-57.56, 'kJ/mol'),
+        S298=(-139.36, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H3C-OH vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.316 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.31650 eV, gamma_C(X) = 0.000.
-            The two lowest frequencies, 16.5 and 57.9 cm-1, where replaced by the 2D gas model.
+    shortDesc=u"""Came from averaged CH3OH, CH3OCH3, H2CO2H2, CH3OCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R3C-OR
     :
@@ -1751,14 +1821,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.7, 1.83, 2.54, 2.98, 3.47, 3.7, 3.9], 'cal/(mol*K)'),
-        H298=(-105.88, 'kcal/mol'),
-        S298=(-42.29, 'cal/(mol*K)'),
+        Cpdata=([-1.53, 3.23, 6.15, 7.98, 10.0, 10.99, 11.95], 'J/(mol*K)'),
+        H298=(-440.52, 'kJ/mol'),
+        S298=(-184.43, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HC-C bidentate, single- and double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -4.100 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_C2 = -6.750 eV, psi = 0.96689 eV, gamma_C1(X) = 0.250, gamma_C2(X) = 0.500.
+    shortDesc=u"""Came from CHC-bi single- and double bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  RC--C
   |  ||
@@ -1769,40 +1842,41 @@ entry(
 )
 
 
-###Vinyl only converged as bidentate on Pt111, so this input is not consistent with the underlying geometry. I am commenting it out for that reason, 
-### and since we already have bidentate vinyl in this library (index 48). -- KB 
-#entry(
-#    index = 57,
-#    label = "C-*RCR2",
-#    group =
-#"""
-#1 * X u0  p0 c0 {2,S}
-#2 C  u0  p0 c0 {1,S} {3,D} {4,S}
-#3 C  u0  p0 c0 {2,D} {5,S} {6,S}
-#4 R  u0  p0 c0 {2,S}
-#5 R  u0  p0 c0 {3,S}
-#6 R  u0  p0 c0 {3,S}
-#""",
-#    thermo=ThermoData(
-#        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-#        Cpdata=([0.18, 1.6, 2.46, 2.99, 3.55, 3.79, 3.99], 'cal/(mol*K)'),
-#        H298=(-75.37, 'kcal/mol'),
-#        S298=(-48.91, 'cal/(mol*K)'),
-#    ),
-#    shortDesc=u"""Came from HC-CH2 single-bonded on Pt(111)""",
-#    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-#            DFT binding energy: -2.790 eV.
-#            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -1.09643 eV, gamma_C(X) = 0.250.
-#
-#   CR2
-#  ||
-#   C-R
-#   |
-#***********
-#""",
-#    metal = "Pt",
-#    facet = "111",
-#)
+entry(
+    index = 57,
+    label = "C-*RCR2",
+    group =
+"""
+1 * X u0  p0 c0 {2,S}
+2 C  u0  p0 c0 {1,S} {3,D} {4,S}
+3 C  u0  p0 c0 {2,D} {5,S} {6,S}
+4 R  u0  p0 c0 {2,S}
+5 R  u0  p0 c0 {3,S}
+6 R  u0  p0 c0 {3,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([1.29, 4.86, 7.35, 9.04, 10.97, 11.92, 12.82], 'J/(mol*K)'),
+        H298=(-288.17, 'kJ/mol'),
+        S298=(-182.51, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged CH2CCH3, CH2COH, CHCCH2, CHCH2, CHCHCH3 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+
+   CR2
+  ||
+   C-R
+   |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
 
 entry(
     index = 58,
@@ -1819,14 +1893,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.9, 1.71, 2.25, 2.61, 3.03, 3.26, 3.57], 'cal/(mol*K)'),
-        H298=(-93.91, 'kcal/mol'),
-        S298=(-44.11, 'cal/(mol*K)'),
+        Cpdata=([1.78, 4.72, 6.6, 7.86, 9.39, 10.26, 11.34], 'J/(mol*K)'),
+        H298=(-372.23, 'kJ/mol'),
+        S298=(-179.04, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HC-CH3 double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -3.580 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.20205 eV, gamma_C(X) = 0.500.
+    shortDesc=u"""Came from averaged CH3*CCH3, CH3*COH, *CHCH2CH3, *CHCH3 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    CR3
    |
@@ -2008,14 +2085,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.38, 2.19, 2.7, 3.02, 3.37, 3.53, 3.73], 'cal/(mol*K)'),
-        H298=(-63.82, 'kcal/mol'),
-        S298=(-36.89, 'cal/(mol*K)'),
+        Cpdata=([-0.65, 2.4, 4.38, 5.69, 7.2, 7.95, 8.71], 'J/(mol*K)'),
+        H298=(-282.27, 'kJ/mol'),
+        S298=(-161.1, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCO single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -2.210 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.52049 eV, gamma_C(X) = 0.250.
+    shortDesc=u"""Came from averaged HCO, COOH, CH3CO, CHCO, CH3CH2CO on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    R
    |
@@ -2040,14 +2120,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.99, 2.22, 2.94, 3.34, 3.67, 3.78, 3.86], 'cal/(mol*K)'),
-        H298=(-57.18, 'kcal/mol'),
-        S298=(-45.92, 'cal/(mol*K)'),
+        Cpdata=([5.91, 10.27, 12.84, 14.27, 15.45, 15.81, 16.1], 'J/(mol*K)'),
+        H298=(-238.17, 'kJ/mol'),
+        S298=(-167.73, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCO-h bidentate, double- and single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -1.900 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_O2 = -1.030 eV, psi = 1.99512 eV, gamma_C1(X) = 0.500, gamma_O2(X) = 0.500.
+    shortDesc=u"""Came from HCO-bi double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
   R
   |
@@ -2072,14 +2155,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.53, 2.45, 2.96, 3.26, 3.59, 3.75, 3.92], 'cal/(mol*K)'),
-        H298=(-76.64, 'kcal/mol'),
-        S298=(-39.75, 'cal/(mol*K)'),
+        Cpdata=([-0.05, 2.82, 4.47, 5.52, 6.78, 7.48, 8.24], 'J/(mol*K)'),
+        H298=(-325.89, 'kJ/mol'),
+        S298=(-146.57, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCOH double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -2.960 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = 0.42191 eV, gamma_C(X) = 0.500.
+    shortDesc=u"""Came from averaged H*COH and CH3*COH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    OR
    |
@@ -2099,8 +2185,23 @@ entry(
 1 * X u0 {2,[S,D,T,Q]}
 2 C  ux {1,[S,D,T,Q]}
 """,
-    thermo=u'C-*R3',
-    longDesc=u"""Thermo is currently for C-*R3.  Maybe should average all the children instead?""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.31, 3.22, 5.55, 7.13, 8.99, 9.99, 11.1], 'J/(mol*K)'),
+        H298=(-359.63, 'kJ/mol'),
+        S298=(-173.0, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all children on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -2123,13 +2224,28 @@ entry(
 1 * X u0 {2,[S,D]}
 2 O  ux {1,[S,D]}
 """,
-    thermo=u'O-*R',
-    longDesc=u"""Thermo is currently for O-*R.  Maybe should average all the children instead?""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([5.66, 7.38, 8.31, 8.88, 9.52, 9.88, 10.36], 'J/(mol*K)'),
+        H298=(-215.12, 'kJ/mol'),
+        S298=(-155.61, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all children on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
     index = 70,
-    label = "R*single_chemisorbed",
+    label = "R*single-chemisorbed",
     group =
 """
 1 * X u0 {2,[S,D,T,Q]}
@@ -2137,11 +2253,19 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.07, 1.05, 1.77, 2.43, 2.8, 3.08, 3.39], 'cal/(mol*K)'),
-        H298=(-48.58, 'kcal/mol'),
-        S298=(-38.17, 'cal/(mol*K)'),
+        Cpdata=([0.84, 4.02, 6.08, 7.46, 9.09, 9.97, 10.96], 'J/(mol*K)'),
+        H298=(-331.96, 'kJ/mol'),
+        S298=(-169.67, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Average of C-*R3, N-*R2 and O-*R thermo. """,
+    shortDesc=u"""Averaged from all children on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
     metal = "Pt",
     facet = "111",
 )
@@ -2156,8 +2280,23 @@ entry(
 3 C  u0 {1,[S,D]} {4,[S,D]}
 4 C  u0 {2,[S,D]} {3,[S,D]}
 """,
-    thermo=u'C-*R2C-*R2',
-    longDesc=u"""Thermo is currently for C-*R2C-*R2.  Maybe should average all the children instead?""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.88, 5.67, 8.7, 10.62, 12.69, 13.65, 14.5], 'J/(mol*K)'),
+        H298=(-353.37, 'kJ/mol'),
+        S298=(-192.89, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all children on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -2174,6 +2313,8 @@ entry(
     longDesc=u"""Thermo is currently for C=*RN-*R.  Maybe should average all the children instead?""",
 )
 
+#Changed the adjacency list because O can only have a single bond to the surface and another atom. 
+#Always 2 free electron pairs. BK 2023/1/10
 entry(
     index = 73,
     label = "C*O*",
@@ -2181,10 +2322,26 @@ entry(
 """
 1 * X u0 {3,[S,D,T]}
 2 X u0 {4,S}
-3 C  u0 {1,[S,D,T]} {4,[S,D,T]}
-4 O  u0 {2,S} {3,[S,D,T]}
+3 C  u0 {1,[S,D,T]} {4,S}
+4 O  u0 p2 {2,S} {3,S}
 """,
-    thermo=u'C=*RO-*',
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([7.34, 11.93, 14.46, 15.74, 16.6, 16.72, 16.63], 'J/(mol*K)'),
+        H298=(-149.6, 'kJ/mol'),
+        S298=(-169.0, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all child nodes on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
 )
 
 entry(
@@ -2213,11 +2370,19 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.51, 2.68, 3.31, 3.65, 3.92, 4.00, 4.02], 'cal/(mol*K)'),
-        H298=(-45.455, 'kcal/mol'),
-        S298=(-43.39, 'cal/(mol*K)'),
+        Cpdata=([1.59, 6.37, 9.34, 11.19, 13.12, 13.99, 14.74], 'J/(mol*K)'),
+        H298=(-330.73, 'kJ/mol'),
+        S298=(-190.23, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Average of C-*R2C-*R2, C=*RN-*R, C=*RO-* and N-*RN-*R thermo. """,
+    shortDesc=u"""Averaged from all child nodes on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
     metal = "Pt",
     facet = "111",
 )
@@ -2232,11 +2397,19 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.23, 1.71, 2.00, 2.19, 2.39, 2.50, 2.61], 'cal/(mol*K)'),
-        H298=(-7.937, 'kcal/mol'),
-        S298=(-20.48, 'cal/(mol*K)'),
+        Cpdata=([7.25, 8.33, 8.9, 9.23, 9.56, 9.7, 9.8], 'J/(mol*K)'),
+        H298=(-56.05, 'kJ/mol'),
+        S298=(-125.18, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Average of (CR4)*, (NR3)* and (OR2)* thermo. """,
+    shortDesc=u"""Averaged of (CR4)*, (CR3)*, and (OR2)* (nitrogen is not included) on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
     metal = "Pt",
     facet = "111",
 )
@@ -2312,8 +2485,21 @@ entry(
 4 R   u0 {2,S}
 5 R   u0 {2,S}
 """,
-    thermo=u'(CR2CR)*',
-    longDesc=u"""Perhaps should be an average?""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([6.54, 7.68, 8.34, 8.74, 9.14, 9.32, 9.44], 'J/(mol*K)'),
+        H298=(-74.45, 'kJ/mol'),
+        S298=(-130.43, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all children on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
     metal = "Pt",
     facet = "111",
 )
@@ -2392,15 +2578,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([1.02, 1.36, 1.56, 1.69, 1.82, 1.89, 1.95], 'cal/(mol*K)'),
-        H298=(-10.488, 'kcal/mol'),
-        S298=(-10.33, 'cal/(mol*K)'),
+        Cpdata=([1.69, 1.89, 2.02, 2.13, 2.46, 2.9, 3.96], 'J/(mol*K)'),
+        H298=(-59.58, 'kJ/mol'),
+        S298=(-115.19, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH-CH vdW-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.200 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.20021 eV, gamma_C(X) = 0.000.
-            The two lowest frequencies, 8.5 and 8.7 cm-1, where replaced by the 2D gas model.
+    shortDesc=u"""Came from averaged CHCH and CHCCH3 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
   RC#CR
     :
@@ -2484,14 +2672,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.98, 0.54, 1.55, 2.21, 2.95, 3.32, 3.69], 'cal/(mol*K)'),
-        H298=(-102.06, 'kcal/mol'),
-        S298=(-48.06, 'cal/(mol*K)'),
+        Cpdata=([2.94, 6.26, 8.08, 9.18, 10.4, 11.04, 11.77], 'J/(mol*K)'),
+        H298=(-429.79, 'kJ/mol'),
+        S298=(-168.79, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from C=CH2 double-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -3.980 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.60024 eV, gamma_C(X) = 0.500.
+    shortDesc=u"""Came from averaged *CCH2, *CCCH2, *CCO on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
    C
   ||
@@ -2520,15 +2711,17 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([2.02, 3.22, 3.83, 4.11, 4.25, 4.22, 4.11], 'cal/(mol*K)'),
-        H298=(-14.92, 'kcal/mol'),
-        S298=(-41.48, 'cal/(mol*K)'),
+        Cpdata=([8.78, 13.6, 16.07, 17.2, 17.75, 17.62, 17.16], 'J/(mol*K)'),
+        H298=(-61.03, 'kJ/mol'),
+        S298=(-170.27, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2CO-h bidentate, twice single-bonded on Pt(111)""",
-    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
-            Based on DFT calculations by Jelena Jelic at KIT.
-            DFT binding energy: -0.236 eV.
-            Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_O2 = -1.030 eV, psi = 1.96700 eV, gamma_C1(X) = 0.250, gamma_O2(X) = 0.500.
+    shortDesc=u"""Came from H2CO-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
 
  R2C--O
    |  |
@@ -2552,14 +2745,981 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([0.5, 1.37, 1.81, 2.02, 2.14, 2.13, 2.08], 'cal/(mol*K)'),
-        H298=(-1.0, 'kcal/mol'),
-        S298=(-33.14, 'cal/(mol*K)'),
+        Cpdata=([7.43, 9.04, 9.92, 10.43, 10.9, 11.07, 11.17], 'J/(mol*K)'),
+        H298=(-76.74, 'kJ/mol'),
+        S298=(-143.86, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Made up by Emily""",
-    longDesc=u"""
+    shortDesc=u"""Came from averaged CH2CH2, CH3CHCH2, CH2CCH2 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
  R2C=CR
     :
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+
+entry(
+    index = 90,
+    label = "C=*RC-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {4,S}
+3 C  u0 p0 c0 {1,D} {4,S} {5,S}
+4 C  u0 p0 c0 {2,S} {3,S} {6,D}
+5 R  u0 p0 c0 {3,S}
+6 R!H  u0 p0 c0 {4,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-5.37, 0.67, 4.68, 7.31, 10.25, 11.63, 12.69], 'J/(mol*K)'),
+        H298=(-396.35, 'kJ/mol'),
+        S298=(-202.17, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCO-bi double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+   RC---C=R
+    ||  |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 91,
+    label = "C#*C-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {4,S}
+3 C  u0 p0 c0 {1,T} {4,S}
+4 C  u0 p0 c0 {2,S} {3,S} {5,D}
+5 R!H  u0 p0 c0 {4,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([2.41, 8.3, 11.6, 13.47, 15.23, 15.91, 16.41], 'J/(mol*K)'),
+        H298=(-440.28, 'kJ/mol'),
+        S298=(-204.35, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CCCH2-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+     C---C=R
+    |||  |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 92,
+    label = "C#*C-*R2",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {4,S}
+3 C  u0 p0 c0 {1,T} {4,S}
+4 C  u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
+5 R  u0 p0 c0 {4,S}
+6 R  u0 p0 c0 {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.9, 4.58, 8.22, 10.59, 13.24, 14.53, 15.76], 'J/(mol*K)'),
+        H298=(-436.46, 'kJ/mol'),
+        S298=(-201.88, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged *C*CH2 and *C*CHCH3 on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+     C---CR2
+    |||  |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+
+entry(
+    index = 93,
+    label = "C-*R2C-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {4,S}
+3 C  u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 C  u0 p0 c0 {2,S} {3,S} {7,D}
+5 R  u0 p0 c0 {3,S}
+6 R  u0 p0 c0 {3,S}
+7 R!H  u0 p0 c0 {4,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([6.18, 10.54, 13.14, 14.74, 16.34, 16.95, 17.2], 'J/(mol*K)'),
+        H298=(-179.99, 'kJ/mol'),
+        S298=(-191.92, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CH2CCH2-bi single and single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  R2C--C=R
+    |  |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 95,
+    label = "C-*RC-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {4,S}
+3 C  u0 p0 c0 {1,S} {4,D} {5,S}
+4 C  u0 p0 c0 {2,S} {3,D} {6,S}
+5 R  u0 p0 c0 {3,S}
+6 R  u0 p0 c0 {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-1.8, 1.82, 4.66, 6.68, 9.21, 10.78, 13.11], 'J/(mol*K)'),
+        H298=(-227.58, 'kJ/mol'),
+        S298=(-194.29, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCCH3-bi single and single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+ RC==CR
+  |  |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 96,
+    label = "C#*C=*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {4,D}
+3 C  u0 p0 c0 {1,T} {4,S}
+4 C  u0 p0 c0 {2,D} {3,S} {5,S}
+5 R  u0 p0 c0 {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-2.0, 1.29, 3.27, 4.54, 5.97, 6.69, 7.48], 'J/(mol*K)'),
+        H298=(-488.53, 'kJ/mol'),
+        S298=(-158.38, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CCCH3-bi triple and double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  C--CR
+ ||| ||
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 97,
+    label = "C=*=R-C-*R2",
+    group =
+"""
+1 * X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,D} {4,D} 
+4 R  u0 p0 c0 {3,D} {5,S}
+5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+6 R  u0 p0 c0 {5,S}
+7 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-3.01, 2.84, 6.84, 9.5, 12.5, 13.99, 15.5], 'J/(mol*K)'),
+        H298=(-543.25, 'kJ/mol'),
+        S298=(-229.45, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CCHCH2-bi double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  C=R--CR2
+ ||    |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 98,
+    label = "R2C-*-R-C-*R2",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
+4 R  u0 p0 c0 {3,S} {5,S}
+5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+6 R  u0 p0 c0 {5,S}
+7 R  u0 p0 c0 {5,S}
+8 R  u0 p0 c0 {3,S}
+9 R  u0 p0 c0 {3,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-1.02, 3.61, 7.1, 9.67, 12.99, 14.82, 16.51], 'J/(mol*K)'),
+        H298=(-389.14, 'kJ/mol'),
+        S298=(-209.34, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CH2CH2CH2-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+ R2C--R--CR2
+   |     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 99,
+    label = "RC=*-R=C-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,D} {4,S} {6,S}
+4 R  u0 p0 c0 {3,S} {5,D}
+5 C  u0 p0 c0 {2,S} {4,D} {7,S}
+6 R  u0 p0 c0 {3,S}
+7 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-6.06, -1.1, 2.74, 5.57, 9.12, 11.14, 13.63], 'J/(mol*K)'),
+        H298=(-612.92, 'kJ/mol'),
+        S298=(-200.99, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCHCH-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC--R==CR
+  ||     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 100,
+    label = "RC-*=R-C-*R2",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,S} {4,D} {6,S}
+4 R  u0 p0 c0 {3,D} {5,S}
+5 C  u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+6 R  u0 p0 c0 {3,S}
+7 R  u0 p0 c0 {5,S}
+8 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.12, 6.05, 9.54, 11.64, 13.78, 14.75, 15.73], 'J/(mol*K)'),
+        H298=(-426.75, 'kJ/mol'),
+        S298=(-227.78, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCHCH2-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC==R--CR2
+  |      |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 101,
+    label = "RC=*-R-C-*R2",
+    group =
+"""
+1 * X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,D} {4,S} {6,S}
+4 R  u0 p0 c0 {3,S} {5,S}
+5 C  u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
+6 R  u0 p0 c0 {3,S}
+7 R  u0 p0 c0 {5,S}
+8 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-7.57, -2.61, 1.61, 4.87, 9.19, 11.68, 14.45], 'J/(mol*K)'),
+        H298=(-529.03, 'kJ/mol'),
+        S298=(-222.29, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCH2CH2-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC--R--CR2
+  ||     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 102,
+    label = "RC-*=R=C-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,S} {4,D} {6,S}
+4 R  u0 p0 c0 {3,D} {5,D}
+5 C  u0 p0 c0 {2,S} {4,D} {7,S}
+6 R  u0 p0 c0 {3,S}
+7 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([3.01, 7.65, 10.53, 12.32, 14.26, 15.17, 16.03], 'J/(mol*K)'),
+        H298=(-370.79, 'kJ/mol'),
+        S298=(-196.35, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCCH-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC==R==CR
+   |     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 103,
+    label = "RC-*=R=C=*",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,D}
+3 C  u0 p0 c0 {1,S} {4,D} {6,S}
+4 R  u0 p0 c0 {3,D} {5,D}
+5 C  u0 p0 c0 {2,D} {4,D}
+6 R  u0 p0 c0 {3,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.81, 3.88, 6.24, 7.94, 10.04, 11.14, 12.17], 'J/(mol*K)'),
+        H298=(-432.93, 'kJ/mol'),
+        S298=(-179.15, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCC-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC==R==C
+   |     ||
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 104,
+    label = "O-*-R-O-*",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,S}
+3 O  u0 p2 c0 {1,S} {4,S}
+4 R  u0 p0 c0 {3,S} {5,S}
+5 O  u0 p2 c0 {2,S} {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([3.33, 6.34, 8.03, 9.06, 10.2, 10.82, 11.57], 'J/(mol*K)'),
+        H298=(-354.62, 'kJ/mol'),
+        S298=(-179.72, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged CO3-bi and H2CO2-bi on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+   O--R--O
+   |     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 105,
+    label = "RC-*=R-O-*",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,S} {4,D} {6,S}
+4 R  u0 p0 c0 {3,D} {5,S}
+5 O  u0 p2 c0 {2,S} {4,S}
+6 R  u0 p0 c0 {3,S} 
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([2.77, 6.69, 9.4, 11.28, 13.55, 14.75, 15.95], 'J/(mol*K)'),
+        H298=(-446.49, 'kJ/mol'),
+        S298=(-211.15, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCHO-bi single and single -bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC==R--O
+   |     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 106,
+    label = "C-*R2",
+    group =
+"""
+1 * X u0  p0 c0 {2,S}
+2 C  u0  p0 c0 {1,S} {3,D} {4,S}
+3 R!H u0  px c0 {2,D}
+4 R  u0  px c0 {2,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.32, 3.63, 5.87, 7.37, 9.08, 9.94, 10.77], 'J/(mol*K)'),
+        H298=(-285.22, 'kJ/mol'),
+        S298=(-171.81, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all children on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 107,
+    label = "C=*RCR2",
+    group =
+"""
+1 * X u0 p0 c0 {3,D}
+2 C  u0 p0 c0 {3,S} {4,S} {5,D}
+3 C  u0 p0 c0 {1,D} {2,S} {6,S}
+4 R  u0 p0 c0 {2,S}
+5 R  u0 c0 {2,D}
+6 R  u0 c0 {3,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.82, 4.08, 6.24, 7.7, 9.5, 10.49, 11.57], 'J/(mol*K)'),
+        H298=(-379.17, 'kJ/mol'),
+        S298=(-179.05, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged CHCHCH2 and CHCHO on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+
+   CR2
+   |
+   C-R
+  ||
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 108,
+    label = "C#*CR2",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 C  u0 p0 c0 {3,S} {4,S} {5,D}
+3 C  u0 p0 c0 {1,T} {2,S}
+4 R  u0 p0 c0 {2,S}
+5 R  u0 c0 {2,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.45, 2.64, 4.89, 6.54, 8.67, 9.9, 11.29], 'J/(mol*K)'),
+        H298=(-565.15, 'kJ/mol'),
+        S298=(-180.28, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CCHCH2 and CCHO triple-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+
+   CR2
+   |
+   C
+  |||
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 109,
+    label = "O-*CR2",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 C  u0 p0 c0 {3,S} {4,S} {5,D}
+3 O  u0 p2 c0 {1,S} {2,S}
+4 R  u0 p0 c0 {2,S}
+5 R  u0 c0 {2,D}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([11.17, 13.37, 14.54, 15.21, 15.91, 16.23, 16.51], 'J/(mol*K)'),
+        H298=(-228.04, 'kJ/mol'),
+        S298=(-194.23, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+
+   CR2
+   |
+   O
+   |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 110,
+    label = "(R3COR)*",
+    group =
+"""
+1 * X u0 p0 c0
+2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3 O  u0 p2 c0 {2,S} {7,S}
+4 R  u0 p0 c0 {2,S}
+5 R  u0 p0 c0 {2,S}
+6 R  u0 p0 c0 {2,S}
+7 R  u0 p0 c0 {3,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([8.44, 9.53, 10.02, 10.25, 10.41, 10.45, 10.47], 'J/(mol*K)'),
+        H298=(-57.56, 'kJ/mol'),
+        S298=(-139.36, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged CH3OH, CH3OCH3, H2CO2H2, CH3OCH2OH on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+
+ R3C-OR
+    :
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 111,
+    label = "C*RC*",
+    group =
+"""
+1 * X u0 {3,[S,D,T]}
+2 X u0 {4,[S,D,T]}
+3 C  u0 {1,[S,D,T]} {5,[S,D,T]}
+4 C  u0 {2,[S,D,T]} {5,[S,D,T]}
+5 R  u0 {3,[S,D,T]} {4,[S,D,T]}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([0.71, 5.77, 9.02, 11.15, 13.56, 14.75, 15.84], 'J/(mol*K)'),
+        H298=(-461.69, 'kJ/mol'),
+        S298=(-209.35, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all child nodes on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 112,
+    label = "R*bridged-bidentate",
+    group =
+"""
+1 * X  u0 {3,[S,D,T]}
+2 X  u0 {4,[S,D,T]}
+3 R!H ux {1,[S,D,T]} {5,[S,D,T]}
+4 R!H ux {2,[S,D,T]} {5,[S,D,T]}
+5 R!H ux {3,[S,D,T]} {4,[S,D,T]}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([1.19, 5.91, 8.92, 10.88, 13.11, 14.22, 15.28], 'J/(mol*K)'),
+        H298=(-446.4, 'kJ/mol'),
+        S298=(-205.52, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Averaged from all child nodes on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 113,
+    label = "C*RO*",
+    group =
+"""
+1 * X u0 {3,[S,D,T]}
+2 X u0 {4,S}
+3 C  u0 {1,[S,D,T]} {5,[S,D,T]}
+4 O  u0 p2 {2,S} {5,S}
+5 R  u0 {3,[S,D,T]} {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([2.77, 6.69, 9.4, 11.28, 13.55, 14.75, 15.95], 'J/(mol*K)'),
+        H298=(-446.49, 'kJ/mol'),
+        S298=(-211.15, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCHO-bi single and single -bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 114,
+    label = "O*RO*",
+    group =
+"""
+1 * X u0 p0 c0 {3,S}
+2 X u0 p0 c0 {5,S}
+3 O  u0 p2 c0 {1,S} {4,S}
+4 R  u0 p0 c0 {3,S} {5,S}
+5 O  u0 p2 c0 {2,S} {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([3.33, 6.34, 8.03, 9.06, 10.2, 10.82, 11.57], 'J/(mol*K)'),
+        H298=(-354.62, 'kJ/mol'),
+        S298=(-179.72, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from averaged CO3-bi and H2CO2-bi on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+   O--R--O
+   |     |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 115,
+    label = "C#*-R-C-*R2",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,T} {4,S} 
+4 R  u0 p0 c0 {3,S} {5,S}
+5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
+6 R  u0 p0 c0 {5,S}
+7 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.53, 3.81, 6.89, 9.14, 12.06, 13.73, 15.5], 'J/(mol*K)'),
+        H298=(-477.2, 'kJ/mol'),
+        S298=(-200.61, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CCH2CH2-bi double-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  C--R--CR2
+ |||    |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 116,
+    label = "C#*-R=C-*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {5,S}
+3 C  u0 p0 c0 {1,T} {4,S} 
+4 R  u0 p0 c0 {3,S} {5,D}
+5 C  u0 p0 c0 {2,S} {4,D} {6,S} 
+6 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([6.8, 11.4, 13.67, 14.88, 16.0, 16.45, 16.74], 'J/(mol*K)'),
+        H298=(-402.33, 'kJ/mol'),
+        S298=(-202.29, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCHC-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  C--R==CR2
+ |||    |
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 116,
+    label = "C#*-R-C#*",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {5,T}
+3 C  u0 p0 c0 {1,T} {4,S} 
+4 R  u0 p0 c0 {3,S} {5,S}
+5 C  u0 p0 c0 {2,T} {4,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-4.88, 4.76, 10.17, 13.18, 15.82, 16.67, 17.03], 'J/(mol*K)'),
+        H298=(-671.16, 'kJ/mol'),
+        S298=(-243.65, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CCH2C-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  C--R--C
+ |||   |||
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 117,
+    label = "RC=*-R-C=*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,D}
+2 X u0 p0 c0 {5,D}
+3 C  u0 p0 c0 {1,D} {4,S} {6,S}
+4 R  u0 p0 c0 {3,S} {5,S}
+5 C  u0 p0 c0 {2,D} {4,S} {7,S} 
+6 R  u0 p0 c0 {3,S}
+7 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([5.9, 10.63, 13.33, 14.98, 16.74, 17.49, 17.8], 'J/(mol*K)'),
+        H298=(-230.02, 'kJ/mol'),
+        S298=(-203.94, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCH2CH-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  RC--R--CR
+  ||     ||
+***********
+""",
+    metal = "Pt",
+    facet = "111",
+)
+
+entry(
+    index = 118,
+    label = "C#*-R-C=*R",
+    group =
+"""
+1 * X u0 p0 c0 {3,T}
+2 X u0 p0 c0 {5,D}
+3 C  u0 p0 c0 {1,T} {4,S} 
+4 R  u0 p0 c0 {3,S} {5,S}
+5 C  u0 p0 c0 {2,D} {4,S} {6,S} 
+6 R  u0 p0 c0 {5,S}
+""",
+    thermo=ThermoData(
+        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
+        Cpdata=([-0.0, 5.76, 9.53, 11.98, 14.68, 15.93, 16.88], 'J/(mol*K)'),
+        H298=(-457.3, 'kJ/mol'),
+        S298=(-222.49, 'J/(mol*K)'),
+    ),
+    shortDesc=u"""Came from CHCH2C-bi single-bonded on Pt(111)""",
+    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
+            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
+            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
+            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
+            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
+            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
+  C--R--CR
+ |||    ||
 ***********
 """,
     metal = "Pt",
@@ -2570,6 +3730,24 @@ entry(
 tree(
 """
 L1: R*
+    L2: R*bridged-bidentate
+        L3: C*RC*
+            L4: C=*=R-C-*R2
+            L4: R2C-*-R-C-*R2
+            L4: RC=*-R=C-*R
+            L4: RC-*=R-C-*R2
+            L4: RC=*-R-C-*R2
+            L4: RC-*=R=C-*R
+            L4: RC-*=R=C=*
+            L4: C#*-R-C-*R2
+            L4: C#*-R=C-*R
+            L4: C#*-R-C#*
+            L4: RC=*-R-C=*R
+            L4: C#*-R-C=*R
+        L3: C*RO*
+            L4: RC-*=R-O-*
+        L3: O*RO*
+            L4: O-*-R-O-*
     L2: R*bidentate
         L3: C*C*
             L4: C-*C-*
@@ -2577,6 +3755,12 @@ L1: R*
             L4: C-*R2C-*R2
             L4: C-*R2C=*R
             L4: C-*RC=*
+            L4: C=*RC-*R
+            L4: C#*C-*R
+            L4: C#*C-*R2
+            L4: C#*C=*R
+            L4: C-*R2C-*R
+            L4: C-*RC-*R
         L3: C*N*
             L4: C-*R2N=*
             L4: C-*R2N-*R
@@ -2592,17 +3776,19 @@ L1: R*
         L3: N*O*
             L4: N=*O-*
         L3: O*O*
-    L2: R*single_chemisorbed
+    L2: R*single-chemisorbed
         L3: C*
             L4: Cq*
             L4: C#*R
                 L5: C#*CR3
                 L5: C#*NR2
                 L5: C#*OR
+                L5: C#*CR2
             L4: C=*R2
                 L5: C=*RCR3
                 L5: C=*RNR2
                 L5: C=*ROR
+                L5: C=*RCR2
             L4: C=*(=R)
                 L5: C=*(=C)
                 L5: C=*(=NR)
@@ -2611,7 +3797,9 @@ L1: R*
                 L5: C-*R2NR2
                 L5: C-*R2OR
                 L5: C-*RNR
+            L4: C-*R2
                 L5: C-*RO
+                L5: C-*RCR2
         L3: N*
             L4: N#*
             L4: N=*R
@@ -2629,6 +3817,7 @@ L1: R*
             L4: O=*
             L4: O-*R
                 L5: O-*CR3
+                L5: O-*CR2
                 L5: O-*NR2
                 L5: O-*OR
     L2: R*vdW
@@ -2651,5 +3840,6 @@ L1: R*
             L4: (NRNR)*
         L3: (OR2)*
             L4: (OROR)*
+            L4: (R3COR)*
 """,
 )

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -2275,10 +2275,10 @@ entry(
     label = "C*C*",
     group =
 """
-1 * X u0 {3,[S,D]}
-2 X u0 {4,[S,D]}
-3 C  u0 {1,[S,D]} {4,[S,D]}
-4 C  u0 {2,[S,D]} {3,[S,D]}
+1 * X u0 {3,[S,D,T]}
+2 X u0 {4,[S,D,T]}
+3 C  u0 {1,[S,D,T]} {4,[S,D,T]}
+4 C  u0 {2,[S,D,T]} {3,[S,D,T]}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2971,7 +2971,7 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,D} {4,D} 
-4 R  u0 p0 c0 {3,D} {5,S}
+4 R!H  u0 p0 c0 {3,D} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
 6 R  u0 p0 c0 {5,S}
 7 R  u0 p0 c0 {5,S}
@@ -3005,7 +3005,7 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
-4 R  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 p0 c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
 6 R  u0 p0 c0 {5,S}
 7 R  u0 p0 c0 {5,S}
@@ -3041,7 +3041,7 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,D} {4,S} {6,S}
-4 R  u0 p0 c0 {3,S} {5,D}
+4 R!H  u0 p0 c0 {3,S} {5,D}
 5 C  u0 p0 c0 {2,S} {4,D} {7,S}
 6 R  u0 p0 c0 {3,S}
 7 R  u0 p0 c0 {5,S}
@@ -3075,7 +3075,7 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
-4 R  u0 p0 c0 {3,D} {5,S}
+4 R!H  u0 p0 c0 {3,D} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
 6 R  u0 p0 c0 {3,S}
 7 R  u0 p0 c0 {5,S}
@@ -3110,7 +3110,7 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,D} {4,S} {6,S}
-4 R  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 p0 c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
 6 R  u0 p0 c0 {3,S}
 7 R  u0 p0 c0 {5,S}
@@ -3145,7 +3145,7 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
-4 R  u0 p0 c0 {3,D} {5,D}
+4 R!H  u0 p0 c0 {3,D} {5,D}
 5 C  u0 p0 c0 {2,S} {4,D} {7,S}
 6 R  u0 p0 c0 {3,S}
 7 R  u0 p0 c0 {5,S}
@@ -3179,7 +3179,7 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,D}
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
-4 R  u0 p0 c0 {3,D} {5,D}
+4 R!H  u0 p0 c0 {3,D} {5,D}
 5 C  u0 p0 c0 {2,D} {4,D}
 6 R  u0 p0 c0 {3,S}
 """,
@@ -3206,13 +3206,13 @@ entry(
 
 entry(
     index = 104,
-    label = "O-*-R-O-*",
+    label = "O-*-C-O-*",
     group =
 """
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 O  u0 p2 c0 {1,S} {4,S}
-4 R  u0 p0 c0 {3,S} {5,S}
+4 C  u0 p0 c0 {3,S} {5,S}
 5 O  u0 p2 c0 {2,S} {4,S}
 """,
     thermo=ThermoData(
@@ -3244,7 +3244,7 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
-4 R  u0 p0 c0 {3,D} {5,S}
+4 R!H  u0 p0 c0 {3,D} {5,S}
 5 O  u0 p2 c0 {2,S} {4,S}
 6 R  u0 p0 c0 {3,S} 
 """,
@@ -3307,7 +3307,7 @@ entry(
 2 C  u0 p0 c0 {3,S} {4,S} {5,D}
 3 C  u0 p0 c0 {1,D} {2,S} {6,S}
 4 R  u0 p0 c0 {2,S}
-5 R  u0 c0 {2,D}
+5 R!H  u0 c0 {2,D}
 6 R  u0 c0 {3,S}
 """,
     thermo=ThermoData(
@@ -3343,7 +3343,7 @@ entry(
 2 C  u0 p0 c0 {3,S} {4,S} {5,D}
 3 C  u0 p0 c0 {1,T} {2,S}
 4 R  u0 p0 c0 {2,S}
-5 R  u0 c0 {2,D}
+5 R!H  u0 c0 {2,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3378,7 +3378,7 @@ entry(
 2 C  u0 p0 c0 {3,S} {4,S} {5,D}
 3 O  u0 p2 c0 {1,S} {2,S}
 4 R  u0 p0 c0 {2,S}
-5 R  u0 c0 {2,D}
+5 R!H  u0 c0 {2,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3406,41 +3406,6 @@ entry(
 
 entry(
     index = 110,
-    label = "(R3COR)*",
-    group =
-"""
-1 * X u0 p0 c0
-2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
-3 O  u0 p2 c0 {2,S} {7,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {2,S}
-7 R  u0 p0 c0 {3,S}
-""",
-    thermo=ThermoData(
-        Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([8.44, 9.53, 10.02, 10.25, 10.41, 10.45, 10.47], 'J/(mol*K)'),
-        H298=(-57.56, 'kJ/mol'),
-        S298=(-139.36, 'J/(mol*K)'),
-    ),
-    shortDesc=u"""Came from averaged CH3OH, CH3OCH3, H2CO2H2, CH3OCH2OH on Pt(111)""",
-    longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
-            Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
-            using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
-            following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
-            kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
-            See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
-
- R3C-OR
-    :
-***********
-""",
-    metal = "Pt",
-    facet = "111",
-)
-
-entry(
-    index = 111,
     label = "C*RC*",
     group =
 """
@@ -3448,7 +3413,7 @@ entry(
 2 X u0 {4,[S,D,T]}
 3 C  u0 {1,[S,D,T]} {5,[S,D,T]}
 4 C  u0 {2,[S,D,T]} {5,[S,D,T]}
-5 R  u0 {3,[S,D,T]} {4,[S,D,T]}
+5 R!H  u0 {3,[S,D,T]} {4,[S,D,T]}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3470,7 +3435,7 @@ entry(
 )
 
 entry(
-    index = 112,
+    index = 111,
     label = "R*bridged-bidentate",
     group =
 """
@@ -3500,7 +3465,7 @@ entry(
 )
 
 entry(
-    index = 113,
+    index = 112,
     label = "C*RO*",
     group =
 """
@@ -3508,7 +3473,7 @@ entry(
 2 X u0 {4,S}
 3 C  u0 {1,[S,D,T]} {5,[S,D,T]}
 4 O  u0 p2 {2,S} {5,S}
-5 R  u0 {3,[S,D,T]} {4,S}
+5 R!H  u0 {3,[S,D,T]} {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3529,15 +3494,15 @@ entry(
 )
 
 entry(
-    index = 114,
+    index = 113,
     label = "O*RO*",
     group =
 """
 1 * X u0 p0 c0 {3,S}
-2 X u0 p0 c0 {5,S}
-3 O  u0 p2 c0 {1,S} {4,S}
-4 R  u0 p0 c0 {3,S} {5,S}
-5 O  u0 p2 c0 {2,S} {4,S}
+2 X u0 p0 c0 {4,S}
+3 O  u0 p2 c0 {1,S} {5,S}
+4 O  u0 p2 c0 {2,S} {5,S}
+5 R!H  u0 p0 c0 {3,S} {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3561,14 +3526,14 @@ entry(
 )
 
 entry(
-    index = 115,
+    index = 114,
     label = "C#*-R-C-*R2",
     group =
 """
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 p0 c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
 6 R  u0 p0 c0 {5,S}
 7 R  u0 p0 c0 {5,S}
@@ -3595,14 +3560,14 @@ entry(
 )
 
 entry(
-    index = 116,
+    index = 115,
     label = "C#*-R=C-*R",
     group =
 """
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R  u0 p0 c0 {3,S} {5,D}
+4 R!H  u0 p0 c0 {3,S} {5,D}
 5 C  u0 p0 c0 {2,S} {4,D} {6,S} 
 6 R  u0 p0 c0 {5,S}
 """,
@@ -3619,7 +3584,7 @@ entry(
             following the procedure outlined by Blondal et al (DOI:10.1021/acs.iecr.9b01464). The following settings were applied:
             kpoints=(5x5x1), 4 layers (2 bottom layers fixed), ecutwfc=60 Ry, smearing='mazari-vanderbilt', mixing_mode='local-TF',fmax=2.5e-2.
             See Kreitz et al. 2023 (DOI:10.1021/acscatal.2c03378) for details on the DFT method. 
-  C--R==CR2
+  C--R==CR
  |||    |
 ***********
 """,
@@ -3635,7 +3600,7 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,T}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 p0 c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,T} {4,S}
 """,
     thermo=ThermoData(
@@ -3667,7 +3632,7 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,D}
 3 C  u0 p0 c0 {1,D} {4,S} {6,S}
-4 R  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 p0 c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,D} {4,S} {7,S} 
 6 R  u0 p0 c0 {3,S}
 7 R  u0 p0 c0 {5,S}
@@ -3701,7 +3666,7 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,D}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 p0 c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,D} {4,S} {6,S} 
 6 R  u0 p0 c0 {5,S}
 """,
@@ -3747,7 +3712,7 @@ L1: R*
         L3: C*RO*
             L4: RC-*=R-O-*
         L3: O*RO*
-            L4: O-*-R-O-*
+            L4: O-*-C-O-*
     L2: R*bidentate
         L3: C*C*
             L4: C-*C-*
@@ -3796,10 +3761,10 @@ L1: R*
                 L5: C-*R2CR3
                 L5: C-*R2NR2
                 L5: C-*R2OR
-                L5: C-*RNR
             L4: C-*R2
                 L5: C-*RO
                 L5: C-*RCR2
+                L5: C-*RNR
         L3: N*
             L4: N#*
             L4: N=*R
@@ -3840,6 +3805,5 @@ L1: R*
             L4: (NRNR)*
         L3: (OR2)*
             L4: (OROR)*
-            L4: (R3COR)*
 """,
 )

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -2,11 +2,15 @@
 # encoding: utf-8
 
 name = "Surface Adsorption Corrections Pt(111)"
-shortDesc = u"Surface adsorption Pt(111), Blondal 2018 & Kreitz 2023"
+shortDesc = u"Surface adsorption corrections Pt(111)"
 longDesc = u"""
-Changes due to adsorbing on a surface.
-Here, Pt(111)
-Note: "-h" means "horizontal"
+Changes in thermophysical properties due to adsorption on a surface, here Pt(111). Adsorption corrections are based on DFT calculations performed by Katrin Blondal and 
+Bjarne Kreitz (Brown University). The computational methods and details are explained in Kreitz, Blöndal, Goldsmith et al. ACS Catal, 2022, 12,
+11137-11151 (https://doi.org/10.1021/acscatal.2c03378) and Kreitz, Goldsmith et al., Angew. Chem. Int. Ed., 2023, 62, e202306514 (https://onlinelibrary.wiley.com/doi/10.1002/anie.202306514). 
+The calculation of the adsorption corrections is explained in detail in the SI. 
+If you use these adsorption corrections database in your work, please cite the publications mentioned above. 
+
+TODO: Update adsorption corrections for N containing molecules. 
 """
 
 entry(
@@ -84,7 +88,7 @@ R*bidentate or R*single_chemisorbed and thus not R*vdW.
 #         H298=(-1.45, 'kcal/mol'),
 #         S298=(-7.73, 'cal/(mol*K)'),
 #     ),
-#     shortDesc=u"""Came from H2 vdW-bonded on Pt(111)""",
+#     shortDesc=u"""Came from H2 physisorbed on Pt(111)""",
 #     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
 #             DFT binding energy: -0.054 eV.
 #             Linear scaling parameters: ref_adatom_H = -2.479 eV, psi = -0.05448 eV, gamma_H(X) = 0.000.
@@ -114,7 +118,7 @@ entry(
         H298=(-49.08, 'kJ/mol'),
         S298=(-123.53, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged H2O, HOOH, CH3OH, HCOOH, CH3CH2OH, CH3OCH3, CH3OCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged H2OX, HOOHX, CH3OHX, HCOOHX, CH3CH2OHX, CH3OCH3X, CH3OCH2OHX on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -145,7 +149,7 @@ entry(
         H298=(-194.2, 'kJ/mol'),
         S298=(-157.49, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *OCH3, *OH, *OCH2CH3, HC*O3, HC*OO, *OCHCH2, *OOH, *OCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged XOCH3, XOH, XOCH2CH3, HOC(O)XO, HC(O)XO, XOCHCH2, XOOH, XOCH2OH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -180,7 +184,7 @@ entry(
         H298=(-63.01, 'kJ/mol'),
         S298=(-110.35, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HOOH vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from HOOHX physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -214,7 +218,7 @@ entry(
         H298=(-107.21, 'kJ/mol'),
         S298=(-167.43, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from O2-bi bidentate, twice single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XOXO, twice single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -246,7 +250,7 @@ entry(
         H298=(-134.04, 'kJ/mol'),
         S298=(-120.71, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from OOH single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XOOH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -278,7 +282,7 @@ entry(
         H298=(-382.56, 'kJ/mol'),
         S298=(-140.6, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from O double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XO double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -311,7 +315,7 @@ entry(
         H298=(-30.61, 'kcal/mol'),
         S298=(-35.75, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from O-NH2 single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XONH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.698 eV.
             Linear scaling parameters: ref_adatom_O = -3.586 eV, psi = 1.09537 eV, gamma_O(X) = 0.500.
@@ -344,7 +348,7 @@ entry(
         H298=(-182.55, 'kJ/mol'),
         S298=(-149.81, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *OCH3, *OCH2CH3, and *OCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged XOCH3, XOCH2CH3, and XOCH2OH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -379,7 +383,7 @@ entry(
         H298=(-16.11, 'kcal/mol'),
         S298=(-32.0, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from NH3 vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from NH3X physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.673 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.67337 eV, gamma_N(X) = 0.000.
@@ -407,7 +411,7 @@ entry(
         H298=(-53.39, 'kcal/mol'),
         S298=(-47.88, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from NH2 single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -2.030 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.58258 eV, gamma_N(X) = 0.333.
@@ -435,7 +439,7 @@ entry(
         H298=(-88.28, 'kcal/mol'),
         S298=(-40.72, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from NH double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNH double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -3.440 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.54193 eV, gamma_N(X) = 0.667.
@@ -462,7 +466,7 @@ entry(
         H298=(-103.33, 'kcal/mol'),
         S298=(-32.92, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from N triple-bonded on Pt(111)""",
+    shortDesc=u"""Came from XN triple-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -4.352 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = 0.00000 eV, gamma_N(X) = 1.000.
@@ -493,7 +497,7 @@ entry(
         H298=(-18.16, 'kcal/mol'),
         S298=(-32.2, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2N-OH vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from H2XNOH physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.654 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.65407 eV, gamma_N(X) = 0.000.
@@ -523,7 +527,7 @@ entry(
         H298=(-39.84, 'kcal/mol'),
         S298=(-37.88, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-O vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from HNOX physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.270 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.
@@ -553,7 +557,7 @@ entry(
         H298=(-44.41, 'kcal/mol'),
         S298=(-45.51, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-OH single-bonded on Pt(111)""",
+    shortDesc=u"""Came from HXNOH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.370 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = 0.08004 eV, gamma_N(X) = 0.333.
@@ -581,7 +585,7 @@ entry(
         H298=(-47.5, 'kcal/mol'),
         S298=(-40.63, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from NO single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNO single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.580 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.13417 eV, gamma_N(X) = 0.333.
@@ -612,7 +616,7 @@ entry(
         H298=(-42.57, 'kcal/mol'),
         S298=(-35.43, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from NO-h bidentate, double- and single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNXO bidentate, double- and single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.390 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = 1.51181 eV, gamma_N(X) = 0.667.
@@ -641,7 +645,7 @@ entry(
         H298=(-70.93, 'kcal/mol'),
         S298=(-44.7, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from NOH double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNOH double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -3.260 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.35381 eV, gamma_N(X) = 0.667.
@@ -675,7 +679,7 @@ entry(
         H298=(-26.81, 'kcal/mol'),
         S298=(-31.95, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2N-NH2 vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from NH2NH2X physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.977 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.97746 eV, gamma_N(X) = 0.000.
@@ -706,7 +710,7 @@ entry(
         H298=(-24.31, 'kcal/mol'),
         S298=(-42.07, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-NH vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from NHNHX physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.676 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.67607 eV, gamma_N(X) = 0.000.
@@ -735,7 +739,7 @@ entry(
 #        H298=(-6.31, 'kcal/mol'),
 #        S298=(-15.27, 'cal/(mol*K)'),
 #    ),
-#    shortDesc=u"""Came from NN vdW-bonded on Pt(111)""",
+#    shortDesc=u"""Came from NN physisorbed on Pt(111)""",
 #    longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
 #            DFT binding energy: -0.109 eV.
 #            Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.10949 eV, gamma_N(X) = 0.000.
@@ -765,7 +769,7 @@ entry(
         H298=(-40.74, 'kcal/mol'),
         S298=(-45.43, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-NH2 single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNHNH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.270 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = 0.18029 eV, gamma_N(X) = 0.333.
@@ -794,7 +798,7 @@ entry(
         H298=(-37.65, 'kcal/mol'),
         S298=(-43.45, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from N-NH single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNNH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.060 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = 0.39360 eV, gamma_N(X) = 0.333.
@@ -826,7 +830,7 @@ entry(
         H298=(-59.44, 'kcal/mol'),
         S298=(-43.17, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from N-NH2 double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNNH2 double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -2.040 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = 0.86160 eV, gamma_N(X) = 0.667.
@@ -859,7 +863,7 @@ entry(
         H298=(-27.1, 'kcal/mol'),
         S298=(-42.53, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-NH-h bidentate, twice single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNHXNH bidentate, twice single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.982 eV.
             Linear scaling parameters: ref_adatom_N1 = -4.352 eV, ref_adatom_N2 = -4.352 eV, psi = 1.91976 eV, gamma_N1(X) = 0.333, gamma_N2(X) = 0.333.
@@ -891,7 +895,7 @@ entry(
         H298=(-51.48, 'kcal/mol'),
         S298=(-46.63, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-CH3 single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNHCH3 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.850 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.40192 eV, gamma_N(X) = 0.333.
@@ -921,7 +925,7 @@ entry(
         H298=(-50.13, 'kcal/mol'),
         S298=(-44.16, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from N-CH2 single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNCH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.660 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.21342 eV, gamma_N(X) = 0.333.
@@ -954,7 +958,7 @@ entry(
         H298=(-84.35, 'kcal/mol'),
         S298=(-47.17, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from N-CH3 double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNCH3 double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -3.050 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -0.14794 eV, gamma_N(X) = 0.667.
@@ -1014,7 +1018,7 @@ entry(
         H298=(-657.91, 'kJ/mol'),
         S298=(-133.84, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from C quadruple-bonded on Pt(111)""",
+    shortDesc=u"""Came from XC quadruple-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1046,7 +1050,7 @@ entry(
         H298=(-613.35, 'kJ/mol'),
         S298=(-163.77, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CC-bi double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCXC double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1077,7 +1081,7 @@ entry(
         H298=(-429.79, 'kJ/mol'),
         S298=(-168.79, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *CCH2, *CCCH2, *CCO on Pt(111)""",
+    shortDesc=u"""Came from averaged XCCH2, XCCCH2, XCCO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1116,7 +1120,7 @@ entry(
         H298=(-594.9, 'kJ/mol'),
         S298=(-174.23, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *CCH3, *CCH2CH3, *CCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCCH3, XCCH2CH3, XCCH2OH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1149,7 +1153,7 @@ entry(
         H298=(-571.12, 'kJ/mol'),
         S298=(-176.66, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *CH, *CCH3, *COH, *CCHCH2, *CCH2CH3, CCHO, CCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCH, XCCH3, XCOH, XCCHCH2, XCCH2CH3, XCCHO, XCCH2OH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1185,7 +1189,7 @@ entry(
         H298=(-221.27, 'kJ/mol'),
         S298=(-175.96, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCH-bi double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHXCH double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1217,7 +1221,7 @@ entry(
         H298=(-370.06, 'kJ/mol'),
         S298=(-174.19, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *CH2, CH3*CCH3, CH3*COH, *CHCH2CH3, *CHCH3, *CHCHCH2-mono, *CHCHO-mono, *HCOH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCH2, CH3XCCH3, CH3XCOH, XCHCH2CH3, XCHCH3, XCHCHCH2, XCHCHO, XCHOH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1253,7 +1257,7 @@ entry(
         H298=(-124.09, 'kJ/mol'),
         S298=(-192.34, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH2CH2 and CH3CHCH2 on Pt(111)""",
+    shortDesc=u"""Came from averaged XCH2XCH2 and CH3XCHXCH2 on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1286,7 +1290,7 @@ entry(
         H298=(-212.02, 'kJ/mol'),
         S298=(-176.19, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH2CH2CH3, CH2CH2OH, CH2CH3, CH2CHCH2, CH2CHO, CH3, CH3CHCH3, CH3CHOH, H2COH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCH2CH2CH3, XCH2CH2OH, XCH2CH3, XCH2CHCH2, XCH2CHO, XCH3, CH3XCHCH3, CH3XCHOH, XCH2OH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1323,7 +1327,7 @@ entry(
         H298=(-29.6, 'kJ/mol'),
         S298=(-137.34, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH3CH3, CH3CH2CH3, CH3CH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged CH3CH3X, CH3CH2CH3X, CH3CH2OHX on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1357,7 +1361,7 @@ entry(
         H298=(-41.27, 'kJ/mol'),
         S298=(-125.91, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH4, CH3CH3, CH3CH2CH3, CH3CH2OH, CH3OH, CH3OCH3, CH3OCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged CH4X, CH3CH3X, CH3CH2CH3X, CH3CH2OHX, CH3OHX, CH3OCH3X, CH3OCH2OHX on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1389,7 +1393,7 @@ entry(
         H298=(-88.23, 'kcal/mol'),
         S298=(-34.98, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from CN bidentate, double- and single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCXN bidentate, double- and single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -3.340 eV.
             Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_N2 = 0.525 eV, psi = -0.13303 eV, gamma_C1(X) = 0.500, gamma_N2(X) = 0.333.
@@ -1418,7 +1422,7 @@ entry(
         H298=(-48.26, 'kcal/mol'),
         S298=(-30.68, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from CNH double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCNH double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.740 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = 1.63638 eV, gamma_C(X) = 0.500.
@@ -1450,7 +1454,7 @@ entry(
         H298=(-106.38, 'kcal/mol'),
         S298=(-49.82, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from CNH2 triple-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCNH2 triple-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -4.060 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = 1.00119 eV, gamma_C(X) = 0.750.
@@ -1513,7 +1517,7 @@ entry(
         H298=(-463.49, 'kJ/mol'),
         S298=(-187.54, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from COH triple-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCOH triple-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1550,7 +1554,7 @@ entry(
         H298=(-330.81, 'kJ/mol'),
         S298=(-214.97, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CHCH2, CH2COH, CHCHCH3 on Pt(111)""",
+    shortDesc=u"""Came from averaged XCHXCH2, XCH2XCOH, XCHXCHCH3 on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1586,7 +1590,7 @@ entry(
         H298=(-214.46, 'kJ/mol'),
         S298=(-192.28, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH2CH2CH3, CH2CH2OH, CH2CH3, CH3CHCH3, CH3CHOH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCH2CH2CH3, XCH2CH2OH, XCH2CH3, CH3XCHCH3, CH3XCHOH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1622,7 +1626,7 @@ entry(
         H298=(-12.55, 'kcal/mol'),
         S298=(-33.14, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2C-NH vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from H2CNHX physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.228 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.22807 eV, gamma_C(X) = 0.000.
@@ -1655,7 +1659,7 @@ entry(
         H298=(-53.29, 'kcal/mol'),
         S298=(-39.03, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2C-NH2 single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCH2NH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.980 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.29283 eV, gamma_C(X) = 0.250.
@@ -1687,7 +1691,7 @@ entry(
         H298=(-73.08, 'kJ/mol'),
         S298=(-122.36, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged H2CO, HCOOH, CH3CHO, OCO2H2, CH2CO on Pt(111)""",
+    shortDesc=u"""Came from averaged H2COX, HCOOHX, CH3CHOX, OCO2H2X, CH2COX on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1721,7 +1725,7 @@ entry(
         H298=(-225.57, 'kJ/mol'),
         S298=(-157.56, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged H2COH, CH3CHOH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCH2OH, CH3XCHOH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1759,7 +1763,7 @@ entry(
         H298=(-23.1, 'kcal/mol'),
         S298=(-33.73, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H3C-NH2 vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from CH3NH2X physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.879 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.87925 eV, gamma_C(X) = 0.000.
@@ -1792,7 +1796,7 @@ entry(
         H298=(-57.56, 'kJ/mol'),
         S298=(-139.36, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH3OH, CH3OCH3, H2CO2H2, CH3OCH2OH on Pt(111)""",
+    shortDesc=u"""Came from averaged CH3OHX, CH3OCH3X, H2CO2H2X, CH3OCH2OHX on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1825,7 +1829,7 @@ entry(
         H298=(-440.52, 'kJ/mol'),
         S298=(-184.43, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHC-bi single- and double bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHXC single- and double bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1860,7 +1864,7 @@ entry(
         H298=(-288.17, 'kJ/mol'),
         S298=(-182.51, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH2CCH3, CH2COH, CHCCH2, CHCH2, CHCHCH3 on Pt(111)""",
+    shortDesc=u"""Came from averaged CH2XCCH3, CH2XCOH, XCHCCH2, XCHCH2, XCHCHCH3 on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1897,7 +1901,7 @@ entry(
         H298=(-372.23, 'kJ/mol'),
         S298=(-179.04, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH3*CCH3, CH3*COH, *CHCH2CH3, *CHCH3 on Pt(111)""",
+    shortDesc=u"""Came from averaged CH3XCCH3, CH3XCOH, XCHCH2CH3, XCHCH3 on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -1931,7 +1935,7 @@ entry(
         H298=(-7.52, 'kcal/mol'),
         S298=(-22.92, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCN vdW-bonded on Pt(111)""",
+    shortDesc=u"""Came from HCNX physisorbed on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.010 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.00995 eV, gamma_C(X) = 0.000.
@@ -1962,7 +1966,7 @@ entry(
         H298=(-22.54, 'kcal/mol'),
         S298=(-35.76, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCN-h bidentate, twice double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCXNH, twice double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.650 eV.
             Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_N2 = 0.525 eV, psi = 2.37733 eV, gamma_C1(X) = 0.500, gamma_N2(X) = 0.667.
@@ -1994,7 +1998,7 @@ entry(
         H298=(-63.07, 'kcal/mol'),
         S298=(-38.15, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCNH single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHNH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -2.220 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.52691 eV, gamma_C(X) = 0.250.
@@ -2027,7 +2031,7 @@ entry(
         H298=(-70.06, 'kcal/mol'),
         S298=(-46.17, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCNH-h bidentate, double- and single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHXNH, double- and single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -2.490 eV.
             Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_N2 = 0.525 eV, psi = 0.71054 eV, gamma_C1(X) = 0.500, gamma_N2(X) = 0.333.
@@ -2058,7 +2062,7 @@ entry(
         H298=(-69.75, 'kcal/mol'),
         S298=(-37.75, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCNH2 double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHNH2 double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -2.670 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = 0.70666 eV, gamma_C(X) = 0.500.
@@ -2089,7 +2093,7 @@ entry(
         H298=(-282.27, 'kJ/mol'),
         S298=(-161.1, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged HCO, COOH, CH3CO, CHCO, CH3CH2CO on Pt(111)""",
+    shortDesc=u"""Came from averaged HXCO, OXCOH, CH3XCO, CHXCO, CH3CH2XCO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2124,7 +2128,7 @@ entry(
         H298=(-238.17, 'kJ/mol'),
         S298=(-167.73, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from HCO-bi double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHXO double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2159,7 +2163,7 @@ entry(
         H298=(-325.89, 'kJ/mol'),
         S298=(-146.57, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged H*COH and CH3*COH on Pt(111)""",
+    shortDesc=u"""Came from averaged XCHOH and CH3XCOH on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2514,7 +2518,7 @@ entry(
 3 R!H u0 {2,T}
 4 R   u0 {2,S}
 """,
-    thermo=u'(CRN)*',
+    thermo=u'(CRCR)*',
     metal = "Pt",
     facet = "111",
 )
@@ -2552,7 +2556,7 @@ entry(
         H298=(-43.06, 'kcal/mol'),
         S298=(-45.85, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from HN-N-h bidentate, single- and double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XNHXN single- and double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.280 eV.
             Linear scaling parameters: ref_adatom_N1 = -4.352 eV, ref_adatom_N2 = -4.352 eV, psi = 3.07184 eV, gamma_N1(X) = 0.333, gamma_N2(X) = 0.667.
@@ -2582,7 +2586,7 @@ entry(
         H298=(-59.58, 'kJ/mol'),
         S298=(-115.19, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CHCH and CHCCH3 on Pt(111)""",
+    shortDesc=u"""Came from averaged CHCHX and CHCCH3X on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2616,7 +2620,7 @@ entry(
         H298=(-51.5, 'kcal/mol'),
         S298=(-47.12, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2CN-h bidentate, single- and double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCH2XN bidentate, single- and double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.710 eV.
             Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_N2 = 0.525 eV, psi = -0.37462 eV, gamma_C1(X) = 0.250, gamma_N2(X) = 0.667.
@@ -2648,7 +2652,7 @@ entry(
         H298=(-25.1, 'kcal/mol'),
         S298=(-47.43, 'cal/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2CNH-h bidentate, twice single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCH2XNH twice single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.756 eV.
             Linear scaling parameters: ref_adatom_C1 = -6.750 eV, ref_adatom_N2 = 0.525 eV, psi = 0.75753 eV, gamma_C1(X) = 0.250, gamma_N2(X) = 0.333.
@@ -2676,7 +2680,7 @@ entry(
         H298=(-429.79, 'kJ/mol'),
         S298=(-168.79, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *CCH2, *CCCH2, *CCO on Pt(111)""",
+    shortDesc=u"""Came from averaged XCCH2, XCCCH2, XCCO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2715,7 +2719,7 @@ entry(
         H298=(-61.03, 'kJ/mol'),
         S298=(-170.27, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from H2CO-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCH2XO single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2749,7 +2753,7 @@ entry(
         H298=(-76.74, 'kJ/mol'),
         S298=(-143.86, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CH2CH2, CH3CHCH2, CH2CCH2 on Pt(111)""",
+    shortDesc=u"""Came from averaged CH2CH2X, CH3CHCH2X, CH2CCH2X on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2783,7 +2787,7 @@ entry(
         H298=(-396.35, 'kJ/mol'),
         S298=(-202.17, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCO-bi double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHXCO double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2815,7 +2819,7 @@ entry(
         H298=(-440.28, 'kJ/mol'),
         S298=(-204.35, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CCCH2-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCXCCH2 twice single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2848,7 +2852,7 @@ entry(
         H298=(-436.46, 'kJ/mol'),
         S298=(-201.88, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged *C*CH2 and *C*CHCH3 on Pt(111)""",
+    shortDesc=u"""Came from averaged XCXCH2 and XCXCHCH3 on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2883,7 +2887,7 @@ entry(
         H298=(-179.99, 'kJ/mol'),
         S298=(-191.92, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH2CCH2-bi single and single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCH2CXCH2 single and single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2916,7 +2920,7 @@ entry(
         H298=(-227.58, 'kJ/mol'),
         S298=(-194.29, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCCH3-bi single and single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHXCCH3 single and single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2948,7 +2952,7 @@ entry(
         H298=(-488.53, 'kJ/mol'),
         S298=(-158.38, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CCCH3-bi triple and double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCXCCH3 triple and double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -2982,7 +2986,7 @@ entry(
         H298=(-543.25, 'kJ/mol'),
         S298=(-229.45, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CCHCH2-bi double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCCHXCH2 double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3018,7 +3022,7 @@ entry(
         H298=(-389.14, 'kJ/mol'),
         S298=(-209.34, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CH2CH2CH2-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCH2CH2XCH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3052,7 +3056,7 @@ entry(
         H298=(-612.92, 'kJ/mol'),
         S298=(-200.99, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCHCH-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCHXCH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3087,7 +3091,7 @@ entry(
         H298=(-426.75, 'kJ/mol'),
         S298=(-227.78, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCHCH2-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCHXCH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3122,7 +3126,7 @@ entry(
         H298=(-529.03, 'kJ/mol'),
         S298=(-222.29, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCH2CH2-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCH2XCH2 single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3156,7 +3160,7 @@ entry(
         H298=(-370.79, 'kJ/mol'),
         S298=(-196.35, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCCH-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCXCH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3189,7 +3193,7 @@ entry(
         H298=(-432.93, 'kJ/mol'),
         S298=(-179.15, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCC-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCXC single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3221,7 +3225,7 @@ entry(
         H298=(-354.62, 'kJ/mol'),
         S298=(-179.72, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CO3-bi and H2CO2-bi on Pt(111)""",
+    shortDesc=u"""Came from averaged OC(XO)XO and H2C(XO)XO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3254,7 +3258,7 @@ entry(
         H298=(-446.49, 'kJ/mol'),
         S298=(-211.15, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCHO-bi single and single -bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCHXO single and single -bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3316,7 +3320,7 @@ entry(
         H298=(-379.17, 'kJ/mol'),
         S298=(-179.05, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CHCHCH2 and CHCHO on Pt(111)""",
+    shortDesc=u"""Came from averaged XCHCHCH2 and XCHCHO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3351,7 +3355,7 @@ entry(
         H298=(-565.15, 'kJ/mol'),
         S298=(-180.28, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CCHCH2 and CCHO triple-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCCHCH2 and XCCHO triple-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3386,7 +3390,7 @@ entry(
         H298=(-228.04, 'kJ/mol'),
         S298=(-194.23, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged on Pt(111)""",
+    shortDesc=u"""Came from averaged XOCHCH2, HOC(O)XO, HC(O)XO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3481,7 +3485,7 @@ entry(
         H298=(-446.49, 'kJ/mol'),
         S298=(-211.15, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCHO-bi single and single -bonded on Pt(111)""",
+    shortDesc=u"""Same as child node RC-*=R-O-*""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3510,7 +3514,7 @@ entry(
         H298=(-354.62, 'kJ/mol'),
         S298=(-179.72, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from averaged CO3-bi and H2CO2-bi on Pt(111)""",
+    shortDesc=u"""Came from averaged OC(XO)XO and H2C(XO)XO on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3544,7 +3548,7 @@ entry(
         H298=(-477.2, 'kJ/mol'),
         S298=(-200.61, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CCH2CH2-bi double-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCCH2XCH2 double-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3577,7 +3581,7 @@ entry(
         H298=(-402.33, 'kJ/mol'),
         S298=(-202.29, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCHC-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCHXC single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3609,7 +3613,7 @@ entry(
         H298=(-671.16, 'kJ/mol'),
         S298=(-243.65, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CCH2C-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCCH2XC single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3643,7 +3647,7 @@ entry(
         H298=(-230.02, 'kJ/mol'),
         S298=(-203.94, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCH2CH-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCH2XCH single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)
@@ -3676,7 +3680,7 @@ entry(
         H298=(-457.3, 'kJ/mol'),
         S298=(-222.49, 'J/(mol*K)'),
     ),
-    shortDesc=u"""Came from CHCH2C-bi single-bonded on Pt(111)""",
+    shortDesc=u"""Came from XCHCH2XC single-bonded on Pt(111)""",
     longDesc=u"""Calculated by Bjarne Kreitz at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb).
             Based on DFT calculations by Bjarne Kreitz from Brown University. DFT calculations were performed with Quantum Espresso
             using PAW pseudopotentials and the BEEF-vdW functional for an optimized 3x3 supercell (1/9ML coverage)


### PR DESCRIPTION
**Description**

I completely overhauled the adsorption correction database for Pt(111). The current adsorption corrections are based on the initial Pt(111) database create by Katrin (DOI:[10.1021/acs.iecr.9b01464](https://doi.org/10.1021/acs.iecr.9b01464)). I have updated the adsorption corrections to include all the adsorbates that I have added recently (DOI: [10.1021/acscatal.2c03378](https://doi.org/10.1021/acscatal.2c03378)). Additionally, I have revised the thermo tree for bidentate and included a new branch for bridged bidentate species. The new adsorption correction trees can be found in the SI of this paper DOI: [10.1002/anie.202306514](https://doi.org/10.1002/anie.202306514). Our previous adsorption correction for the enthalpy of formation for bidentate species was a simple addition of two monodentate corrections. This is grossly wrong (usually a few hundred kJ/mol). 
In order to provide better estimates, I have averaged the corrections for all species that are at a specific node. Higher level nodes are averaged over all children. 

I have not touched the adsorption corrections for adsorbates containing N. 

**Review suggestions**

Generate a mechanism with and without the new adsorption corrections and include bidentate species. 
Please go carefully through the adsorption correction tree. 