### PR TITLE
Add Fe110 to metal database

### DIFF
--- a/input/surface/libraries/metal.py
+++ b/input/surface/libraries/metal.py
@@ -407,3 +407,25 @@ entry(
 
 """,
 )
+
+entry(
+    index = 21,
+    label = "Fe110",
+    bindingEnergies = {
+        'H': (-3.02, 'eV/molecule'),
+        'C': (-7.60, 'eV/molecule'),
+        'N': (-6.15, 'eV/molecule'),
+        'O': (-6.09, 'eV/molecule'),
+        'S': (-5.72, 'eV/molecule'),
+    },
+    surfaceSiteDensity = (2.891174e-09, 'mol/cm^2'),
+    facet = "110",
+    metal = "Fe",
+    shortDesc = """bcc""",
+    longDesc =
+"""
+Calculated by Xu L, Kirvassilis D, Bai Y, Mavrikakis M. Atomic and molecular adsorption on Fe(110).
+Surface science. 2018;667:54-65. doi:10.1016/j.susc.2017.09.002
+Lattice constant using PW91 is a=2.85 Angstrom.
+""",
+)


### PR DESCRIPTION
Add the Fe110 facet to RMG's database.

Values taken from:

Xu L, Kirvassilis D, Bai Y, Mavrikakis M. Atomic and molecular adsorption on Fe(110).
Surface science. 2018;667:54-65. doi:10.1016/j.susc.2017.09.002

The lattice constant PW91 is given in the paper as a=2.85 Angstrom.
Then surface site density was calculated using the following code

```
import ase.build
import numpy as np
import ase.visualize
import rmgpy.constants

a = 2.85  # A
surface = ase.build.bcc110("Fe", (3, 3, 3), a=a, periodic=True)

a1 = surface.cell[0]
a2 = surface.cell[1]
unit_cell_area = np.linalg.norm(np.cross(a1, a2))
print(f'Unit cell area:\t{area:0.5f}\tA^2')

site_area = unit_cell_area / 9.0
print(f'Site area:\t{site_area:0.5f}\t\tA^2/site')
print(f'Site density:\t{1.0 / site_area:0.5f}\t\tsites/A^2')

SDEN = 1.0 / site_area * (1e20) / rmgpy.constants.Na
print(f'Site density:\t{SDEN:0.5e}\tmols/m^2')
SDEN = 1.0 / site_area * (1e16) / rmgpy.constants.Na
print(f'Site density:\t{SDEN:0.5e}\tmols/cm^2')
```

