### PR TITLE
Fix broken conda upload logic

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -38,20 +38,20 @@ jobs:
       - name: Install Build Tools
         run: conda install python anaconda-client conda-build
 
-      - name: Configure Auto-Upload
-        if: github.ref == 'refs/heads/stable'
-        run: |
-          conda config --set anaconda_upload yes
-
       - name: Build Binary
+        env:
+          CONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          # set a default value to the conda_token if needed (like from forks)
-          : "${CONDA_TOKEN:=${{ secrets.ANACONDA_TOKEN }}}"
-          : "${CONDA_TOKEN:=default_value}"
-          echo "CONDA_TOKEN=$CONDA_TOKEN" >> $GITHUB_ENV
           conda config --add channels rmg
           conda config --add channels conda-forge
-          CONDA_PY=${{ matrix.python-version }} conda build --token $CONDA_TOKEN --user rmg .
+
+          if [[ "${GITHUB_REF}" == "refs/heads/stable" ]]; then
+            CONDA_PY=${{ matrix.python-version }} \
+              conda build --token "$CONDA_TOKEN" --user rmg .
+          else
+            CONDA_PY=${{ matrix.python-version }} \
+              conda build --no-anaconda-upload .
+          fi
 
   result:
     if: ${{ always() }}


### PR DESCRIPTION
I discovered while debugging https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2996 that our current conda build config is uploading conda binaries for RMG-database (and RMG-Py) on _every_ push to _any_ branch.

Fixing this for... obvious reasons.