### PR TITLE
Fix Regression Testing Issue by Simplifying CI to Match RMG-Py

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,57 +38,6 @@ env:
   RMG_PY_BRANCH: main
 
 jobs:
-  build-osx:
-    runs-on: macos-latest
-    # skip scheduled runs from forks
-    if: ${{ !( github.repository != 'ReactionMechanismGenerator/RMG-database' && github.event_name == 'schedule' ) }}
-    defaults:
-      run:
-        shell: bash -l {0}
-        working-directory: RMG-Py
-    steps:
-      - name: Clone RMG-database
-        uses: actions/checkout@v3
-        with:
-          path: RMG-database
-
-      - name: Checkout RMG-Py
-        uses: actions/checkout@v3
-        with:
-          path: RMG-Py
-          repository: ReactionMechanismGenerator/RMG-Py
-          ref: ${{ env.RMG_PY_BRANCH }}
-
-      # configures the mamba environment manager and builds the environment
-      - name: Setup Mambaforge Python 3.7
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          environment-file: RMG-Py/environment.yml
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          python-version: 3.7
-          activate-environment: rmg_env
-          use-mamba: true
-
-      # list the environment for debugging purposes
-      - name: mamba info
-        run: |
-          mamba info
-          mamba list
-
-      # modify env variables as directed in the RMG installation instructions
-      - name: Set Environment Variables
-        run: |
-          RUNNER_CWD=$(pwd)
-          echo "PYTHONPATH=$RUNNER_CWD/RMG-Py:$PYTHONPATH" >> $GITHUB_ENV
-          echo "$RUNNER_CWD/RMG-Py" >> $GITHUB_PATH
-
-      # RMG build step
-      - name: make RMG
-        run: |
-          make clean
-          make
-
   build-and-test-linux:
     runs-on: ubuntu-latest
     # skip scheduled runs from forks
@@ -101,23 +50,23 @@ jobs:
         shell: bash -l {0}
         working-directory: RMG-Py
     steps:
-      - name: Clone RMG-database
-        uses: actions/checkout@v3
-        with:
-          path: RMG-database
-
       - name: Checkout RMG-Py
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          path: RMG-Py
           repository: ReactionMechanismGenerator/RMG-Py
           ref: ${{ env.RMG_PY_BRANCH }}
+          path: RMG-Py
+
+      - name: Checkout RMG-database
+        uses: actions/checkout@v4
+        with:
+          path: RMG-database
 
       # configures the mamba environment manager and builds the environment
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
-          environment-file: RMG-Py/environment.yml
+          environment-file: environment.yml
           miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: 3.7
@@ -155,7 +104,6 @@ jobs:
 
       # non-regression testing
       - name: Run Database Tests
-        # aggregate into one command so we only have to eat the collection time once
         run: make test-database
 
       # Regression Testing - Test Execution
@@ -187,16 +135,6 @@ jobs:
           path: |
             test/regression
 
-      # Upload Regression Results as Stable if Scheduled or Push to Main
-      - name: Upload Results as Reference
-        # upload the results for scheduled CI (on main) and pushes to main
-        if: ${{ env.REFERENCE_JOB == 'true' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: stable_regression_results
-          path: |
-            test/regression
-
       # Upload Regression Results as Dynamic if Push to non-main Branch
       - name: Upload Results as Dynamic
         if: ${{ env.REFERENCE_JOB == 'false' }}
@@ -220,7 +158,7 @@ jobs:
         # the stable regression results
           workflow: CI.yml
           workflow_conclusion: success
-          repo: ReactionMechanismGenerator/RMG-database
+          repo: ReactionMechanismGenerator/RMG-Py
           branch: main
           name: stable_regression_results
           path: stable_regression_results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-        working-directory: RMG-Py
+        working-directory: RMG-Py  # only applies to 'run' steps
     steps:
       - name: Checkout RMG-Py
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Mambaforge Python 3.7
         uses: conda-incubator/setup-miniconda@v2
         with:
-          environment-file: environment.yml
+          environment-file: RMG-Py/environment.yml
           miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: 3.7
@@ -133,7 +133,7 @@ jobs:
         with:
           name: failed_regression_results
           path: |
-            test/regression
+            RMG-Py/test/regression
 
       # Upload Regression Results as Dynamic if Push to non-main Branch
       - name: Upload Results as Dynamic
@@ -142,7 +142,7 @@ jobs:
         with:
           name: dynamic_regression_results
           path: |
-            test/regression
+            RMG-Py/test/regression
 
       - name: mkdir stable_regression_results
         if: ${{ env.REFERENCE_JOB == 'false' }}
@@ -161,7 +161,7 @@ jobs:
           repo: ReactionMechanismGenerator/RMG-Py
           branch: main
           name: stable_regression_results
-          path: stable_regression_results
+          path: RMG-Py/stable_regression_results
           search_artifacts: true  # retrieves the last run result, either scheduled daily or on push to main
           ensure_latest: true     # ensures that the latest run is retrieved
           # should result in a set of folders inside stable_regression_results
@@ -271,11 +271,11 @@ jobs:
         if : ${{ github.event_name == 'pull_request' }}
         with:
           name: regression_summary
-          path: summary.txt
+          path: RMG-Py/summary.txt
 
       - name: Upload Comparison Results
         uses: actions/upload-artifact@v3
         with:
           name: regression_test_comparison_results
           path: |
-            test/regression-diff
+            RMG-Py/test/regression-diff


### PR DESCRIPTION
ci is currently failing to download reference results for regression testing because it also failing to _upload_ them. I'm not sure why, but I do know that it's working on RMG-Py, so I have modified the ci configuration file to work more like RMG-Py.