### PR TITLE
fix Surface_Abstraction training reactions format

### DIFF
--- a/input/kinetics/families/Surface_Abstraction/training/dictionary.txt
+++ b/input/kinetics/families/Surface_Abstraction/training/dictionary.txt
@@ -40,22 +40,22 @@ CHX_4
 2 *4 H u0 p0 {1,S}
 3 *2 X u0 p0 {1,T}
 
-O*
+OX_1
 1 *2 X u0 p0 c0 {2,D}
 2 *1 O u0 p2 c0 {1,D}
 
-HCO*
+HCOX_3
 1    O u0 p2 c0 {2,D}
 2 *3 C u0 p0 c0 {1,D} {3,S} {4,S}
 3 *4 H u0 p0 c0 {2,S}
 4 *5 X u0 p0 c0 {2,S}
 
-OH*
+HOX_4
 1 *1 O u0 p2 c0 {2,S} {3,S}
 2 *4 H u0 p0 c0 {1,S}
 3 *2 X u0 p0 c0 {1,S}
 
-CO*
+COX_5
 1    O u0 p2 c0 {2,D}
 2 *3 C u0 p0 c0 {1,D} {3,D}
 3 *5 X u0 p0 c0 {2,D}

--- a/input/kinetics/families/Surface_Abstraction/training/reactions.py
+++ b/input/kinetics/families/Surface_Abstraction/training/reactions.py
@@ -74,7 +74,7 @@ Catalysts, 2015, 5, 871-904. Reaction R26
 
 entry(
     index = 28,
-    label = "HOX_3 + CX_1 <=> OX_5 + CHX_4 ",
+    label = "CX_1 + HOX_3 <=> CHX_4 + OX_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A=(2.43E17, 'm^2/(mol*s)'),
@@ -95,7 +95,7 @@ Catalysts, 2015, 5, 871-904. Reaction R28
 
 entry(
     index = 39,
-    label = "O* + HCO* <=> OH* + CO*",
+    label = "OX_1 + HCOX_3 <=> HOX_4 + COX_5",
     degeneracy = 1,
     kinetics = SurfaceArrhenius(
         A=(3.298e17, 'm^2/(mol*s)'),
@@ -104,14 +104,14 @@ entry(
         Tmin = (298, 'K'),
         Tmax = (2000, 'K'),
     ),
-    rank = 1,
+    rank = 3,
     shortDesc = u"""Default""",
     longDesc = u"""
 Reaction 39 from table 2 in "Mechanism of Methanol Synthesis on Cu through CO2
 and CO Hydrogenation", Grabow and Mavrikakis.  doi:10.1021/cs200055d
 
 A factor from paper / surface site density of Cu
-1.0e13 m^4/(mol^2 * s) / 2.943e‐5 mol/m^2 = 3.298e17 m^2/(mol*s)
+1.0e13 1/s / 2.943e‐5 mol/m^2 = 3.298e17 m^2/(mol*s)
 """,
     metal = "Cu",
 )


### PR DESCRIPTION
**Issue**

The CI/build-and-test-linux is failing for the recent pull requests. This failure is caused by the Surface_Abstraction family and we get the following error message.

`Kinetics surface family Surface_Abstraction: entries can be used to generate rate rules? ... ERROR: Unable to dlopen(cxxpath) in parent!`

This PR is related to issue #632 

**Solution**
The reaction with index 39 in `reactions.py` was not correctly formatted, I think. After adjusting the format to match the other training reactions, I was able to run the `databaseTest` locally without any errors. Let's see if the `databaseTest` on Github works now, too. 
