### PR TITLE
Removes duplicate bad fits in the Benson Group Fitting Notebook

### DIFF
--- a/scripts/fitThermoGroupsFromThermoLibrary.ipynb
+++ b/scripts/fitThermoGroupsFromThermoLibrary.ipynb
@@ -1360,10 +1360,20 @@
     "    if diff_new>n*4.18:\n",
     "        bad_fit_spc_index_list.append(spc_index)\n",
     "        \n",
+    "bad_fit_spc_index_list = list(set(bad_fit_spc_index_list))\n",
+    "print(f\"{len(bad_fit_spc_index_list)} out of {len(entries)} species have bad fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "for spc_index in bad_fit_spc_index_list:\n",
     "    print(\"Warning: these are bad fits:\")\n",
     "    check_data(index=spc_index)\n",
-    "    print(\"====\")"
+    "    print(\"===========================================================================\")"
    ]
   },
   {


### PR DESCRIPTION
Currently the block checking for bad fits will repeatedly add the species index with bad fit if more than one criterion for bad fits is met. This makes the output cell very long if there are multiple "bad fit species". This PR removes the duplicates as well as providing feedback on how many species out of the library have bad fits. 