### PR TITLE
Forbid charged nitrogen species from breaking to prevent AtomType error on N++ species

### DIFF
--- a/input/kinetics/families/Surface_Dissociation_vdW/groups.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/groups.py
@@ -58,7 +58,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 R!H u0 px cx {2,S}
+1 *1 R!H u0 px c0 {2,S}
 2 *2 H   u0 p0 c0 {1,S}
 3 *3 Xv  u0 p0 c0
 """,
@@ -71,7 +71,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 C  u0 px cx {2,S}
+1 *1 C  u0 px c0 {2,S}
 2 *2 H  u0 p0 c0 {1,S}
 3 *3 Xv u0 p0 c0
 """,
@@ -84,7 +84,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 O  u0 px cx {2,S}
+1 *1 O  u0 px c0 {2,S}
 2 *2 H  u0 p0 c0 {1,S}
 3 *3 Xv u0 p0 c0
 """,
@@ -97,7 +97,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 N  u0 px cx {2,S}
+1 *1 N  u0 px c0 {2,S}
 2 *2 H  u0 p0 c0 {1,S}
 3 *3 Xv u0 p0 c0
 """,
@@ -154,7 +154,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 C   u0 px cx {2,S} {3,S} {4,D}
+1 *1 C   u0 px c0 {2,S} {3,S} {4,D}
 2 *2 H   u0 p0 c0 {1,S}
 3    H   u0 p0 c0 {1,S}
 4    R!H u0 px cx {1,D}
@@ -170,7 +170,7 @@ entry(
 """
 multiplicity [1]
 1    R!H u0 px cx {2,S}
-2 *1 C   u0 px cx {1,S} {3,S} {4,S} {5,S}
+2 *1 C   u0 px c0 {1,S} {3,S} {4,S} {5,S}
 3 *2 H   u0 p0 c0 {2,S}
 4    H   u0 p0 c0 {2,S}
 5    H   u0 p0 c0 {2,S}
@@ -198,7 +198,7 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 R!H u0 px cx {2,[S,D]}
+1 *1 R!H u0 px c0 {2,[S,D]}
 2 *2 C   u0 p0 c0 {1,[S,D]}
 3 *3 Xv  u0 p0 c0
 """,

--- a/input/kinetics/families/Surface_Dissociation_vdW/groups.py
+++ b/input/kinetics/families/Surface_Dissociation_vdW/groups.py
@@ -35,8 +35,8 @@ entry(
     group =
 """
 multiplicity [1]
-1 *1 R!H u0 px cx {2,[S,D]}
-2 *2 R   u0 px cx {1,[S,D]}
+1 *1 R!H u0 px c0 {2,[S,D]}
+2 *2 R   u0 px c0 {1,[S,D]}
 3 *3 Xv  u0 p0 c0
 """,
     kinetics = None,


### PR DESCRIPTION
See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2764

RMG crashed from an AtomType Error from trying to apply the Surface_Dissociation_vdW template to various species containing N+ in the 1* or 2* template label location.

I don't know if there's some deeper issue with how RMG handles bond breaking and updating the charge on N, but this is one possible fix/bandaid. It forbids any species that has N+ (charged nitrogen) in the 1* or 2* label positions.