### PR TITLE
Fixed a potential infinite loop in the script for fitting Benson groups. 

### DIFF
--- a/scripts/fitThermoGroupsFromThermoLibrary.ipynb
+++ b/scripts/fitThermoGroupsFromThermoLibrary.ipynb
@@ -528,7 +528,7 @@
     "                                        group = make_group(atom, n_degree_neighbor=n_degree_neighbor)\n",
     "                                        group_str = make_group_name(atom, n_degree_neighbor=n_degree_neighbor)\n",
     "\n",
-    "                                    while any([(group.make_sample_molecule()).is_subgraph_isomorphic(child.item) for child in node.children]):\n",
+    "                                    while any([(group.make_sample_molecule()).is_subgraph_isomorphic(child.item, generate_initial_map = True) for child in node.children]):\n",
     "                                        #Child-node can't be the child of other children\n",
     "                                        #to avoid ambiguous group selection\n",
     "                                        n_degree_neighbor+=1\n",


### PR DESCRIPTION
In the `fitThermoGroupsFromThermoLibrary` script, an inifinite loop may occur when making missing groups. 

In particular, during the step where the code is searching for all child nodes that are subgraph isomorphic to a newly generated group, the function for isomorphic checks may misidentify two graphs as isomorphic even if their labeled atoms do not match. This will cause an inifinite loop where no matter how specific a newly generated group is, there will always be a child node that is subgraph isomorphic to it. This is resolved by turning the `generate_initial_map` option on. 