### PR TITLE
Added kinetics "CH3OH+H=CH3+H2O"

### DIFF
--- a/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
+++ b/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
@@ -11210,7 +11210,7 @@ entry(
 
 entry(
     index = 586,
-    label = "CH3OH + H <=> CH3 + OH",
+    label = "CH3OH + H <=> CH3 + H2O",
     degeneracy = 1,
     kinetics = Arrhenius(A=(2.9558e+5, 'cm^3/(mol*s)'), n=2.485, Ea=(52234, 'cal/mol'), T0=(1, 'K')),
     shortDesc = u"""Added from Moses et al., Astrophysical Journal, 737:15 (37pp), 2011. The ab-initio calculation was done by Stephen J. Klippenstein at the QCISD(T)/CBS//QCISD(T)/cc-pVTZ with the spin-restricted formalism using the MOLPRO""",

--- a/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
+++ b/input/kinetics/libraries/Klippenstein_Glarborg2016/reactions.py
@@ -11208,3 +11208,11 @@ entry(
     shortDesc = u"""The chemkin file reaction is HOCH2CH2OO + C2H4 => CH2O + CH2OH + CH3CHO""",
 )
 
+entry(
+    index = 586,
+    label = "CH3OH + H <=> CH3 + OH",
+    degeneracy = 1,
+    kinetics = Arrhenius(A=(2.9558e+5, 'cm^3/(mol*s)'), n=2.485, Ea=(52234, 'cal/mol'), T0=(1, 'K')),
+    shortDesc = u"""Added from Moses et al., Astrophysical Journal, 737:15 (37pp), 2011. The ab-initio calculation was done by Stephen J. Klippenstein at the QCISD(T)/CBS//QCISD(T)/cc-pVTZ with the spin-restricted formalism using the MOLPRO""",
+)
+


### PR DESCRIPTION
Add kinetics data for CH3OH + H that leads to CH3 + H2O.

Originally it only contained two channels which are:

1. CH3OH + H = CH3O + H2
2. CH3OH + H = CH2OH + H2

However, there is another channel that leads to CH3 + H2O. Although the branching ratio of this reaction is still small compared to the other two channels, it will be important at the elevated temperature above ~800 K and pressure. In the deep planetary atmosphere (e.g., Jupiter), this channel would be a significant channel for CO-CH4 conversion. 

The ab initio calculation for this rate coefficient was done by Stephen J. Klippenstein in Moses, et al., (2011), The Astrophysical Journal, 737(1), 15. [https://iopscience.iop.org/article/10.1088/0004-637X/737/1/15/meta](url)

at the QCISD(T)/CBS//QCISD(T)/cc-pVTZ with the spin-restricted formalism using the MOLPRO.

