### PR TITLE
make adsorptionPt111 more flexible with lone pairs px

### DIFF
--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -1788,7 +1788,7 @@ entry(
 4 R  u0 px c0 {2,S}
 5 R  u0 px c0 {2,S}
 6 R  u0 px c0 {2,S}
-7 R  u0 p0 c0 {3,S}
+7 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -175,8 +175,8 @@ entry(
 1 * X u0 p0 c0
 2 O  u0 p2 c0 {3,S} {4,S}
 3 O  u0 p2 c0 {2,S} {5,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -3672,7 +3672,7 @@ entry(
 3 C  u0 p0 c0 {1,T} {4,S} 
 4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,D} {4,S} {6,S} 
-6 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -338,9 +338,9 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
 3 O  u0 p2 c0 {1,S} {2,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {2,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {2,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1110,9 +1110,9 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
 3 C  u0 p0 c0 {1,T} {2,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {2,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {2,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1180,8 +1180,8 @@ entry(
 2 X u0 p0 c0 {4,D}
 3 C  u0 p0 c0 {1,D} {4,S} {5,S}
 4 C  u0 p0 c0 {2,D} {3,S} {6,S}
-5 R  u0 p0 c0 {3,S}
-6 R  u0 p0 c0 {4,S}
+5 R  u0 px c0 {3,S}
+6 R  u0 px c0 {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1246,10 +1246,10 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
 4 C  u0 p0 c0 {2,S} {3,S} {7,S} {8,S}
-5 R  u0 p0 c0 {3,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {4,S}
-8 R  u0 p0 c0 {4,S}
+5 R  u0 px c0 {3,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {4,S}
+8 R  u0 px c0 {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1314,12 +1314,12 @@ entry(
 1 * X u0 p0 c0
 2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
 3 C  u0 p0 c0 {2,S} {7,S} {8,S} {9,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {2,S}
-7 R  u0 p0 c0 {3,S}
-8 R  u0 p0 c0 {3,S}
-9 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {2,S}
+7 R  u0 px c0 {3,S}
+8 R  u0 px c0 {3,S}
+9 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1509,7 +1509,7 @@ entry(
 1 * X u0 p0 c0 {2,T}
 2 C  u0 p0 c0 {1,T} {3,S}
 3 O  u0 p2 c0 {2,S} {4,S}
-4 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1544,9 +1544,9 @@ entry(
 2 X u0 p0 c0 {4,D}
 3 C  u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
 4 C  u0 p0 c0 {2,D} {3,S} {7,S}
-5 R  u0 p0 c0 {3,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {4,S}
+5 R  u0 px c0 {3,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1578,11 +1578,11 @@ entry(
 1 * X u0 p0 c0 {2,S}
 2 C  u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
 3 C  u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {3,S}
-8 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {3,S}
+8 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1682,8 +1682,8 @@ entry(
 1 * X u0 p0 c0
 2 C  u0 p0 c0 {3,D} {4,S} {5,S}
 3 O  u0 p2 c0 {2,D}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1715,9 +1715,9 @@ entry(
 1 * X u0 p0 c0 {2,S}
 2 C  u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
 3 O  u0 p2 c0 {2,S} {6,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1785,9 +1785,9 @@ entry(
 1 * X u0 p0 c0
 2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
 3 O  u0 p2 c0 {2,S} {7,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {2,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {2,S}
 7 R  u0 p0 c0 {3,S}
 """,
     thermo=ThermoData(
@@ -1821,7 +1821,7 @@ entry(
 2 X u0  p0 c0 {4,D}
 3 C  u0  p0 c0 {1,S} {4,D} {5,S}
 4 C  u0  p0 c0 {2,D} {3,D}
-5 R  u0  p0 c0 {3,S}
+5 R  u0  px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1854,9 +1854,9 @@ entry(
 1 * X u0  p0 c0 {2,S}
 2 C  u0  p0 c0 {1,S} {3,D} {4,S}
 3 C  u0  p0 c0 {2,D} {5,S} {6,S}
-4 R  u0  p0 c0 {2,S}
-5 R  u0  p0 c0 {3,S}
-6 R  u0  p0 c0 {3,S}
+4 R  u0  px c0 {2,S}
+5 R  u0  px c0 {3,S}
+6 R  u0  px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -1890,10 +1890,10 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 C  u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
 3 C  u0 p0 c0 {1,D} {2,S} {7,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {2,S}
-7 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {2,S}
+7 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2085,7 +2085,7 @@ entry(
 1 * X u0  p0 c0 {2,S}
 2 C  u0  p0 c0 {1,S} {3,D} {4,S}
 3 O  u0  p2 c0 {2,D}
-4 R  u0  p0 c0 {2,S}
+4 R  u0  px c0 {2,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2120,7 +2120,7 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,D} {4,S} {5,S}
 4 O  u0 p2 c0 {2,S} {3,S}
-5 R  u0 p0 c0 {3,S}
+5 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2154,8 +2154,8 @@ entry(
 1 * X u0 p0 c0 {2,D}
 2 C  u0 p0 c0 {1,D} {3,S} {4,S}
 3 O  u0 p2 c0 {2,S} {5,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2577,8 +2577,8 @@ entry(
 1 * X u0 p0 c0
 2 C  u0 p0 c0 {3,T} {4,S}
 3 C  u0 p0 c0 {2,T} {5,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2710,8 +2710,8 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
 4 O  u0 p2 c0 {2,S} {3,S}
-5 R  u0 p0 c0 {3,S}
-6 R  u0 p0 c0 {3,S}
+5 R  u0 px c0 {3,S}
+6 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2743,9 +2743,9 @@ entry(
 1 * X u0 p0 c0
 2 C  u0 p0 c0 {3,D} {4,S} {5,S}
 3 C  u0 p0 c0 {2,D} {6,S}
-4 R  u0 p0 c0 {2,S}
-5 R  u0 p0 c0 {2,S}
-6 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R  u0 px c0 {2,S}
+6 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2778,8 +2778,8 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,D} {4,S} {5,S}
 4 C  u0 p0 c0 {2,S} {3,S} {6,D}
-5 R  u0 p0 c0 {3,S}
-6 R!H  u0 p0 c0 {4,D}
+5 R  u0 px c0 {3,S}
+6 R!H  u0 px c0 {4,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2811,7 +2811,7 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,T} {4,S}
 4 C  u0 p0 c0 {2,S} {3,S} {5,D}
-5 R!H  u0 p0 c0 {4,D}
+5 R!H  u0 px c0 {4,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2843,8 +2843,8 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,T} {4,S}
 4 C  u0 p0 c0 {2,S} {3,S} {5,S} {6,S}
-5 R  u0 p0 c0 {4,S}
-6 R  u0 p0 c0 {4,S}
+5 R  u0 px c0 {4,S}
+6 R  u0 px c0 {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2877,9 +2877,9 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
 4 C  u0 p0 c0 {2,S} {3,S} {7,D}
-5 R  u0 p0 c0 {3,S}
-6 R  u0 p0 c0 {3,S}
-7 R!H  u0 p0 c0 {4,D}
+5 R  u0 px c0 {3,S}
+6 R  u0 px c0 {3,S}
+7 R!H  u0 px c0 {4,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2911,8 +2911,8 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 C  u0 p0 c0 {1,S} {4,D} {5,S}
 4 C  u0 p0 c0 {2,S} {3,D} {6,S}
-5 R  u0 p0 c0 {3,S}
-6 R  u0 p0 c0 {4,S}
+5 R  u0 px c0 {3,S}
+6 R  u0 px c0 {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2944,7 +2944,7 @@ entry(
 2 X u0 p0 c0 {4,D}
 3 C  u0 p0 c0 {1,T} {4,S}
 4 C  u0 p0 c0 {2,D} {3,S} {5,S}
-5 R  u0 p0 c0 {4,S}
+5 R  u0 px c0 {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -2975,10 +2975,10 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,D} {4,D} 
-4 R!H  u0 p0 c0 {3,D} {5,S}
+4 R!H  u0 px c0 {3,D} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
-6 R  u0 p0 c0 {5,S}
-7 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {5,S}
+7 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3009,12 +3009,12 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,S} {8,S} {9,S}
-4 R!H  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
-6 R  u0 p0 c0 {5,S}
-7 R  u0 p0 c0 {5,S}
-8 R  u0 p0 c0 {3,S}
-9 R  u0 p0 c0 {3,S}
+6 R  u0 px c0 {5,S}
+7 R  u0 px c0 {5,S}
+8 R  u0 px c0 {3,S}
+9 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3045,10 +3045,10 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,D} {4,S} {6,S}
-4 R!H  u0 p0 c0 {3,S} {5,D}
+4 R!H  u0 px c0 {3,S} {5,D}
 5 C  u0 p0 c0 {2,S} {4,D} {7,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3079,11 +3079,11 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
-4 R!H  u0 p0 c0 {3,D} {5,S}
+4 R!H  u0 px c0 {3,D} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {5,S}
-8 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {5,S}
+8 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3114,11 +3114,11 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,D} {4,S} {6,S}
-4 R!H  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {7,S} {8,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {5,S}
-8 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {5,S}
+8 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3151,8 +3151,8 @@ entry(
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
 4 R!H  u0 p0 c0 {3,D} {5,D}
 5 C  u0 p0 c0 {2,S} {4,D} {7,S}
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3185,7 +3185,7 @@ entry(
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
 4 R!H  u0 p0 c0 {3,D} {5,D}
 5 C  u0 p0 c0 {2,D} {4,D}
-6 R  u0 p0 c0 {3,S}
+6 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3248,9 +3248,9 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,S} {4,D} {6,S}
-4 R!H  u0 p0 c0 {3,D} {5,S}
+4 R!H  u0 px c0 {3,D} {5,S}
 5 O  u0 p2 c0 {2,S} {4,S}
-6 R  u0 p0 c0 {3,S} 
+6 R  u0 px c0 {3,S} 
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3310,9 +3310,9 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 C  u0 p0 c0 {3,S} {4,S} {5,D}
 3 C  u0 p0 c0 {1,D} {2,S} {6,S}
-4 R  u0 p0 c0 {2,S}
-5 R!H  u0 c0 {2,D}
-6 R  u0 c0 {3,S}
+4 R  u0 px c0 {2,S}
+5 R!H  u0 px c0 {2,D}
+6 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3346,8 +3346,8 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 C  u0 p0 c0 {3,S} {4,S} {5,D}
 3 C  u0 p0 c0 {1,T} {2,S}
-4 R  u0 p0 c0 {2,S}
-5 R!H  u0 c0 {2,D}
+4 R  u0 px c0 {2,S}
+5 R!H  u0 px c0 {2,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3381,8 +3381,8 @@ entry(
 1 * X u0 p0 c0 {3,S}
 2 C  u0 p0 c0 {3,S} {4,S} {5,D}
 3 O  u0 p2 c0 {1,S} {2,S}
-4 R  u0 p0 c0 {2,S}
-5 R!H  u0 c0 {2,D}
+4 R  u0 px c0 {2,S}
+5 R!H  u0 px c0 {2,D}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3477,7 +3477,7 @@ entry(
 2 X u0 {4,S}
 3 C  u0 {1,[S,D,T]} {5,[S,D,T]}
 4 O  u0 p2 {2,S} {5,S}
-5 R!H  u0 {3,[S,D,T]} {4,S}
+5 R!H  u0 px {3,[S,D,T]} {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3506,7 +3506,7 @@ entry(
 2 X u0 p0 c0 {4,S}
 3 O  u0 p2 c0 {1,S} {5,S}
 4 O  u0 p2 c0 {2,S} {5,S}
-5 R!H  u0 p0 c0 {3,S} {4,S}
+5 R!H  u0 px c0 {3,S} {4,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3537,10 +3537,10 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R!H  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,S} {4,S} {6,S} {7,S}
-6 R  u0 p0 c0 {5,S}
-7 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {5,S}
+7 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3571,9 +3571,9 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,S}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R!H  u0 p0 c0 {3,S} {5,D}
+4 R!H  u0 px c0 {3,S} {5,D}
 5 C  u0 p0 c0 {2,S} {4,D} {6,S} 
-6 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3604,7 +3604,7 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,T}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R!H  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,T} {4,S}
 """,
     thermo=ThermoData(
@@ -3636,10 +3636,10 @@ entry(
 1 * X u0 p0 c0 {3,D}
 2 X u0 p0 c0 {5,D}
 3 C  u0 p0 c0 {1,D} {4,S} {6,S}
-4 R!H  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,D} {4,S} {7,S} 
-6 R  u0 p0 c0 {3,S}
-7 R  u0 p0 c0 {5,S}
+6 R  u0 px c0 {3,S}
+7 R  u0 px c0 {5,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
@@ -3670,7 +3670,7 @@ entry(
 1 * X u0 p0 c0 {3,T}
 2 X u0 p0 c0 {5,D}
 3 C  u0 p0 c0 {1,T} {4,S} 
-4 R!H  u0 p0 c0 {3,S} {5,S}
+4 R!H  u0 px c0 {3,S} {5,S}
 5 C  u0 p0 c0 {2,D} {4,S} {6,S} 
 6 R  u0 p0 c0 {5,S}
 """,

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -242,7 +242,7 @@ entry(
 1 * X u0 p0 c0 {2,S}
 2 O  u0 p2 c0 {1,S} {3,S}
 3 O  u0 p2 c0 {2,S} {4,S}
-4 R  u0 p0 c0 {3,S}
+4 R  u0 px c0 {3,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),

--- a/input/thermo/groups/adsorptionPt111.py
+++ b/input/thermo/groups/adsorptionPt111.py
@@ -109,8 +109,8 @@ entry(
 """
 1 * X u0 p0 c0
 2 O  u0 p2 c0 {3,S} {4,S}
-3 R  u0 p[0,1,2] c0 {2,S}
-4 R  u0 p[0,1,2] c0 {2,S}
+3 R  u0 px c0 {2,S}
+4 R  u0 px c0 {2,S}
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),


### PR DESCRIPTION
**Description**

The nodes in the adsorption correction file adsorptionPt111.py were rather restrictive. In most nodes it was specified that the general`R` cannot have lone pairs `p0`. I didn't pay close attention to this when I restructured the adsorption correction database because the `R` was mostly C in the training data. However, this is not correct. In most cases, the R can also be replaced with O/N. Actually, in some cases the training data that I used contained O, but the node would not have been used to estimate the thermo for this species. @kirkbadger18 caught this detail. 

I revised now the adjacency lists and made the nodes more permissive, by changing the `p0` to `px` whenever it is reasonable. 
I did not touch the nodes containing nitrogen, because @kirkbadger18 is doing a complete overhaul of the nitrogen adsorption corrections. 

**Testing**

I generated a mechanism for the oxidation of ethane on Pt(111) without (left log file) and with (right log file) these changes. The mechanisms are indeed slightly different. 

![Screenshot 2024-09-18 at 1 16 34 PM](https://github.com/user-attachments/assets/b8c97ace-a006-4719-a960-d6c36b37d716)

With the more permissible adsorption corrections, RMG deems a bidentate carboxyl to be important 

![Screenshot 2024-09-18 at 1 18 08 PM](https://github.com/user-attachments/assets/64285591-a9df-4dfb-8d2f-66e7c006cfcf)

Previously, this species was discovered, but remained in the edge. 

![Screenshot 2024-09-18 at 1 18 54 PM](https://github.com/user-attachments/assets/d9d752bd-7cef-4c95-8ee1-7fc5cf9b7bb5)

You see that the thermochemistry of the species has changed because RMG used the top level node `C*O*` to estimate the thermo and now it uses the more specific `C=*RO-*`. Whether this species should exist is another story (because there is also a monodentate carboxyl). However, I think that these updates to the adsorption corrections are necessary since they can affect our thermo estimate for some species and make them (supposedly) more accurate.  

**Review**
Carefully review that I haven't missed a node or an `R`. @kirkbadger18 will make another PR soon that changes the N-containing nodes. 
Generate a mechanism for system of your choice and check if everything works accordingly. 

