### PR TITLE
Changes to CI to match RMG-Py

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@
 #
 # Changelog:
 # 2023-10    - Copied from RMG-Py, adapted for RMG-database
+# 2024/10/02  Mambaforge is deprecated. Use Miniforge3 instead. 
 
 name: Continuous Integration
 
@@ -63,11 +64,11 @@ jobs:
           path: RMG-database
 
       # configures the mamba environment manager and builds the environment
-      - name: Setup Mambaforge Python 3.7
+      - name: Setup Miniforge Python 3.7
         uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: RMG-Py/environment.yml
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           python-version: 3.7
           activate-environment: rmg_env
@@ -152,16 +153,16 @@ jobs:
       - name : Find ID of Reference Results
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # this will search for the last successful execution of CI on main
         run: |
-          run_id=$(gh run list -R ReactionMechanismGenerator/RMG-Py --workflow="Continuous Integration" --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+          run_id=$(gh run list -R ReactionMechanismGenerator/RMG-Py --workflow="Continuous Integration" --branch main --limit 15 --json databaseId,conclusion --jq 'map(select(.conclusion == "success")) | .[0].databaseId')
           echo "CI_RUN_ID=$run_id" >> $GITHUB_ENV
 
       - name: Retrieve Stable Regression Results
         if: ${{ env.REFERENCE_JOB == 'false' }}
         uses: actions/download-artifact@v4
         with:
-        # this will search for the last successful execution of CI on main and download
-        # the stable regression results
+        # download stable regression results
           run-id: ${{ env.CI_RUN_ID }}
           repository: ReactionMechanismGenerator/RMG-Py
           github-token:  ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Matches the corresponding PR on RMG-Py. 

- [x] Changes CI to use Miniforge3 instead of Mambaforge. 
- [x] Non-reference CIs will now download reference regression results from the most recent successful reference CI run in the past 15 days.